### PR TITLE
28647 Performance improvements & other changes for Workfiles v2

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -520,24 +520,20 @@ class Tank(object):
         """
         return context.from_entity(self, entity_type, entity_id)
 
-    def context_from_entities(self, project=None, entity=None, step=None, task=None, user=None):
+    def context_from_entity_dictionary(self, entity_dictionary):
         """
-        Derive a context from a set of known Shotgun entities.
-        
-        Note: It is the responsibility of the calling code to ensure that both the entities and the
-        relationships between them are valid.  
-        
-        This only results in a Shotgun query if context_additional_entities are specified in the
-        configuration!        
-        
-        :param project: The project entity dictionary to use when constructing the context
-        :param entity:  The entity entity dictionary to use when constructing the context
-        :param step:    The step entity dictionary to use when constructing the context
-        :param task:    The task entity dictionary to use when constructing the context
-        :param user:    The user entity dictionary to use when constructing the context
-        :returns:       A Context constructed from the specified entities.        
+        Derives a context from a shotgun entity dictionary.  This will try to use any 
+        linked information available in the dictionary where possible but if it can't 
+        determine a valid context then it will fall back to 'context_from_entity' which 
+        may result in a Shotgun path cache query and be considerably slower.
+
+        :param entity_dictionary:   A Shotgun entity dictionary containing at least 'type'
+                                    and 'id'
+        :type  entity_dictionary:   dict.
+
+        :returns: Context object.
         """
-        return context.from_entities(self, project, entity, step, task, user)
+        return context.from_entity_dictionary(self, entity_dictionary)
 
     def synchronize_filesystem_structure(self, full_sync=False):
         """

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -520,6 +520,25 @@ class Tank(object):
         """
         return context.from_entity(self, entity_type, entity_id)
 
+    def context_from_entities(self, project=None, entity=None, step=None, task=None, user=None):
+        """
+        Derive a context from a set of known Shotgun entities.
+        
+        Note: It is the responsibility of the calling code to ensure that both the entities and the
+        relationships between them are valid.  
+        
+        This only results in a Shotgun query if context_additional_entities are specified in the
+        configuration!        
+        
+        :param project: The project entity dictionary to use when constructing the context
+        :param entity:  The entity entity dictionary to use when constructing the context
+        :param step:    The step entity dictionary to use when constructing the context
+        :param task:    The task entity dictionary to use when constructing the context
+        :param user:    The user entity dictionary to use when constructing the context
+        :returns:       A Context constructed from the specified entities.        
+        """
+        return context.from_entities(self, project, entity, step, task, user)
+
     def synchronize_filesystem_structure(self, full_sync=False):
         """
         Ensures that the filesystem structure on this machine is in sync

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -527,6 +527,40 @@ class Tank(object):
         determine a valid context then it will fall back to 'context_from_entity' which 
         may result in a Shotgun path cache query and be considerably slower.
 
+        The following values for 'entity_dictionary' will result in a context being
+        created without falling back to a potential Shotgun query - each entity in the
+        dictionary (including linked entities) must have the fields: 'type', 'id' and 
+        'name' (or the name equivelent for specific entity types, e.g. 'content' for 
+        Step entities, 'code' for Shot entities, etc.):
+
+            - {"type":"Project", "id":123, "name":"My Project"}
+
+            - {"type":"Shot", "id":456, "code":"Shot 001", 
+                "project":{"type":"Project", "id":123, "name":"My Project"}
+                }
+
+            - {"type":"Task", "id":789, "name":"Animation",
+                "project":{"type":"Project", "id":123, "name":"My Project"}} 
+                "entity":{"type":"Shot", "id":456, "name":"Shot 001"}
+                "step":{"type":"Step", "id":101112, "name":"Anm"}
+                }
+
+        The following values for 'entity_dictionary' don't contain enough information to
+        fully form a context so the code will fall back to 'context_from_entity()' which 
+        may then result in a Shotgun query to retrieve the missing information:
+
+            - # missing project name
+              {"type":"Project", "id":123}
+
+            - # missing linked project
+              {"type":"Shot", "id":456, "code":"Shot 001"}
+
+            - # missing linked project name and linked step
+              {"type":"Task", "id":789, "name":"Animation",
+                "project":{"type":"Project", "id":123}} 
+                "entity":{"type":"Shot", "id":456, "name":"Shot 001"}
+                }
+
         :param entity_dictionary:   A Shotgun entity dictionary containing at least 'type'
                                     and 'id'
         :type  entity_dictionary:   dict.

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -668,83 +668,6 @@ def create_empty(tk):
     """
     return Context(tk)
 
-def from_entities(tk, project, entity, step, task, user):
-    """
-    Construct a new context from the specified entities.
-
-    Note: It is the responsibility of the calling code to ensure that both the entities and the
-    relationships between them are valid.  
-    
-    This only does a Shotgun query if the context_additional_entities hook specifies additional
-    fields on a task to look for additional entities on!
-
-    :param tk:      An sgtk API instance
-    :param project: The project entity dictionary to use when constructing the context
-    :param entity:  The entity entity dictionary to use when constructing the context
-    :param step:    The step entity dictionary to use when constructing the context
-    :param task:    The task entity dictionary to use when constructing the context
-    :param user:    The user entity dictionary to use when constructing the context
-    :returns:       A Context constructed from the specified entities.
-    """
-    # prep our return data structure
-    context = {
-        "tk": tk,
-        "project": None,
-        "entity": None,
-        "step": None,
-        "user": None,
-        "task": None,
-        "additional_entities": []
-    }    
-
-    if project and "type" in project and "id" in project:
-        context["project"] = {
-            "type":project["type"], 
-            "id":project["id"], 
-            "name":project.get("name")
-        }
-
-    if entity and "type" in entity and "id" in entity and entity["type"] != "Project":
-        name_field = {"HumanUser":"name", "Task":"content"}.get(entity["type"], "code")
-        context["entity"] = {
-            "type":entity["type"], 
-            "id":entity["id"], 
-            # name can either be the name field or 'name' if the entity dict has come from another context
-            "name":(entity.get(name_field) or project.get("name"))
-        }
-
-    if step and "type" in step and "id" in step:
-        context["step"] = {
-            "type":step["type"], 
-            "id":step["id"],
-            # name can either be 'code' or 'name' if the entity dict has come from another context
-            "name":(step.get("code") or step.get("name"))
-        }
-        
-    if user and "type" in user and "id" in user:
-        context["user"] = {
-            "type":user["type"], 
-            "id":user["id"], 
-            "name":user.get("name")
-        }
-
-    if task and "type" in task and "id" in task:
-        # first check to see if there are any additional entities specified:
-        additional_fields = tk.execute_core_hook("context_additional_entities").get("entity_fields_on_task", [])
-        if additional_fields:
-            # unfortunately we have to fall back to an sg query to get the additional entities :(
-            task_context = _task_from_sg(tk, task["id"], additional_fields)
-            context["additional_entities"] = task_context.get("additional_entities", [])
-            
-        context["task"] = {
-            "type":task["type"], 
-            "id":task["id"],
-            # name can either be 'content' or 'name' if the entity dict has come from another context
-            "name":(task.get("content") or task.get("name"))
-        }
-            
-    return Context(**context)
-
 def from_entity(tk, entity_type, entity_id):
     """
     Constructs a context from a shotgun entity.
