### PR TITLE
Security cleanup

### DIFF
--- a/python/tank/platform/interactive_authentication.py
+++ b/python/tank/platform/interactive_authentication.py
@@ -21,7 +21,6 @@ import threading
 from tank.errors import TankAuthenticationError, TankAuthenticationDisabled
 from tank.util import authentication
 from tank.util.login import get_login_name
-from tank.util import shotgun
 
 # FIXME: Quick hack to easily disable logging in this module while keeping the
 # code compatible. We have to disable it by default because Maya will print all out
@@ -328,6 +327,7 @@ def console_logout():
     Logs out of the currently cached session and prints whether it worked or not.
     """
     if authentication.logout():
-        print "Succesfully logged out of", shotgun.get_associated_sg_base_url()
+        connection_info = authentication.get_connection_information()
+        print "Succesfully logged out of", connection_info["host"]
     else:
         print "Not logged in."

--- a/python/tank/platform/interactive_authentication.py
+++ b/python/tank/platform/interactive_authentication.py
@@ -71,30 +71,24 @@ class AuthenticationHandlerBase(object):
     be impossible to authenticate again.
     """
 
-    def authenticate(self, force_human_user_authentication):
+    def authenticate(self):
         """
         Common login logic, regardless of how we are actually logging in. It will first try to reuse
         any existing session and if that fails then it will ask for credentials and upon success
         the credentials will be cached.
-        :param force_human_user_authentication: Indicates if we should force authentication to be user based.
-                                                Setting to True disables automatic authentication as a script_user.
         :raises: TankAuthenticationError Thrown if the authentication is cancelled.
         :raises: TankAuthenticationDisabled Thrown if authentication was cancelled before.
         """
         with AuthenticationHandlerBase._authentication_lock:
             # If we are authenticated, we're done here.
-            if force_human_user_authentication and authentication.is_human_user_authenticated():
-                return
-            elif not force_human_user_authentication and authentication.is_authenticated():
+            if authentication.is_authenticated():
                 return
             # If somebody disabled authentication, we're done here as well.
             elif AuthenticationHandlerBase._authentication_disabled:
                 raise TankAuthenticationDisabled()
 
             # Get the current authentication values.
-            connection_information = authentication.get_connection_information(
-                force_human_user_authentication=True
-            )
+            connection_information = authentication.get_connection_information()
 
             try:
                 logger.debug("Not authenticated, requesting user input.")
@@ -301,38 +295,32 @@ def ui_renew_session():
     """
     Prompts the user to enter his password in a dialog to retrieve a new session token.
     """
-    # Force human user authentication, since ression renewal is always in the context of a user login.
-    UiAuthenticationHandler(is_session_renewal=True).authenticate(force_human_user_authentication=True)
+    UiAuthenticationHandler(is_session_renewal=True).authenticate()
 
 
-def ui_authenticate(force_human_user_authentication=False):
+def ui_authenticate():
     """
     Authenticates the current process. Authentication can be done through script user authentication
     or human user authentication. If doing human user authentication and there is no session cached, a
     dialgo asking for user credentials will appear.
-    :param force_human_user_authentication: If force_human_user_authentication is set to True, any configured
-                                            script user will be ignored.
     """
-    UiAuthenticationHandler(is_session_renewal=False).authenticate(force_human_user_authentication)
+    UiAuthenticationHandler(is_session_renewal=False).authenticate()
 
 
 def console_renew_session():
     """
     Prompts the user to enter his password on the command line to retrieve a new session token.
     """
-    # Force human user authentication, since ression renewal is always in the context of a user login.
-    ConsoleRenewSessionHandler().authenticate(force_human_user_authentication=True)
+    ConsoleRenewSessionHandler().authenticate()
 
 
-def console_authenticate(force_human_user_authentication=False):
+def console_authenticate():
     """
     Authenticates the current process. Authentication can be done through script user authentication
     or human user authentication. If doing human user authentication and there is no session cached, the
     user credentials will be retrieved from the console.
-    :param force_human_user_authentication: If force_human_user_authentication is set to True, any configured
-                                            script user will be ignored.
     """
-    ConsoleLoginHandler().authenticate(force_human_user_authentication)
+    ConsoleLoginHandler().authenticate()
 
 
 def console_logout():

--- a/python/tank/platform/interactive_authentication.py
+++ b/python/tank/platform/interactive_authentication.py
@@ -92,7 +92,7 @@ class AuthenticationHandlerBase(object):
                 raise TankAuthenticationDisabled()
 
             # Get the current authentication values.
