### PR TITLE
#26630 wrap command callbacks to ensure exceptions bubble up in Maya

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -455,18 +455,25 @@ class Engine(TankBundle):
                 # also add a prefix key in the properties dict
                 properties["prefix"] = prefix
         
-        # we're wrapping the callback here to ensure that any exceptions don't get 
-        # "stuck" because we're using evalDeferred
-        def wrap_cb(cb):
+        # Due to a bug in Maya (2012-2015), we're wrapping the callback here to ensure that 
+        # any exceptions don't get silently hidden because we're using evalDeferred. 
+        def wrap_cb_in_try_block(cb):
+            """
+            Decorator that wraps the callback in a try/except block so we can use our 
+            own log_exception method to ensure any exception that occurs gets propagated up.
+            
+            Returns the callback function wrapped in a try/except block.
+            """
             def wrapped_cb():
                 try:
                     cb()
                 except Exception, e:
-                    # using string formatting is imperative to un-sticking the exception
-                    self.log_exception("%s" % e)
+                    # NB: We must include at least some string in this message to force the exception 
+                    #     out.
+                    self.log_exception("Error executing one of the registered Toolkit commands.")
             return wrapped_cb
 
-        wrapped_callback = wrap_cb(callback)    
+        wrapped_callback = wrap_cb_in_try_block(callback)    
         self.__commands[name] = { "callback": wrapped_callback, "properties": properties }
 
     def execute_in_main_thread(self, func, *args, **kwargs):


### PR DESCRIPTION
Because we use evalDeferred for stability on Linux, we've exposed a bug in Maya that causes any exceptions that are raised during the callback to get "stuck" and could potentially cause a crash. This works around the issue by wrapping the callback in a try/except clause and logging our own exception with the error and traceback info.