@@ -818,6 +741,129 @@ def from_entity(tk, entity_type, entity_id):
             # no need to set entity to point at project in this case
             # that only produces double entries.
             context["entity"] = None
+
+    return Context(**context)
+
+def from_entity_dictionary(tk, entity_dictionary):
+    """
+    Constructs a context from a shotgun entity dictionary.  This method will
+    try to use any linked information available in the dictionary where possible
+    but if it can't determine a valid context then it will fall back to
+    'from_entity' which may result in a Shotgun path cache query and be considerably
+    slower.
+
+    :param tk:                  Sgtk API handle
+    :param entity_dictionary:   The entity dictionary to create the context from 
+                                containing at least: {"type":entity_type, "id":entity_id}
+    :returns:                   A Context object
+    """
+    # perform validation of the entity dictionary:
+    if not isinstance(entity_dictionary, dict):
+        raise TankError("Cannot create a context from an empty or invalid entity dictionary!")
+    if "type" not in entity_dictionary:
+        raise TankError("Cannot create a context without an entity type!")
+    if "id" not in entity_dictionary:
+        raise TankError("Cannot create a context without an entity id!")
+    
+    # prep our context data structure
+    context = {
+        "tk": tk,
+        "project": None,
+        "entity": None,
+        "step": None,
+        "user": None,
+        "task": None,
+        "additional_entities": []
+    }
+
+    entity_type = entity_dictionary["type"]
+    entity_id = entity_dictionary["id"]
+
+    # try to determine the various entities from the entity dictionary:
+    project = None
+    entity = None
+    step = None
+    task = None
+    fallback_to_ctx_from_entity = False
+    if entity_type == "Project":
+        # find entities for a project context
+        project = entity_dictionary
+    elif entity_type == "Task":
+        # find entities for a task context
+        task = entity_dictionary
+        if "project" not in task or "entity" not in task or "step" not in task:
+            fallback_to_ctx_from_entity = True
+        else:
+            project = task["project"]
+            entity = task["entity"]
+            step = task["step"]
+    elif entity_type in ["PublishedFile", "TankPublishedFile"]:
+        # special case handling for published files:
+        if entity_dictionary.get("task"):
+            # construct a task context
+            return from_entity_dictionary(tk, entity_dictionary["task"])
+        elif entity_dictionary.get("entity"):
+            # construct an entity context
+            return from_entity_dictionary(tk, entity_dictionary["entity"])
+        elif entity_dictionary.get("project"):
+            # construct project context
+            return from_entity_dictionary(tk, entity_dictionary["project"])
+        else:
+            # fall back on from_entity:
+            fallback_to_ctx_from_entity = True
+    else:
+        # find entities for an entity context
+        entity = entity_dictionary
+        if "project" not in entity:
+            fallback_to_ctx_from_entity = True
+        else:
+            project = entity["project"]
+
+    if not fallback_to_ctx_from_entity:
+        # clean up entities and populate context structure:
+        def _build_clean_entity(ent):
+            """
+            Ensure entity has id, type and name fields:
+            """
+            if "id" not in ent or "type" not in ent:
+                return None
+            ent_name = _get_entity_name(ent)
+            if ent_name == None:
+                return None
+            return {"type":ent["type"], "id":ent["id"], "name":ent_name}
+        
+        if project:
+            context["project"] = _build_clean_entity(project)
+            if not context["project"]:
+                fallback_to_ctx_from_entity = True
+                
+        if not fallback_to_ctx_from_entity and entity:
+            context["entity"] = _build_clean_entity(entity)
+            if not context["entity"]:
+                fallback_to_ctx_from_entity = True
+        
+        if not fallback_to_ctx_from_entity and step:
+            context["step"] = _build_clean_entity(step)
+            if not context["step"]:
+                fallback_to_ctx_from_entity = True
+
+        if not fallback_to_ctx_from_entity and task:
+            context["task"] = _build_clean_entity(task)
+            if not context["task"]:
+                fallback_to_ctx_from_entity = True
+
+    if fallback_to_ctx_from_entity:
+        # entity dict doesn't contain enough information to build a 
+        # safe, valid context so fall back on 'from_entity':
+        return from_entity(tk, entity_type, entity_id)
+
+    if task:
+        # one final check if we have a task:
+        additional_fields = tk.execute_core_hook("context_additional_entities").get("entity_fields_on_task", [])
+        if additional_fields:
+            # unfortunately we have to fall back to an sg query to get the additional entities :(
+            task_context = _task_from_sg(tk, task["id"], additional_fields)
+            context.update(task_context)
 
     return Context(**context)
 
