### PR TITLE
#26335 Tweaks to logic when running tank setup_project from a localized API

### DIFF
--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -613,6 +613,12 @@ class SetupProjectAction(Action):
             # So we cannot use that as a default. In this case, simply don't provide 
             # a default parameter.
             pass
+
+        elif core_locations[sys.platform] is None:
+            # edge case: the shared core location that we are trying to install from
+            # is not set up to work with this operating system. In that case, skip
+            # default generation 
+            pass
         
         elif os.path.abspath(os.path.join(core_locations[sys.platform], "..")).lower() == primary_local_path.lower():
             # ok the parent of the install root matches the primary storage - means OLD STYLE (pre core 0.12)

--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -594,7 +594,8 @@ class SetupProjectAction(Action):
         # - 0.13 style layout, where they all sit together in an install location
         # - 0.12 style layout, where there is a tank folder which is the studio location
         #   and each project has its own folder.
-        # - something else!
+        # - installing off a localized core api, meaning that there is no obvious
+        #   relationship between the config location and the core location
                 
         location = {"darwin": None, "linux2": None, "win32": None}
         
@@ -604,8 +605,16 @@ class SetupProjectAction(Action):
         curr_core_path = pipelineconfig_utils.get_path_to_current_core()
         core_locations = pipelineconfig_utils.resolve_all_os_paths_to_core(curr_core_path)
         
+        if pipelineconfig_utils.is_localized(curr_core_path):
+            # the API we are using to run the setup from was localized. This means
+            # that the API will not be shared between projects and with something
+            # like the shotgun desktop workflow, the core API is installed in a 
+            # system location like %APPDATA% or ~/Library.
+            # So we cannot use that as a default. In this case, simply don't provide 
+            # a default parameter.
+            pass
         
-        if os.path.abspath(os.path.join(core_locations[sys.platform], "..")).lower() == primary_local_path.lower():
+        elif os.path.abspath(os.path.join(core_locations[sys.platform], "..")).lower() == primary_local_path.lower():
             # ok the parent of the install root matches the primary storage - means OLD STYLE (pre core 0.12)
             #
             # in this setup, we would have the following structure: 

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -713,7 +713,9 @@ class ProjectSetupParameters(object):
             raise TankError("Need to define a core location!") 
         
         if self._core_path[sys.platform] is None:
-            raise TankError("Need to define a core for the current os!")
+            raise TankError("The core API you are trying to use in conjunction with this project "
+                            "has not been set up to operate on the current operating system. Please update "
+                            "the install_location.yml file and try again.")
         
         # make sure all parameters have been specified
         if self._config_template is None:


### PR DESCRIPTION
Previously, the logic would be trying to suggest a config location based on the location of the core API.
This worked well with our standard setup where a 'studio' api was shared across projects.
However, with the desktop, things are more localized, and these locations may also be in 
`%APPDATA%` or `Library` locations, meaning that it doesn't make sense to base new config
default on them. This fix removes the default logic whenever the core that is used to run the setup 
from is localized rather than shared.