### PR TITLE
Allows MSYS to run tank binary with redirect.

### DIFF
--- a/setup/root_binaries/tank
+++ b/setup/root_binaries/tank
@@ -76,6 +76,10 @@ else
    # so try and get the parent and call its tank script
    # the parent location is stored in a config file
    curr_platform=`uname`
+   if [ "$curr_platform" == MINGW32_NT* ] || [ "$curr_platform" ==  CYGWIN_NT* ];
+   then
+     curr_platform="Windows"
+   fi
    parent_config_file="$SELF_PATH/install/core/core_${curr_platform}.cfg"
 
    if [ ! -f "$parent_config_file" ];


### PR DESCRIPTION
If `uname` returns MINGW32_NT\* or CYGWIN_NT*, sets $curr_platform to "Windows".