@@ -1061,6 +1107,35 @@ yaml.add_constructor(u'!TankContext', context_yaml_constructor)
 ################################################################################################
 # utility methods
 
+def _get_entity_type_sg_name_field(entity_type):
+    """
+    Return the Shotgun name field to use for the specified entity type.  This
+    is needed as not all entity types are consistent!
+
+    :param entity_type:     The entity type to get the name field for
+    :returns:               The name field for the specified entity type
+    """
+    return {"HumanUser":"name", 
+            "Task":"content", 
+            "Project":"name"}.get(entity_type, "code")
+
+def _get_entity_name(entity_dictionary):
+    """
+    Extract the entity name from the specified entity dictionary if it can
+    be found.  The entity dictionary must contain at least 'type'
+
+    :param entity_dictionary:   An entity dictionary to extract the name from
+    :returns:                   The name of the entity if found in the entity
+                                dictionary, otherwise None
+    """
+    name_field = _get_entity_type_sg_name_field(entity_dictionary["type"])
+    entity_name = entity_dictionary.get(name_field)
+    if entity_name == None:
+        # Also check to see if entity contains 'name':
+        if name_field != "name":
+            entity_name = entity_dictionary.get("name")
+    return entity_name
+
 def _task_from_sg(tk, task_id, additional_fields = None):
     """
     Constructs a context from a shotgun task.
@@ -1140,17 +1215,10 @@ def _entity_from_sg(tk, entity_type, entity_id):
                         }
                             
     """
-
-    # deal with funny naming for certain entities 
-    if entity_type == "HumanUser":
-        # note: previously this would return 'login' but this was inconsistent as the HumanUser
-        # entity already has a name field and this could lead to errors later on!
-        name_field = "name"
-    elif entity_type == "Project":
-        name_field = "name"
-    else:
-        name_field = "code"
-
+    # get the sg name field for the specified entity type:
+    name_field = _get_entity_type_sg_name_field(entity_type)
+    
+    # get the entity data from Shotgun
     data = tk.shotgun.find_one(entity_type, [["id", "is", entity_id]], ["project", name_field])
 
     if not data:

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -709,6 +709,9 @@ class TankBundle(object):
         :param key:   setting name
         :param value: setting value
         """
+        if value is None:
+            return value
+        
         # try to get the type for the setting
         # (may fail if the key does not exist in the schema,
         # which is an old use case we need to support now...)

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -23,6 +23,8 @@ from . import environment_includes
 from ..errors import TankError
 from ..deploy import descriptor
 
+from ..util.yaml_cache import YamlCache
+
 
 class Environment(object):
     """
@@ -61,19 +63,13 @@ class Environment(object):
     def __refresh(self):
         """Refreshes the environment data from disk
         """
-
         if not os.path.exists(self.__env_path):
             raise TankError("Attempting to load non-existent environment file: %s" % self.__env_path)
 
-        try:
-            env_file = open(self.__env_path, "r")
-            data = yaml.load(env_file)
-            env_file.close()
-        except Exception, exp:
-            raise TankError("Could not parse file %s. Error reported: %s" % (self.__env_path, exp))
+        data = self.__load_data(self.__env_path)
 
         self.__env_data = environment_includes.process_includes(self.__env_path, data, self.__context)
-
+        
         if not self.__env_data:
             raise TankError('No data in env file: %s' % (self.__env_path))
 
@@ -342,15 +338,7 @@ class Environment(object):
         """
         loads the main data from disk, raw form
         """
