### PR TITLE
Path cache db folder create hook

### DIFF
--- a/hooks/path_cache_db_folder_create.py
+++ b/hooks/path_cache_db_folder_create.py
@@ -11,14 +11,12 @@ import os
 
 class PathCacheDbFolderCreate(Hook):
 
-    def execute(self, db_path, **kwargs):
+    def execute(self, cache_folder, **kwargs):
         """
         The default implementation creates the path cache db folder.
         """
-        cache_folder = os.path.dirname(db_path)
-        if not os.path.exists(cache_folder):
-            old_umask = os.umask(0)
-            try:
-                os.mkdir(cache_folder, 0777)
-            finally:
-                os.umask(old_umask)
+        old_umask = os.umask(0)
+        try:
+            os.mkdir(cache_folder, 0777)
+        finally:
+            os.umask(old_umask)

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -40,7 +40,9 @@ class PathCache(object):
         # note that the cache folder is inside of the tank folder
         # so no need to attempt a recursive creation here.
         db_path = pipeline_configuration.get_path_cache_location()
-        pipeline_configuration.execute_hook(constants.PATH_CACHE_DB_FOLDER_CREATE_HOOK_NAME, db_path=db_path)
+        cache_folder = os.path.dirname(db_path)
+        if not os.path.exists(cache_folder):
+            pipeline_configuration.execute_hook(constants.PATH_CACHE_DB_FOLDER_CREATE_HOOK_NAME, cache_folder=cache_folder)
 
         # make sure to set open permissions on the db file if we are the first ones
         # to create it

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -74,6 +74,7 @@ TANK_ENGINE_INIT_HOOK_NAME = "engine_init"
 # hook that is executed whenever a bundle has initialized
 TANK_BUNDLE_INIT_HOOK_NAME = "bundle_init"
 
+# hook that is executed if the path cache db folder is missing.
 PATH_CACHE_DB_FOLDER_CREATE_HOOK_NAME = "path_cache_db_folder_create"
 
 # hook to get current login


### PR DESCRIPTION
Adds hook for PathCache db folder creation.  Only executes if the folder is missing.

Requires Pull Request: https://github.com/shotgunsoftware/tk-core/pull/11

-tony
