### PR TITLE
Adds "Entity" field to context.as_template_fields

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -68,28 +68,28 @@ class Context(object):
         msg.append("  User: %s" % str(self.__user))
         msg.append("  Shotgun URL: %s" % self.shotgun_url)
         msg.append("  Additional Entities: %s" % str(self.__additional_entities))
-        
+
         return "<Sgtk Context: %s>" % ("\n".join(msg))
 
     def __str__(self):
         # smart looking string representation
-        
+
         if self.project is None:
             # empty context!
             ctx_name = "Empty Context"
-        
+
         elif self.entity is None:
             # project-only!
             ctx_name = "%s" % self.project.get("name")
-        
+
         elif self.step is None and self.task is None:
             # entity only
             # e.g. Shot ABC_123
-            
+
             # resolve custom entities to their real display
-            entity_display_name = shotgun.get_entity_type_display_name(self.__tk, 
+            entity_display_name = shotgun.get_entity_type_display_name(self.__tk,
                                                                        self.entity.get("type"))
-            
+
             ctx_name = "%s %s" % (entity_display_name, self.entity.get("name"))
 
         else:
@@ -99,17 +99,17 @@ class Context(object):
                 task_step = self.step.get("name")
             if self.task:
                 task_step = self.task.get("name")
-            
+
             # e.g. Lighting, Shot ABC_123
-            
+
             # resolve custom entities to their real display
-            entity_display_name = shotgun.get_entity_type_display_name(self.__tk, 
+            entity_display_name = shotgun.get_entity_type_display_name(self.__tk,
                                                                        self.entity.get("type"))
-            
-            ctx_name = "%s, %s %s" % (task_step, 
-                                      entity_display_name, 
+
+            ctx_name = "%s, %s %s" % (task_step,
+                                      entity_display_name,
                                       self.entity.get("name"))
-        
+
         return ctx_name
 
     def __eq__(self, other):
@@ -138,18 +138,18 @@ class Context(object):
         """
         # construct copy with current api instance:
         ctx_copy = Context(self.__tk)
-        
+
         # deepcopy all other members:
         ctx_copy.__project = copy.deepcopy(self.__project, memo)
         ctx_copy.__entity = copy.deepcopy(self.__entity, memo)
         ctx_copy.__step = copy.deepcopy(self.__step, memo)
         ctx_copy.__task = copy.deepcopy(self.__task, memo)
-        ctx_copy.__user = copy.deepcopy(self.__user, memo)        
+        ctx_copy.__user = copy.deepcopy(self.__user, memo)
         ctx_copy.__additional_entities = copy.deepcopy(self.__additional_entities, memo)
-        
+
         # except:
         # ctx_copy._entity_fields_cache
-        
+
         return ctx_copy
 
     ################################################################################################
@@ -208,7 +208,7 @@ class Context(object):
     def user(self):
         """
         The shotgun human user, associated with this context.
-        
+
         ``{'type': 'HumanUser', 'id': 212, 'name': 'William Winter'}``
 
         :returns: A std shotgun link dictionary.
@@ -220,8 +220,8 @@ class Context(object):
         if self.__user is None:
             user = login.get_current_user(self.__tk)
             if user is not None:
-                self.__user = {"type": user.get("type"), 
-                               "id": user.get("id"), 
+                self.__user = {"type": user.get("type"),
+                               "id": user.get("id"),
                                "name": user.get("name")}
         return self.__user
 
@@ -252,44 +252,44 @@ class Context(object):
     @property
     def shotgun_url(self):
         """
-        Returns the shotgun detail page url that best represents this context. Depending on 
-        the context, this may be a task, a shot, an asset or a project. If the context is 
+        Returns the shotgun detail page url that best represents this context. Depending on
+        the context, this may be a task, a shot, an asset or a project. If the context is
         completely empty, the root url of the associated shotgun installation is returned.
         """
-        
+
         # walk up task -> entity -> project -> site
-        
+
         if self.task is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Task", self.task["id"])            
-        
+            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Task", self.task["id"])
+
         if self.entity is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, self.entity["type"], self.entity["id"])            
+            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, self.entity["type"], self.entity["id"])
 
         if self.project is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Project", self.project["id"])            
-        
+            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Project", self.project["id"])
+
         # fall back on just the site main url
         return self.__tk.shotgun.base_url
-        
+
     @property
     def filesystem_locations(self):
         """
         A list of filesystem locations associated with this context.
         """
-        
+
         # first handle special cases: empty context
         if self.project is None:
             return []
-        
+
         # first handle special cases: project context
         if self.entity is None:
             return self.__tk.paths_from_entity("Project", self.project["id"])
-            
+
         # at this stage we know that the context contains an entity
-        # start off with all the paths matching this entity and then cull it down 
+        # start off with all the paths matching this entity and then cull it down
         # based on constraints.
         entity_paths = self.__tk.paths_from_entity(self.entity["type"], self.entity["id"])
-                
+
         # for each of these paths, get the context and compare it against our context
         # todo: optimize this!
         matching_paths = []
@@ -305,24 +305,24 @@ class Context(object):
                 # both contexts have user data - is it matching?
                 if ctx.user["id"] == self.user["id"]:
                     matching = True
-            
+
             if matching:
                 # ok so user looks good, now check task.
                 # it is possible that with a context that comes from shotgun
                 # there is a task populated which is not being used in the file system
-                # so when we compare tasks, only if there are differing task ids, 
+                # so when we compare tasks, only if there are differing task ids,
                 # we should treat it as a mismatch.
                 task_matching = True
                 if ctx.task is not None and self.task is not None:
                     if ctx.task["id"] != self.task["id"]:
                         task_matching = False
-                
+
                 if task_matching:
                     # both user and task is matching
                     matching_paths.append(p)
-                    
+
         return matching_paths
-                    
+
     @property
     def tank(self):
         """
@@ -376,19 +376,19 @@ class Context(object):
                 entities[add_entity["type"]] = add_entity
 
         fields = {}
-        
+
         # Try to populate fields using paths caches for entity
         if isinstance(template, TemplatePath):
-            
+
             # first, sanity check that we actually have a path cache entry
-            # this relates to ticket 22541 where it is possible to create 
+            # this relates to ticket 22541 where it is possible to create
             # a context object purely from Shotgun without having it in the path cache
             # (using tk.context_from_entity(Task, 1234) for example)
             #
             # Such a context can result in erronous lookups in the later commands
             # since these make the assumption that the path cache contains the information
             # that is being saught after.
-            # 
+            #
             # therefore, if the context object contains an entity object and this entity is
             # not represented in the path cache, raise an exception.
             if self.entity and len(self.entity_locations) == 0:
@@ -397,30 +397,35 @@ class Context(object):
                                 "does not have any associated folders created on disk yet and "
                                 "therefore no template data can be extracted. Please run the folder "
                                 "creation for %s and try again!" % (self, self.shotgun_url))
-            
+
             # first look at which ENTITY paths are associated with this context object
             # and use these to extract the right fields for this template
             fields = self._fields_from_entity_paths(template)
-            
+
             # Determine field values by walking down the template tree
             fields.update(self._fields_from_template_tree(template, fields, entities))
 
         # get values for shotgun query keys in template
         fields.update(self._fields_from_shotgun(template, entities))
+        # If entity is valid and the entity type is in the fields to be
+        # returned, add an additional field "Entity" which allows
+        # additional abstraction in the templates.
+        if self.entity and self.entity.get("type") in fields:
+            fields["Entity"] = fields.get(self.entity.get("type"))
         return fields
 
     def create_copy_for_user(self, user):
         """
-        Duplicate the context for the specified 
+        Duplicate the context for the specified
         user
-        
+
         :param user:    overrides the user
-        
+
         :returns: Context object
         """
         ctx_copy = copy.deepcopy(self)
         ctx_copy.__user = user
-        return ctx_copy       
+        return ctx_copy
 
     ################################################################################################
     # private methods
@@ -433,25 +438,25 @@ class Context(object):
         fields = {}
         # for any sg query field
         for key in template.keys.values():
-            
+
             # check each key to see if it has shotgun query information that we should resolve
             if key.shotgun_field_name:
-                # this key is a shotgun value that needs fetching! 
-                
+                # this key is a shotgun value that needs fetching!
+
                 # ensure that the context actually provides the desired entities
                 if not key.shotgun_entity_type in entities:
                     raise TankError("Key '%s' in template '%s' could not be populated by "
                                     "context '%s' because the context does not contain a "
                                     "shotgun entity of type '%s'!" % (key, template, self, key.shotgun_entity_type))
-                    
+
                 entity = entities[key.shotgun_entity_type]
-                
-                # check the context cache 
+
+                # check the context cache
                 cache_key = (entity["type"], entity["id"], key.shotgun_field_name)
                 if cache_key in self._entity_fields_cache:
                     # already have the value cached - no need to fetch from shotgun
                     fields[key.name] = self._entity_fields_cache[cache_key]
-                
+
                 else:
                     # get the value from shotgun
                     filters = [["id", "is", entity["id"]]]
@@ -462,37 +467,37 @@ class Context(object):
                         raise TankError("Could not retrieve Shotgun data for key '%s' in "
                                         "template '%s'. No records in Shotgun are matching "
                                         "entity '%s' (Which is part of the current "
-                                        "context '%s')" % (key, template, entity, self))                        
+                                        "context '%s')" % (key, template, entity, self))
 
                     value = result.get(key.shotgun_field_name)
 
-                    # note! It is perfectly possible (and may be valid) to return None values from 
-                    # shotgun at this point. In these cases, a None field will be returned in the 
+                    # note! It is perfectly possible (and may be valid) to return None values from
+                    # shotgun at this point. In these cases, a None field will be returned in the
                     # fields dictionary from as_template_fields, and this may be injected into
                     # a template with optional fields.
-    
+
                     if value is None:
                         processed_val = None
-                    
+
                     else:
 
                         # now convert the shotgun value to a string.
                         # note! This means that there is no way currently to create an int key
                         # in a tank template which matches an int field in shotgun, since we are
                         # force converting everything into strings...
-                                 
+
                         processed_val = shotgun_entity.sg_entity_to_string(self.__tk,
                                                                            key.shotgun_entity_type,
                                                                            entity.get("id"),
-                                                                           key.shotgun_field_name, 
+                                                                           key.shotgun_field_name,
                                                                            value)
-                    
-                        if not key.validate(processed_val):                    
+
+                        if not key.validate(processed_val):
                             raise TankError("Template validation failed for value '%s'. This "
                                             "value was retrieved from entity %s in Shotgun to "
                                             "represent key '%s' in "
                                             "template '%s'." % (processed_val, entity, key, template))
-                            
+
                     # all good!
                     # populate dictionary and cache
                     fields[key.name] = processed_val
@@ -511,13 +516,13 @@ class Context(object):
         project_roots = self.__tk.pipeline_configuration.get_data_roots().values()
 
         # get all locations on disk for our context object from the path cache
-        path_cache_locations = self.entity_locations 
-        
-        # now loop over all those locations and check if one of the locations 
+        path_cache_locations = self.entity_locations
+
+        # now loop over all those locations and check if one of the locations
         # are matching the template that is passed in. In that case, try to
         # extract the fields values.
         for cur_path in path_cache_locations:
-            
+
             # walk up path until we reach the project root and get values
             while cur_path not in project_roots:
                 if template.validate(cur_path):
@@ -531,7 +536,7 @@ class Context(object):
                     break
                 else:
                     cur_path = os.path.dirname(cur_path)
-                    
+
         return fields
 
     def _fields_from_template_tree(self, template, fields, entities):
@@ -539,12 +544,12 @@ class Context(object):
         Determines values for a template's keys based on the context by walking down the template tree
         matching template keys with entity types.
         """
-        
+
         # Step 1 - Cull out ambigious templates
         fields = fields.copy()
         for key, value in fields.items():
             if value is None:
-                # Note: A none value here indicates an ambiguity 
+                # Note: A none value here indicates an ambiguity
                 # and was set in the _fields_from_entity_paths method.
                 del(fields[key])
 
@@ -553,11 +558,11 @@ class Context(object):
         #
         # Use cached paths to find field values
         # these will be returned in top-down order:
-        # [<Sgtk TemplatePath sequences/{Sequence}>, 
-        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}>, 
-        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}>, 
-        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}/publish>, 
-        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}/publish/maya>, 
+        # [<Sgtk TemplatePath sequences/{Sequence}>,
+        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}>,
+        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}>,
+        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}/publish>,
+        #  <Sgtk TemplatePath sequences/{Sequence}/{Shot}/{Step}/publish/maya>,
         #  <Sgtk TemplatePath maya_shot_publish: sequences/{Sequence}/{Shot}/{Step}/publish/maya/{name}.v{version}.ma>]
         templates = _get_template_ancestors(template)
 
