### PR TITLE
#24117 - Adds methods to hook base class to resolve local paths on disk from publishes

### DIFF
--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -35,6 +35,41 @@ class Hook(object):
     def parent(self):
         return self.__parent
     
+    def get_publish_path(self, sg_publish_data):
+        """
+        Resolves a local path on disk given a shotgun 
+        data dictionary representing a publish.
+        
+        :param sg_publish_data: Shotgun dictionary containing
+                                information about a publish.
+        :returns: String representing a local path on disk.
+        """
+        return self.get_publish_paths([ sg_publish_data ])[0]
+        
+    def get_publish_paths(self, sg_publish_data_list):
+        """
+        Returns several local paths on disk given a
+        list of shotgun data dictionaries representing publishes.
+        
+        :param sg_publish_data_list: List of shotgun data dictionaries 
+                                     containing publish data.
+        :returns: List of strings representing local paths on disk.
+        """
+        paths = []
+        for sg_data in sg_publish_data_list:
+            path_field = sg_data.get("path")
+            if path_field is None:
+                raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
+                                "not contain a valid path definition" % sg_data)
+            
+            local_path = path_field.get("local_path")
+            if local_path is None:
+                raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
+                                "not contain a valid path definition" % sg_data)
+            paths.append(local_path)
+        
+        return paths
+    
     def load_framework(self, framework_instance_name):
         """
         Loads and returns a framework given an environment instance name.


### PR DESCRIPTION
Adds methods to the Hook base class, making it easier to retrieve paths to publishes inside of hooks. 

This is a first step in a plan to future proof how file paths are being resolved from publishes - by not having this logic in each hook we open up for more advanced path resolution methods in the future. Instead of a hard coded implementation (like now), this method could instead call out to a core hook, or even have a more advanced scheme where for example frameworks could register handlers (e.g. hello, I am the perforce framework and I can resolve `perforce://` urls) and this method could act as a broker, dispatching the various path resolution calls to various apps/engines/frameworks who would in turn contain the business logic how to resolve them.