-        # load the data in
-        try:
-            env_file = open(path, "r")
-            data = yaml.load(env_file)
-            env_file.close()
-        except Exception, exp:
-            raise TankError("Could not parse file %s. Error reported: %s" % (path, exp))
-
-        return data
+        return YamlCache.instance().load(path)
 
     def __write_data(self, path, data):
         """

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -23,7 +23,7 @@ from . import environment_includes
 from ..errors import TankError
 from ..deploy import descriptor
 
-from ..util.yaml_cache import YamlCache
+from ..util.yaml_cache import g_yaml_cache
 
 
 class Environment(object):
@@ -338,7 +338,7 @@ class Environment(object):
         """
         loads the main data from disk, raw form
         """
-        return YamlCache.instance().load(path)
+        return g_yaml_cache.get(path)
 
     def __write_data(self, path, data):
         """

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -41,7 +41,7 @@ from ..templatekey import StringKey
 
 from . import constants
 
-from ..util.yaml_cache import YamlCache
+from ..util.yaml_cache import g_yaml_cache
 
 def _resolve_includes(file_name, data, context):
     """
@@ -230,7 +230,7 @@ def _process_includes_r(file_name, data, context):
     for include_file in include_files:
                 
         # path exists, so try to read it
-        included_data = YamlCache.instance().load(include_file)
+        included_data = g_yaml_cache.get(include_file)
                 
         # now resolve this data before proceeding
         included_data, included_fw_lookup = _process_includes_r(include_file, included_data, context)
@@ -275,7 +275,7 @@ def find_framework_location(file_name, framework_name, context):
                             defined in or None if not found.
     """
     # load the data in for the root file:
-    data = YamlCache.instance().load(file_name)
+    data = g_yaml_cache.get(file_name)
 
     # track root frameworks:
     root_fw_lookup = {}
@@ -298,7 +298,7 @@ def find_reference(file_name, context, token):
     """
     
     # load the data in 
-    data = YamlCache.instance().load(file_name)
+    data = g_yaml_cache.get(file_name)
     
     # first build our big fat lookup dict
     include_files = _resolve_includes(file_name, data, context)
@@ -308,7 +308,7 @@ def find_reference(file_name, context, token):
     for include_file in include_files:
                 
         # path exists, so try to read it
-        included_data = YamlCache.instance().load(include_file)
+        included_data = g_yaml_cache.get(include_file)
         
         if token in included_data:
             found_file = include_file

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -41,6 +41,8 @@ from ..templatekey import StringKey
 
 from . import constants
 
+from ..util.yaml_cache import YamlCache
+
 def _resolve_includes(file_name, data, context):
     """
     Parses the includes section and returns a list of valid paths
@@ -228,11 +230,7 @@ def _process_includes_r(file_name, data, context):
     for include_file in include_files:
                 
         # path exists, so try to read it
-        fh = open(include_file, "r")
-        try:
-            included_data = yaml.load(fh) or {}
-        finally:
-            fh.close()
+        included_data = YamlCache.instance().load(include_file)
                 
         # now resolve this data before proceeding
         included_data, included_fw_lookup = _process_includes_r(include_file, included_data, context)
@@ -277,14 +275,7 @@ def find_framework_location(file_name, framework_name, context):
                             defined in or None if not found.
     """
     # load the data in for the root file:
-    data = None
-    try:
-        fh = open(file_name, "r")
-        data = yaml.load(fh)
-    except Exception, e:
-        raise TankError("Could not parse file %s. Error reported: %s" % (file_name, e))
-    finally:
-        fh.close()
+    data = YamlCache.instance().load(file_name)
 
     # track root frameworks:
     root_fw_lookup = {}
@@ -307,13 +298,7 @@ def find_reference(file_name, context, token):
     """
     
     # load the data in 
-    try:
-        fh = open(file_name, "r")
-        data = yaml.load(fh)
-    except Exception, exp:
-        raise TankError("Could not parse file %s. Error reported: %s" % (file_name, exp))
-    finally:
-        fh.close()
+    data = YamlCache.instance().load(file_name)
     
     # first build our big fat lookup dict
     include_files = _resolve_includes(file_name, data, context)
@@ -323,11 +308,7 @@ def find_reference(file_name, context, token):
     for include_file in include_files:
                 
         # path exists, so try to read it
-        fh = open(include_file, "r")
-        try:
-            included_data = yaml.load(fh) or {}
-        finally:
-            fh.close()
+        included_data = YamlCache.instance().load(include_file)
         
         if token in included_data:
             found_file = include_file

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -79,23 +79,18 @@ class TemplateKey(object):
     @property
     def choices(self):
         """
-        :returns:    List of choices available for this key
+        :returns:   List of choices available for this key - retained for backwards
+                    compatibility
         """
         return self._choices.keys()
     
     @property
-    def choice_labels(self):
+    def labelled_choices(self):
         """
-        :returns:    List of labels for choices available for this key
+        :returns:   Dictionary of choices together with their labels that are available 
+                    for this key
         """
-        return self._choices.values()
-    
-    def get_choice_label(self, choice):
-        """
-        Get the label for the specified choice.
-        :returns:    The choice label
-        """
-        return self._choices.get(choice, "")
+        return self._choices
     
     def str_from_value(self, value=None, ignore_type=False):
         """

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -30,7 +30,8 @@ class TemplateKey(object):
         """
         :param name: Key's name.
         :param default: Default value for this key.
