### PR TITLE
#25973 Sparse Localize

### DIFF
--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -168,19 +168,18 @@ def do_localize(log, pc_root_path, suppress_prompts):
 
         for idx, descriptor in enumerate(descriptors.values()):
             
-            path = descriptor["path"]
-            name = descriptor["name"]
+            descriptor_path = descriptor["path"]
             
             # print one based indices for more human friendly output
-            log.info("%s/%s: Copying %s..." % (idx+1, len(descriptors), name))
+            log.info("%s/%s: Copying %s..." % (idx+1, len(descriptors), descriptor["name"]))
             
-            if path.startswith(source_base_path):
-                target_path = path.replace(source_base_path, target_base_path)
+            if descriptor_path.startswith(source_base_path):
+                target_path = descriptor_path.replace(source_base_path, target_base_path)
                 if not os.path.exists(target_path):
                     # create all folders
                     os.makedirs(target_path, 0777)
                     # and copy content
-                    util._copy_folder(log, path, target_path)
+                    util._copy_folder(log, descriptor_path, target_path)
             
     except Exception, e:
         raise TankError("Could not localize: %s" % e)


### PR DESCRIPTION
This adjusts the localize command to be a little less blunt.

Previously, it would copy all versions of apps, engines etc. across from the core api source location to the pipeline configuration. Now it instead iterates over all descriptors currently used by the environments and only copies those across.

For large studio locations where there has been a buildup of versions, this will improve performance of the localize process.
