### PR TITLE
Better error message in is_auto_path

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -157,6 +157,10 @@ class PipelineConfiguration(object):
                            [["id", "is", self.get_shotgun_id()]],
                            ["linux_path", "windows_path", "mac_path"])
 
+        if data is None:
+            raise TankError("Cannot find a Pipeline configuration in Shotgun "
+                            "that has id %s." % self.get_shotgun_id())
+
         def _is_empty(d):
             """
             Returns true if value is "" or None, False otherwise


### PR DESCRIPTION
There is the possibility that a Pipeline configuration in Shotgun is deleted so that the config on disk points at a non-existent entity.  Right now the message raised by is_auto_path when this happens is that 'NoneType' object has no attribute 'get'.  Raise a more specific exception in this case.
