### PR TITLE
#27241 Improved QT checks beyond checking has_ui

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -230,8 +230,8 @@ class Engine(TankBundle):
                     # just update the message for the existing window 
                     self.__global_progress_widget.set_contents(title, details)
 
-            # make sure events are properly processed and the window is updated
-            QtCore.QCoreApplication.processEvents()
+                # make sure events are properly processed and the window is updated
+                QtCore.QCoreApplication.processEvents()
         
         else:
             # no UI support! Instead, just emit a log message


### PR DESCRIPTION
If the shell and/or shotgun engines have not been updated recently, it is possible for the new 0.15 core to generate QT errors because the has_ui method is implemented incorrectly in the engines. We need to add extra error trapping here to ensure there is a graceful step-down in that case.