-            authentication_credentials = authentication.get_authentication_credentials(
+            connection_information = authentication.get_connection_information(
                 force_human_user_authentication=True
             )
 
@@ -100,9 +100,9 @@ class AuthenticationHandlerBase(object):
                 logger.debug("Not authenticated, requesting user input.")
                 # Do the actually credentials prompting and authenticating.
                 hostname, login, session_token = self._do_authentication(
-                    authentication_credentials["host"],
-                    authentication_credentials.get("login", get_login_name()),
-                    authentication_credentials.get("http_proxy")
+                    connection_information["host"],
+                    connection_information.get("login", get_login_name()),
+                    connection_information.get("http_proxy")
                 )
             except TankAuthenticationError:
                 AuthenticationHandlerBase._authentication_disabled = True
@@ -112,7 +112,7 @@ class AuthenticationHandlerBase(object):
             logger.debug("Login successful!")
 
             # Cache the credentials so subsequent session based logins can reuse the session id.
-            authentication.cache_authentication_credentials(hostname, login, session_token)
+            authentication.cache_connection_information(hostname, login, session_token)
 
     def _do_authentication(self, host, login, http_proxy):
         """

--- a/python/tank/platform/interactive_authentication.py
+++ b/python/tank/platform/interactive_authentication.py
@@ -26,7 +26,7 @@ from tank.util import shotgun
 # FIXME: Quick hack to easily disable logging in this module while keeping the
 # code compatible. We have to disable it by default because Maya will print all out
 # debug strings.
-if True:
+if False:
     # Configure logging
     logger = logging.getLogger("sgtk.interactive_authentication")
     logger.setLevel(logging.DEBUG)

--- a/python/tank/util/authentication.py
+++ b/python/tank/util/authentication.py
@@ -12,20 +12,19 @@
 Shotgun authentication for Toolkit
 """
 
-import os
 import logging
 
 from tank_vendor.shotgun_api3 import Shotgun
 from tank_vendor.shotgun_api3.lib import httplib2
 from tank_vendor.shotgun_api3 import AuthenticationFault, ProtocolError
-from tank.errors import TankError, TankAuthenticationError
-from ConfigParser import SafeConfigParser
-from tank.util import shotgun
+from tank.errors import TankAuthenticationError
+
+from .authentication_manager import AuthenticationManager
 
 # FIXME: Quick hack to easily disable logging in this module while keeping the
 # code compatible. We have to disable it by default because Maya will print all out
 # debug strings.
-if True:
+if False:
     # Configure logging
     logger = logging.getLogger("sgtk.authentication")
     logger.setLevel(logging.DEBUG)
@@ -210,7 +209,7 @@ def _create_sg_connection_from_session(authentication_credentials):
         return sg
     else:
         # Session token was invalid, so uncache it to make sure nobody else tries using it.
-        AuthenticationManager.get_instance().clear_cached_credentials()
+        clear_cached_credentials()
         logger.debug("Failed refreshing the token.")
         return None
 
@@ -244,209 +243,20 @@ def create_authenticated_sg_connection():
         return _create_or_renew_sg_connection_from_session(authentication_credentials)
 
 
-class AuthenticationManager(object):
+def logout():
     """
-    Manages authentication information.
+    Logs out of the currently cached session.
+    :returns: True is logging out was successful, False is no session was cached.
     """
+    if _is_session_token_cached():
+        # Forget the current hostname.
+        clear_cached_credentials()
+        return True
+    else:
+        return False
 
-    @classmethod
-    def get_instance(cls):
-        """
-        Returns the AuthenticationManager for this process. If no AuthenticationManager
-        has been activated, Toolkit's default AuthenticationManager will be activated.
-        :returns: A singleton instance of the AuthenticationManager class.
-        """
-        if not hasattr(AuthenticationManager, "_instance"):
-            AuthenticationManager.activate()
-        return AuthenticationManager._instance
 
-    @classmethod
-    def activate(cls, *args, **kwargs):
-        """
-        Activates an authentication manager. Any unnamed and named arguments to this method
-        will be passed to the classes's initiliazation method.
-        :raises: TankError if a manager has already been activated.
-        """
-        if hasattr(AuthenticationManager, "_instance"):
-            raise TankError("AuthenticationManager can't be activated twice.")
-        setattr(AuthenticationManager, "_instance", cls(*args, **kwargs))
-
-    @staticmethod
-    def deactivate():
-        if not hasattr(AuthenticationManager, "_instance"):
-            raise TankError("No AuthenticationManager have been activated yet.")
-        delattr(AuthenticationManager, "_instance")
-
-    def __init__(self):
-        """
-        Constructor.
-        """
-        self._core_config_data = shotgun.get_associated_sg_config_data()
-        self._force_human_user_authentication = False
-
-    def get_host(self):
-        """
-        Returns the current host.
-        :returns: A string with the hostname.
-        """
-        return self._core_config_data["host"]
-
-    def get_http_proxy(self):
-        """
-        Returns the optional http_proxy.
-        :returns: A string with the hostname of the proxy. Can be None.
-        """
-        return self._core_config_data.get("http_proxy")
-
-    def get_credentials(self, force_human_user_authentication):
-        """
-        Retrieves the credentials for the current user.
-        :param force_human_user_authentication: Skips script user credentials if True.
-        :returns: A dictionary holding the credentials that were found. Can either contains keys:
-                  - api_script and api_key
-                  - login, session_token
-                  - an empty dictionary.
-                  The dictionary will be empty if no credentials were found.
-        """
-        force = self._force_human_user_authentication or force_human_user_authentication
-        if not force and _is_script_user_authenticated(self._core_config_data):
-            return self._slice_dict(self._core_config_data, "api_script", "api_key")
-        else:
-            login_info = self._get_login_info(self.get_host())
-            if login_info:
-                return self._slice_dict(login_info, "login", "session_token")
-            else:
-                return {}
-
-    def get_authentication_credentials(self, force_human_user_authentication):
-        """
-        Returns a dictionary with connection parameters and user credentials.
-        :param force_human_user_authentication: Skips script user credentials if True.
-        :returns: A dictionary with keys host, http_proxy and all the keys returned from get_credentials.
-        """
-        connection_info = {}
-        connection_info["host"] = self.get_host()
-        connection_info["http_proxy"] = self.get_http_proxy()
-        connection_info.update(self.get_credentials(force_human_user_authentication))
-        return connection_info
-
-    def clear_cached_credentials(self):
-        """
-        Clears any cached credentials.
-        """
-        self._delete_session_data()
-
-    def cache_authentication_credentials(self, host, login, session_token):
-        """
-        Caches authentication credentials.
-        :param host: Host to cache.
-        :param login: Login to cache.
-        :param session_token: Session token to cache.
-        """
-        self._force_human_user_authentication = True
-        # For now, only cache session data to disk.
-        self._cache_session_data(host, login, session_token)
-
-    def _slice_dict(self, dictionary, *keys):
-        """
-        Extracts all fields passed in from a dictionary.
-        :param dictionary: Dictionary we want to get a slice of.
-        :param keys: List of keys that need to be extracted.
-        :returns: A dictionary containing at most all the keys that were specified.
-        """
-        return {k: v for k, v in dictionary.iteritems() if k in keys}
-
-    def _delete_session_data(self):
-        """
-        Clears the session cache for the current site.
-        """
-        host = self.get_host()
-        logger.debug("Clearing session cached on disk.")
-        try:
-            info_path = self._get_login_info_location(host)
-            if os.path.exists(info_path):
-                logger.debug("Session file found.")
-                os.remove(info_path)
-                logger.debug("Session cleared.")
-            else:
-                logger.debug("Session file not found: %s", info_path)
-        except:
-            logger.exception("Couldn't delete the site cache file")
-
-    def _get_login_info(self, base_url):
-        """
-        Returns the cached login info if found.
-        :param base_url: The site we want the login information for.
-        :returns: Returns a dictionary with keys login and session_token or None
-        """
-        # Retrieve the location of the cached info
-        info_path = self._get_login_info_location(base_url)
-        # Nothing was cached, return an empty dictionary.
-        if not os.path.exists(info_path):
-            logger.debug("No cache found at %s" % info_path)
-            return None
-        try:
-            # Read the login information
-            config = SafeConfigParser({"login": None, "session_token": None})
-            config.read(info_path)
-            if not config.has_section("LoginInfo"):
-                logger.debug("No Login info was found")
-                return None
-
-            login = config.get("LoginInfo", "login", raw=True)
-            session_token = config.get("LoginInfo", "session_token", raw=True)
-
-            if not login or not session_token:
-                logger.debug("Incomplete settings (login:%s, session_token:%s)" % (login, session_token))
-                return None
-
-            return {"login": login, "session_token": session_token}
-        except Exception:
-            logger.exception("Exception thrown while loading cached session info.")
-            return None
-
-    def _get_login_info_location(self, base_url):
-        """
-        Returns the location of the session file on disk for a specific site.
-        :param base_url: The site we want the login information for.
-        :returns: Path to the login information.
-        """
-        from tank.util import path
-        return os.path.join(
-            path.get_local_site_cache_location(base_url),
-            "authentication",
-            "login.ini"
-        )
-
-    def _cache_session_data(self, host, login, session_token):
-        """
-        Caches the session data for a site and a user.
-        :param host: Site we want to cache a session for.
-        :param login: User we want to cache a session for.
-        :param session_token: Session token we want to cache.
-        """
-        # Retrieve the cached info file location from the host
-        info_path = self._get_login_info_location(host)
-
-        # make sure the info_dir exists!
-        info_dir, info_file = os.path.split(info_path)
-        if not os.path.exists(info_dir):
-            os.makedirs(info_dir, 0700)
-
-        logger.debug("Caching login info at %s...", info_path)
-        # Create a document with the following format:
-        # [LoginInfo]
-        # login=username
-        # session_token=some_unique_id
-        config = SafeConfigParser()
-        config.add_section("LoginInfo")
-        config.set("LoginInfo", "login", login)
-        config.set("LoginInfo", "session_token", session_token)
-        # Write it to disk.
-        with open(info_path, "w") as configfile:
-            config.write(configfile)
-        logger.debug("Cached!")
-
+# Shothands for AuthenticationManager.get_instance().xxx
 
 def get_authentication_credentials(force_human_user_authentication=False):
     """
@@ -476,14 +286,3 @@ def cache_authentication_credentials(host, login, session_token):
     AuthenticationManager.get_instance().cache_authentication_credentials(host, login, session_token)
 
 
-def logout():
-    """
-    Logs out of the currently cached session.
-    :returns: True is logging out was successful, False is no session was cached.
-    """
-    if _is_session_token_cached():
-        # Forget the current hostname.
-        AuthenticationManager.get_instance().clear_cached_credentials()
-        return True
-    else:
-        return False

--- a/python/tank/util/authentication.py
+++ b/python/tank/util/authentication.py
@@ -317,7 +317,7 @@ def _create_sg_connection_from_session(config_data=None):
         return None
 
 
-def _create_sg_connection_from_script_user(config_data=None):
+def create_sg_connection_from_script_user(config_data=None):
     """
     Create a Shotgun connection based on a script user.
     :param config_data: A dictionary with keys host, api_script, api_key and an optional http_proxy
@@ -331,16 +331,17 @@ def _create_sg_connection_from_script_user(config_data=None):
     )
 
 
