### PR TITLE
Allows environment variable expansion in core_{os}.cfg files.

### DIFF
--- a/setup/root_binaries/tank
+++ b/setup/root_binaries/tank
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # get absolute location of this script
@@ -95,7 +95,10 @@ else
    fi
 
    # now get path to parent
-   parent_location=`cat "$parent_config_file"`
+   # the syntax below makes it possible to put an environment variable
+   # e.g. $STUDIO_TANK_PATH in the core_Windows|Linux|etc file
+   # the parent location will then be the value of that environment variable.
+   parent_location=$( eval echo $( cat "$parent_config_file" ) )
    # and check that it exists...
    if [ ! -d "$parent_location" ];
    then


### PR DESCRIPTION
This allows the use of an environment variable inside of the core_{os}.cfg files that are used to redirect the binary scripts to the actual tank installation location.

Thanks!

-tony
