### PR TITLE
#27788 Fixes regression in 0.15 for setups running windows with a local storage defined as a drive letter without a backslash

### DIFF
--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -330,11 +330,22 @@ def _get_pipeline_configs_for_path(path, data):
             # all pipeline configurations are associated
             # with a project which has a tank_name set
             project_name = pc["project.Project.tank_name"]
+            
             # for multi level projects, there may be slashes, e.g
             # project_name is "parent/child"
             # ensure this is translated to "parent\child" on windows
             project_name = project_name.replace("/", os.path.sep)
-            # and concatenate it with the storage 
+            
+            # now, another windows edge case we need to ensure is covered
+            # if a windows storage is defined as 'x:', then 
+            # os.path.join('x:', 'folder') will return 'x:folder'
+            # and not 'x:\folder as we would expect
+            # so ensure that any path on this form is extended:
+            # 'x:' --> 'x:\'
+            if len(s) == 2 and s.endswith(":"):
+                s = "%s%s" % (s, os.path.sep)
+            
+            # and concatenate it with the storage
             project_path = os.path.join(s, project_name)
             # associate this path with the pipeline configuration
             project_paths[project_path].append(pc)

--- a/tests/folder_tests/test_configuration.py
+++ b/tests/folder_tests/test_configuration.py
@@ -29,7 +29,7 @@ class TestFolderConfiguration(TankTestBase):
     """
     def setUp(self):
         super(TestFolderConfiguration, self).setUp()
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
     def test_project_root_mismatch(self):
         """

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -62,7 +62,7 @@ class TestSchemaCreateFolders(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy
@@ -642,7 +642,7 @@ class TestSchemaCreateFoldersWorkspaces(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy

--- a/tests/folder_tests/test_optional_fields.py
+++ b/tests/folder_tests/test_optional_fields.py
@@ -62,7 +62,7 @@ class TestSchemaCreateFoldersSecondaryEntity(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy

--- a/tests/folder_tests/test_secondary_entity.py
+++ b/tests/folder_tests/test_secondary_entity.py
@@ -91,7 +91,7 @@ class TestSchemaCreateFoldersSecondaryEntity(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy

--- a/tests/folder_tests/test_step_node.py
+++ b/tests/folder_tests/test_step_node.py
@@ -81,7 +81,7 @@ class TestSchemaCreateFoldersSingleStep(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy
@@ -239,7 +239,7 @@ class TestSchemaCreateFoldersMultiStep(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy
@@ -375,7 +375,7 @@ class TestSchemaCreateFoldersStepAndUserSandbox(TankTestBase):
 
         
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy
@@ -512,7 +512,7 @@ class TestSchemaCreateFoldersCustomStep(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -83,7 +83,7 @@ class TestSchemaCreateFoldersSingleStep(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy
@@ -243,7 +243,7 @@ class TestSchemaCreateFoldersMultiStep(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
         self.FolderIOReceiverBackup = folder.folder_io.FolderIOReceiver.execute_folder_creation
         folder.folder_io.FolderIOReceiver.execute_folder_creation = execute_folder_creation_proxy

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -40,7 +40,7 @@ class TestApplication(TankTestBase):
         self.shot_step_path = os.path.join(shot_path, "step_name")
         self.add_production_path(self.shot_step_path, step)
 
-        self.test_resource = os.path.join(self.project_root, "tank", "config", "foo", "bar.png")
+        self.test_resource = os.path.join(self.pipeline_config_root, "config", "foo", "bar.png")
         os.makedirs(os.path.dirname(self.test_resource))
         fh = open(self.test_resource, "wt")
         fh.write("test")

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -39,7 +39,7 @@ class TestStartEngine(TankTestBase):
         self.add_production_path(self.shot_step_path, step)
         
         
-        self.test_resource = os.path.join(self.project_root, "tank", "config", "foo", "bar.png")
+        self.test_resource = os.path.join(self.pipeline_config_root, "config", "foo", "bar.png")
         os.makedirs(os.path.dirname(self.test_resource))
         fh = open(self.test_resource, "wt")
         fh.write("test")
@@ -50,7 +50,7 @@ class TestStartEngine(TankTestBase):
 
     def test_get_engine_path(self):
         engine_path = tank.platform.get_engine_path("test_engine", self.tk, self.context)
-        expected_engine_path = os.path.join(self.project_root, "tank", "config", "test_engine")
+        expected_engine_path = os.path.join(self.pipeline_config_root, "config", "test_engine")
         self.assertEquals(engine_path, expected_engine_path)
 
     def test_valid_engine(self):

--- a/tests/platform_tests/test_validation.py
+++ b/tests/platform_tests/test_validation.py
@@ -197,7 +197,7 @@ class TestValidateSettings(TankTestBase):
         tk = None
         settings = {hook_name:hook_value}
         schema = {hook_name:{"type":"hook"}}
-        hooks_location = os.path.join(self.project_root, "tank", "config", "hooks")
+        hooks_location = os.path.join(self.pipeline_config_root, "config", "hooks")
 
         self.assertRaises(TankError, validate_settings, self.app_name, self.tk, self.context, schema, settings)
 
@@ -524,7 +524,7 @@ class TestValidateFixtures(TankTestBase):
         env = self.tk.pipeline_configuration.get_environment(self.test_env, context)
 
         # make sure our tmp file exists on disk for the disk_path property
-        self.test_resource = os.path.join(self.project_root, "tank", "config", "foo", "bar.png")
+        self.test_resource = os.path.join(self.pipeline_config_root, "config", "foo", "bar.png")
         os.makedirs(os.path.dirname(self.test_resource))
         fh = open(self.test_resource, "wt")
         fh.write("test")

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -115,8 +115,7 @@ class TankTestBase(unittest.TestCase):
 
         self.project_root = os.path.join(self.tank_temp, self.project["tank_name"].replace("/", os.path.sep) )
         
-        #self.pipeline_config_root = os.path.join(self.tank_temp, "pipeline_configuration")
-        self.pipeline_config_root = os.path.join(self.project_root, "tank")
+        self.pipeline_config_root = os.path.join(self.tank_temp, "pipeline_configuration")
           
         # move away previous data
         self._move_project_data()
@@ -473,6 +472,7 @@ class TankTestBase(unittest.TestCase):
         """
         Calls _move_data for all project roots.
         """        
+        _move_data(self.pipeline_config_root)
         _move_data(self.project_root)
         _move_data(self.alt_root_1)
         _move_data(self.alt_root_2)

--- a/tests/test_path_cache.py
+++ b/tests/test_path_cache.py
@@ -346,7 +346,7 @@ class TestShotgunSync(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
     def _get_path_cache(self):
         path_cache = tank.path_cache.PathCache(self.tk)
@@ -462,7 +462,7 @@ class TestShotgunSync013AutoPush(TankTestBase):
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
 
-        self.schema_location = os.path.join(self.project_root, "tank", "config", "core", "schema")
+        self.schema_location = os.path.join(self.pipeline_config_root, "config", "core", "schema")
 
     def _get_path_cache(self):
         path_cache = tank.path_cache.PathCache(self.tk)


### PR DESCRIPTION
see title. This fixes a regression issue affecting setups where a shotgun local storage is defined on the form `x:`