### PR TITLE
#28033 Toolkit script credentials not copied by the project wizard

### DIFF
--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -8,14 +8,18 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-
+# make sure that py25 has access to with statement
+from __future__ import with_statement
 
 
 import os
 import sys
 import stat
+import copy
 import shutil
 import datetime
+
+from tank_vendor import yaml
 
 from ...errors import TankError
 from .. import util
@@ -56,7 +60,7 @@ class CoreLocalizeAction(Action):
         """
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
-        return do_localize(log, pc_root, suppress_prompts=True)
+        return do_localize(log, pc_root, suppress_prompts=True, strip_toolkit_credentials=False)
     
     def run_interactive(self, log, args):
         """
@@ -67,16 +71,19 @@ class CoreLocalizeAction(Action):
 
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
-        return do_localize(log, pc_root, suppress_prompts=False)
+        return do_localize(log, pc_root, suppress_prompts=False, strip_toolkit_credentials=False)
     
     
-def do_localize(log, pc_root_path, suppress_prompts):
+def do_localize(log, pc_root_path, suppress_prompts, strip_toolkit_credentials):
     """
     Perform the actual localize command.
     
     :param log: logging object
     :param pc_root_path: Path to the config that should be localized.
     :param suppress_prompts: Boolean to indicate if no questions should be asked.
+    :param strip_toolkit_credentials: Boolean to indicate if shotgun script credentials should 
+                                      be removed as the shotgun.yml is being carried across into the localized
+                                      configuration.
     """ 
 
     pc = pipelineconfig_factory.from_path(pc_root_path)
@@ -187,6 +194,41 @@ def do_localize(log, pc_root_path, suppress_prompts):
     finally:
         os.umask(old_umask)
             
+    if strip_toolkit_credentials:
+        # open the target shotgun.yml file and remove script crendetials
+        shotgun_cfg_path = os.path.join(pc_root_path, "config", "core", "shotgun.yml")
+        
+        if os.path.exists(shotgun_cfg_path):
+            
+            try:
+                with open(shotgun_cfg_path) as fh:                
+                    shotgun_yml_data = yaml.load(fh)
+                original_shotgun_yml_data = copy.deepcopy(shotgun_yml_data)
+            
+                # this is the anticipated structure:
+                #
+                # host: https://mannedev.shotgunstudio.com
+                # api_script: Toolkit
+                # api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                # http_proxy: null
+                
+                # look for keys api_script and api_key and
+                # if they are set, clear them
+                if "api_script" in shotgun_yml_data:
+                    shotgun_yml_data["api_script"] = None
+                if "api_key" in shotgun_yml_data:
+                    shotgun_yml_data["api_key"] = None
+                
+                # if the data has changed, write it back
+                if shotgun_yml_data != original_shotgun_yml_data:
+                    log.info("Removing script credentials from shotgun.yml as it is being localized...")
+                    with open(shotgun_cfg_path, "wt") as fh:
+                        yaml.dump(shotgun_yml_data, fh)
+
+            except Exception, e:
+                # don't break execution, just issue a warning
+                log.warning("Could not strip credentials from shotgun.yml file '%s': %s" % (shotgun_cfg_path, e))
+                
     log.info("The Core API was successfully localized.")
 
     log.info("")

--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -198,6 +198,8 @@ def do_localize(log, pc_root_path, suppress_prompts, strip_toolkit_credentials):
         # open the target shotgun.yml file and remove script crendetials
         shotgun_cfg_path = os.path.join(pc_root_path, "config", "core", "shotgun.yml")
         
+        # if no shotgun.yml file is found, there are no crendetials to strip, so
+        # simply continue.
         if os.path.exists(shotgun_cfg_path):
             
             try:

--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -120,7 +120,6 @@ class SetupProjectAction(Action):
         """
         API accessor
         """
-        
         # validate params and seed default values
         computed_params = self._validate_parameters(parameters)
         
@@ -162,7 +161,10 @@ class SetupProjectAction(Action):
         # api is the same as the root path for the associated pc
         if pipelineconfig_utils.is_localized(curr_core_path):
             log.info("Localizing Core...")
-            core_localize.do_localize(log, params.get_configuration_location(sys.platform), suppress_prompts=True)
+            core_localize.do_localize(log, 
+                                      params.get_configuration_location(sys.platform), 
+                                      suppress_prompts=True,
+                                      strip_toolkit_credentials=False)
                         
                         
                         
@@ -238,7 +240,10 @@ class SetupProjectAction(Action):
         # api is the same as the root path for the associated pc
         if pipelineconfig_utils.is_localized(curr_core_path):
             log.info("Localizing Core...")
-            core_localize.do_localize(log, params.get_configuration_location(sys.platform), suppress_prompts=True)        
+            core_localize.do_localize(log, 
+                                      params.get_configuration_location(sys.platform), 
+                                      suppress_prompts=True,
+                                      strip_toolkit_credentials=False)        
         
         # display readme etc.
         readme_content = params.get_configuration_readme()

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -602,5 +602,6 @@ class SetupProjectWizard(object):
         if core_settings["localize"]:
             core_localize.do_localize(self._log, 
                                       self._params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True)
+                                      suppress_prompts=True,
+                                      strip_toolkit_credentials=True)
         

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -599,6 +599,13 @@ class SetupProjectWizard(object):
         run_project_setup(self._log, self._sg, self._sg_app_store, self._sg_app_store_script_user, self._params)
         
         # check if we should run the localization afterwards
+        # note - when running via the wizard, toolkit script credentials are stripped
+        # out as the core is copied across as part of a localization.
+        #
+        # this is primarily targeting the Shotgun desktop, meaning that even if the 
+        # shotgun desktop's site configuration contains script credentials, these are
+        # not propagated into newly created toolkit projects.
+        #
         if core_settings["localize"]:
             core_localize.do_localize(self._log, 
                                       self._params.get_configuration_location(sys.platform), 


### PR DESCRIPTION
This changes the behaviour of the project setup wizard so that when new projects are created using the wizard, script credentials are not copied across as part of the localization.

This change primarily target the shotgun desktop install wizard. Normally, the setup runs from a hidden site config located in something like `~/Library/Application Support/Shotgun/mysite.shotgunstudio.com/site`. In the case the `shotgun.yml` file in this location contains script credentials, these will not be copied across to a new project as part of the setup.