### PR TITLE
For #26314 - Configuration paths on OSX can now contain spaces

### DIFF
--- a/python/tank/deploy/tank_commands/setup_project_core.py
+++ b/python/tank/deploy/tank_commands/setup_project_core.py
@@ -172,8 +172,8 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     # resuffle list of associated local storages to be a dict keyed by storage name
     # and with keys mac_path/windows_path/linux_path
 
-    log.debug("Writing roots.yml...")
-    roots_path = os.path.join(config_location_curr_os, "config", "core", "roots.yml")
+    log.debug("Writing %s..." % constants.STORAGE_ROOTS_FILE)
+    roots_path = os.path.join(config_location_curr_os, "config", "core", constants.STORAGE_ROOTS_FILE)
     
     roots_data = {}
     for storage_name in setup_params.get_required_storages():

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -867,7 +867,7 @@ class TemplateConfiguration(object):
         :returns: A dictionary for keyed by storage
         """
         # get the roots definition
-        root_file_path = os.path.join(self._cfg_folder, "core", "roots.yml")
+        root_file_path = os.path.join(self._cfg_folder, "core", constants.STORAGE_ROOTS_FILE)
         if os.path.exists(root_file_path):
             root_file = open(root_file_path, "r")
             try:

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -987,7 +987,7 @@ def _get_pc_roots_metadata(pipeline_config_root_path):
     # now read in the roots.yml file
     # this will contain something like
     # {'primary': {'mac_path': '/studio', 'windows_path': None, 'linux_path': '/studio'}}
-    roots_yml = os.path.join(pipeline_config_root_path, "config", "core", "roots.yml")
+    roots_yml = os.path.join(pipeline_config_root_path, "config", "core", constants.STORAGE_ROOTS_FILE)
 
     if not os.path.exists(roots_yml):
         raise TankError("Roots metadata file '%s' missing! Please contact support." % roots_yml)

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -44,7 +44,7 @@ def is_pipeline_config(pipeline_config_path):
     :returns: true if pipeline config, false if not
     """
     # probe by looking for the existence of a key config file.
-    pc_file = os.path.join(pipeline_config_path, "config", "core", constants.CONTENT_TEMPLATES_FILE)
+    pc_file = os.path.join(pipeline_config_path, "config", "core", constants.STORAGE_ROOTS_FILE)
     return os.path.exists(pc_file)
     
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -181,6 +181,9 @@ CONTENT_TEMPLATES_FILE = "templates.yml"
 # the name of the file that holds the inverse root defs
 CONFIG_BACK_MAPPING_FILE = "tank_configs.yml"
 
+# the name of the file that contains the storage root definitions
+STORAGE_ROOTS_FILE = "roots.yml"
+
 # the name of the include section in env and template files
 SINGLE_INCLUDE_SECTION = "include"
 

--- a/setup/root_binaries/tank
+++ b/setup/root_binaries/tank
@@ -13,18 +13,18 @@
 SELF_PATH=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
 
 # resolve symlinks
-while [ -h $SELF_PATH ]; do
+while [ -h "$SELF_PATH" ]; do
     # 1) cd to directory of the symlink
     # 2) cd to the directory of where the symlink points
     # 3) get the pwd
     # 4) append the basename
     DIR=$(dirname -- "$SELF_PATH")
-    SYM=$(readlink $SELF_PATH)
-    SELF_PATH=$(cd $DIR && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+    SYM=$(readlink "$SELF_PATH")
+    SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
 done
 
 # chop off the file name
-SELF_PATH=$(dirname $SELF_PATH)
+SELF_PATH=$(dirname "$SELF_PATH")
 
 
 # first of all, for performance, check if the command is shotgun_get_actions
@@ -66,9 +66,9 @@ fi
 # when using multiple work dev areas.
 # since we are recursing upwards, only set it if it is not already set.
 # we only set this when it is a pipeline location. Check this by looking for
-# the templates file
-TEMPLATES_FILE="$SELF_PATH/config/core/templates.yml"
-if [ -z "$TANK_CURRENT_PC" ] && [ -f "$TEMPLATES_FILE" ]; then
+# the roots.yml file
+ROOTS_FILE="$SELF_PATH/config/core/roots.yml"
+if [ -z "$TANK_CURRENT_PC" ] && [ -f "$ROOTS_FILE" ]; then
     export TANK_CURRENT_PC=$SELF_PATH
 fi
 
@@ -76,7 +76,7 @@ fi
 if [ -f "$LOCAL_SCRIPT" ];
 then
    # run local script
-   $LOCAL_SCRIPT "$SELF_PATH" "$@"
+   "$LOCAL_SCRIPT" "$SELF_PATH" "$@"
 else
    # there is no local install
    # so try and get the parent and call its tank script
@@ -107,7 +107,7 @@ else
    fi
 
    # all good, execute tank script in parent location
-   $parent_location/tank "$@" --pc="$SELF_PATH"
+   "$parent_location/tank" "$@" --pc="$SELF_PATH"
 
 fi
 

--- a/setup/root_binaries/tank.bat
+++ b/setup/root_binaries/tank.bat
@@ -26,11 +26,11 @@ rem -- this is to help the tank core API figure out for example tank.tank_from_p
 rem -- when using multiple work dev areas.
 rem -- since we are recursing upwards, only set it if it is not already set. 
 rem -- we only set this when it is a pipeline location. Check this by looking for 
-rem -- the templates file
-set TEMPLATES_FILE=%SELF_PATH%\config\core\templates.yml
+rem -- the roots.yml file
+set ROOTS_FILE=%SELF_PATH%\config\core\roots.yml
 
 rem -- if this var is not set AND the templates file exists, set the var.
-IF "%TANK_CURRENT_PC%" == "" IF EXIST "%TEMPLATES_FILE%" set TANK_CURRENT_PC=%SELF_PATH%
+IF "%TANK_CURRENT_PC%" == "" IF EXIST "%ROOTS_FILE%" set TANK_CURRENT_PC=%SELF_PATH%
 
 rem -- check if there is a local core
 set LOCAL_SCRIPT=%SELF_PATH%\install\core\scripts\tank_cmd.bat


### PR DESCRIPTION
- Previously, if the configuration was installed to a location that contained spaces in the path on OSX then the tank command would fail to run.
- Updated to check for the required roots.yml config file rather than the now optional templates.yml when determining if a path relates to a pipeline configuration.
