### PR TITLE
Retrieve and restore execution permissions on unpack

### DIFF
--- a/python/tank/deploy/zipfilehelper.py
+++ b/python/tank/deploy/zipfilehelper.py
@@ -10,7 +10,6 @@
 
 import os
 import zipfile
-import stats
 
 def _process_item(zip_obj, item_path, targetpath):
     """


### PR DESCRIPTION
Retrieve permissions from zip info property, check if
any execution bit is set, gives everyone execution rights
if any is set.