@@ -577,9 +582,9 @@ class Context(object):
                             temp_fields = _values_from_path_cache(entity, cur_template, path_cache, fields)
                             fields.update(temp_fields)
 
-        finally:    
+        finally:
             path_cache.close()
-        
+
         return fields
 
 
@@ -608,13 +613,13 @@ def from_entity(tk, entity_type, entity_id):
 
     :returns: a context object
     """
-    
+
     if entity_type is None:
         raise TankError("Cannot create a context from an entity type 'None'!")
-    
+
     if entity_id is None:
         raise TankError("Cannot create a context from an entity id set to 'None'!")
-    
+
     # prep our return data structure
     context = {
         "tk": tk,
@@ -632,35 +637,35 @@ def from_entity(tk, entity_type, entity_id):
         context.update(task_context)
 
     elif entity_type in ["PublishedFile", "TankPublishedFile"]:
-        
-        sg_entity = tk.shotgun.find_one(entity_type, 
-                                        [["id", "is", entity_id]], 
+
+        sg_entity = tk.shotgun.find_one(entity_type,
+                                        [["id", "is", entity_id]],
                                         ["project", "entity", "task"])
-        
+
         if sg_entity is None:
             raise TankError("Entity %s with id %s not found in Shotgun!" % (entity_type, entity_id))
-        
+
         if sg_entity.get("task"):
             # base the context on the task for the published file
             return from_entity(tk, "Task", sg_entity["task"]["id"])
-        
+
         elif sg_entity.get("entity"):
             # base the context on the entity that the published is linked with
             return from_entity(tk, sg_entity["entity"]["type"], sg_entity["entity"]["id"])
-        
+
         elif sg_entity.get("project"):
             # base the context on the project that the published is linked with
             return from_entity(tk, "Project", sg_entity["project"]["id"])
-    
+
     else:
         # Get data from path cache
         entity_context = _context_data_from_cache(tk, entity_type, entity_id)
-                    
+
         # make sure this was actually found in the cache
         # fall back on a shotgun lookup if not found
         if entity_context["project"] is None:
             entity_context = _entity_from_sg(tk, entity_type, entity_id)
-        
+
         context.update(entity_context)
 
     if entity_type == "Project":
@@ -718,7 +723,7 @@ def from_path(tk, path, previous_context=None):
             # Don't worry about entity types we've already got in the context. In the future
             # we should look for entity ids that conflict in order to flag a degenerate schema.
             entities.append(curr_entity)
-        
+
         # add secondary entities
         secondary_entities.extend( path_cache.get_secondary_entities(curr_path) )
 
@@ -764,24 +769,24 @@ def from_path(tk, path, previous_context=None):
         if curr_entity["type"] == "Project":
             if context["project"] is None:
                 context["project"] = curr_entity
-        
+
         elif curr_entity["type"] == "Step":
             if context["step"] is None:
                 context["step"] = curr_entity
-        
+
         elif curr_entity["type"] == "Task":
             if context["task"] is None:
                 context["task"] = curr_entity
-        
+
         elif curr_entity["type"] == "HumanUser":
             if context["user"] is None:
                 context["user"] = curr_entity
-        
+
         elif curr_entity["type"] in additional_types:
             # is this entity in the list already
-            if curr_entity not in context["additional_entities"]:            
+            if curr_entity not in context["additional_entities"]:
                 context["additional_entities"].append(curr_entity)
-        
+
         else:
             if context["entity"] is None:
                 context["entity"] = curr_entity
@@ -801,7 +806,7 @@ def from_path(tk, path, previous_context=None):
         if context.get("task") is None and context.get("step") == previous_context.step:
             context["task"] = previous_context.task
 
-    # ensure that we don't have a Project as the entity. Projects should only 
+    # ensure that we don't have a Project as the entity. Projects should only
     # appear on the projects level, despite being entities.
     if context["project"] and context["entity"] and context["entity"]["type"] == "Project":
         # remove double entry!
@@ -826,21 +831,21 @@ def serialize(context):
         "_pc_path": context.tank.pipeline_configuration.get_path()
     }
     return pickle.dumps(data)
-    
-    
+
+
 def deserialize(context_str):
     """
     Deserializaes a string created with serialize() into a context object
     """
     # lazy load this to avoid cyclic dependencies
     from .api import Tank
-    
+
     data = pickle.loads(context_str)
 
     # first get the pc path out of the dict
-    pipeline_config_path = data["_pc_path"] 
+    pipeline_config_path = data["_pc_path"]
     del data["_pc_path"]
-    
+
     # create a Sgtk API instance.
     tk = Tank(pipeline_config_path)
 
@@ -849,7 +854,7 @@ def deserialize(context_str):
 
     # and lastly make the obejct
     return Context(**data)
-    
+
 
 
 
@@ -861,8 +866,8 @@ def context_yaml_representer(dumper, context):
     Custom serializer.
     Creates yaml code for a context object
     """
