### PR TITLE
Fix for when the path to python has spaces in it.

### DIFF
--- a/scripts/tank_cmd.bat
+++ b/scripts/tank_cmd.bat
@@ -24,7 +24,7 @@ set INTERPRETER_CONFIG_FILE=%1config\core\interpreter_Windows.cfg
 IF NOT EXIST "%INTERPRETER_CONFIG_FILE%" GOTO NO_INTERPRETER_CONFIG
 
 rem -- now get path to python interpreter by reading config file
-for /f %%G in (%INTERPRETER_CONFIG_FILE%) do (SET PYTHON_INTERPRETER=%%G)
+for /f "tokens=*" %%G in (%INTERPRETER_CONFIG_FILE%) do (SET PYTHON_INTERPRETER=%%G)
 IF NOT EXIST %PYTHON_INTERPRETER% GOTO NO_INTERPRETER
 
 rem -- execute the python script which does the actual work.


### PR DESCRIPTION
  Note, interpreter config file still needs quotes around the path to the interpreter.
