### PR TITLE
#26843 Hooks not configurable when executed from an engine.

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -454,10 +454,10 @@ class TankBundle(object):
                     # note - this technically violates the generic nature of the bundle
                     # base class implementation (because the engine member is not defined in bundle
                     # but in App and Framework but NOT in the Engine class) - an engine trying to define
-                    # a hook using the {engine_name} construct will therefore see get an error.
+                    # a hook using the {engine_name} construct will therefore get an error.
                     engine_name = self.engine.name
                 except:
-                    raise TankError("%s: Failed to be able to find the associated engine "
+                    raise TankError("%s: Failed to find the associated engine "
                                     "when trying to access hook %s" % (self, hook_expression))
                 
                 resolved_hook_name = default_hook_name.replace(constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)
@@ -610,10 +610,10 @@ class TankBundle(object):
                         # note - this technically violates the generic nature of the bundle
                         # base class implementation (because the engine member is not defined in bundle
                         # but in App and Framework but NOT in the Engine class) - an engine trying to define
-                        # a hook using the {engine_name} construct will therefore see get an error.
+                        # a hook using the {engine_name} construct will therefore get an error.
                         engine_name = self.engine.name
                     except:
-                        raise TankError("%s: Failed to be able to find the associated engine "
+                        raise TankError("%s: Failed to find the associated engine "
                                         "when trying to access hook %s" % (self, hook_expression))
                     
                     default_value = default_value.replace(constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)


### PR DESCRIPTION
There is logic in the bundle base class trying to resolve `{engine_name}` token, but this fails for any engine level hooks because it tries to access self.engine which obviously an engine doesn't have. The `{engine_name}` token doesn't make sense in the context of an engine. This small fix makes it possible to run engine level hooks.