-def create_authenticated_sg_connection(config_data):
+def create_authenticated_sg_connection():
     """
     Creates an authenticated Shotgun connection.
     :param config_data: A dictionary holding the site configuration.
     :returns: A Shotgun instance.
     """
+    config_data = shotgun.get_associated_sg_config_data()
     # If no configuration information
     if _is_script_user_authenticated(config_data):
         # create API
-        return _create_sg_connection_from_script_user(config_data)
+        return create_sg_connection_from_script_user(config_data)
     else:
         return _create_or_renew_sg_connection_from_session(config_data)
 

--- a/python/tank/util/authentication.py
+++ b/python/tank/util/authentication.py
@@ -18,7 +18,7 @@ import logging
 from tank_vendor.shotgun_api3 import Shotgun
 from tank_vendor.shotgun_api3.lib import httplib2
 from tank_vendor.shotgun_api3 import AuthenticationFault, ProtocolError
-from tank.errors import TankAuthenticationError
+from tank.errors import TankError, TankAuthenticationError
 from ConfigParser import SafeConfigParser
 from tank.util import shotgun
 
@@ -58,63 +58,15 @@ else:
 _shotgun_instance_factory = Shotgun
 
 
-def _get_login_info_location(base_url):
-    """
-    Returns the location of the session file on disk for a specific site.
-    :param base_url: The site we want the login information for.
-    :returns: Path to the login information.
-    """
-    from tank.util import path
-    return os.path.join(
-        path.get_local_site_cache_location(base_url),
-        "authentication",
-        "login.ini"
-    )
-
-
 def _is_session_token_cached():
     """
     Returns if there is a cached session token for the current user.
     :returns: True is there is, False otherwise.
     """
-    if get_login_info(get_authentication_credentials()["host"]):
+    if _is_human_user_authenticated(get_authentication_credentials()):
         return True
     else:
-
         return False
-
-
-def get_login_info(base_url):
-    """
-    Returns the cached login info if found.
-    :param base_url: The site we want the login information for.
-    :returns: Returns a dictionary with keys login and session_token or None
-    """
-    # Retrieve the location of the cached info
-    info_path = _get_login_info_location(base_url)
-    # Nothing was cached, return an empty dictionary.
-    if not os.path.exists(info_path):
-        logger.debug("No cache found at %s" % info_path)
-        return None
-    try:
-        # Read the login information
-        config = SafeConfigParser({"login": None, "session_token": None})
-        config.read(info_path)
-        if not config.has_section("LoginInfo"):
-            logger.debug("No Login info was found")
-            return None
-
-        login = config.get("LoginInfo", "login", raw=True)
-        session_token = config.get("LoginInfo", "session_token", raw=True)
-
-        if not login or not session_token:
-            logger.debug("Incomplete settings (login:%s, session_token:%s)" % (login, session_token))
-            return None
-
-        return {"login": login, "session_token": session_token}
-    except Exception:
-        logger.exception("Exception thrown while loading cached session info.")
-        return None
 
 
 def _validate_session_token(host, session_token, http_proxy):
@@ -139,54 +91,6 @@ def _validate_session_token(host, session_token, http_proxy):
         # Session was expired.
         logger.exception(e)
         return None
-
-
-def _cache_session_data(host, login, session_token):
-    """
-    Caches the session data for a site and a user.
-    :param host: Site we want to cache a session for.
-    :param login: User we want to cache a session for.
-    :param session_token: Session token we want to cache.
-    """
-    # Retrieve the cached info file location from the host
-    info_path = _get_login_info_location(host)
-
-    # make sure the info_dir exists!
-    info_dir, info_file = os.path.split(info_path)
-    if not os.path.exists(info_dir):
-        os.makedirs(info_dir, 0700)
-
-    logger.debug("Caching login info at %s...", info_path)
-    # Create a document with the following format:
-    # [LoginInfo]
-    # login=username
-    # session_token=some_unique_id
-    config = SafeConfigParser()
-    config.add_section("LoginInfo")
-    config.set("LoginInfo", "login", login)
-    config.set("LoginInfo", "session_token", session_token)
-    # Write it to disk.
-    with open(info_path, "w") as configfile:
-        config.write(configfile)
-    logger.debug("Cached!")
-
-
-def _delete_session_data():
-    """
-    Clears the session cache for the current site.
-    """
-    host = get_authentication_credentials()["host"]
-    logger.debug("Clearing session cached on disk.")
-    try:
-        info_path = _get_login_info_location(host)
-        if os.path.exists(info_path):
-            logger.debug("Session file found.")
-            os.remove(info_path)
-            logger.debug("Session cleared.")
-        else:
-            logger.debug("Session file not found: %s", info_path)
-    except:
-        logger.exception("Couldn't delete the site cache file")
 
 
 def generate_session_token(hostname, login, password, http_proxy):
@@ -260,7 +164,7 @@ def _create_or_renew_sg_connection_from_session(config_data):
     expired.
     :param config_data: A dictionary holding the "host" and "http_proxy"
     :returns: A valid Shotgun instance.
-    :raises TankAuthenticationError: If we couldn't get a valid session, a TankError is thrown.
+    :raises TankAuthenticationError: If we couldn't get a valid session, a TankAuthenticationError is thrown.
     """
     from ..platform import engine
 
@@ -306,7 +210,7 @@ def _create_sg_connection_from_session(authentication_credentials):
         return sg
     else:
         # Session token was invalid, so uncache it to make sure nobody else tries using it.
-        _delete_session_data()
+        AuthenticationManager.get_instance().clear_cached_credentials()
         logger.debug("Failed refreshing the token.")
         return None
 
@@ -340,29 +244,208 @@ def create_authenticated_sg_connection():
         return _create_or_renew_sg_connection_from_session(authentication_credentials)
 
 
-def logout():
+class AuthenticationManager(object):
     """