-        :param choices: List of possible values for this key.
+        :param choices: List of possible values for this key.  Can be either a list or a dictionary
+                        of choice:label pairs.
         :param shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
         :param shotgun_field_name: For keys directly linked to a shotgun field, the field name.
         :param exclusions: List of values which are not allowed.
@@ -39,7 +40,17 @@ class TemplateKey(object):
         """
         self.name = name
         self.default = default
-        self.choices = choices or []
+
+        # special handling for choices:
+        if isinstance(choices, dict):
+            # new style choices dictionary containing choice:label pairs:
+            self._choices = choices
+        elif isinstance(choices, list) or isinstance(choices, set):
+            # old style choices - labels and choices are the same:
+            self._choices = dict(zip(choices, choices))
+        else:
+            self._choices = {}
+
         self.exclusions = exclusions or []
         self.shotgun_entity_type = shotgun_entity_type
         self.shotgun_field_name = shotgun_field_name
@@ -48,7 +59,6 @@ class TemplateKey(object):
         self._last_error = ""
 
         # check that the key name doesn't contain invalid characters
-        
         if not re.match(r"^%s$" % constants.TEMPLATE_KEY_NAME_REGEX, name):
             raise TankError("%s: Name contains invalid characters. "
                             "Valid characters are %s." % (self, constants.VALID_TEMPLATE_KEY_NAME_DESC))
@@ -65,6 +75,27 @@ class TemplateKey(object):
         
         if not all(self.validate(choice) for choice in self.choices):
             raise TankError(self._last_error)
+    
+    @property
+    def choices(self):
+        """
+        :returns:    List of choices available for this key
+        """
+        return self._choices.keys()
+    
+    @property
+    def choice_labels(self):
+        """
+        :returns:    List of labels for choices available for this key
+        """
+        return self._choices.values()
+    
+    def get_choice_label(self, choice):
+        """
+        Get the label for the specified choice.
+        :returns:    The choice label
+        """
+        return self._choices.get(choice, "")
     
     def str_from_value(self, value=None, ignore_type=False):
         """
@@ -119,7 +150,7 @@ class TemplateKey(object):
             self._last_error = "%s Illegal value: %s is forbidden for this key." % (self, value)
             return False
 
-        if not((value is None) or (self.choices == [])):
+        if value is not None and self.choices:
             if str_value.lower() not in [str(x).lower() for x in self.choices]:
                 self._last_error = "%s Illegal value: '%s' not in choices: %s" % (self, value, str(self.choices))
                 return False

--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -24,18 +24,6 @@ class YamlCache(object):
     """
     Main yaml cache class
     """
-    _instance = None
-
-    @staticmethod
-    def instance():
-        """
-        Obtain the single instance of the YamlCache
-        :returns:    The single YamlCache instance
-        """
-        if not YamlCache._instance:
-            YamlCache._instance = YamlCache()
-        return YamlCache._instance
-    
     def __init__(self):
         """
         Construction
@@ -43,9 +31,11 @@ class YamlCache(object):
         self._cache = {}
         self._lock = threading.Lock()
             
-    def load(self, path):
+    def get(self, path):
         """
-        Load the yaml data for the specified path.
+        Retrieve the yaml data for the specified path.  If it's not already
+        in the cache of the cached version is out of date then this will load
+        the Yaml file from disk.
         
         :param path:    The path of the yaml file to load.
         :returns:       The raw yaml data loaded from the file.
@@ -136,3 +126,6 @@ class YamlCache(object):
                 return cache_entry
         finally:
             self._lock.release()
+
+# the global instance of the YamlCache
+g_yaml_cache = YamlCache()

