### PR TITLE
Enable alias use for the interpreter

### DIFF
--- a/scripts/tank_cmd.sh
+++ b/scripts/tank_cmd.sh
@@ -58,7 +58,7 @@ then
 fi
 
 # and check that it exists...
-if [ ! -f "$interpreter" ];
+if [ ! -f "$interpreter" ] && [[ ! `type $interpreter` ]];
 then
     echo "Cannot find interpreter $interpreter defined in config file $interpreter_config_file!"
     exit 1

--- a/scripts/tank_cmd_login.sh
+++ b/scripts/tank_cmd_login.sh
@@ -65,7 +65,7 @@ then
 fi
 
 # and check that it exists...
-if [ ! -f "$interpreter" ];
+if [ ! -f "$interpreter" ] && [[ ! `type $interpreter` ]];
 then
     echo "Cannot find interpreter $interpreter defined in config file $interpreter_config_file!"
     exit 1


### PR DESCRIPTION
To be able to have, for example, a "python" alias that can depend on the current environment.
Otherwise only real paths are accepted.