-    Logs out of the currently cached session.
-    :returns: True is logging out was successful, False is no session was cached.
+    Manages authentication information.
     """
-    if _is_session_token_cached():
-        # Forget the current hostname.
-        clear_cached_credentials()
-        return True
-    else:
-        return False
 
+    @classmethod
+    def get_instance(cls):
+        """
+        Returns the AuthenticationManager for this process. If no AuthenticationManager
+        has been activated, Toolkit's default AuthenticationManager will be activated.
+        :returns: A singleton instance of the AuthenticationManager class.
+        """
+        if not hasattr(AuthenticationManager, "_instance"):
+            AuthenticationManager.activate()
+        return AuthenticationManager._instance
 
-# FIXME: This is a hack for the desktop app so that once we have human user authenticated,
-# we always use human user authentication. Once we implement a CredentialsManager that can
-# be overloaded by an app, we will be able to get rid of the force_human_user_authentication
-# flag nonsense.
-_force_human_user_authentication = False
+    @classmethod
+    def activate(cls, *args, **kwargs):
+        """
+        Activates an authentication manager. Any unnamed and named arguments to this method
+        will be passed to the classes's initiliazation method.
+        :raises: TankError if a manager has already been activated.
+        """
+        if hasattr(AuthenticationManager, "_instance"):
+            raise TankError("AuthenticationManager can't be activated twice.")
+        setattr(AuthenticationManager, "_instance", cls(*args, **kwargs))
 
+    @staticmethod
+    def deactivate():
+        if not hasattr(AuthenticationManager, "_instance"):
+            raise TankError("No AuthenticationManager have been activated yet.")
+        delattr(AuthenticationManager, "_instance")
 
-def _is_force_human_user_authentication_enabled(force_human_user_authentication):
-    global _force_human_user_authentication
-    return _force_human_user_authentication or force_human_user_authentication
+    def __init__(self):
+        """
+        Constructor.
+        """
+        self._core_config_data = shotgun.get_associated_sg_config_data()
+        self._force_human_user_authentication = False
+
+    def get_host(self):
+        """
+        Returns the current host.
+        :returns: A string with the hostname.
+        """
+        return self._core_config_data["host"]
+
+    def get_http_proxy(self):
+        """
+        Returns the optional http_proxy.
+        :returns: A string with the hostname of the proxy. Can be None.
+        """
+        return self._core_config_data.get("http_proxy")
+
+    def get_credentials(self, force_human_user_authentication):
+        """
+        Retrieves the credentials for the current user.
+        :param force_human_user_authentication: Skips script user credentials if True.
+        :returns: A dictionary holding the credentials that were found. Can either contains keys:
+                  - api_script and api_key
+                  - login, session_token
+                  - an empty dictionary.
+                  The dictionary will be empty if no credentials were found.
+        """
+        force = self._force_human_user_authentication or force_human_user_authentication
+        if not force and _is_script_user_authenticated(self._core_config_data):
+            return self._slice_dict(self._core_config_data, "api_script", "api_key")
+        else:
+            login_info = self._get_login_info(self.get_host())
+            if login_info:
+                return self._slice_dict(login_info, "login", "session_token")
+            else:
+                return {}
+
+    def get_authentication_credentials(self, force_human_user_authentication):
+        """
+        Returns a dictionary with connection parameters and user credentials.
+        :param force_human_user_authentication: Skips script user credentials if True.
+        :returns: A dictionary with keys host, http_proxy and all the keys returned from get_credentials.
+        """
+        connection_info = {}
+        connection_info["host"] = self.get_host()
+        connection_info["http_proxy"] = self.get_http_proxy()
+        connection_info.update(self.get_credentials(force_human_user_authentication))
+        return connection_info
+
+    def clear_cached_credentials(self):
+        """
+        Clears any cached credentials.
+        """
+        self._delete_session_data()
+
+    def cache_authentication_credentials(self, host, login, session_token):
+        """
+        Caches authentication credentials.
+        :param host: Host to cache.
+        :param login: Login to cache.
+        :param session_token: Session token to cache.
+        """
+        self._force_human_user_authentication = True
+        # For now, only cache session data to disk.
+        self._cache_session_data(host, login, session_token)
+
+    def _slice_dict(self, dictionary, *keys):
+        """
+        Extracts all fields passed in from a dictionary.
+        :param dictionary: Dictionary we want to get a slice of.
+        :param keys: List of keys that need to be extracted.
+        :returns: A dictionary containing at most all the keys that were specified.
+        """
+        return {k: v for k, v in dictionary.iteritems() if k in keys}
+
+    def _delete_session_data(self):
+        """
+        Clears the session cache for the current site.
+        """
+        host = self.get_host()
+        logger.debug("Clearing session cached on disk.")
+        try:
+            info_path = self._get_login_info_location(host)
+            if os.path.exists(info_path):
+                logger.debug("Session file found.")
+                os.remove(info_path)
+                logger.debug("Session cleared.")
+            else:
+                logger.debug("Session file not found: %s", info_path)
+        except:
+            logger.exception("Couldn't delete the site cache file")
+
+    def _get_login_info(self, base_url):
+        """
+        Returns the cached login info if found.
+        :param base_url: The site we want the login information for.
+        :returns: Returns a dictionary with keys login and session_token or None
+        """
+        # Retrieve the location of the cached info
+        info_path = self._get_login_info_location(base_url)
+        # Nothing was cached, return an empty dictionary.
+        if not os.path.exists(info_path):
+            logger.debug("No cache found at %s" % info_path)
+            return None
+        try:
+            # Read the login information
+            config = SafeConfigParser({"login": None, "session_token": None})
+            config.read(info_path)
+            if not config.has_section("LoginInfo"):
+                logger.debug("No Login info was found")
+                return None
+
+            login = config.get("LoginInfo", "login", raw=True)
+            session_token = config.get("LoginInfo", "session_token", raw=True)
+
+            if not login or not session_token:
+                logger.debug("Incomplete settings (login:%s, session_token:%s)" % (login, session_token))
+                return None
+
+            return {"login": login, "session_token": session_token}
+        except Exception:
+            logger.exception("Exception thrown while loading cached session info.")
+            return None
+
+    def _get_login_info_location(self, base_url):
+        """
+        Returns the location of the session file on disk for a specific site.
+        :param base_url: The site we want the login information for.
+        :returns: Path to the login information.
+        """
+        from tank.util import path
+        return os.path.join(
+            path.get_local_site_cache_location(base_url),
+            "authentication",
+            "login.ini"
+        )
+
+    def _cache_session_data(self, host, login, session_token):
+        """
+        Caches the session data for a site and a user.
+        :param host: Site we want to cache a session for.
+        :param login: User we want to cache a session for.
+        :param session_token: Session token we want to cache.
+        """
+        # Retrieve the cached info file location from the host
+        info_path = self._get_login_info_location(host)
+
+        # make sure the info_dir exists!
+        info_dir, info_file = os.path.split(info_path)
+        if not os.path.exists(info_dir):
+            os.makedirs(info_dir, 0700)
+
+        logger.debug("Caching login info at %s...", info_path)
+        # Create a document with the following format:
+        # [LoginInfo]
+        # login=username
+        # session_token=some_unique_id
+        config = SafeConfigParser()
+        config.add_section("LoginInfo")
+        config.set("LoginInfo", "login", login)
+        config.set("LoginInfo", "session_token", session_token)
+        # Write it to disk.
+        with open(info_path, "w") as configfile:
+            config.write(configfile)
+        logger.debug("Cached!")
 
 
 def get_authentication_credentials(force_human_user_authentication=False):
@@ -373,26 +456,14 @@ def get_authentication_credentials(force_human_user_authentication=False):
               If the authentication is made using a human user, a dictionary with the following keys will
               be returned: host, login, session_token. In both cases, an optional http_proxy entry can be present.
     """
-    force = _is_force_human_user_authentication_enabled(force_human_user_authentication)
-    # Read the core's configuration data.
-    config_data = shotgun.get_associated_sg_config_data()
-
-    # If we are forcing human user authentication or we are not authenticated as a script user in the
-    # shotgun.yml file.
-    if force or not _is_script_user_authenticated(config_data):
-        # Retrieved the cached credentials from disk.
-        login_info = get_login_info(config_data["host"])
-        if login_info:
-            config_data["login"] = login_info["login"]
-            config_data["session_token"] = login_info["session_token"]
-    return config_data
+    return AuthenticationManager.get_instance().get_authentication_credentials(force_human_user_authentication)
 
 
 def clear_cached_credentials():
     """
     Clears cached credentials.
     """
