### PR TITLE
For #25587 - Spaces in Windows PC & Python paths are now supported.

### DIFF
--- a/scripts/tank_cmd.bat
+++ b/scripts/tank_cmd.bat
@@ -14,21 +14,28 @@ setlocal EnableExtensions
 
 rem -- this script is called by the main tank script
 rem -- the first parameter contains the path to the pipeline config root
-rem -- additional pameters are passed into the python script
+rem -- additional parameters are passed into the python script
+
+rem -- grab the pipeline configuration root and remove any trailing slash
+set PC_ROOT=%~1
+IF %PC_ROOT:~-1%==\ SET PC_ROOT=%PC_ROOT:~0,-1%
+
 rem -- now add tank to the pythonpath
-set PYTHONPATH=%1install\core\python;%PYTHONPATH%
+set PYTHONPATH=%PC_ROOT%\install\core\python;%PYTHONPATH%
 
 rem -- now figure out which interpreter to use for Tank
 rem -- this is stored in a config file
-set INTERPRETER_CONFIG_FILE=%1config\core\interpreter_Windows.cfg
+set INTERPRETER_CONFIG_FILE=%PC_ROOT%\config\core\interpreter_Windows.cfg
 IF NOT EXIST "%INTERPRETER_CONFIG_FILE%" GOTO NO_INTERPRETER_CONFIG
 
 rem -- now get path to python interpreter by reading config file
-for /f "tokens=*" %%G in (%INTERPRETER_CONFIG_FILE%) do (SET PYTHON_INTERPRETER=%%G)
-IF NOT EXIST %PYTHON_INTERPRETER% GOTO NO_INTERPRETER
+rem -- 'usebackq' is used to allow quoting of the path which could potentially contain spaces
+rem -- 'tokens=*' is used to ensure each line of the file doesn't get split on whitespace
+for /f "usebackq tokens=*" %%G in ("%INTERPRETER_CONFIG_FILE%") do (SET PYTHON_INTERPRETER=%%G)
+IF NOT EXIST "%PYTHON_INTERPRETER%" GOTO NO_INTERPRETER
 
 rem -- execute the python script which does the actual work.
-%PYTHON_INTERPRETER% "%1install\core\scripts\tank_cmd.py" %*
+"%PYTHON_INTERPRETER%" "%PC_ROOT%\install\core\scripts\tank_cmd.py" %*
 
 rem -- pass along the return code
 exit /b %ERRORLEVEL%

--- a/setup/root_binaries/tank.bat
+++ b/setup/root_binaries/tank.bat
@@ -15,6 +15,9 @@ setlocal EnableExtensions
 rem -- get absolute location of this folder (note- always ends with a \)
 set SELF_PATH=%~dp0
 
+rem -- remove the trailing slash otherwise it causes all sorts of problems later!
+IF %SELF_PATH:~-1%==\ SET SELF_PATH=%SELF_PATH:~0,-1%
+
 rem -- First of all, for performance, check if the command is shotgun_get_actions
 IF "%1"=="shotgun_get_actions" GOTO CHECK_CACHE
 
@@ -24,17 +27,17 @@ rem -- when using multiple work dev areas.
 rem -- since we are recursing upwards, only set it if it is not already set. 
 rem -- we only set this when it is a pipeline location. Check this by looking for 
 rem -- the templates file
-set TEMPLATES_FILE=%SELF_PATH%config\core\templates.yml
+set TEMPLATES_FILE=%SELF_PATH%\config\core\templates.yml
 
 rem -- if this var is not set AND the templates file exists, set the var.
-IF "%TANK_CURRENT_PC%" == "" IF EXIST "%TEMPLATES_FILE%" set TANK_CURRENT_PC=%SELF_PATH% 
+IF "%TANK_CURRENT_PC%" == "" IF EXIST "%TEMPLATES_FILE%" set TANK_CURRENT_PC=%SELF_PATH%
 
 rem -- check if there is a local core
-set LOCAL_SCRIPT=%SELF_PATH%install\core\scripts\tank_cmd.bat
+set LOCAL_SCRIPT=%SELF_PATH%\install\core\scripts\tank_cmd.bat
 IF NOT EXIST "%LOCAL_SCRIPT%" GOTO NO_LOCAL_INSTALL 
 
 rem -- this is a local install! Run the wrapper script
-call %LOCAL_SCRIPT% %SELF_PATH% %*
+call "%LOCAL_SCRIPT%" "%SELF_PATH%" %*
 
 rem -- pass along the return code
 exit /b %ERRORLEVEL%
@@ -46,15 +49,17 @@ rem -- so try and get the parent and call its tank script
 rem -- the parent location is stored in a config file
 :NO_LOCAL_INSTALL
 
-set PARENT_CONFIG_FILE=%SELF_PATH%install\core\core_Windows.cfg
+set PARENT_CONFIG_FILE=%SELF_PATH%\install\core\core_Windows.cfg
 IF NOT EXIST "%PARENT_CONFIG_FILE%" GOTO NO_PARENT_CONFIG
 
 rem -- get contents of file
-for /f %%G in (%PARENT_CONFIG_FILE%) do (SET PARENT_LOCATION=%%G)
+rem -- 'usebackq' is used to allow quoting of the path which could potentially contain spaces
+rem -- 'tokens=*' is used to ensure each line of the file doesn't get split on whitespace
+for /f "usebackq tokens=*" %%G in ("%PARENT_CONFIG_FILE%") do (SET PARENT_LOCATION=%%G)
 IF NOT EXIST "%PARENT_LOCATION%" GOTO NO_PARENT_LOCATION
 
 rem -- all good, execute tank script in parent location
-call %PARENT_LOCATION%\tank.bat %* --pc=%SELF_PATH%
+call "%PARENT_LOCATION%\tank.bat" %* --pc="%SELF_PATH%"
 
 rem -- pass along the return code
 exit /b %ERRORLEVEL%
@@ -68,8 +73,8 @@ rem -- returns 1 if the cache file is older than the yml file.
 rem -- returns 2 if the yml file does not exist
 :CHECK_CACHE
 
-set CACHE_FILE=%SELF_PATH%cache\%2
-set ENV_FILE=%SELF_PATH%config\env\%3
+set CACHE_FILE=%SELF_PATH%\cache\%2
+set ENV_FILE=%SELF_PATH%\config\env\%3
 
 rem -- if env file does not exist exit with error code 2
 IF NOT EXIST "%ENV_FILE%" exit /b 2


### PR DESCRIPTION
Spaces are now supported in paths for Pipeline Configurations on Windows when using the latest version of the tank.bat file.  Additionally, Python can now be installed into a path with spaces in (e.g. C:\Program Files) if needed.
