### PR TITLE
#28310 Improved error handling around invalid key names. Added period as a valid character for key names.

### DIFF
--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -175,6 +175,12 @@ DEFAULT_CFG = "tk-config-default"
 # the name of the shell engine
 SHELL_ENGINE = "tk-shell"
 
+# valid characters for a template key name
+TEMPLATE_KEY_NAME_REGEX = "[a-zA-Z_ 0-9\.]+"
+
+# a human readable explanation of the above. For error messages.
+VALID_TEMPLATE_KEY_NAME_DESC = "letters, numbers, underscore, space and period"
+
 # the name of the file that holds the templates.yml config
 CONTENT_TEMPLATES_FILE = "templates.yml"
 

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -26,7 +26,7 @@ class Template(object):
     """
     Object which manages the translation between paths and file templates
     """
-    _key_name_regex = "[a-zA-Z_ 0-9]+"
+    
     
     
     @classmethod
@@ -46,7 +46,7 @@ class Template(object):
         names_keys = {}
         ordered_keys = []
         # regular expression to find key names
-        regex = r"(?<={)%s(?=})" % cls._key_name_regex
+        regex = r"(?<={)%s(?=})" % constants.TEMPLATE_KEY_NAME_REGEX
         key_names = re.findall(regex, definition)
         for key_name in key_names:
             key = keys.get(key_name)
@@ -260,7 +260,7 @@ class Template(object):
                 continue
             if token.startswith('['):
                 # check that optional contains a key
-                if not re.search("{*%s}" % self._key_name_regex, token): 
+                if not re.search("{*%s}" % constants.TEMPLATE_KEY_NAME_REGEX, token): 
                     raise TankError("Optional sections must include a key definition.")
 
                 # Add definitions skipping this optional value
@@ -296,7 +296,7 @@ class Template(object):
 
     def _clean_definition(self, definition):
         # Create definition with key names as strings with no format, enum or default values
-        regex = r"{(%s)}" % self._key_name_regex
+        regex = r"{(%s)}" % constants.TEMPLATE_KEY_NAME_REGEX
         cleaned_definition = re.sub(regex, "%(\g<1>)s", definition)
         return cleaned_definition
 
@@ -308,7 +308,7 @@ class Template(object):
         # case we just want to parse the prefix.  For example, in the case of a path template, 
         # having an empty definition would result in expanding to the project/storage root
         expanded_definition = os.path.join(self._prefix, definition) if definition else self._prefix
-        regex = r"{%s}" % self._key_name_regex
+        regex = r"{%s}" % constants.TEMPLATE_KEY_NAME_REGEX
         tokens = re.split(regex, expanded_definition.lower())
         # Remove empty strings
         return [x for x in tokens if x]

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -13,7 +13,7 @@ Classes for fields on TemplatePaths and TemplateStrings
 """
 
 import re
-
+from .platform import constants
 from .errors import TankError
 
 class TemplateKey(object):
@@ -46,6 +46,12 @@ class TemplateKey(object):
         self.is_abstract = abstract
         self.length = length
         self._last_error = ""
+
+        # check that the key name doesn't contain invalid characters
+        
+        if not re.match(r"^%s$" % constants.TEMPLATE_KEY_NAME_REGEX, name):
+            raise TankError("%s: Name contains invalid characters. "
+                            "Valid characters are %s." % (self, constants.VALID_TEMPLATE_KEY_NAME_DESC))
 
         # Validation
         if self.shotgun_field_name and not self.shotgun_entity_type:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -46,10 +46,15 @@ class TestInit(TestTemplate):
         template = Template("some/definition", self.keys)
         self.assertRaises(AttributeError, setattr, template, "definition", "other")
 
-    def test_defalt_enum_whitespace(self):
+    def test_default_enum_whitespace(self):
         self.keys["S hot"] = StringKey("S hot")
         template = Template("/something/{S hot}/something", self.keys)
         self.assertEquals(self.keys["S hot"], template.keys["S hot"])
+
+    def test_default_period(self):
+        self.keys["S.hot"] = StringKey("S.hot")
+        template = Template("/something/{S.hot}/something", self.keys)
+        self.assertEquals(self.keys["S.hot"], template.keys["S.hot"])
 
     def test_confilicting_key_names(self):
         """

--- a/tests/test_templatekey.py
+++ b/tests/test_templatekey.py
@@ -29,6 +29,9 @@ class TestStringKey(TankTestBase):
         self.choice_field = StringKey("field_name", choices=["a", "b"])
         self.default_field = StringKey("field_name", default="b")
 
+    def test_invalid(self):
+        self.assertRaises(TankError, StringKey, "S!hot")
+
     def test_default(self):
         default_value = "default_value"
         template_field = StringKey("field_name", default=default_value)


### PR DESCRIPTION
- Period is now allowed in key names.
- If a key name contains illegal characters, an exception is raised. Previously, this would lead to failures down the line.
- Moved the valid key name definition into the constants file for readability.