### PR TITLE
#24807 Hidden folders are no longer omitted by schema logic

### DIFF
--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -93,10 +93,15 @@ class FolderConfiguration(object):
         """
         directory_paths = []
         for file_name in os.listdir(parent_path):
+            
+            # check our ignore list
+            if any(fnmatch.fnmatch(file_name, p) for p in self._ignore_files):
+                continue
+            
             full_path = os.path.join(parent_path, file_name)
-            # ignore files
             if os.path.isdir(full_path):
                 directory_paths.append(full_path)
+                
         return directory_paths
 
     def _get_files_in_folder(self, parent_path):


### PR DESCRIPTION
Previously, if there was a hidden folder (e.g. folder name starting with a `.` character) in the schema, this simply would simply be ignored by the folder creation. This pull requests stops that behaviour. This means that we are subtly changing the behaviour of the folder creation logic and anyone who has got hidden folders stored in the schema configuration would suddenly have these carried across at folder creation time. 
