### PR TITLE
#27977 Cached environment objects to increase speed of tank command

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -121,7 +121,7 @@ class Context(object):
         equal &= (self.__entity == other.__entity)
         equal &= (self.__step == other.__step)
         equal &= (self.__task == other.__task)
-        equal &= (self.__user == self.__user)
+        equal &= (self.__user == other.__user)
         equal &= (self.__additional_entities == other.__additional_entities)
         return equal
 

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -117,12 +117,12 @@ class Context(object):
             return NotImplemented
 
         equal = True
-        equal &= (self.project == other.project)
-        equal &= (self.entity == other.entity)
-        equal &= (self.step == other.step)
-        equal &= (self.task == other.task)
-        equal &= (self.user == other.user)
-        equal &= (self.additional_entities == other.additional_entities)
+        equal &= (self.__project == other.__project)
+        equal &= (self.__entity == other.__entity)
+        equal &= (self.__step == other.__step)
+        equal &= (self.__task == other.__task)
+        equal &= (self.__user == self.__user)
+        equal &= (self.__additional_entities == other.__additional_entities)
         return equal
 
     def __ne__(self, other):

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -528,6 +528,9 @@ class PipelineConfiguration(object):
         all the environment names.
         """
         
+        # because of all the yaml parsing going on, this operation is 
+        # surprisingly cpu intensive. It turns out it's very beneficial to 
+        # cache the result - the tank command in particular runs noticably faster.
         cache_key = (env_name, context)
         
         if cache_key in self._cached_environments:

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -47,6 +47,8 @@ class PipelineConfiguration(object):
         """
         self._pc_root = pipeline_configuration_path
 
+        self._cached_environments = {}
+
         # validate that the current code version matches or is compatible with
         # the code that is locally stored in this config!!!!
         our_associated_api_version = self.get_associated_core_version()
@@ -525,12 +527,21 @@ class PipelineConfiguration(object):
         You can use the get_environments() method to get a list of
         all the environment names.
         """
-        env_file = os.path.join(self._pc_root, "config", "env", "%s.yml" % env_name)
-        if not os.path.exists(env_file):
-            raise TankError("Cannot load environment '%s': Environment configuration "
-                            "file '%s' does not exist!" % (env_name, env_file))
-
-        return Environment(env_file, self, context)
+        
+        cache_key = (env_name, context)
+        
+        if cache_key in self._cached_environments:
+            val = self._cached_environments[cache_key]
+        
+        else:
+            env_file = os.path.join(self._pc_root, "config", "env", "%s.yml" % env_name)
+            if not os.path.exists(env_file):
+                raise TankError("Cannot load environment '%s': Environment configuration "
+                                "file '%s' does not exist!" % (env_name, env_file))
+            val = Environment(env_file, self, context)
+            self._cached_environments[cache_key] = val
+        
+        return val
 
     def get_templates_config(self):
         """


### PR DESCRIPTION
Turns out toolkit spends a bunch of cycles parsing yaml files. This fix helps improve performance of any environment where the multi launch app is frequently used. An environment lookup which is carried out multiple times over and over again is memoized, resulting in significantly improved performance when running the tank command. I haven't tested, but I would expect similar gains in the desktop and shotgun engines.

Note: This change also addresses a known slowness in the context equality operator.