-    
-    # first get the stuff which represents all the Context() 
+
+    # first get the stuff which represents all the Context()
     # constructor parameters
     context_dict = {
         "project": context.project,
@@ -872,9 +877,9 @@ def context_yaml_representer(dumper, context):
         "task": context.task,
         "additional_entities": context.additional_entities
     }
-    
-    # now we also need to pass a TK instance to the constructor when we 
-    # are deserializing the object. For this purpose, pass a 
+
+    # now we also need to pass a TK instance to the constructor when we
+    # are deserializing the object. For this purpose, pass a
     # PC path as part of the dict
     context_dict["_pc_path"] = context.tank.pipeline_configuration.get_path()
 
@@ -887,14 +892,14 @@ def context_yaml_constructor(loader, node):
     """
     # lazy load this to avoid cyclic dependencies
     from .api import Tank
-    
+
     # get the dict from yaml
     context_constructor_dict = loader.construct_mapping(node)
-    
+
     # first get the pc path out of the dict
-    pipeline_config_path = context_constructor_dict["_pc_path"] 
+    pipeline_config_path = context_constructor_dict["_pc_path"]
     del context_constructor_dict["_pc_path"]
-    
+
     # create a Sgtk API instance.
     tk = Tank(pipeline_config_path)
 
@@ -917,7 +922,7 @@ def _task_from_sg(tk, task_id):
     which has both a project, an entity a step and a task associated with it.
 
     Manne 9 April 2013: could we use the path cache primarily and fall back onto
-                        a shotgun lookup? 
+                        a shotgun lookup?
 
     :param tk:           a Sgtk API instance
     :param task_id:      The shotgun task id to produce a context for.
@@ -976,13 +981,13 @@ def _entity_from_sg(tk, entity_type, entity_id):
     :param task_id:      The shotgun task id to produce a context for.
     """
 
