### PR TITLE
SG Ticket #21952 renaming the default suggested location at install time from tank to shotgun. 

### DIFF
--- a/python/tank/deploy/setup_project.py
+++ b/python/tank/deploy/setup_project.py
@@ -104,19 +104,19 @@ class CmdlineSetupInteraction(object):
                 pp = primary_local_storage.get("mac_path")
                 if pp.endswith("/"):
                     pp = pp[:-1] 
-                location["darwin"] = "%s/%s/tank" % (pp, project_disk_name)
+                location["darwin"] = "%s/%s/shotgun" % (pp, project_disk_name)
                 
             if primary_local_storage.get("windows_path"):
                 pp = primary_local_storage.get("windows_path")
                 if pp.endswith("\\"):
                     pp = pp[:-1] 
-                location["win32"] = "%s\\%s\\tank" % (pp, project_disk_name)
+                location["win32"] = "%s\\%s\\shotgun" % (pp, project_disk_name)
                 
             if primary_local_storage.get("linux_path"):
                 pp = primary_local_storage.get("linux_path")
                 if pp.endswith("/"):
                     pp = pp[:-1] 
-                location["linux2"] = "%s/%s/tank" % (pp, project_disk_name)
+                location["linux2"] = "%s/%s/shotgun" % (pp, project_disk_name)
             
         else:
             # assume new style setup - in this case we need to go figure out the different


### PR DESCRIPTION
note! This should not be merged until we have made changes to tank generally to support a data root folder location called shotgun - otherwise old project style setups (pre0.13) may be weird, with both a shotgun and a tank folder.
