### PR TITLE
#28332 Better error message around core version mismatch

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -66,14 +66,13 @@ class PipelineConfiguration(object):
             # and then try to do sgtk_from_path("/path/to/pipeline/config") and that config
             # is using a more recent version of the core. 
             
-            raise TankError("You are running Toolkit %s located in '%s'. "
-                            "The configuration you are trying to launch needs "
-                            "core version %s or higher. To fix this, start "
-                            "the configuration with the tank command (or Toolkit core API) "
-                            "located in '%s'." % (current_api_version, 
-                                                  current_api_path, 
-                                                  our_associated_api_version, 
-                                                  self.get_install_location()))            
+            raise TankError("You are running Toolkit %s located in '%s'. The configuration you are "
+                            "trying to use needs core version %s or higher. To fix this, "
+                            "use the tank command (or Toolkit core API) located at '%s' "
+                            "which is associated with this configuration." % (current_api_version, 
+                                                                              current_api_path, 
+                                                                              our_associated_api_version, 
+                                                                              self.get_install_location()))            
 
 
         self._roots = pipelineconfig_utils.get_roots_metadata(self._pc_root)

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -61,8 +61,8 @@ class PipelineConfiguration(object):
             
             # tell the user that their core is too old
             raise TankError("You are running Toolkit %s located in '%s'. "
-                            "The configuration you are trying to launch needs to "
-                            "be run with a core version %s or higher. To fix this, start "
+                            "The configuration you are trying to launch needs "
+                            "core version %s or higher. To fix this, start "
                             "the configuration with the tank command (or Toolkit core API) "
                             "located in '%s'." % (current_api_version, 
                                                   current_api_path, 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -59,7 +59,13 @@ class PipelineConfiguration(object):
             # currently running API is too old!
             current_api_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
             
-            # tell the user that their core is too old
+            # tell the user that their core is too old for this config
+            #
+            # this can happen if you are running a configuration but you are getting the core
+            # API from somewhere else. For example, if you have added a core to your pythonpath
+            # and then try to do sgtk_from_path("/path/to/pipeline/config") and that config
+            # is using a more recent version of the core. 
+            
             raise TankError("You are running Toolkit %s located in '%s'. "
                             "The configuration you are trying to launch needs "
                             "core version %s or higher. To fix this, start "

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -58,18 +58,16 @@ class PipelineConfiguration(object):
            util.is_version_older(current_api_version, our_associated_api_version):
             # currently running API is too old!
             current_api_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-            raise TankError("You are currently running Core API %s located in '%s'. "
-                            "The Pipeline Configuration you are trying to create ('%s') is "
-                            "associated with a more recent version of the API, "
-                            "%s, located here: '%s'. Initialization cannot proceed at this point, "
-                            "because the currently running Core API is too old. "
-                            "To fix this, please import "
-                            "the API located in '%s' and try again." % (current_api_version,
-                                                                        current_api_path,
-                                                                        self.get_path(),
-                                                                        our_associated_api_version,
-                                                                        self.get_install_location(),
-                                                                        self.get_core_python_location()))
+            
+            # tell the user that their core is too old
+            raise TankError("You are running Toolkit %s located in '%s'. "
+                            "The configuration you are trying to launch needs to "
+                            "be run with a core version %s or higher. To fix this, start "
+                            "the configuration with the tank command (or Toolkit core API) "
+                            "located in '%s'." % (current_api_version, 
+                                                  current_api_path, 
+                                                  our_associated_api_version, 
+                                                  self.get_install_location()))            
 
 
         self._roots = pipelineconfig_utils.get_roots_metadata(self._pc_root)

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -89,9 +89,9 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
         if config_context_path not in local_pc_paths:
             # the tank command / api proxy which this session was launched for is *not*
             # associated with the given entity type and entity id!
-            raise TankError("The Toolkit configuration in '%s' is not associated with "
-                            "%s %s. To see which Toolkit configurations are available for a "
-                            "Project, go to the Pipeline Configurations page "
+            raise TankError("The pipeline configuration in '%s' is is associated with a different "
+                            "project from %s %s. To see which pipeline configurations are available " 
+                            "for a project, open the pipeline configurations page "
                             "in Shotgun." % (config_context_path, entity_type, entity_id))                        
             
         # ok we got a pipeline config matching the tank command from which we launched.

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -114,9 +114,9 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
             # for an entity lookup, there should be no ambiguity - an entity belongs to a project
             # and a project has got a distinct set of pipeline configs, exactly one of which
             # is the primary.
-            raise TankError("It looks like there are several Primary pipeline configurations "
-                            "associated with the entity %s %s: %s - Please contact support "
-                            "on toolkitsupport@shotgunsoftware.com." % (entity_type, entity_id, primary_pc_paths))
+            raise TankError("More than one primary pipeline configuration is associated "
+                            "with the entity %s %s: %s - Please contact support at "
+                            "toolkitsupport@shotgunsoftware.com." % (entity_type, entity_id, primary_pc_paths))            
 
         # looks good, we got a primary pipeline config that exists
         return PipelineConfiguration(primary_pc_paths[0])
@@ -211,16 +211,17 @@ def _from_path(path, force_reread_shotgun_cache):
         # now if this tank command is associated with the path, the registered path should be in 
         # in the list of paths found in the tank data backlink file
         if config_context_path not in local_pc_paths:
-            raise TankError("You are trying to start Toolkit using the configuration and tank command "
+            raise TankError("You are trying to start Toolkit using the pipeline configuration "
                             "located in '%s'. The path '%s' you are trying to load is not "
                             "associated with that configuration. Instead, it is "
-                            "associated with the following configurations: %s. "
+                            "associated with the following pipeline configurations: %s. "
                             "Please use the tank command or Toolkit API in any of those "
                             "locations in order to continue. This error can occur if you "
-                            "have moved a configuration on disk without correctly updating "
-                            "it in Shotgun. It can also occur if you are trying to use a tank command "
-                            "associated with Project A to try to operate on a Shot or Asset that "
-                            "that belongs to a project B." % (config_context_path, path, local_pc_paths))
+                            "have moved a configuration manually rather than using "
+                            "the 'tank move_configuration command'. It can also occur if you " 
+                            "are trying to use a tank command associated with Project A "
+                            "to try to operate on a Shot or Asset that belongs to a "
+                            "project B." % (config_context_path, path, local_pc_paths))
 
         # okay so this PC is valid!
         return PipelineConfiguration(config_context_path)
@@ -229,8 +230,8 @@ def _from_path(path, force_reread_shotgun_cache):
         # we are running a studio level tank command.
         # find the primary pipeline configuration in the list of matching configurations.        
         if len(primary_pc_paths) == 0:
-            raise TankError("Cannot find a Primary Pipeline Configuration for path '%s'. "
-                            "The following Pipeline configuration are associated with the "
+            raise TankError("Cannot find a primary pipeline configuration for path '%s'. "
+                            "The following pipeline configurations are associated with the "
                             "path, but none of them is marked as Primary: %s" % (path, local_pc_paths))
 
         if len(primary_pc_paths) > 1:

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -90,7 +90,7 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
             # the tank command / api proxy which this session was launched for is *not*
             # associated with the given entity type and entity id!
             raise TankError("The Toolkit configuration in '%s' is not associated with "
-                            "% %s. To see which Toolkit configurations are available for a "
+                            "%s %s. To see which Toolkit configurations are available for a "
                             "Project, go to the Pipeline Configurations page "
                             "in Shotgun." % (config_context_path, entity_type, entity_id))                        
             
@@ -115,8 +115,8 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
             # and a project has got a distinct set of pipeline configs, exactly one of which
             # is the primary.
             raise TankError("It looks like there are several Primary pipeline configurations "
-                            "associated with the entity %s %s: %s - "
-                            "Please contact Toolkit support." % (entity_type, entity_id, primary_pc_paths))
+                            "associated with the entity %s %s: %s - Please contact support "
+                            "on toolkitsupport@shotgunsoftware.com." % (entity_type, entity_id, primary_pc_paths))
 
         # looks good, we got a primary pipeline config that exists
         return PipelineConfiguration(primary_pc_paths[0])

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -74,9 +74,8 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
     associated_sg_pipeline_configs = _get_pipeline_configs_for_project(project_id, data)
     
     if len(associated_sg_pipeline_configs) == 0:
-        raise TankError("Cannot resolve a pipeline configuration object from %s %s - looks "
-                        "like its associated Shotgun Project has not been set up with "
-                        "the Shotgun Pipeline Toolkit!" % (entity_type, entity_id))
+        raise TankError("Cannot resolve a pipeline configuration for %s %s - Toolkit is not "
+                        "enabled for that Shotgun project." % (entity_type, entity_id)) 
 
     # extract path data from the pipeline configuration shotgun data
     (local_pc_paths, primary_pc_paths) = _get_pipeline_configuration_paths(associated_sg_pipeline_configs)
@@ -89,12 +88,11 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
         
         if config_context_path not in local_pc_paths:
             # the tank command / api proxy which this session was launched for is *not*
-            # associated with the given entity type and entity id!            
-            raise TankError("Error launching %s %s from the configuration located in '%s'. "
-                            "This config is not associated with that project. For a list of "
-                            "which configurations can be used with this project, go to the "
-                            "Pipeline Configurations page in Shotgun "
-                            "for the project." % (entity_type, entity_id, config_context_path))
+            # associated with the given entity type and entity id!
+            raise TankError("The Toolkit configuration in '%s' is not associated with "
+                            "% %s. To see which Toolkit configurations are available for a "
+                            "Project, go to the Pipeline Configurations page "
+                            "in Shotgun." % (config_context_path, entity_type, entity_id))                        
             
         # ok we got a pipeline config matching the tank command from which we launched.
         # because we found the PC in the list of PCs for this project, we know that it must be valid!
@@ -116,11 +114,9 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
             # for an entity lookup, there should be no ambiguity - an entity belongs to a project
             # and a project has got a distinct set of pipeline configs, exactly one of which
             # is the primary.
-            raise TankError("More than one primary pipeline configuration detected! Please contact "
-                            "toolkit support for help. It looks like you have several primary "
-                            "pipeline configurations associated with the entity %s %s: %s" % (entity_type, 
-                                                                                              entity_id, 
-                                                                                              primary_pc_paths))
+            raise TankError("It looks like there are several Primary pipeline configurations "
+                            "associated with the entity %s %s: %s - "
+                            "Please contact Toolkit support." % (entity_type, entity_id, primary_pc_paths))
 
         # looks good, we got a primary pipeline config that exists
         return PipelineConfiguration(primary_pc_paths[0])
@@ -217,12 +213,12 @@ def _from_path(path, force_reread_shotgun_cache):
         if config_context_path not in local_pc_paths:
             raise TankError("You are trying to start Toolkit using the configuration and tank command "
                             "located in '%s'. The path '%s' you are trying to load is not "
-                            "associated with that configuration. The path you are trying to load "
-                            "is associated with the following configurations: %s. "
+                            "associated with that configuration. Instead, it is "
+                            "associated with the following configurations: %s. "
                             "Please use the tank command or Toolkit API in any of those "
                             "locations in order to continue. This error can occur if you "
-                            "have moved a Configuration on disk without correctly updating "
-                            "it. It can also occur if you are trying to use a tank command "
+                            "have moved a configuration on disk without correctly updating "
+                            "it in Shotgun. It can also occur if you are trying to use a tank command "
                             "associated with Project A to try to operate on a Shot or Asset that "
                             "that belongs to a project B." % (config_context_path, path, local_pc_paths))
 


### PR DESCRIPTION
If you are trying to run a pipeline configuration which is associated with a core v0.15.43 but you are using an earlier core version, the error message previously would say:

```
You are currently running Core API v0.15.6 located in
'/sgtk/software/shotgun/studio/install/core/python'. The Pipeline
Configuration you are trying to create ('/sgtk/software/shotgun/site') is
associated with a more recent version of the API, v0.15.10, located here:
'/sgtk/software/shotgun/site'. Initialization cannot proceed at this point,
because the currently running Core API is too old. To fix this, please import
the API located in '/sgtk/software/shotgun/site/install/core/python' and try
again.
```

This is now simplified down to

```
You are running Toolkit v0.15.6 located in '/sgtk/software/shotgun/studio/install/core/python'. 
The configuration you are trying to launch needs core version v0.15.10 or higher. 
To fix this, start the configuration with the tank command (or Toolkit core API) 
located in '/sgtk/software/shotgun/site'.
```
