### PR TITLE
#24475 Current user now resolved JIT rather than at folder config init

### DIFF
--- a/python/tank/folder/folder_types.py
+++ b/python/tank/folder/folder_types.py
@@ -1322,19 +1322,10 @@ class UserWorkspace(Entity):
         constructor
         """
         
-        # this query confirms that there is a matching HumanUser in shotgun for the local login
-        # This means that a query for the user happens twice, here and later during _get_entities
-        # TODO possibly keep the result from this query instead and remove the later, duplicate, one
-        user = login.get_current_user(tk) 
-
-        if not user:
-            msg = "Could not find a HumanUser in shotgun with login matching the local login. "
-            msg += "Check that the local login corresponds to a user in shotgun."
-            raise TankError(msg)
-
-        user_filter = { "path": "id", "relation": "is", "values": [ user["id"] ] }
-        entity_filter["conditions"].append( user_filter )
-                
+        # lazy setup: we defer the lookup of the current user until the folder node
+        # is actually being utilized, see extract_shotgun_data_upwards() below
+        self._user_initialized = False
+        
         # user work spaces are always deferred so make sure to add a setting to the metadata
         # note: This should ideally be a parameter passed to the base class.
         metadata["defer_creation"] = True
@@ -1348,6 +1339,38 @@ class UserWorkspace(Entity):
                         field_name_expression, 
                         entity_filter, 
                         create_with_parent=True)
+        
+    def create_folders(self, io_receiver, path, sg_data, is_primary, explicit_child_list, engine):
+        """
+        Inherited and wrapps base class implementation
+        """
+        
+        # wraps around the Entity.create_folders() method and adds
+        # the current user to the filer query in case this has not already been done.
+        # having this set up before the first call to create_folders rather than in the
+        # constructor is partly for performance, but primarily so that a valid current user 
+        # isn't required unless you actually create a user sandbox folder. For example,
+        # if you have a dedicated machine that creates higher level folders, this machine
+        # shouldn't need to have a user id set up - only the artists that actually create 
+        # the user folders should need to.
+        
+        if not self._user_initialized:
+
+            # this query confirms that there is a matching HumanUser in shotgun for the local login
+            user = login.get_current_user(self._tk) 
+    
+            if not user:
+                msg = ("Folder Creation Error: Could not find a HumanUser in shotgun with login " 
+                       "matching the local login. Check that the local login corresponds to a "
+                       "user in shotgun.")
+                raise TankError(msg)
+    
+            user_filter = { "path": "id", "relation": "is", "values": [ user["id"] ] }
+            self._filters["conditions"].append( user_filter )            
+            self._user_initialized = True
+        
+        return Entity.create_folders(self, io_receiver, path, sg_data, is_primary, explicit_child_list, engine)
+        
 
 
 class ShotgunStep(Entity):


### PR DESCRIPTION
This change relates to the user workspace node in the folder creation setup. Previously, if such a node was present in the folder config, toolkit would try to resolve the current shotgun user in the constructor, meaning that any machine that wanted to carry out folder creation had to have a valid shotgun user associated with each machine account. This was causing problems with setups that had a special machine dedicated to do folder creation - this machine needed to be set up with a shogun user account despite not actually creating any user workspaces. This change moves the resolve to happen JIT, meaning that it is only when you _actually_ try to create a user workspace that the current user is resolved.