-    # deal with funny naming for certain entities 
+    # deal with funny naming for certain entities
     if entity_type == "HumanUser":
         name_field = "login"
-        
+
     elif entity_type == "Project":
         name_field = "name"
-    
+
     else:
         name_field = "code"
 
@@ -993,13 +998,13 @@ def _entity_from_sg(tk, entity_type, entity_id):
 
     # create context
     context = {}
-    
+
     if entity_type == "Project":
         context["project"] = {"type":"Project", "id": entity_id, "name": data.get(name_field) }
-    
+
     else:
         context["entity"] = {"type": entity_type, "id": entity_id, "name": data.get(name_field) }
-        context["project"] = data.get("project")     
+        context["project"] = data.get("project")
 
     return context
 
@@ -1028,7 +1033,7 @@ def _context_data_from_cache(tk, entity_type, entity_id):
     # Grab all project roots
     project_roots = tk.pipeline_configuration.get_data_roots().values()
 
-    # Special case for project as we have the primary data path, which 
+    # Special case for project as we have the primary data path, which
     # always points at a project.
     context["project"] = path_cache.get_entity(tk.pipeline_configuration.get_primary_data_root())
 
@@ -1038,7 +1043,7 @@ def _context_data_from_cache(tk, entity_type, entity_id):
         # now recurse upwards and look for entity types we haven't found yet
         curr_path = path
         curr_entity = path_cache.get_entity(curr_path)
