### PR TITLE
#27476 Localize command now tries to switch more intelligently.

### DIFF
--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -25,6 +25,14 @@ from ... import pipelineconfig_utils
 from ... import pipelineconfig_factory
 
 
+# these are the items that need to be copied across
+# when a configuration is upgraded to contain a core API
+CORE_FILES_FOR_LOCALIZE = ["app_store.yml", 
+                           "shotgun.yml", 
+                           "interpreter_Darwin.cfg", 
+                           "interpreter_Linux.cfg", 
+                           "interpreter_Windows.cfg"]
+
 class CoreLocalizeAction(Action):
     """
     Action to localize the Core API
@@ -169,12 +177,7 @@ def do_localize(log, pc_root_path, suppress_prompts):
         
         # copy some core config files across
         log.info("Copying Core Configuration Files...")
-        file_names = ["app_store.yml", 
-                      "shotgun.yml", 
-                      "interpreter_Darwin.cfg", 
-                      "interpreter_Linux.cfg", 
-                      "interpreter_Windows.cfg"]
-        for fn in file_names:
+        for fn in CORE_FILES_FOR_LOCALIZE:
             src = os.path.join(core_api_root, "config", "core", fn)
             tgt = os.path.join(pc_root_path, "config", "core", fn)
             log.debug("Copy %s -> %s" % (src, tgt))


### PR DESCRIPTION
Previously, the `tank localize` command would first copy and set up the core api for a pipeline configuration and once that was done it would copy all engines, apps and frameworks across. This caused a potentially extended period of time where the pipeline configuration was in half-completed state and wasn't operational. This was causing issues in production.

This fix moves things around so that the apps and engines are copied first, and then the API is copied. While not a perfect fix, this should hopefully still resolve most issues.
