### PR TITLE
#27868 Improved path cache migration

### DIFF
--- a/python/tank/deploy/tank_commands/path_cache.py
+++ b/python/tank/deploy/tank_commands/path_cache.py
@@ -148,7 +148,7 @@ class PathCacheMigrationAction(Action):
         # first load up the current path cache file and make sure 
         # shotgun has got all those entries present as FilesystemLocations.
         log.info("")
-        log.info("Step 1/3: Pushing data from the current path cache to Shotgun...")
+        log.info("Phase 1/3: Pushing data from the current path cache to Shotgun...")
         curr_pc = path_cache.PathCache(self.tk)
         try:
             curr_pc.ensure_all_entries_are_in_shotgun(log)
@@ -158,12 +158,12 @@ class PathCacheMigrationAction(Action):
         # now turn on the cloud based path cache. This means that from now on, a new path 
         # cache, stored on the local disk, will be used instead of the previous (shared) one.
         log.info("")
-        log.info("Step 2/3: Switching on the Shotgun Path Cache...")
+        log.info("Phase 2/3: Switching on the Shotgun Path Cache...")
         self.tk.pipeline_configuration.turn_on_shotgun_path_cache()
          
         # and synchronize path cache
         log.info("")
-        log.info("Step 3/3: Synchronizing your local machine with Shotgun...")
+        log.info("Phase 3/3: Synchronizing your local machine with Shotgun...")
         pc = path_cache.PathCache(self.tk)
         try:
             pc.synchronize(log, full_sync=True)

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -1184,7 +1184,7 @@ class PathCache(object):
         :param log: Std python logger 
         """
 
-        SG_BATCH_SIZE = 3
+        SG_BATCH_SIZE = 50
 
         log.info("")
         log.info("Step 1 - Downloading current path data from Shotgun...")


### PR DESCRIPTION
This changes the logic around the path cache migration:
- Instead of happening on the fly, the migration now runs explicitly as part of the `tank upgrade_folders`. This ensures that all the path cache data is correctly pushed to shotgun.
- The algorithm has been tweaked to support the case where a path cache contains references to objects which have been retired in Shotgun
- The logic now allows for the migration to run any number of times without creating duplicates. Previously, the duplicate tracking was on the sqlite side, now it is on the shotgun side.