### PR TITLE
#25240 #25418 #25450 Tank command improvements

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -606,15 +606,14 @@ def from_entity(entity_type, entity_id):
     e = sg.find_one(entity_type, [["id", "is", entity_id]], ["project", "name"])
 
     if e is None:
-        raise TankError("Cannot resolve a pipeline configuration object from %s %s - this object "
-                        "does not exist in Shotgun!" % (entity_type, entity_id))
+        raise TankError("Cannot find a %s with id %s in Shotgun!" % (entity_type, entity_id))
 
     if entity_type == "Project":
         proj = {"type": "Project", "id": entity_id, "name": e.get("name")}
 
     else:
         if e.get("project") is None:
-            raise TankError("Cannot resolve a pipeline configuration object from %s %s - this object "
+            raise TankError("Cannot resolve %s %s - this object "
                             "is not linked to a project!" % (entity_type, entity_id))
         proj = e.get("project")
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -914,7 +914,7 @@ def run_engine_cmd(log, pipeline_config_root, context_items, command, using_cwd,
             tk =  tank.tank_from_path(pipeline_config_root)
             project_id = tk.pipeline_configuration.get_project_id()
             studio_command_mode = False
-                    
+                   
         else:
             # studio level command
             project_id = None


### PR DESCRIPTION
- Improved the error message you get if you run `tank Project foo` from a project specific tank command.
- Added support for a digits only syntax, so that the tank command will correctly find a shot named 123 when the command `tank Shot 123` is executed. If no shot named 123 is found, the tank command will fall back and assume 123 is a shogun id and use that for the lookup instead.
- Added better scoping for tasks: it is now possible to use the syntax `tank Task proj_a:Shot:123:light` to start a command for the light task for a given entity.
- The project specific tank command no longer consumes and ignores a specific project specified as part of an entity (e.g. `tank Shot proj_foo:abc123`) but instead leaves it unprocessed.

Note that this means that the behaviour of the tank command changes slightly:
- If you are currently launching entities via their ids (`tank Shot 123`) and also have your shot named numeric codes, this change means that the name suddenly takes precedence, meaning that there may be a change in behaviour as a consequence.
- If you are running project level tank commands with the extended project syntax, you may find that the queries no longer match objects. This is because previously, the project command `tank Shot foo:bar` would simply drop the hint that it is in project _foo_ that we should look for bar. Now it instead ignores this and will start looking for a Shot named 'foo:bar'.
