### PR TITLE
Allows tank to resolve contexts from paths using parallel configs.

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -38,13 +38,13 @@ class PipelineConfiguration(object):
         """
         Constructor. Do not call this directly, use the factory methods
         at the bottom of this file.
-        
+
         NOTE ABOUT SYMLINKS!
-        
+
         The pipeline_configuration_path is always populated by the paths
         that were registered in shotgun, regardless of how the symlink setup
         is handled on the OS level.
-        
+
         """
         self._pc_root = pipeline_configuration_path
 
@@ -162,7 +162,7 @@ class PipelineConfiguration(object):
 
     def get_shotgun_id(self):
         """
-        Returns the shotgun id for this PC. 
+        Returns the shotgun id for this PC.
         May connect to Shotgun to retrieve this.
         """
         if self._pc_id is None:
@@ -178,7 +178,7 @@ class PipelineConfiguration(object):
 
     def get_project_id(self):
         """
-        Returns the shotgun id for the project associated with this PC. 
+        Returns the shotgun id for the project associated with this PC.
         May connect to Shotgun to retrieve this.
         """
         if self._project_id is None:
@@ -301,7 +301,12 @@ class PipelineConfiguration(object):
         """
         Returns the path to the path cache file.
         """
-        return os.path.join(self.get_primary_data_root(), "tank", "cache", constants.CACHE_DB_FILENAME)
+
+        # PSYOP
+        project_pc_location = os.getenv("TANK_PROJECT_PC_PATH", "tank")
+        # END PSYOP
+
+        return os.path.join(self.get_primary_data_root(), project_pc_location, "cache", constants.CACHE_DB_FILENAME)
 
 
     ########################################################################################
@@ -467,7 +472,12 @@ class StorageConfigurationMapping(object):
 
     def __init__(self, data_root):
         self._root = data_root
-        self._config_file = os.path.join(self._root, "tank", "config", constants.CONFIG_BACK_MAPPING_FILE)
+
+        # PSYOP
+        project_pc_location = os.getenv("TANK_PROJECT_PC_PATH", "tank")
+        # END PSYOP
+
+        self._config_file = os.path.join(self._root, project_pc_location, "config", constants.CONFIG_BACK_MAPPING_FILE)
 
     def clear_mappings(self):
         """
@@ -576,10 +586,10 @@ def from_entity(entity_type, entity_id):
     # ok now we have all the PCs in Shotgun for this project.
     # apply the following logic:
     #
-    # if this method was called from a generic tank command, just find the primary PC 
+    # if this method was called from a generic tank command, just find the primary PC
     # and use that.
     #
-    # if this was called from a specific tank command, use that. 
+    # if this was called from a specific tank command, use that.
 
     if "TANK_CURRENT_PC" not in os.environ:
         # we are running the generic tank command, the code that we are running
@@ -691,7 +701,7 @@ def from_path(path):
     if os.path.exists(pc_config):
         # done deal!
 
-        # resolve the "real" location that is stored in Shotgun and 
+        # resolve the "real" location that is stored in Shotgun and
         # cached in the file system
         pc_registered_path = get_pc_registered_location(path)
 
@@ -709,8 +719,13 @@ def from_path(path):
 
     cur_path = path
     config_path = None
+
+    # PSYOP
+    project_pc_location = os.getenv("TANK_PROJECT_PC_PATH", "tank")
+    # END PSYOP
+
     while True:
-        config_path = os.path.join(cur_path, "tank", "config", constants.CONFIG_BACK_MAPPING_FILE)
+        config_path = os.path.join(cur_path, project_pc_location, "config", constants.CONFIG_BACK_MAPPING_FILE)
         # need to test for something in project vs studio config
         if os.path.exists(config_path):
             break
@@ -739,12 +754,12 @@ def from_path(path):
     # if we are using a specific tank command, try to use that PC
 
     if "TANK_CURRENT_PC" not in os.environ:
-        # we are running a studio level tank command - not associated with 
-        # a particular PC. Out of the list of PCs associated with this location, 
+        # we are running a studio level tank command - not associated with
+        # a particular PC. Out of the list of PCs associated with this location,
         # find the Primary PC and use that.
 
-        # try to figure out what the primary storage is by looking for a metadata 
-        # file in each PC. 
+        # try to figure out what the primary storage is by looking for a metadata
+        # file in each PC.
         for pc_path in current_os_pcs:
             data = None
             try:
@@ -756,7 +771,7 @@ def from_path(path):
             if pc_name == constants.PRIMARY_PIPELINE_CONFIG_NAME:
                 return PipelineConfiguration(pc_path)
 
-        # no luck - this may be because some projects don't have this 
+        # no luck - this may be because some projects don't have this
         # metadata cached. Now try by looking in Shotgun instead.
 
         # in the list of paths found in the inverse lookup table on disk, find the primary.
@@ -803,7 +818,7 @@ def from_path(path):
             curr_pc_path = curr_pc_path[:-1]
 
         # the path stored in the TANK_CURRENT_PC env var may be a symlink etc.
-        # now we need to find which PC entity this corresponds to in Shotgun.        
+        # now we need to find which PC entity this corresponds to in Shotgun.
         pc_registered_path = get_pc_registered_location(curr_pc_path)
 
         if pc_registered_path is None:
@@ -811,7 +826,7 @@ def from_path(path):
                             "it looks like this pipeline configuration and tank command "
                             "has not been configured for the current operating system." % curr_pc_path)
 
-        # now if this tank command is associated with the path, the registered path should be in 
+        # now if this tank command is associated with the path, the registered path should be in
         # in the list of paths found in the tank data backlink file
         if pc_registered_path not in current_os_pcs:
             raise TankError("You are trying to start using the configuration and tank command "
@@ -836,7 +851,7 @@ def from_path(path):
 
 
 ################################################################################################
-# method for loading configuration data. 
+# method for loading configuration data.
 
 def get_core_api_version_for_pc(pc_root):
     """
@@ -881,14 +896,14 @@ def get_pc_registered_location(pipeline_config_root_path):
     Loads the location metadata file from install_location.yml
     This contains a reflection of the paths given in the pc entity.
 
-    Returns the path that has been registered for this pipeline configuration 
+    Returns the path that has been registered for this pipeline configuration
     for the current OS.
     This is the path that has been defined in shotgun. It is also the path that is being
     used in the inverse pointer files that exist in each storage.
-    
+
     This is useful when drive letter mappings or symlinks are being used - in these
     cases get_path() may not return the same value as get_registered_location_path().
-    
+
     This may return None if no path has been registered for the current os.
     """
     # now read in the pipeline_configuration.yml file
@@ -918,7 +933,7 @@ def get_pc_registered_location(pipeline_config_root_path):
 
 def get_pc_disk_metadata(pipeline_config_root_path):
     """
-    Loads the config metadata file from disk.    
+    Loads the config metadata file from disk.
     """
 
     # now read in the pipeline_configuration.yml file


### PR DESCRIPTION
Hey Guys,

I'd love to talk about this one.  Basically this allows us to set an environment variable to tell tank where in the project it can find the tank_config.  This allows us to run parallel configs that can still use the from_path methods.

If the environment variable isn't found, it's business as usual!

-tony