--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Implements a caching mechanism to avoid loading the same yaml file multiple times
+unless it's changed on disk.
+"""
+
+import os
+import copy
+import threading
+
+from tank_vendor import yaml
+from ..errors import TankError
+
+class YamlCache(object):
+    """
+    Main yaml cache class
+    """
+    _instance = None
+
+    @staticmethod
+    def instance():
+        """
+        Obtain the single instance of the YamlCache
+        :returns:    The single YamlCache instance
+        """
+        if not YamlCache._instance:
+            YamlCache._instance = YamlCache()
+        return YamlCache._instance
+    
+    def __init__(self):
+        """
+        Construction
+        """
+        self._cache = {}
+        self._lock = threading.Lock()
+            
+    def load(self, path):
+        """
+        Load the yaml data for the specified path.
+        
+        :param path:    The path of the yaml file to load.
+        :returns:       The raw yaml data loaded from the file.
+        """
+        if not os.path.exists(path):
+            raise TankError("File '%s' could not be found!" % path)            
+        
+        # get info about the file:
+        fstat = os.stat(path)
+        modified_at = fstat.st_mtime
+        file_size = fstat.st_size
+        
+        # see if this file is already cached:
+        cache_entry = self._get(path)
+        if (not cache_entry
+            or cache_entry["modified_at"] != modified_at
+            or cache_entry["file_size"] != file_size):
+            # try to load the file data:
+            try:
+                fh = open(path, "r")
+            except Exception, e:
+                raise TankError("Could not open file '%s'. Error reported: '%s'" % (path, e))
+            
+            try:
+                # load the data:
+                raw_data = yaml.load(fh)
+                # add/update the data in the cache - note that only the latest version of the 
+                # data is retained!
+                cache_entry = self._add(path, raw_data, modified_at, file_size)
+            except Exception, e:
+                raise TankError("Could not parse file '%s'. Error reported: '%s'" % (path, e))
+            finally:
+                fh.close()            
+
+        # always return a deep copy of the cached data to ensure that 
+        # the cached data is not updated accidentally!:
+        data = copy.deepcopy(cache_entry["data"])
+        
+        return data
+
+    def _get(self, path):
+        """
+        Return the cache entry for the specified path if it exists.  
+        This method is thread-safe
+
+        :param path:    The path of the yaml file to return the entry for
+        :returns:       A dictionary containing the data, modified_at time and file size
+                        of the cached data.
+        """
+        self._lock.acquire()
+        try:
+            return self._cache.get(path)
+        finally:
+            self._lock.release()
+            
+    def _add(self, path, data, modified_at, file_size):
+        """
+        Add the specified data to the cache if it doesn't already exist.  If the data
+        does exist in the cache with the same modified time and file size then the
+        already cached version will be returned.
+        This method is thread-safe.
+        
+        :param path:        The path of the yaml file being cached
+        :param data:        The raw yaml data being cached
+        :param modified_at: The time the file was last modified
+        :param file_size:   The size of the yaml file
+        :returns:           A dictionary containing the data, modified_at time and file size
+                            of the cached data.
+        """
+        self._lock.acquire()
+        try:
+            # see if the item is already in the cache:
+            cache_entry = self._cache.get(path)
+            if (cache_entry
+                and cache_entry["modified_at"] == modified_at
+                and cache_entry["file_size"] == file_size):
+                # must have been loaded by another thread so just use 
+                # this one instead!
+                return cache_entry
+            else:
+                # add new item to cache and return:
+                cache_entry = {
+                    "modified_at":modified_at, 
+                    "file_size":file_size, 
+                    "data":data
+                }
+                self._cache[path] = cache_entry
+                return cache_entry
+        finally:
+            self._lock.release()

--- a/tests/data/default_core/templates.yml
+++ b/tests/data/default_core/templates.yml
@@ -58,6 +58,10 @@ keys:
     Asset:
         type: str
         exclusions: [Seq, Shot]
+    maya_extension:
+        type: str
+        choices: {'ma':'Maya Ascii (.ma)', 'mb':'Maya Binary (.mb)'}
+        default: ma
 
 
 paths:
@@ -72,13 +76,13 @@ paths:
     # Shot pipeline - maya publishing and snapshotting locations
 
     # The location of WIP files
-    maya_shot_work: sequences/{Sequence}/{Shot}/{Step}/work/{name}.v{version}.ma
+    maya_shot_work: sequences/{Sequence}/{Shot}/{Step}/work/{name}.v{version}.{maya_extension}
 
     # The location of backups of WIP files
-    maya_shot_snapshot: sequences/{Sequence}/{Shot}/{Step}/work/snapshots/{name}.v{version}.{timestamp}.ma
+    maya_shot_snapshot: sequences/{Sequence}/{Shot}/{Step}/work/snapshots/{name}.v{version}.{timestamp}.{maya_extension}
 
     # The location of published maya files
-    maya_shot_publish: sequences/{Sequence}/{Shot}/{Step}/publish/{name}.v{version}.ma
+    maya_shot_publish: sequences/{Sequence}/{Shot}/{Step}/publish/{name}.v{version}.{maya_extension}
 
 
 

--- a/tests/data/yaml_cache/test_data.yml
+++ b/tests/data/yaml_cache/test_data.yml
@@ -1,0 +1,8 @@
+- 1
+- two
+- 8: {9: nine, ten: 10}
+  four: [5, 6, 7]
+  three: A
+- [11, twelve]
+- {13: 13, fourteen: fourteen}
+- 15: [16, seventeen]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -480,61 +480,76 @@ class TestFromEntity(TestContext):
         task = {"type": "Task", "id": 13, "name": "never_seen_me_before", "content": "no_content"}
         self.assertRaises(TankError, context.from_entity, self.tk, task["type"], task["id"])
 
+    @patch("tank.context.from_entity")
     @patch("tank.util.login.get_current_user")
-    def test_from_entities(self, get_current_user):
+    def test_from_entity_dictionary(self, get_current_user, from_entity):
         """
