### PR TITLE
For #27751 - Fixed regression in hook loading.

### DIFF
--- a/tests/data/env/test.yml
+++ b/tests/data/env/test.yml
@@ -24,6 +24,9 @@ engines:
                 test_hook_inheritance_1: "{self}/inheritance1.py"
                 test_hook_inheritance_2: "{config}/inherit.py"
                 
+                test_hook_inheritance_old_style: "{self}/inheritance_old_style.py"
+                test_hook_inheritance_old_style_fails: "{self}/inheritance_old_style_fails.py"
+                
                 test_hook_new_style_config_old_style_hook: "{config}/config_test_hook.py"
                 test_default_syntax_with_new_style_hook: default
                 

--- a/tests/data/test_app/hooks/inheritance_old_style.py
+++ b/tests/data/test_app/hooks/inheritance_old_style.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class FirstLevelDerived(Hook):
+    pass
+
+class SecondLevelDerived(FirstLevelDerived):
+    pass
+
+class TestHook(SecondLevelDerived):
+    
+    def execute(self, dummy_param):
+        return "doubly derived class"
+        

--- a/tests/data/test_app/hooks/inheritance_old_style_fails.py
+++ b/tests/data/test_app/hooks/inheritance_old_style_fails.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class FirstLevelDerived(Hook):
+    pass
+
+class FirstLevelDerivedB(Hook):
+    pass
+
+class SecondLevelDerived(FirstLevelDerived):
+    pass
+
+class TestHook(SecondLevelDerived):
+    
+    def execute(self, dummy_param):
+        return "doubly derived class"
+        

--- a/tests/data/test_app/info.yml
+++ b/tests/data/test_app/info.yml
@@ -60,6 +60,16 @@ configuration:
     test_hook_inheritance_2:
         type: hook
         default_value: "{self}/inheritance2.py"
+        
+        
+    test_hook_inheritance_old_style:
+        type: hook
+        default_value: "{self}/inheritance_old_style.py"
+        
+    test_hook_inheritance_old_style_fails:
+        type: hook
+        default_value: "{self}/inheritance_old_style_fails.py"
+        
     
     test_hook_new_style_config_old_style_hook:
         type: hook

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -182,6 +182,24 @@ class TestExecuteHook(TestApplication):
         app = self.engine.apps["test_app"]
         self.assertEqual(app.execute_hook_method("test_hook_inheritance_2", "foo2", bar=True), "custom class base class")
         
+    def test_inheritance_old_style(self):
+        """
+        Test that a hook that contains multiple levels of derivation works as long as there is only one leaf
+        level class 
+        """
+        app = self.engine.apps["test_app"]
+        self.assertEqual(app.execute_hook("test_hook_inheritance_old_style", dummy_param=True), "doubly derived class")
+
+    def test_inheritance_old_style_fails(self):
+        """
+        Test that a hook file that contains multiple levels of derivation raises a TankError when there 
+        are multiple leaf level classes derived from 'Hook'
+        """
+        app = self.engine.apps["test_app"]
+        self.assertRaises(TankError, 
+                         app.execute_hook,
+                         "test_hook_inheritance_old_style_fails", dummy_param=True)
+        
     def test_new_style_config_old_style_hook(self):
         app = self.engine.apps["test_app"]        
         self.assertTrue(app.execute_hook("test_hook_new_style_config_old_style_hook", dummy_param=True))


### PR DESCRIPTION
- Hook loading was recently made more deterministic but as a side-effect of that work it became more strict and specifically, having derived classes in a single Hook file no longer works.  This is fixed with this
change.

Example:

This would previously not be allowed:

```python
class MyBaseHook(Hook):
    pass
class MyHook(MyBaseHook):
   pass
```

Now it will work and MyHook will be used.  If the code doesn't find exactly one leaf level class derived from Hook then it will raise an exception.