-    _delete_session_data()
+    AuthenticationManager.get_instance().clear_cached_credentials()
 
 
 def cache_authentication_credentials(host, login, session_token):
@@ -402,7 +473,17 @@ def cache_authentication_credentials(host, login, session_token):
     :param login: Login to cache.
     :param session_token: Session token to cache.
     """
-    global _force_human_user_authentication
-    _force_human_user_authentication = True
-    # For now, only cache session data to disk.
-    _cache_session_data(host, login, session_token)
+    AuthenticationManager.get_instance().cache_authentication_credentials(host, login, session_token)
+
+
+def logout():
+    """
+    Logs out of the currently cached session.
+    :returns: True is logging out was successful, False is no session was cached.
+    """
+    if _is_session_token_cached():
+        # Forget the current hostname.
+        AuthenticationManager.get_instance().clear_cached_credentials()
+        return True
+    else:
+        return False

--- a/python/tank/util/authentication.py
+++ b/python/tank/util/authentication.py
@@ -222,8 +222,8 @@ def create_sg_connection_from_script_user(connection_information):
     """
     return _shotgun_instance_factory(
         connection_information["host"],
-        connection_information["api_script"],
-        connection_information["api_key"],
+        script_name=connection_information["api_script"],
+        api_key=connection_information["api_key"],
         http_proxy=connection_information.get("http_proxy", None)
     )
 
@@ -249,7 +249,6 @@ def logout():
     :returns: True is logging out was successful, False is no session was cached.
     """
     if _is_session_token_cached():
-        # Forget the current hostname.
         clear_cached_credentials()
         return True
     else:
@@ -258,7 +257,7 @@ def logout():
 
 # Shothands for AuthenticationManager.get_instance().xxx
 
-def get_connection_information(force_human_user_authentication=False):
+def get_connection_information():
     """
     Retrieves the authentication credentials.
     :returns: A dictionary with credentials to connect to a site. If the authentication is made using
@@ -266,7 +265,7 @@ def get_connection_information(force_human_user_authentication=False):
               If the authentication is made using a human user, a dictionary with the following keys will
               be returned: host, login, session_token. In both cases, an optional http_proxy entry can be present.
     """
-    return AuthenticationManager.get_instance().get_connection_information(force_human_user_authentication)
+    return AuthenticationManager.get_instance().get_connection_information()
 
 
 def clear_cached_credentials():

--- a/python/tank/util/authentication_manager.py
+++ b/python/tank/util/authentication_manager.py
@@ -244,7 +244,7 @@ class AuthenticationManager(object):
         if _is_script_user_authenticated(self._core_config_data):
             return {
                 "api_key": self._core_config_data.get("api_key"),
-                "api_script": self._core_config_data("api_script")
+                "api_script": self._core_config_data.get("api_script")
             }
         else:
             return {}

--- a/python/tank/util/authentication_manager.py
+++ b/python/tank/util/authentication_manager.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+from tank import errors
+from tank.util import shotgun
+from ConfigParser import SafeConfigParser
+
+# FIXME: Quick hack to easily disable logging in this module while keeping the
+# code compatible. We have to disable it by default because Maya will print all out
+# debug strings.
+if False:
+    import logging
+    # Configure logging
+    logger = logging.getLogger("sgtk.authentication_manager")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.StreamHandler())
+else:
+    class logger:
+        @staticmethod
+        def debug(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def info(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def warning(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def error(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def exception(*args, **kwargs):
+            pass
+
+
+class AuthenticationManager(object):
+    """
+    Manages authentication information.
+    """
+
+    @classmethod
+    def get_instance(cls):
+        """
+        Returns the AuthenticationManager for this process. If no AuthenticationManager
+        has been activated, Toolkit's default AuthenticationManager will be activated.
+        :returns: A singleton instance of the AuthenticationManager class.
+        """
+        if not hasattr(AuthenticationManager, "_instance"):
+            AuthenticationManager.activate()
+        return AuthenticationManager._instance
+
+    @classmethod
+    def activate(cls, *args, **kwargs):
+        """
+        Activates an authentication manager. Any unnamed and named arguments to this method
+        will be passed to the classes's initiliazation method.
+        :raises: TankError if a manager has already been activated.
+        """
+        if hasattr(AuthenticationManager, "_instance"):
+            raise errors.TankError(
+                "An AuthenticationManager has already been activated: %s" %
+                AuthenticationManager._instance.__class__.__name__
+            )
+        setattr(AuthenticationManager, "_instance", cls(*args, **kwargs))
+
+    @staticmethod
+    def deactivate():
+        """
+        Deactivates the current authentication manager.
+        :raises: TankError if a manager has not been activated.
+        """
+        if not hasattr(AuthenticationManager, "_instance"):
+            raise errors.TankError("No AuthenticationManager have been activated yet.")
+        delattr(AuthenticationManager, "_instance")
+
+    def __init__(self):
+        """
+        Constructor.
+        """
+        self._core_config_data = shotgun.get_associated_sg_config_data()
+
+        # FIXME: This is a workarond for the desktop app. Now that we have an authentication
+        # manager, we can go in the Desktop app and derive from the default authentication
+        # manager to provide extra functionality, notably disabling script user authentication
+        # which is as simple as overloading _get_script_user_credentials to return an
+        # empty dictionary in a new manager class and activating that manager.
+        self._force_human_user_authentication = False
+
+    def get_host(self):
+        """
+        Returns the current host.
+        :returns: A string with the hostname.
+        """
+        return self._core_config_data["host"]
+
+    def get_http_proxy(self):
+        """
+        Returns the optional http_proxy.
+        :returns: A string with the hostname of the proxy. Can be None.
+        """
+        return self._core_config_data.get("http_proxy")
+
+    def get_credentials(self, force_human_user_authentication):
+        """
+        Retrieves the credentials for the current user.
+        :param force_human_user_authentication: Skips script user credentials if True.
+        :returns: A dictionary holding the credentials that were found. Can either contains keys:
+                  - api_script and api_key
+                  - login, session_token
+                  - an empty dictionary.
+                  The dictionary will be empty if no credentials were found.
+        """
+        force = self._force_human_user_authentication or force_human_user_authentication
+        # Break circular dependency by importing locally.
+        if not force:
+            script_user_credentials = self._get_script_user_credentials()
+            if script_user_credentials:
+                return script_user_credentials
+
+        login_info = self._get_login_info(self.get_host())
+        if login_info:
+            return login_info
+        else:
+            return {}
+
+    def get_authentication_credentials(self, force_human_user_authentication):
+        """
+        Returns a dictionary with connection parameters and user credentials.
+        :param force_human_user_authentication: Skips script user credentials if True.
+        :returns: A dictionary with keys host, http_proxy and all the keys returned from get_credentials.
+        """
+        connection_info = {}
+        connection_info["host"] = self.get_host()
+        connection_info["http_proxy"] = self.get_http_proxy()
+        connection_info.update(self.get_credentials(force_human_user_authentication))
+        return connection_info
+
+    def clear_cached_credentials(self):
+        """
+        Clears any cached credentials.
+        """
+        self._delete_session_data()
+
+    def cache_authentication_credentials(self, host, login, session_token):
+        """
+        Caches authentication credentials.
+        :param host: Host to cache.
+        :param login: Login to cache.
+        :param session_token: Session token to cache.
+        """
+        self._force_human_user_authentication = True
+        # For now, only cache session data to disk.
+        self._cache_session_data(host, login, session_token)
+
+    def _slice_dict(self, dictionary, *keys):
+        """
+        Extracts all fields passed in from a dictionary.
+        :param dictionary: Dictionary we want to get a slice of.
+        :param keys: List of keys that need to be extracted.
+        :returns: A dictionary containing at most all the keys that were specified.
+        """
+        return {k: v for k, v in dictionary.iteritems() if k in keys}
+
+    def _delete_session_data(self):
+        """
+        Clears the session cache for the current site.
+        """
+        host = self.get_host()
+        logger.debug("Clearing session cached on disk.")
+        try:
+            info_path = self._get_login_info_location(host)
+            if os.path.exists(info_path):
+                logger.debug("Session file found.")
+                os.remove(info_path)
+                logger.debug("Session cleared.")
+            else:
+                logger.debug("Session file not found: %s", info_path)
+        except:
+            logger.exception("Couldn't delete the site cache file")
+
+    def _get_login_info(self, base_url):
+        """
+        Returns the cached login info if found.
+        :param base_url: The site we want the login information for.
+        :returns: Returns a dictionary with keys login and session_token or None
+        """
+        # Retrieve the location of the cached info
+        info_path = self._get_login_info_location(base_url)
+        # Nothing was cached, return an empty dictionary.
+        if not os.path.exists(info_path):
+            logger.debug("No cache found at %s" % info_path)
+            return None
+        try:
+            # Read the login information
+            config = SafeConfigParser({"login": None, "session_token": None})
+            config.read(info_path)
+            if not config.has_section("LoginInfo"):
+                logger.debug("No Login info was found")
+                return None
+
+            login = config.get("LoginInfo", "login", raw=True)
+            session_token = config.get("LoginInfo", "session_token", raw=True)
+
+            if not login or not session_token:
+                logger.debug("Incomplete settings (login:%s, session_token:%s)" % (login, session_token))
+                return None
+
+            return {"login": login, "session_token": session_token}
+        except Exception:
+            logger.exception("Exception thrown while loading cached session info.")
+            return None
+
+    def _get_login_info_location(self, base_url):
+        """
+        Returns the location of the session file on disk for a specific site.
+        :param base_url: The site we want the login information for.
+        :returns: Path to the login information.
+        """
+        from tank.util import path
+        return os.path.join(
+            path.get_local_site_cache_location(base_url),
+            "authentication",
+            "login.ini"
+        )
+
+    def _get_script_user_credentials(self):
+        """
+        Returns the script user credentials
+        """
+        from .authentication import _is_script_user_authenticated
+        if _is_script_user_authenticated(self._core_config_data):
+            return {
+                "api_key": self._core_config_data.get("api_key"),
+                "api_script": self._core_config_data("api_script")
+            }
+        else:
+            return {}
+
+    def _cache_session_data(self, host, login, session_token):
+        """
+        Caches the session data for a site and a user.
+        :param host: Site we want to cache a session for.
+        :param login: User we want to cache a session for.
+        :param session_token: Session token we want to cache.
+        """
+        # Retrieve the cached info file location from the host
+        info_path = self._get_login_info_location(host)
+
+        # make sure the info_dir exists!
+        info_dir, info_file = os.path.split(info_path)
+        if not os.path.exists(info_dir):
+            os.makedirs(info_dir, 0700)
+
+        logger.debug("Caching login info at %s...", info_path)
+        # Create a document with the following format:
+        # [LoginInfo]
+        # login=username
+        # session_token=some_unique_id
+        config = SafeConfigParser()
+        config.add_section("LoginInfo")
+        config.set("LoginInfo", "login", login)
+        config.set("LoginInfo", "session_token", session_token)
+        # Write it to disk.
+        with open(info_path, "w") as configfile:
+            config.write(configfile)
+        logger.debug("Cached!")

--- a/python/tank/util/authentication_manager.py
+++ b/python/tank/util/authentication_manager.py
@@ -136,7 +136,7 @@ class AuthenticationManager(object):
         else:
             return {}
 
-    def get_authentication_credentials(self, force_human_user_authentication):
+    def get_connection_information(self, force_human_user_authentication):
         """
         Returns a dictionary with connection parameters and user credentials.
         :param force_human_user_authentication: Skips script user credentials if True.
