### PR TITLE
#28045 Tweaks to support edge cases with overlapping storage defs.

### DIFF
--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -329,24 +329,35 @@ def _get_pipeline_configs_for_path(path, data):
         - project.Project.tank_name    
 
     
-    Note:
+    Edge case notes:
+    
     Normally, this command returns all the pipeline configurations that
-    are associated with a single project, however there are edge cases where
-    it may return pipeline configurations for *multiple* projects - this is 
-    in the case there are overlapping storage roots, leading to ambiguity
-    going from a path on disk to a project in shotgun.
+    are associated with a single project only. 
+    
+    However, there are edge cases where it may return pipeline configurations 
+    for *multiple* projects.
+      
+    in the case there are overlapping storage roots, or where a project is named 
+    the same name as a storage root, this may lead to a scenario where a path on 
+    disk could potentially belong to *two* projects. In this case, this method will
+    return the pipeline configurations for both projects.
     
     For example, imagine the following setup:
+    
     Storages: f:\ and f:\foo
     Project names: foo and bar
+    
+    (Note that the project name 'foo' is named the same as the storage F:\foo)
+    
     This means we have the following project roots:
     (1) f:\foo      (storage f:\, project foo)
     (2) f:\bar      (storage f:\, project bar)
     (3) f:\foo\foo  (storage f:\foo, project foo)
     (4) f:\foo\bar  (storage f:\foo, project bar)
     
-    The path f:\foo\bar\hello_world.ma could either belong to 
-    project bar (matching 4) or project foo (matching 1).
+    If we have a path f:\foo\bar\hello_world.ma, this could either belong to 
+    project 'bar' (matching 4) or project 'foo' (matching 1).
+    
     In this case, the pipeline configurations for both foo and bar
     are returned.
         

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -238,9 +238,10 @@ def _from_path(path, force_reread_shotgun_cache):
                             "path, but none of them is marked as Primary: %s" % (path, local_pc_paths))
 
         if len(primary_pc_paths) > 1:
