### PR TITLE
#26557 Adds pipeline configuration name to the Core API

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -206,6 +206,15 @@ class Tank(object):
 
         return data
 
+    @property
+    def configuration_name(self):
+        """
+        Returns the name of the currently running pipeline configuration
+        
+        :return: pipeline configuration name as string, e.g. 'primary'
+        """
+        return self.__pipeline_config.get_name()
+
     ##########################################################################################
     # public methods
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -375,25 +375,45 @@ class TestPathsFromTemplateGlob(TankTestBase):
         self.assert_glob(fields, expected_glob, skip_keys)
 
     
-class TestVersionProperty(TankTestBase):
-    """
-    test api.version property
-    """
+class TestApiProperties(TankTestBase):
     def setUp(self):
-        super(TestVersionProperty, self).setUp()
+        super(TestApiProperties, self).setUp()
 
     def test_version_property(self):
+        """
+        test api.version property
+        """
         self.assertEquals(self.tk.version, "HEAD")
 
-class TestDocumentationProperty(TankTestBase):
-    """
-    test api.documentation_url property
-    """
-    def setUp(self):
-        super(TestDocumentationProperty, self).setUp()
-
     def test_doc_property(self):
+        """
+        test api.documentation_url property
+        """
         self.assertEquals(self.tk.documentation_url, None)
+
+    def test_configuration_name_property(self):
+        """
+        test api.configuration_name property
+        """
+        self.assertEquals(self.tk.configuration_name, "Primary")
+
+    def test_roots_property(self):
+        """
+        test api.roots property
+        """
+        self.assertEquals(self.tk.roots, {"primary": self.project_root} )
+
+
+    def test_project_path_property(self):
+        """
+        test api.project_path property
+        """
+        self.assertEquals(self.tk.project_path, self.project_root)
+
+
+
+
+
 
 
 


### PR DESCRIPTION
Adds a property which returns the name of the currently running pipeline configuration.

```
Mannes-MacBook-Pro-2:flame_tech_demo manne$ ./tank shell 

Welcome to the Shotgun Pipeline Toolkit!
For documentation, see https://toolkit.shotgunsoftware.com
Starting Toolkit for your current path '/mnt/software/shotgun/flame_tech_demo'
- The path is not associated with any Shotgun object.
- Falling back on default project settings.
- Using configuration 'Primary' and Core v0.15.10
- Setting the Context to Flame Tech Demo.
- Started Shell Engine version v0.4.0
- Environment: /mnt/software/shotgun/flame_tech_demo/config/env/project.yml.
- Running command shell...


----------------------------------------------------------------------
Command: Shell
----------------------------------------------------------------------

Welcome to Shotgun Pipeline Toolkit Python!
2.7.6 (default, Apr  2 2014, 14:45:52) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.1.00)]
Running on darwin

- A tk API handle is available via the tk variable
- A Shotgun API handle is available via the shotgun variable
- Your current context is stored in the context variable
- The shell engine can be accessed via the engine variable
>>> tk.configuration_name
'Primary'
```