@@ -154,7 +154,7 @@ class AuthenticationManager(object):
         """
         self._delete_session_data()
 
-    def cache_authentication_credentials(self, host, login, session_token):
+    def cache_connection_information(self, host, login, session_token):
         """
         Caches authentication credentials.
         :param host: Host to cache.

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -195,11 +195,11 @@ def _parse_config_data(file_data, user, shotgun_cfg_path):
     return config_data
 
 
-def __create_sg_connection(shotgun_cfg_path, evaluate_script_user, user="default"):
+def __create_sg_connection(config_data, evaluate_script_user, user="default"):
     """
     Creates a standard toolkit shotgun connection.
 
-    :param shotgun_cfg_path: path to a configuration file to read settings from
+    :param shotgun_cfg_path: Configuration data
     :param evaluate_script_user: if True, the id of the script user will be 
                                  looked up and returned.
     :param user: If a multi-user config is used, this is the user to create the connection for.
@@ -207,9 +207,6 @@ def __create_sg_connection(shotgun_cfg_path, evaluate_script_user, user="default
     :returns: tuple with (sg_api_instance, script_user_dict) where script_user_dict is None if
               evaluate_script_user is False else a dictionary with type and id keys. 
     """
-    # get connection parameters
-    config_data = __get_sg_config_data(shotgun_cfg_path, user)
-
     from . import authentication
 
     sg = authentication.create_authenticated_sg_connection(config_data)
@@ -340,7 +337,8 @@ def create_sg_connection(user="default"):
     :param user: Optional shotgun config user to use when connecting to shotgun, as defined in shotgun.yml
     :returns: SG API instance
     """
-    api_handle, _ = __create_sg_connection(__get_sg_config(), evaluate_script_user=False, user=user)
+    config_data = __get_sg_config_data(__get_sg_config())
+    api_handle, _ = __create_sg_connection(config_data, evaluate_script_user=False, user=user)
     return api_handle
 
 def create_sg_app_store_connection():
@@ -356,7 +354,9 @@ def create_sg_app_store_connection():
     global g_app_store_connection
     
     if g_app_store_connection is None:
-        g_app_store_connection = __create_sg_connection(__get_app_store_config(), evaluate_script_user=True)
+        # get connection parameters
+        config_data = __get_sg_config_data(__get_app_store_config())
+        g_app_store_connection = __create_sg_connection(config_data, evaluate_script_user=True)
     
     return g_app_store_connection
 

--- a/tests/platform_tests/test_interactive_authentication.py
+++ b/tests/platform_tests/test_interactive_authentication.py
@@ -41,24 +41,24 @@ class LoginUiTests(TankTestBase):
     def _prepare_mocks(
         self,
         is_authenticated_mock,
-        get_authentication_credentials_mock,
-        cache_authentication_credentials_mock
+        get_connection_information_mock,
+        cache_connection_information_mock
     ):
         """
         Configures all the mocks for the two interactive unit tests.
         :param is_authenticated_mock: Mock for the tank.util.authentication.is_authenticated method.