-            raise TankError("The path '%s' is potentially associated with more than one primary pipeline "
+            raise TankError("The path '%s' is associated with more than one primary pipeline "
                             "configuration. This can happen if there is ambiguity in your project setup, where "
-                            "projects store their data in an overlapping fashion. In this case, try creating "
+                            "projects store their data in an overlapping fashion. For example, if a project is "
+                            "named the same as a local storage root. In this case, try creating "
                             "your API instance (or tank command) directly from the pipeline configuration rather "
                             "than via the studio level API. This will explicitly call out which project you are "
                             "intending to use in conjunction with he path. The pipeline configuration paths "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -625,7 +625,7 @@ class TestTankFromPathOverlapStorage(TankTestBase):
             os.makedirs(test_path_dir)
         
         self.assertRaisesRegexp(TankError, 
-                                "The path '.*' is potentially associated with more than one primary pipeline configuration.",
+                                "The path '.*' is associated with more than one primary pipeline configuration.",
                                 sgtk.sgtk_from_path,
                                 test_path)        
         

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -532,8 +532,10 @@ class TestTankFromPathOverlapStorage(TankTestBase):
     
     The path f:\foo\bar\hello_world.ma could either belong to 
     project bar (matching 4) or project foo (matching 1).
-    In this case, the pipeline configurations for both foo and bar
-    are returned.    
+
+    In this case, sgtk_from_path() should succeed in case you are using a local
+    tank command or API and fail if you are using a studio level command.
+
     """
     
     def setUp(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -516,3 +516,150 @@ class TestTankFromPathWindowsNoSlash(TankTestBase):
     
 
 
+
+class TestTankFromPathOverlapStorage(TankTestBase):
+    """
+    Tests edge case with overlapping storages
+    
+    For example, imagine the following setup:
+    Storages: f:\ and f:\foo
+    Project names: foo and bar
+    This means we have the following project roots:
+    (1) f:\foo      (storage f:\, project foo)
+    (2) f:\bar      (storage f:\, project bar)
+    (3) f:\foo\foo  (storage f:\foo, project foo)
+    (4) f:\foo\bar  (storage f:\foo, project bar)
+    
+    The path f:\foo\bar\hello_world.ma could either belong to 
+    project bar (matching 4) or project foo (matching 1).
+    In this case, the pipeline configurations for both foo and bar
+    are returned.    
+    """
+    
+    def setUp(self):
+        
+        # set up two storages and two projects
+        
+        super(TestTankFromPathOverlapStorage, self).setUp(project_tank_name="foo")
+        
+
+        # add second project
+        self.project_2 = {"type": "Project",
+                          "id": 2345,
+                          "tank_name": "bar",
+                          "name": "project_name"}
+        
+        # define entity for pipeline configuration
+        self.project_2_pc = {"type": "PipelineConfiguration",
+                             "code": "Primary", 
+                             "id": 123456, 
+                             "project": self.project_2, 
+                             "windows_path": "F:\\temp\\bar_pc",
+                             "mac_path": "/tmp/bar_pc",
+                             "linux_path": "/tmp/bar_pc"}
+        
+        self.add_to_sg_mock_db(self.project_2)
+        self.add_to_sg_mock_db(self.project_2_pc)
+
+        # set up std fixtures
+        self.setup_multi_root_fixtures()
+
+        # patch storages
+        self.alt_storage_1["windows_path"] = "C:\\temp"
+        self.alt_storage_1["mac_path"] = "/tmp"
+        self.alt_storage_1["linux_path"] = "/tmp"
+        
+        self.alt_storage_2["windows_path"] = "C:\\temp\\foo"
+        self.alt_storage_2["mac_path"] = "/tmp/foo"
+        self.alt_storage_2["linux_path"] = "/tmp/foo"
+
+        self.add_to_sg_mock_db(self.alt_storage_1)
+        self.add_to_sg_mock_db(self.alt_storage_2)
+
+        # Write roots file
+        roots = {"primary": {}, "alternate_1": {}, "alternate_2": {}}
+        for os_name in ["windows_path", "linux_path", "mac_path"]:
+            roots["primary"][os_name] = os.path.dirname(self.project_root)
+            roots["alternate_1"][os_name] = self.alt_storage_1[os_name]
+            roots["alternate_2"][os_name] = self.alt_storage_2[os_name]              
+        roots_path = os.path.join(self.pipeline_config_root, "config", "core", "roots.yml")     
+        roots_file = open(roots_path, "w") 
+        roots_file.write(yaml.dump(roots))
+        roots_file.close()
+                
+        # need a new PC object that is using the new roots def file we just created
+        self.pipeline_configuration = sgtk.pipelineconfig_factory.from_path(self.pipeline_config_root)
+        # push this new PC into the tk api
+        self.tk._Tank__pipeline_config = self.pipeline_configuration         
+        # force reload templates
+        self.tk.reload_templates()
+
+
+    def test_project_path_lookup_studio_mode(self):
+        """
+        When running this edge case from a studio install, we expect an error:
+        
+        TankError: The path '/tmp/foo/bar' is potentially associated with more than one primary 
+        pipeline configuration. This can happen if there is ambiguity in your project setup, 
+        where projects store their data in an overlapping fashion. In this case, try creating 
+        your API instance (or tank command) directly from the pipeline configuration rather 
+        than via the studio level API. This will explicitly call out which project you are 
+        intending to use in conjunction with he path. The pipeline configuration paths 
+        associated with this path are: 
+        ['/var/folders/fq/65bs7wwx3mz7jdsh4vxm34xc0000gn/T/tankTemporaryTestData_1422967258.765262/pipeline_configuration', 
+        '/tmp/bar_pc']
+        
+        """
+        
+        probe_path = {}
+        probe_path["win32"] = "F:\\temp\\foo\\bar\\test.ma"
+        probe_path["darwin"] = "/tmp/foo/bar/test.ma"
+        probe_path["linux2"] = "/tmp/foo/bar/test.ma"
+        
+        test_path = probe_path[sys.platform]
+        test_path_dir = os.path.dirname(test_path)
+        
+        if not os.path.exists(test_path_dir):
+            os.makedirs(test_path_dir)
+        
+        self.assertRaisesRegexp(TankError, 
+                                "The path '.*' is potentially associated with more than one primary pipeline configuration.",
+                                sgtk.sgtk_from_path,
+                                test_path)        
+        
+
+        
+    def test_project_path_lookup_local_mode(self):
+        """
+        Check that a sgtk init works for this path
+        """
+        
+        # By setting the TANK_CURRENT_PC, we emulate the behaviour
+        # of a local API running. Push this variable
+        old_tank_current_pc = None 
+        if "TANK_CURRENT_PC" in os.environ:
+            old_tank_current_pc = os.environ["TANK_CURRENT_PC"] 
+        os.environ["TANK_CURRENT_PC"] = self.pipeline_config_root
+        
+        probe_path = {}
+        probe_path["win32"] = "F:\\temp\\foo\\bar\\test.ma"
+        probe_path["darwin"] = "/tmp/foo/bar/test.ma"
+        probe_path["linux2"] = "/tmp/foo/bar/test.ma"
+        
+        test_path = probe_path[sys.platform]
+        test_path_dir = os.path.dirname(test_path)
+        
+        if not os.path.exists(test_path_dir):
+            os.makedirs(test_path_dir)
+        
+        self.assertIsInstance(sgtk.sgtk_from_path(test_path), Tank)
+        
+        # and pop the modification   
+        if old_tank_current_pc is None:    
+            del os.environ["TANK_CURRENT_PC"]
+        else:
+            os.environ["TANK_CURRENT_PC"] = old_tank_current_pc
+            
+    
+
+


### PR DESCRIPTION
This improves the logic in `sgtk_from_path()`and `sgtk_from_entity()` in order to handle edge cases with storage setups. 

    For example, imagine the following setup:
    Storages: f:\ and f:\foo
    Project names: foo and bar
    This means we have the following project roots:
    (1) f:\foo      (storage f:\, project foo)
    (2) f:\bar      (storage f:\, project bar)
    (3) f:\foo\foo  (storage f:\foo, project foo)
    (4) f:\foo\bar  (storage f:\foo, project bar)
    
    The path f:\foo\bar\hello_world.ma could either belong to 
    project bar (matching 4) or project foo (matching 1).
    In this case, the pipeline configurations for both foo and bar
    are returned.

