### PR TITLE
For #28450 - Fixes to the context comparison code and HumanUser name stored in the path cache

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -120,19 +120,43 @@ class Context(object):
         :returns:       True if self represents the same context as other, 
                         otherwise False
         """
+        def _entity_dicts_eq(d1, d2):
+            """
+            Test to see if two entity dictionaries are equal.  They are considered
+            equal if both are dictionaries containing 'type' and 'id' with the same
+            values for both keys, For example:
+            
+            Comparing these two dictionaries would return True:
+            - {"type":"Shot", "id":123, "foo":"foo"}
+            - {"type":"Shot", "id":123, "foo":"bar", "bar":"foo"}
+            
+            But comparing these two dictionaries would return False:
+            - {"type":"Shot", "id":123, "foo":"foo"}
+            - {"type":"Shot", "id":567, "foo":"foo"} 
+    
+            :param d1:  First entity dictionary
+            :param d2:  Second entity dictionary
+            :returns:   True if d1 and d2 are considered equal, otherwise False.
+            """
+            if d1 == d2 == None:
+                return True
+            if d1 == None or d2 == None:
+                return False
+            return d1["type"] == d2["type"] and d1["id"] == d2["id"]        
+        
         if not isinstance(other, Context):
             return NotImplemented
 
-        if not self._entity_dicts_eq(self.project, other.project):
+        if not _entity_dicts_eq(self.project, other.project):
             return False
         
-        if not self._entity_dicts_eq(self.entity, other.entity):
+        if not _entity_dicts_eq(self.entity, other.entity):
             return False
         
-        if not self._entity_dicts_eq(self.step, other.step):
+        if not _entity_dicts_eq(self.step, other.step):
             return False
         
-        if not self._entity_dicts_eq(self.task, other.task):
+        if not _entity_dicts_eq(self.task, other.task):
             return False
         
         # compare additional entities
@@ -149,34 +173,10 @@ class Context(object):
 
         # finally compare the user - this may result in a Shotgun look-up 
         # so do this last!
-        if not self._entity_dicts_eq(self.user, other.user):
+        if not _entity_dicts_eq(self.user, other.user):
             return False
         
         return True 
-    
-    def _entity_dicts_eq(self, d1, d2):
-        """
-        Test to see if two entity dictionaries are equal.  They are considered
-        equal if both are dictionaries containing 'type' and 'id' with the same
-        values for both keys, For example:
-        
-        Comparing these two dictionaries would return True:
-        - {"type":"Shot", "id":123, "foo":"foo"}
-        - {"type":"Shot", "id":123, "foo":"bar", "bar":"foo"}
-        
-        But comparing these two dictionaries would return False:
-        - {"type":"Shot", "id":123, "foo":"foo"}
-        - {"type":"Shot", "id":567, "foo":"foo"} 
-
-        :param d1:  First entity dictionary
-        :param d2:  Second entity dictionary
-        :returns:   True if d1 and d2 are considered equal, otherwise False.
-        """
-        if d1 == d2 == None:
-            return True
-        if d1 == None or d2 == None:
-            return False
-        return d1["type"] == d2["type"] and d1["id"] == d2["id"]
 
     def __ne__(self, other):
         """

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1042,21 +1042,32 @@ def _task_from_sg(tk, task_id):
 
 def _entity_from_sg(tk, entity_type, entity_id):
     """
-    Constructs a context from a shotgun task.
-    Because we are constructing the context from a task, we will get a context
-    which has both a project, an entity a step and a task associated with it.
-
-    :param tk:           a Sgtk API instance
-    :param task_id:      The shotgun task id to produce a context for.
+    Determines the entity details for the specified entity type and id by querying Shotgun.
+                        
+    If entity_type is 'Project' then this will return a single dictionary for the project.  For all
+    other entity types, this will return dictionaries for both the entity and the project the entity 
+    exists under.
+                        
+    :param tk:          The sgtk api instance
+    :param entity_type: The entity type to build a context for
+    :param entity_id:   The entity id to build a context for
+    :returns:           Dictionary containing either a project entity-dictionary or both
+                        project and entity entity-dictionaries depending on the input entity type.
+                        e.g. 
+                        {
+                            "project":{"type":"Project", "id":123, "name":"My Project"},
+                            "entity":{"type":"Shot", "id":456, "name":"My Shot"}
+                        }
+                            
     """
 
     # deal with funny naming for certain entities 
     if entity_type == "HumanUser":
-        name_field = "login"
-        
+        # note: previously this would return 'login' but this was inconsistent as the HumanUser
+        # entity already has a name field and this could lead to errors later on!
+        name_field = "name"
     elif entity_type == "Project":
         name_field = "name"
-    
     else:
         name_field = "code"
 

--- a/python/tank/folder/folder_types.py
+++ b/python/tank/folder/folder_types.py
@@ -1005,7 +1005,7 @@ class Entity(Folder):
         """
         return the special name field for a given entity
         """
-        spec_name_fields = {"Project": "name", "Task": "content", "HumanUser": "login"}
+        spec_name_fields = {"Project": "name", "Task": "content", "HumanUser": "name"}
         if entity_type in spec_name_fields:
             return spec_name_fields[entity_type]
         else:
@@ -1048,6 +1048,7 @@ class Entity(Folder):
             my_path = os.path.join(parent_path, folder_name)
                         
             # get the name field - which depends on the entity type
+            # Note: this is the 'name' that will get stored in the path cache for this entity
             name_field = self.__get_name_field_for_et(self._entity_type)
             name_value = entity[name_field]            
             # construct a full entity link dict w name, id, type


### PR DESCRIPTION
- Context comparisons now only check type and id for all entity dictionaries where previously the entire dictionary would have been compared which could lead to unexpected comparison failures.
- HumanUser.name is now stored in the path cache for user sandbox entities instead of HumanUser.login - this fixes an issue where a context created from a user sandbox path would end up with the login instead of the name in context.user["name"]