-        Test context.from_entities - this can contruct a context from
-        a set of provided entities avoiding a Shotgun lookup when
-        possible
+        Test context.from_entity_dictionary - this can contruct a context from
+        an entity dictionary looking at linked entities where available.
+
+        Falls back to 'from_entity' if the entity dictionary doesn't contain
+        everything needed.
         """
         get_current_user.return_value = self.current_user
 
-        result = context.from_entities(self.tk, self.project, self.shot, self.step, None, self.current_user)
+        # overload from_entity to ensure it causes a test fail if from_entity_dictionary
+        # falls back to it:
+        from_entity.return_value = {}
+
+        ent_dict = {"type":self.shot["type"], "id":self.shot["id"], "code":self.shot["code"]}
+        ent_dict["project"] = self.project
+
+        result = context.from_entity_dictionary(self.tk, ent_dict)
+        self.assertIsNotNone(result)
 
         self.check_entity(self.project, result.project)
         self.assertEquals(3, len(result.project))
 
         self.check_entity(self.shot, result.entity)
         self.assertEquals(3, len(result.entity))
-                
+        
+        self.check_entity(self.current_user, result.user)
+
+    @patch("tank.context.from_entity")
+    @patch("tank.util.login.get_current_user")
+    def test_from_entity_dictionary_additional_entities(self, get_current_user, from_entity):
+        """
+        Test context.from_entity_dictionary - this can contruct a context from
+        an entity dictionary looking at linked entities where available.
+        
+        Falls back to 'from_entity' if the entity dictionary doesn't contain
+        everything needed.
+        """
+        get_current_user.return_value = self.current_user
+        
+        # overload from_entity to ensure it causes a test fail if from_entity_dictionary
+        # falls back to it:
+        from_entity.return_value = {}
+
+        add_value = {"name":"additional", "id": 3, "type": "add_type"}
+        ent_dict = {"type":"Task", "id":self.task["id"], "content":self.task["content"], "additional_field":add_value}
+        ent_dict["project"] = self.project
+        ent_dict["entity"] = self.shot
+        ent_dict["step"] = self.step
+
+        result = context.from_entity_dictionary(self.tk, ent_dict)
+        self.assertIsNotNone(result)
+
+        self.check_entity(self.project, result.project)
+        self.assertEquals(3, len(result.project))
+
+        self.check_entity(self.shot, result.entity)
+        self.assertEquals(3, len(result.entity))
+        
         self.check_entity(self.current_user, result.user)
         
         self.check_entity(self.step, result.step)
         self.assertEquals(3, len(result.step))
-
-    @patch("tank.util.login.get_current_user")
-    def test_from_entities_additional_entities(self, get_current_user):
-        """
-        Test context.from_entities with additional entities - this can contruct 
-        a context from a set of provided entities avoiding a Shotgun lookup when
-        possible.  When additional entities are specified a Shotgun lookup is 
-        required!
-        """
-        get_current_user.return_value = self.current_user
-
-        add_value = {"name":"additional", "id": 3, "type": "add_type"}
-        self.task["additional_field"] = add_value
-
-        result = context.from_entities(self.tk, self.project, self.shot, self.step, self.task, self.current_user)
-
-        self.check_entity(self.project, result.project)
-        self.assertEquals(3, len(result.project))
-
-        self.check_entity(self.shot, result.entity)
-        self.assertEquals(3, len(result.entity))
-                
-        self.check_entity(self.current_user, result.user)
-
+        
         self.assertEquals(self.task["type"], result.task["type"])
         self.assertEquals(self.task["id"], result.task["id"])
         self.assertEquals(self.task["content"], result.task["name"])
         self.assertEquals(3, len(result.task))
-        
-        self.check_entity(self.step, result.step)
-        self.assertEquals(3, len(result.step))
-        
-        add_result = result.additional_entities[0]
-        self.check_entity(add_value, add_result)
 
     def check_entity(self, first_entity, second_entity):
         "Checks two entity dictionaries have the same values for keys type, id and name."

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -349,7 +349,7 @@ class TestMakeTemplateStrings(TankTestBase):
         template_string = result.get("template_name")
         self.assertEquals(self.template_path, template_string.validate_with)
 
-    def test_validate_tempalte_missing(self):
+    def test_validate_template_missing(self):
         data = {"template_name": {"definition": "something.{Shot}",
                                   "validate_with": "non-exitant-template"}}
         self.assertRaises(TankError, make_template_strings, data, self.keys, self.template_paths)
@@ -363,8 +363,17 @@ class TestReadTemplates(TankTestBase):
 
     def test_choices(self):
         """Check a template key which uses choices."""
+        # check old-style (list) choices
         key = self.tk.templates["nuke_shot_render_stereo"].keys["eye"]
-        self.assertEquals(["Left", "Right"], key.choices)
+        self.assertEquals(["Right", "Left"], key.choices)
+        self.assertEquals(["Right", "Left"], key.choice_labels)
+        self.assertEquals("Left", key.get_choice_label("Left"))
+        
+        # check new-style (dict) choices
+        key = self.tk.templates["maya_shot_work"].keys["maya_extension"]
+        self.assertEquals(["ma", "mb"], key.choices)
+        self.assertEquals(["Maya Ascii (.ma)", "Maya Binary (.mb)"], key.choice_labels)
+        self.assertEquals("Maya Ascii (.ma)", key.get_choice_label("ma"))
 
     def test_exclusions(self):
         key = self.tk.templates["asset_work_area"].keys["Asset"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -366,14 +366,12 @@ class TestReadTemplates(TankTestBase):
         # check old-style (list) choices
         key = self.tk.templates["nuke_shot_render_stereo"].keys["eye"]
         self.assertEquals(["Right", "Left"], key.choices)
-        self.assertEquals(["Right", "Left"], key.choice_labels)
-        self.assertEquals("Left", key.get_choice_label("Left"))
+        self.assertEquals({"Right":"Right", "Left":"Left"}, key.labelled_choices)
         
         # check new-style (dict) choices
         key = self.tk.templates["maya_shot_work"].keys["maya_extension"]
         self.assertEquals(["ma", "mb"], key.choices)
-        self.assertEquals(["Maya Ascii (.ma)", "Maya Binary (.mb)"], key.choice_labels)
-        self.assertEquals("Maya Ascii (.ma)", key.get_choice_label("ma"))
+        self.assertEquals({'ma':'Maya Ascii (.ma)', 'mb':'Maya Binary (.mb)'}, key.labelled_choices)
 
     def test_exclusions(self):
         key = self.tk.templates["asset_work_area"].keys["Asset"]

--- a/tests/test_templatekey.py
+++ b/tests/test_templatekey.py
@@ -529,7 +529,7 @@ class TestSequenceKey(TankTestBase):
     def test_choices_frame_spec(self):
         frame_specs = set(["%d", "#", "@", "$F", "<UDIM>", "$UDIM"])
         seq_frame = SequenceKey("field_name", choices=frame_specs)
-        self.assertEquals(frame_specs, seq_frame.choices)
+        self.assertEquals(list(frame_specs), seq_frame.choices)
 
 
 class TestMakeKeys(TankTestBase):

--- a/tests/util_tests/test_yaml_cache.py
+++ b/tests/util_tests/test_yaml_cache.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import copy
+
+import sgtk
+from sgtk.util.yaml_cache import YamlCache
+from sgtk import TankError
+from tank_vendor import yaml
+from tank_test.tank_test_base import *
+
+class TestYamlCache(TankTestBase):
+    """
+    Tests to ensure that the YamlCache behaves correctly
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Construction
+        """
+        TankTestBase.__init__(self, *args, **kwargs)
+
+        # data root for all test data:
+        self._data_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data", "yaml_cache"))
+
+    def test_get_incorrect_path(self):
+        """
+        Test that an error is correctly raised when the yaml cache is asked
+        for data from an incorrect path
+        """
+        yaml_path = os.path.join(self._data_root, "incorrect_path.yml")
+
+        yaml_cache = YamlCache()
+        self.assertRaises(TankError, yaml_cache.get, yaml_path)
+
+    def test_get_valid_path(self):
+        """
+        Test that the correct data is retrieved when a valid path is
+        provided to YamlCache.get().
+        
+        Also ensure that the data returned from the cache is a copy of the
+        cached data (to ensure it is clean and hasn't been accidentally
+        overrwritten by the calling code) and that the cache correctly reloads
+        the data from the file when it has been modified.
+        """
+        yaml_path = os.path.join(self._data_root, "test_data.yml")
+
+        test_data = [1, 
+                     "two", 
+                     {"three":"A", "four":[5,6,7], 8:{9:"nine", "ten":10}}, 
+                     [11, "twelve"], 
+                     {13:13, "fourteen":"fourteen"}
+                     ]
+
+        modified_test_data = copy.deepcopy(test_data)
+        modified_test_data.append({15:[16, "seventeen"]})
+
+        # 1. Check that the cache loads the data correctly
+        #
+
+        # write out the test data:
+        yaml_file = open(yaml_path, "w")
+        try: 
+            yaml_file.write(yaml.dump(test_data))
+        finally:
+            yaml_file.close() 
+
+        # create a yaml cache instance and get the data from the file:
+        yaml_cache = YamlCache()
+        read_data = yaml_cache.get(yaml_path)
+
+        # check the read data matches the input data:
+        self.assertEquals(read_data, test_data)
+
+        # 2. Ensure that the data returned is a copy of the cached data
+        #
+
+        # inspect the cache itself and make sure that the data returned is a copy 
+        # of the internal cached data and not the internal cached data itself:
+        self.assertEquals(len(yaml_cache._cache), 1)
+        self.assertEquals(yaml_cache._cache.keys()[0], yaml_path)
+        self.assertEquals(yaml_cache._cache.values()[0]["data"], read_data)
+        cached_data_id = id(yaml_cache._cache.values()[0]["data"])
+        self.assertNotEquals(cached_data_id, id(read_data))
+
+        # 3. Check that the data doesn't get reloaded if it hasn't changed
+        #
+
+        # ask for the data again...
+        read_data = yaml_cache.get(yaml_path)
+
+        # ...and check that the cached data is exactly the same (has the same id):
+        self.assertEquals(len(yaml_cache._cache), 1)
+        new_cached_data_id = id(yaml_cache._cache.values()[0]["data"])
+        self.assertEquals(cached_data_id, new_cached_data_id)
+
+        # 4. Check that the data does get reloaded if it has changed:
+        #
+
+        # update the data in the file:
+        yaml_file = open(yaml_path, "w")
+        try: 
+            yaml_file.write(yaml.dump(modified_test_data))
+        finally:
+            yaml_file.close()
+
+        # ask for the data again...
+        read_data = yaml_cache.get(yaml_path)
+
+        # ...and check that the data in the cache has been updated:
+        self.assertEquals(read_data, modified_test_data)
+
+
+
+


### PR DESCRIPTION
- Added Yaml caching of the environment files to avoid them being loaded multiple times unnecessarily.
- Added context.from_entities() method that can be used to safely construct a context from a set of known entities avoiding a Shotgun query when possible.
- Template key choices can now be a dictionary of choice:label pairs.  This allows specifying a more UI friendly label for each choice.  Specifying a straight list of choices is still valid.
- Added unit tests.