### PR TITLE
#24865 Added associated_entity_type parameter to task and step

### DIFF
--- a/python/tank/folder/operations.py
+++ b/python/tank/folder/operations.py
@@ -27,6 +27,7 @@ from ..platform import constants
 def create_single_folder_item(tk, config_obj, io_receiver, entity_type, entity_id, sg_task_data, engine):
     """
     Creates folders for an entity type and an entity id.
+    
     :param config_obj: a FolderConfiguration object representing the folder configuration
     :param io_receiver: a FolderIOReceiver representing the folder operation callbacks
     :param entity_type: Shotgun entity type
@@ -37,6 +38,7 @@ def create_single_folder_item(tk, config_obj, io_receiver, entity_type, entity_i
     # TODO: Confirm this entity exists and is in this project
     # Recurse over entire tree and find find all Entity folders of this type
     folder_objects = config_obj.get_folder_objs_for_entity_type(entity_type)
+    
     # now we have folder objects representing the entity type we are after.
     # (for example there may be 3 SHOT nodes in the folder config tree)
     # For each folder, find the list of entities needed to build the full path and


### PR DESCRIPTION
When creating a step or task folder, toolkit needs to figure out which parent folder to associate the step or task with. This is currently done by looking up the folder tree and picking the first shotgun folder that is found. However, For complex folder setups, where for example you want to have a structure with `Sequence > Shot > Department > Step`, this approach won't work, because it will find Department rather than the desired Shot level. 

This pull request adds an optional `associated_entity_type` parameter to the folder configs which allows a user to explicitly specify the type of the parent folder to bind the task or step to. In the example above, we would set `associated_entity_type: Shot` in order to tell the system not to associate the step with the department object but instead (correctly) with the Shot object.