-        :param get_authentication_credentials_mock: Mock for the tank.util.authentication.get_authentication_credentials_mock
-        :param cache_authentication_credentials_mock: Mock for the tank.util.authentication.cache_authentication_credentials_mock
+        :param get_connection_information_mock: Mock for the tank.util.authentication.get_connection_information_mock
+        :param cache_connection_information_mock: Mock for the tank.util.authentication.cache_connection_information_mock
         """
         is_authenticated_mock.return_value = False
-        get_authentication_credentials_mock.return_value = {
+        get_connection_information_mock.return_value = {
             "host": "https://enter_your_host_name_here.shotgunstudio.com",
             "login": "enter_your_username_here"
         }
-        cache_authentication_credentials_mock.return_value = None
+        cache_connection_information_mock.return_value = None
 
-    @patch("tank.util.authentication.cache_authentication_credentials")
-    @patch("tank.util.authentication.get_authentication_credentials")
+    @patch("tank.util.authentication.cache_connection_information")
+    @patch("tank.util.authentication.get_connection_information")
     @patch("tank.util.authentication.is_authenticated")
     @interactive
     def test_interactive_login(self, *args):

--- a/tests/platform_tests/test_interactive_authentication.py
+++ b/tests/platform_tests/test_interactive_authentication.py
@@ -41,29 +41,24 @@ class LoginUiTests(TankTestBase):
     def _prepare_mocks(
         self,
         is_authenticated_mock,
-        get_associated_sg_config_data_mock,
-        get_login_info_mock,
-        cache_session_data_mock
+        get_authentication_credentials_mock,
+        cache_authentication_credentials_mock
     ):
         """
         Configures all the mocks for the two interactive unit tests.
         :param is_authenticated_mock: Mock for the tank.util.authentication.is_authenticated method.
-        :param get_associated_sg_config_data_mock: Mock for the tank.util.shotgun.get_associated_sg_config_data
-        :param get_login_info_mock: Mock for the tank.util.authentication.get_login_info
-        :param cache_session_data_mock: Mock for the tank.util.authentication.cache_session_data
+        :param get_authentication_credentials_mock: Mock for the tank.util.authentication.get_authentication_credentials_mock
+        :param cache_authentication_credentials_mock: Mock for the tank.util.authentication.cache_authentication_credentials_mock
         """
         is_authenticated_mock.return_value = False
-        get_associated_sg_config_data_mock.return_value = {
-            "host": "https://enter_your_site_here.shotgunstudio.com"
-        }
-        get_login_info_mock.return_value = {
+        get_authentication_credentials_mock.return_value = {
+            "host": "https://enter_your_host_name_here.shotgunstudio.com",
             "login": "enter_your_username_here"
         }
-        cache_session_data_mock.return_value = None
+        cache_authentication_credentials_mock.return_value = None
 
-    @patch("tank.util.authentication.cache_session_data")
-    @patch("tank.util.authentication.get_login_info")
-    @patch("tank.util.shotgun.get_associated_sg_config_data")
+    @patch("tank.util.authentication.cache_authentication_credentials")
+    @patch("tank.util.authentication.get_authentication_credentials")
     @patch("tank.util.authentication.is_authenticated")
     @interactive
     def test_interactive_login(self, *args):

--- a/tests/util_tests/test_authentication.py
+++ b/tests/util_tests/test_authentication.py
@@ -57,8 +57,12 @@ class SessionTests(TankTestBase):
         When cache info is valid and _validate_session_token succeeds, it's return value
         is returned by create_sg_connection_from_authentication.
         """
+        # The return value of the _validate_session_token is also the return value of
+        # _create_sg_connection_from_session. Make sure we are getting it.
         validate_session_token_mock.return_value = "Success"
-        self.assertEqual(authentication._create_sg_connection_from_session({"host": "abc"}), "Success")
+        self.assertEqual(authentication._create_sg_connection_from_session(
+            {"host": "abc", "login": "login", "session_token": "session_token"}
+        ), "Success")
 
     @patch("tank_test.mockgun.Shotgun.find_one")
     def test_authentication_failure_in_validate_session_token(self, find_one_mock):
@@ -91,5 +95,7 @@ class SessionTests(TankTestBase):
         """
         validate_session_token_mock.return_value = None
         delete_session_data_mock.return_value = None
-        self.assertEqual(authentication._create_sg_connection_from_session({"host": "abc"}), None)
+        self.assertEqual(authentication._create_sg_connection_from_session(
+            {"host": "abc", "login": "login", "session_token": "session_token"}
+        ), None)
         self.assertEqual(delete_session_data_mock.call_count, 1)

--- a/tests/util_tests/test_authentication.py
+++ b/tests/util_tests/test_authentication.py
@@ -28,20 +28,20 @@ class SessionTests(TankTestBase):
     """
 
     @patch("tank.util.authentication._shotgun_instance_factory")
-    @patch("tank.util.authentication.AuthenticationManager.get_authentication_credentials")
+    @patch("tank.util.authentication.AuthenticationManager.get_connection_information")
     @patch("tank.util.shotgun.get_associated_sg_config_data")
     def run(
         self,
         arg0,
         get_associated_sg_config_data_mock,
-        get_authentication_credentials_mock,
+        get_connection_information_mock,
         shotgun_instance_factory_mock
     ):
         """
         Patches some api methods at a higher scope so we don't have to patch all tests individually.
         """
         # Mock the return value
