### PR TITLE
bug in tank.platform.engine.py on printing error message to stderr

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -314,7 +314,7 @@ class Engine(TankBundle):
         Implemented in deriving class - however we provide a basic implementation here.
         """        
         # fall back to std out error reporting if deriving class does not implement this.
-        sys.stderr("Error: %s\n" % msg)
+        sys.stderr.write("Error: %s\n" % msg)
     
     def log_exception(self, msg):
         """


### PR DESCRIPTION
Hi,

I noticed a bug it the engine.py, when I was trying to instantiate an Engine object manually via our inhouse pipeline facilities isolated from the tank environment config for non-UI test code.

It seems there was a slight oversight in the error printing code. Unfortunately it comprises the printing of the actual error that caused it to follow that particular code path. 