-        
+
         if curr_entity is None:
             # this is some sort of anomaly! the path returned by get_paths
             # does not resolve in get_entity. This can happen if the storage
@@ -1046,9 +1051,9 @@ def _context_data_from_cache(tk, entity_type, entity_id):
             #
             # This can also happen if there are extra slashes at the end of the path
             # in the local storage defs and in the pipeline_configuration.yml file.
-            raise TankError("The path '%s' associated with %s id %s does not " 
+            raise TankError("The path '%s' associated with %s id %s does not "
                             "resolve correctly. This may be an indication of an issue "
-                            "with the local storage setup. Please contact " 
+                            "with the local storage setup. Please contact "
                             "sgtksupport@shotgunsoftware.com" % (curr_path, entity_type, entity_id))
 
         # grab the name for the context entity
@@ -1074,24 +1079,24 @@ def _values_from_path_cache(entity, cur_template, path_cache, fields):
     """
     Determine values for templates fields based on an entities cached paths.
     """
-    
+
     # use the databsae to go from shotgun type/id --> paths
     entity_paths = path_cache.get_paths(entity["type"], entity["id"])
-    
+
     # get a list of path cache paths that validate against our current template
     # with the existing field values we have plugged into that template
     matches = [epath for epath in entity_paths if cur_template.validate(epath, fields=fields)]
-    
+
     # Mapping for field values found in conjunction with this entities paths
     temp_fields = {}
     # keys whose values should be removed from return values
     remove_keys = set()
 
     for matched_path in matches:
-        
+
         # Get the filed values for each path
         matched_fields = cur_template.get_fields(matched_path)
-        
+
         # Check values against those found for other paths
         for m_key, m_value in matched_fields.items():
             if m_key in temp_fields and m_value != temp_fields[m_key]:
@@ -1109,7 +1114,7 @@ def _values_from_path_cache(entity, cur_template, path_cache, fields):
                     # ambiguity for Static key
                     temp_fields[m_key] = None
                     remove_keys.add(m_key)
-            
+
             else:
                 temp_fields[m_key] = m_value
 


### PR DESCRIPTION
Not sure if this is going to have any side effects but I wanted to get it up for discussion.  Basically I have a master template for what "output" (future publishes) should be named.  I'd like to keep it all in one template so it's easier to manage in the long run both when configuring apps and making updates.

`output_name: "{Entity}_{Task}_{name}[_{channel}][_{publish_type_short}][.{view}][.{SEQ}][.{extension}]"`

I would like to use `{Entity}` rather than `{Shot}`, `{Asset}`, `{Sequence}`, etc.  The included pull request is really a small change (ignoring the whitespace) that basically adds an additional field to `context.as_template_fields` of key "Entity" and value of whatever the context's current Entity is if one exists.  If the current context doesn't have an entity, this should not be added to the returned template fields.

Hopefully this makes some sense!

-tony