-        get_authentication_credentials_mock.return_value = {
+        get_connection_information_mock.return_value = {
             "login": "tk-user",
             "session_token": "D3ADB33F",
             "host": "https://somewhere.shotguntudio.com"

--- a/tests/util_tests/test_authentication.py
+++ b/tests/util_tests/test_authentication.py
@@ -8,12 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from __future__ import with_statement
 from mock import patch
 
 from tank_test.tank_test_base import *
 from tank_test import mockgun
 
 from tank.util import authentication
+from tank.errors import TankError
 
 from tank_vendor.shotgun_api3 import shotgun
 
@@ -56,6 +58,11 @@ class SessionTests(TankTestBase):
         """
         self.assertEqual(authentication.AuthenticationManager.get_instance()._get_login_info("abc")["login"], "tk-user")
         self.assertEqual(authentication.AuthenticationManager.get_instance()._get_login_info("abc")["session_token"], "D3ADB33F")
+
+    def test_too_many_activations(self):
+        authentication.AuthenticationManager.activate()
+        with self.assertRaises(TankError):
+            authentication.AuthenticationManager.activate()
 
     @patch("tank.util.authentication._validate_session_token")
     def test_create_from_valid_session(self, validate_session_token_mock):

--- a/tests/util_tests/test_authentication_manager.py
+++ b/tests/util_tests/test_authentication_manager.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
+from mock import patch
+
+from tank_test.tank_test_base import *
+from tank_test import mockgun
+
+from tank.util.authentication import AuthenticationManager
+from tank.util import authentication
+from tank.errors import TankError
+
+from tank_vendor.shotgun_api3 import shotgun
+
+
+class SessionTests(TankTestBase):
+
+    def tearDown(self):
+        """
+        """
+        # Deactivate the authentication manager so other tests can use a new instance.
+        AuthenticationManager.deactivate()
+
+    def _prepare_common_mocks_with_script_user(self, get_associated_sg_config_data_mock):
+        """
+        Prepares common mocks to be used in a test involving script users.
+        """
+        # Makes sure the config file returns a script user.
+        get_associated_sg_config_data_mock.return_value = {
+            "api_key": "1234567890",
+            "api_script": "Toolkit",
+            "host": "https://somewhere.shotguntudio.com"
+        }
+
+    @patch("tank.util.shotgun.get_associated_sg_config_data")
+    @patch("tank.util.authentication.AuthenticationManager._get_login_info")
+    def test_script_user_overrides_human_user(self, get_login_info_mock, get_associated_sg_config_data_mock):
+        self._prepare_common_mocks_with_script_user(get_associated_sg_config_data_mock)
+        get_login_info_mock.side_effect = Exception("Should not try to get login information.")
+
+        cred = AuthenticationManager.get_instance().get_authentication_credentials(force_human_user_authentication=False)
+        self.assertTrue(authentication._is_script_user_authenticated(cred))
+        self.assertFalse(authentication._is_human_user_authenticated(cred))
+
+    @patch("tank.util.shotgun.get_associated_sg_config_data")
+    def test_too_many_activations(self, get_associated_sg_config_data_mock):
+        """
+        Makes sure activating an AuthenticationManager twice will throw.
+        """
+        self._prepare_common_mocks_with_script_user(get_associated_sg_config_data_mock)
+        authentication.AuthenticationManager.activate()
+        with self.assertRaises(TankError):
+            authentication.AuthenticationManager.activate()
+
+    @patch("tank.util.shotgun.get_associated_sg_config_data")
+    def test_activating_derived_class_instantiates_derived_class(self, get_associated_sg_config_data_mock):
+        """
+        Makes sure that ClassDerivedFromAuthenticationManager.activate() instantiates the right
+        class.
+        """
+        class Derived(AuthenticationManager):
+            def __init__(self, payload):
+                super(Derived, self).__init__()
+                self.payload = payload
+
+        # Activate our derived class.
+        Derived.activate("payload")
+        # Make sure the instance is the derived class.
+        self.assertIsInstance(AuthenticationManager.get_instance(), Derived)
+        # Make sure that the payload was
+        self.assertTrue(AuthenticationManager.get_instance().payload == "payload")
+
+
+

--- a/tests/util_tests/test_authentication_manager.py
+++ b/tests/util_tests/test_authentication_manager.py
@@ -46,7 +46,7 @@ class SessionTests(TankTestBase):
         self._prepare_common_mocks_with_script_user(get_associated_sg_config_data_mock)
         get_login_info_mock.side_effect = Exception("Should not try to get login information.")
 
-        cred = AuthenticationManager.get_instance().get_authentication_credentials(force_human_user_authentication=False)
+        cred = AuthenticationManager.get_instance().get_connection_information(force_human_user_authentication=False)
         self.assertTrue(authentication._is_script_user_authenticated(cred))
         self.assertFalse(authentication._is_human_user_authenticated(cred))
 
@@ -60,15 +60,14 @@ class SessionTests(TankTestBase):
         with self.assertRaises(TankError):
             authentication.AuthenticationManager.activate()
 
-    @patch("tank.util.shotgun.get_associated_sg_config_data")
-    def test_activating_derived_class_instantiates_derived_class(self, get_associated_sg_config_data_mock):
+    def test_activating_derived_class_instantiates_derived_class(self):
         """
         Makes sure that ClassDerivedFromAuthenticationManager.activate() instantiates the right
         class.
         """
         class Derived(AuthenticationManager):
             def __init__(self, payload):
-                super(Derived, self).__init__()
+                # Do not call the base class so we don't need to mock get_associated_sg_config_data.
                 self.payload = payload
 
         # Activate our derived class.
@@ -77,6 +76,3 @@ class SessionTests(TankTestBase):
         self.assertIsInstance(AuthenticationManager.get_instance(), Derived)
         # Make sure that the payload was
         self.assertTrue(AuthenticationManager.get_instance().payload == "payload")
-
-
-

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -444,12 +444,12 @@ class TestCreateSessionBasedConnection(TankTestBase):
     Tests the creation of a session based Shotgun connection.
     """
 
-    @patch("tank.util.authentication.get_authentication_credentials")
+    @patch("tank.util.authentication.get_connection_information")
     @patch("tank.util.authentication._create_or_renew_sg_connection_from_session")
     def test_no_script_user_uses_human_user(
         self,
         create_or_renew_sg_connection_from_session_mock,
-        get_authentication_credentials_mock
+        get_connection_information_mock
     ):
         """
         Makes sure having no user configured in shotgun.yml will invoke the
@@ -458,7 +458,7 @@ class TestCreateSessionBasedConnection(TankTestBase):
         config_data = {
             "host": "https://something.shotgunstudio.com"
         }
-        get_authentication_credentials_mock.return_value = config_data
+        get_connection_information_mock.return_value = config_data
         create_or_renew_sg_connection_from_session_mock.return_value = mockgun.Shotgun(
             config_data["host"]
         )

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -466,7 +466,7 @@ class TestCreateSessionBasedConnection(TankTestBase):
             config_data["host"]
         )
 
-        tank.util.authentication.create_authenticated_sg_connection(config_data)
+        tank.util.authentication.create_authenticated_sg_connection()
         self.assertEqual(create_or_renew_sg_connection_from_session_mock.call_count, 1)
 
     class MockEngine:

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -8,13 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from __future__ import with_statement
 import os
 import datetime
 
 from mock import patch
 
 import tank
-from tank import context
+from tank import context, errors
 from tank import TankAuthenticationError
 from tank_test.tank_test_base import *
 from tank_test import mockgun
@@ -362,6 +363,60 @@ class TestShotgunRegisterPublish(TankTestBase):
         self.assertEqual(expected_path, actual_path)
         self.assertEqual(expected_path_cache, actual_path_cache)
 
+
+@patch("tank.util.shotgun.__get_api_core_config_location")
+class TestGetSgConfigData(TankTestBase):
+
+    def _prepare_common_mocks(self, get_api_core_config_location_mock):
+        get_api_core_config_location_mock.return_value = "unknown_path_location"
+
+    def test_all_fields_present(self, get_api_core_config_location_mock):
+        self._prepare_common_mocks(get_api_core_config_location_mock)
+        tank.util.shotgun._parse_config_data(
+            {
+                "host": "host",
+                "api_key": "api_key",
+                "api_script": "api_script",
+                "http_proxy": "http_proxy"
+            },
+            "default",
+            "not_a_file.cfg"
+        )
+
+    def test_proxy_is_optional(self, get_api_core_config_location_mock):
+        self._prepare_common_mocks(get_api_core_config_location_mock)
+        tank.util.shotgun._parse_config_data(
+            {
+                "host": "host",
+                "api_key": "api_key",
+                "api_script": "api_script"
+            },
+            "default",
+            "not_a_file.cfg"
+        )
+
+    def test_incomplete_script_user_credentials(self, get_api_core_config_location_mock):
+        self._prepare_common_mocks(get_api_core_config_location_mock)
+
+        with self.assertRaises(errors.TankError):
+            tank.util.shotgun._parse_config_data(
+                {
+                    "host": "host",
+                    "api_script": "api_script"
+                },
+                "default",
+                "not_a_file.cfg"
+            )
+
+        with self.assertRaises(errors.TankError):
+            tank.util.shotgun._parse_config_data(
+                {
+                    "host": "host",
+                    "api_key": "api_key"
+                },
+                "default",
+                "not_a_file.cfg"
+            )
 
 
 class TestCalcPathCache(TankTestBase):


### PR DESCRIPTION
- added some exception handling code I shouldn't have removed inside tank/util/shotgun.py
- refactored create_sg_connection to make a clear distinction between legacy code paths and the new authentication code paths
- removed all code that we're related to create_sg_connection's functionality (like the app's store evaluate_script_user flag) or Psyop's user parameter out of __create_sg_connection
- refactored all credentials reading and writing into an AuthenticationManager class and moved that code to tank/util/authentication_manager.py
- fixed some terminology
- removed force_human_user_authentication flag
- added a few unit tests