### PR TITLE
For #28285, Allow multiple users to use the session management system on the same logged os user.

### DIFF
--- a/python/tank/util/defaults_manager.py
+++ b/python/tank/util/defaults_manager.py
@@ -56,4 +56,4 @@ class CoreDefaultsManager(sg_auth.DefaultsManager):
         data = shotgun.get_associated_sg_config_data()
         if data.get("api_script") and data.get("api_key"):
             return data
-        return None
+        return super(CoreDefaultsManager, self).get_user_credentials()

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -201,7 +201,8 @@ def __create_sg_connection(config_data=None):
     """
 
     if config_data:
-        # Credentials were passed in, so let's run the legacy authentication mechanism for script user.
+        # Credentials were passed in, so let's run the legacy authentication
+        # mechanism for script user.
         sg = shotgun_api3.Shotgun(
             config_data["host"],
             script_name=config_data["api_script"], api_key=config_data["api_key"],
@@ -215,8 +216,10 @@ def __create_sg_connection(config_data=None):
             # This is needed for backwards compatibility with scripts that were
             # written before authentication was put in place. Since those scripts
             # don't set the current user, we have to get the one configured for the
-            # core instead.
-            user = sa.get_user()
+            # core instead. If the script user is configured, then the
+            # CoreDefaultsManager will provide it's credentials for us and
+            # sa.get_default_user will return the ScriptUser instance.
+            user = sa.get_default_user()
         if not user:
             raise AuthenticationError("No current Shotgun user available.")
         sg = user.create_sg_connection()

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -217,7 +217,7 @@ def __create_sg_connection(config_data=None):
             # written before authentication was put in place. Since those scripts
             # don't set the current user, we have to get the one configured for the
             # core instead. If the script user is configured, then the
-            # CoreDefaultsManager will provide it's credentials for us and
+            # CoreDefaultsManager will provide its credentials for us and
             # sa.get_default_user will return the ScriptUser instance.
             user = sa.get_default_user()
         if not user:

--- a/python/tank_vendor/shotgun_authentication/defaults_manager.py
+++ b/python/tank_vendor/shotgun_authentication/defaults_manager.py
@@ -8,8 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import sys
+from . import session_cache
 
 
 class DefaultsManager(object):
@@ -17,6 +16,14 @@ class DefaultsManager(object):
     This class allows the ShotgunAuthenticator to get some default values when
     authenticating a user.
     """
+
+    def __init__(self):
+        """
+        Consructor.
+
+        Reads the default host and login from disk.
+        """
+        self._login = session_cache.get_current_user(self.get_host())
 
     def is_host_fixed(self):
         """
@@ -34,7 +41,7 @@ class DefaultsManager(object):
 
         When the host is fixed, this has to return a value.
 
-        :returns: A string containing the default host name. Default implementation returns None.
+        :returns: A string containing the default host name.
         """
         return None
 
@@ -53,16 +60,7 @@ class DefaultsManager(object):
 
         :returns: Default implementation returns the current os user login name.
         """
-        if sys.platform == "win32":
-            # http://stackoverflow.com/questions/117014/how-to-retrieve-name-of-current-windows-user-ad-or-local-using-python
-            return os.environ.get("USERNAME", None)
-        else:
-            try:
-                import pwd
-                pwd_entry = pwd.getpwuid(os.geteuid())
-                return pwd_entry[0]
-            except:
-                return None
+        return self._login
 
     def get_user_credentials(self):
         """
@@ -70,4 +68,11 @@ class DefaultsManager(object):
 
         :returns: Default implementation returns None.
         """
-        return None
+        return session_cache.get_session_data(self.get_host(), self.get_login())
+
+    def set_login(self, login):
+        """
+        Saves to disk the last user logged in.
+        """
+        self._login = login
+        session_cache.set_current_user(self.get_host(), login)

--- a/python/tank_vendor/shotgun_authentication/interactive_authentication.py
+++ b/python/tank_vendor/shotgun_authentication/interactive_authentication.py
@@ -349,50 +349,58 @@ class UiAuthenticationHandler(object):
 
 # Lock the assures only one thread at a time can execute the authentication logic.
 _renew_session_internal_lock = threading.Lock()
+
+class AuthState:
+    """
+    Authentication can be in three states. Waiting for authentication to complete,
+    authentication was cancelled (user hit Cancel or CTRL-D) and user provided
+    credentials successfully.
+    """
+    waiting = 1
+    cancelled = 2
+    success = 3
 # When a thread cancels session renewal, this flag is set so other threads know
 # to raise an exception as well.
-_is_authentication_cancelled = False
+_auth_state = AuthState.waiting
 
 
-def _renew_session_internal(user, session_token, credentials_handler):
+def _renew_session_internal(user, credentials_handler):
     """
-    Common login logic, regardless of how we are actually logging in. It will first try to reuse
-    any existing session and if that fails then it will ask for credentials and upon success
-    the credentials will be cached.
-    :raises AuthenticationError: Raised if the authentication is cancelled.
-    :raises AuthenticationDisabled: Raised if authentication was cancelled before.
+    Prompts the user for the password. This method should never be called directly
+    and _renew_session should be called instead.
+    :raises AuthenticationCancelled: Raised if the authentication is cancelled.
     """
     logger.debug("About to take the authentication lock.")
     global _renew_session_internal_lock
     with _renew_session_internal_lock:
-        global _is_authentication_cancelled
-        if _is_authentication_cancelled:
-            raise AuthenticationCancelled()
 
         logger.debug("Took the authentication lock.")
 
-        # If somebody refreshed the session token on the user object since we tried with
-        # the session token.
-        if user.get_session_token() != session_token:
+        # When authentication is cancelled, every thread who enter the authentication
+        # critical section should throw as well.
+        global _auth_state
+        if _auth_state == AuthState.cancelled:
+            raise AuthenticationCancelled()
+        # If authentication was successful, simply return.
+        elif _auth_state == AuthState.success:
             return
 
+        # We're the first thread, so authenticate.
         try:
             logger.debug("Not authenticated, requesting user input.")
-            # Do the actually credentials prompting and authenticating.
             hostname, login, session_token = credentials_handler.authenticate(
                 user.get_host(),
                 user.get_login(),
                 user.get_http_proxy()
             )
+            _auth_state = AuthState.success
+            logger.debug("Login successful!")
+            user.set_session_token(session_token)
         except AuthenticationCancelled:
-            _is_authentication_cancelled = True
+            _auth_state = AuthState.cancelled
             logger.debug("Authentication cancelled")
             user.clear_session_token()
             raise
-
-        logger.debug("Login successful!")
-
-        user.set_session_token(session_token)
 
 
 # Makes access to the thread count and executing logic based on it thread
@@ -402,7 +410,22 @@ _renew_session_lock = threading.Lock()
 _renew_session_thread_count = 0
 
 
-def _renew_session(user, session_token, credentials_handler):
+def _renew_session(user, credentials_handler):
+    """
+    Prompts the user for the password. This method is thread-safe, meaning if
+    multiple users call this method at the same time, it will keep track of
+    how many threads are currently running inside it and all threads waiting
+    for the authentication to complete will return with the same result
+    as the thread that actually did the authentication, either returning or
+    raising an exception.
+
+    :param user: SessionUser we are re-authenticating.
+    :param credentials_handler: Method that actually prompts the user for
+                                credentials.
+
+    :raises AuthenticationCancelled: If the user cancels the authentication,
+                                     this exception is raised.
+    """
     # One more renewer.
     global _renew_session_lock
     with _renew_session_lock:
@@ -411,7 +434,7 @@ def _renew_session(user, session_token, credentials_handler):
 
     try:
         # Renew the session
-        _renew_session_internal(user, session_token, credentials_handler)
+        _renew_session_internal(user, credentials_handler)
     finally:
         # We're leaving the method somehow, cleanup!
         with _renew_session_lock:
@@ -419,20 +442,19 @@ def _renew_session(user, session_token, credentials_handler):
             _renew_session_thread_count = _renew_session_thread_count - 1
             # If we're the last one, clear the cancel flag.
             if _renew_session_thread_count == 0:
-                global _is_authentication_cancelled
-                _is_authentication_cancelled = False
+                global _auth_state
+                _auth_state = AuthState.waiting
             # At this point, if the method _renew_session_internal simply
             # returned, this method returns. If the method raised an exception,
             # it will keep being propagated.
 
 
-def renew_session(user, session_token):
+def renew_session(user):
     """
     Prompts the user to enter this password on the console or in a ui to
     retrieve a new session token.
 
     :param user: SessionUser that needs its session token refreshed.
-    :param session_token: The session token value that originally failed.
 
     :raises AuthenticationCancelled: If the user cancels the authentication,
                                      this exception is raised.
@@ -444,7 +466,7 @@ def renew_session(user, session_token):
         authenticator = UiAuthenticationHandler(is_session_renewal=True)
     else:
         authenticator = ConsoleRenewSessionHandler()
-    _renew_session(user, session_token, authenticator)
+    _renew_session(user, authenticator)
 
 
 def authenticate(default_host, default_login, http_proxy, fixed_host):

--- a/python/tank_vendor/shotgun_authentication/interactive_authentication.py
+++ b/python/tank_vendor/shotgun_authentication/interactive_authentication.py
@@ -399,7 +399,7 @@ def _renew_session_internal(user, credentials_handler):
         except AuthenticationCancelled:
             _auth_state = AuthState.cancelled
             logger.debug("Authentication cancelled")
-            user.clear_session_token()
+            user.uncache_session_token()
             raise
 
 

--- a/python/tank_vendor/shotgun_authentication/session_cache.py
+++ b/python/tank_vendor/shotgun_authentication/session_cache.py
@@ -13,12 +13,13 @@ This module will provide basic i/o to read and write session user's credentials
 in the site's cache location.
 """
 
+from __future__ import with_statement
 import os
 import sys
 import urlparse
-from ConfigParser import SafeConfigParser
 from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault, ProtocolError
 from tank_vendor.shotgun_api3.lib import httplib2
+from tank_vendor import yaml
 from .errors import AuthenticationError
 
 # FIXME: Quick hack to easily disable logging in this module while keeping the
@@ -53,6 +54,21 @@ else:
             pass
 
 
+def _get_cache_location():
+    """
+    Returns an OS specific cache location.
+
+    :returns: Path to the OS specific cache folder.
+    """
+    if sys.platform == "darwin":
+        root = os.path.expanduser("~/Library/Caches/Shotgun")
+    elif sys.platform == "win32":
+        root = os.path.join(os.environ["APPDATA"], "Shotgun")
+    elif sys.platform.startswith("linux"):
+        root = os.path.expanduser("~/.shotgun")
+    return root
+
+
 def _get_local_site_cache_location(base_url):
     """
     Returns the location of the site cache root based on a site.
@@ -61,87 +77,197 @@ def _get_local_site_cache_location(base_url):
 
     :returns: An absolute path to the site cache root.
     """
-    if sys.platform == "darwin":
-        root = os.path.expanduser("~/Library/Caches/Shotgun")
-    elif sys.platform == "win32":
-        root = os.path.join(os.environ["APPDATA"], "Shotgun")
-    elif sys.platform.startswith("linux"):
-        root = os.path.expanduser("~/.shotgun")
-
-    # get site only; https://www.foo.com:8080 -> www.foo.com
-    base_url = urlparse.urlparse(base_url)[1].split(":")[0]
-
-    return os.path.join(root, base_url)
+    return os.path.join(
+        _get_cache_location(),
+        # get site only; https://www.foo.com:8080 -> www.foo.com
+        urlparse.urlparse(base_url)[1].split(":")[0]
+    )
 
 
-def _get_session_data_location(base_url):
+def _get_authentication_cache_location(base_url):
     """
-    Returns the location of the session file on disk for a specific site.
+    Returns the location for the authentication cache folder for a given site.
+
+    :param base_url: Site we need to compute the authentication cache path for.
+
+    :returns: An absolute path to the authentication cache root.
+    """
+    return os.path.join(
+        _get_local_site_cache_location(base_url),
+        "authentication"
+    )
+
+
+def _get_users_file_location(base_url):
+    """
+    Returns the location of the users file on disk for a specific site.
 
     :param base_url: The site we want the login information for.
 
     :returns: Path to the login information.
     """
     return os.path.join(
-        _get_local_site_cache_location(base_url),
-        "authentication",
-        "login.ini"
+        _get_authentication_cache_location(base_url),
+        "users.yml"
     )
 
 
-def delete_session_data(host):
+def _get_current_user_file_location(base_url):
     """
-    Clears the session cache for the given site.
+    Returns the location of the users file on disk for a specific site.
+
+    :param base_url: The site we want the login information for.
+
+    :returns: Path to the login information.
+    """
+    return os.path.join(
+        _get_authentication_cache_location(base_url),
+        "current_user.yml"
+    )
+
+
+def _ensure_folder_for_file(filepath):
+    """
+    Makes sure the folder exists for a given file.
+
+    :param filepath: Path to the file we want to make sure the parent directory
+                     exists.
+
+    :returns: The path to the file.
+    """
+    folder, _ = os.path.split(filepath)
+    if not os.path.exists(folder):
+        os.makedirs(folder, 0700)
+    return filepath
+
+
+def _try_load_yaml_file(file_path):
+    """
+    Loads a yaml file.
+
+    :param file_path: The yaml file to load.
+
+    :returns: The dictionary for this yaml file. If the file doesn't exist or is
+              corrupted, returns an empty dictionary.
+    """
+
+    if not os.path.exists(file_path):
+        logger.debug("Yaml file missing: %s" % file_path)
+        return {}
+    try:
+        # Open the file and read it.
+        with open(file_path, "r") as config_file:
+            return yaml.load(config_file)
+    except yaml.YAMLError:
+        # Return to the beginning
+        config_file.seek(0)
+        logger.error("File '%s' is corrupted!" % file_path)
+        # And log the complete file for debugging.
+        for line in config_file:
+            # Log line without \n
+            logger.debug(line.rstrip())
+        # Create an empty document
+        return {}
+
+
+def _try_load_users_file(file_path):
+    """
+    Loads or creates on the file the data for the users file. The users file has the following format:
+        users:
+           {name: "login", session_token: "session_token"}
+           {name: "login", session_token: "session_token"}
+           {name: "login", session_token: "session_token"}
+    """
+    content = _try_load_yaml_file(file_path)
+    # Make sure any mandatory entry is present.
+    content.setdefault("users", [])
+    return content
+
+
+def _try_load_current_user_file(file_path):
+    """
+    Loads or creates the users file
+    """
+    content = _try_load_yaml_file(file_path)
+    # Make sure any mandatody entry is present.
+    content.setdefault("current_user", None)
+    return content
+
+
+def _insert_or_update_user(users_file, login, session_token):
+    """
+    Finds or updates an entry in the users file with the given login and
+    session token.
+
+    :param users_file: Users dictionary to update.
+    :param login: Login of the user to update.
+    :param session_token: Session token of the user to update.
+    """
+    for user in users_file["users"]:
+        if user["login"] == login:
+            user["session_token"] = session_token
+            return
+    users_file["users"].append({"login": login, "session_token": session_token})
+
+
+def _write_users_file(file_path, users_data):
+    """
+    Writes the users file at a given location.
+
+    :param file_path: Where to write the users data
+    :param users_data: Dictionary to write to disk.
+    """
+    with open(file_path, "w") as users_file:
+        yaml.dump(users_data, users_file)
+
+
+def delete_session_data(host, login):
+    """
+    Clears the session cache for the given site and login.
 
     :param host: Site to clear the session cache for.
+    :param login: User to clear the session cache for.
     """
     if not host:
         logger.error("Current host not set, nothing to clear.")
         return
     logger.debug("Clearing session cached on disk.")
     try:
-        info_path = _get_session_data_location(host)
-        if os.path.exists(info_path):
-            logger.debug("Session file found.")
-            os.remove(info_path)
-            logger.debug("Session cleared.")
-        else:
-            logger.debug("Session file not found: %s", info_path)
+        info_path = _get_users_file_location(host)
+        logger.debug("Session file found.")
+        # Read in the file
+        users_file = _try_load_users_file(info_path)
+        # File the users to remove the token
+        users_file["users"] = [u for u in users_file["users"] if u.get("login") != login]
+        # Write back the file.
+        _write_users_file(info_path, users_file)
+        logger.debug("Session cleared.")
     except:
-        logger.exception("Couldn't delete the session cache file!")
+        logger.exception("Couldn't update the session cache file!")
         raise
 
 
-def get_session_data(base_url):
+def get_session_data(base_url, login):
     """
     Returns the cached login info if found.
 
-    :param base_url: The site we want the login information for.
+    :param base_url: The site to look for the login information.
+    :param login: The user we want the login information for.
 
     :returns: Returns a dictionary with keys login and session_token or None
     """
     # Retrieve the location of the cached info
-    info_path = _get_session_data_location(base_url)
-    # Nothing was cached, return an empty dictionary.
-    if not os.path.exists(info_path):
-        logger.debug("No cache found at %s" % info_path)
-        return None
+    info_path = _get_users_file_location(base_url)
     try:
-        # Read the login information
-        config = SafeConfigParser({"login": None, "session_token": None})
-        config.read(info_path)
-        if not config.has_section("LoginInfo"):
-            logger.debug("No Login info was found")
-            return None
-
-        login = config.get("LoginInfo", "login", raw=True)
-        session_token = config.get("LoginInfo", "session_token", raw=True)
-
-        if not login or not session_token:
-            logger.debug("Incomplete settings (login:%s, session_token:%s)" % (login, session_token))
-            return None
-
-        return {"login": login, "session_token": session_token}
+        # Nothing was cached, return an empty dictionary.
+        users_file = _try_load_users_file(info_path)
+        for user in users_file["users"]:
+            if user.get("login") == login:
+                return {
+                    "login": user["login"],
+                    "session_token": user["session_token"]
+                }
+        logger.debug("No cache found at %s" % info_path)
     except Exception:
         logger.exception("Exception thrown while loading cached session info.")
         return None
@@ -156,26 +282,47 @@ def cache_session_data(host, login, session_token):
     :param session_token: Session token we want to cache.
     """
     # Retrieve the cached info file location from the host
-    info_path = _get_session_data_location(host)
+    file_path = _get_users_file_location(host)
+    _ensure_folder_for_file(file_path)
 
-    # make sure the info_dir exists!
-    info_dir, info_file = os.path.split(info_path)
-    if not os.path.exists(info_dir):
-        os.makedirs(info_dir, 0700)
+    logger.debug("Caching login info at %s...", file_path)
 
-    logger.debug("Caching login info at %s...", info_path)
-    # Create a document with the following format:
-    # [LoginInfo]
-    # login=username
-    # session_token=some_unique_id
-    config = SafeConfigParser()
-    config.add_section("LoginInfo")
-    config.set("LoginInfo", "login", login)
-    config.set("LoginInfo", "session_token", session_token)
-    # Write it to disk.
-    with open(info_path, "w") as configfile:
-        config.write(configfile)
+    document = _try_load_users_file(file_path)
+    _insert_or_update_user(document, login, session_token)
+    _write_users_file(file_path, document)
+
     logger.debug("Cached!")
+
+
+def get_current_user(host):
+    """
+    Returns the current user for the given host.
+
+    :param host: Host to fetch the current for.
+
+    :returns: The current user for this host or None if not set.
+    """
+    # Retrieve the cached info file location from the host
+    info_path = _get_current_user_file_location(host)
+    if os.path.exists(info_path):
+        document = _try_load_current_user_file(info_path)
+        return document["current_user"]
+    return None
+
+
+def set_current_user(host, login):
+    """
+    Saves the current user for a given host.
+
+    :param host: Host to save the current user for.
+    :param login: The current user login for specified host.
+    """
+    file_path = _get_current_user_file_location(host)
+    _ensure_folder_for_file(file_path)
+
+    current_user_file = _try_load_current_user_file(file_path)
+    current_user_file["current_user"] = login
+    _write_users_file(file_path, current_user_file)
 
 
 def generate_session_token(hostname, login, password, http_proxy):

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -65,7 +65,7 @@ class ShotgunAuthenticator(object):
                 login=self._defaults_manager.get_login(),
                 http_proxy=self._defaults_manager.get_http_proxy()
             )
-            user.clear_session_token()
+            user.uncache_session_token()
             return user
         except IncompleteCredentials:
             # Not all credentials were found, so there is no default user.
@@ -111,15 +111,8 @@ class ShotgunAuthenticator(object):
         host = host or self._defaults_manager.get_host()
         http_proxy = http_proxy or self._defaults_manager.get_http_proxy()
 
-        if not login:
-            raise IncompleteCredentials("missing login.")
-
-        # If we only have a password, generate a session token.
-        if password and not session_token:
-            session_token = session_cache.generate_session_token(host, login, password, http_proxy)
-
         # Create a session user
-        return user.SessionUser(host, login, session_token, http_proxy)
+        return user.SessionUser(host, login, session_token, http_proxy, password=password)
 
     def create_script_user(self, api_script, api_key, host=None, http_proxy=None):
         """

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -59,21 +59,17 @@ class ShotgunAuthenticator(object):
 
         :returns: If a user was cleared, the user object is returned, None otherwise.
         """
-        host = self._defaults_manager.get_host()
-        # No default host, no so saved user can be found.
-        if not host:
+        try:
+            user = self.create_session_user(
+                host=self._defaults_manager.get_host(),
+                login=self._defaults_manager.get_login(),
+                http_proxy=self._defaults_manager.get_http_proxy()
+            )
+            user.clear_session_token()
+            return user
+        except IncompleteCredentials:
+            # Not all credentials were found, so there is no default user.
             return None
-        login = self._defaults_manager.get_login()
-        if not login:
-            return None
-        sg_user = user.SessionUser.get_saved_user(
-            host,
-            login,
-            self._defaults_manager.get_http_proxy()
-        )
-        if sg_user:
-            sg_user.clear_session_token()
-        return sg_user
 
     def get_user_from_prompt(self):
         """
@@ -204,24 +200,27 @@ class ShotgunAuthenticator(object):
     def get_user(self):
         """
         This method will always return a valid user. It will first ask for the
-        default user to the defaults manager. If no user is returned, then a
-        saved user will be retrieved for the default host. If none is found, the
-        you will be prompted to enter login information interactively.
+        default user to the defaults manager. If none is found, the user will
+        be prompted on the command line or from a dialog for their credentials.
 
-        :returns: A ShotgunUser derived instance.
+        :returns: A ShotgunUser derived instance matching the credentials
+        provided.
+
+        :raises AuthenticationCancelled: This is raised if the user cancelled
+                                         the authentication.
         """
-        # Get the default user first for backward compatibility reasons. Toolkit
-        # provides it's own defaults manager which has a get_user that returns
-        # the credentials for the script user in shotgun.yml, so that has to
-        # have precedence over the saved user.
+        # Make sure we don't already have a user logged in through single
+        # sign-on or provided by a DefaultsManager-derived instance.
         user = self.get_default_user()
         if user:
             return user
 
         # Prompt the client for user credentials and connection information
         user = self.get_user_from_prompt()
-        # Remember that this user and host are the last settings user for
-        # authentication.
+
+        # Remember that this user and host are the last settings used for
+        # authentication in order to provide single sign-on.
         self._defaults_manager.set_host(user.get_host())
         self._defaults_manager.set_login(user.get_login())
+
         return user

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -122,10 +122,6 @@ class ShotgunAuthenticator(object):
         if password and not session_token:
             session_token = session_cache.generate_session_token(host, login, password, http_proxy)
 
-        if not session_token:
-            # todo - find this in our 'phonebook' of stored login/session ids
-            raise IncompleteCredentials("missing session_token")
-
         # Create a session user
         return user.SessionUser(host, login, session_token, http_proxy)
 

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -220,8 +220,6 @@ class ShotgunAuthenticator(object):
 
         # Prompt the client for user credentials and connection information
         user = self.get_user_from_prompt()
-        # Save the user's credentials.
-        user.save()
         # Remember that this user is the last one that was authenticated.
         self._defaults_manager.set_login(user.get_login())
         return user

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -72,7 +72,7 @@ class ShotgunAuthenticator(object):
             self._defaults_manager.get_http_proxy()
         )
         if sg_user:
-            sg_user.clear_saved_credentials()
+            sg_user.clear_session_token()
         return sg_user
 
     def get_user_from_prompt(self):
@@ -220,6 +220,8 @@ class ShotgunAuthenticator(object):
 
         # Prompt the client for user credentials and connection information
         user = self.get_user_from_prompt()
-        # Remember that this user is the last one that was authenticated.
+        # Remember that this user and host are the last settings user for
+        # authentication.
+        self._defaults_manager.set_host(user.get_host())
         self._defaults_manager.set_login(user.get_login())
         return user

--- a/python/tank_vendor/shotgun_authentication/shotgun_wrapper.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_wrapper.py
@@ -43,29 +43,10 @@ class ShotgunWrapper(Shotgun):
         if user.is_script_user(self._user):
             return super(ShotgunWrapper, self)._call_rpc(*args, **kwargs)
 
-        # Capture the current value of the session token. This is not
-        # thread-safe, but it doesn't matter at this point. Let's go through the
-        # scenarios.
-        #
-        # 1) This is the only thread that reads the session token. Nothing to
-        #    worry about.
-        # 2) Two threads read this value, and both end up in the exception
-        #    handler. The first one will take the lock in renew_session while
-        #    the other will wait. Once the first once updates the session token
-        #    on the user, unlocks and the second thread gets the lock, the
-        #    comparison will show that the token did indeed get updated and will
-        #    unlock with asking for credentials.
-        # 3) One thread gets the authentication error and goes as far as updating
-        #    self.config.session_token, but not before another thread has
-        #    initialized original session token with the old value. Since
-        #    self.config.session_token is now valid at the time of the
-        #    _call_rpc call, there is no problem.
-
-        original_session_token = self.config.session_token
         try:
             return super(ShotgunWrapper, self)._call_rpc(*args, **kwargs)
         except AuthenticationFault:
-            interactive_authentication.renew_session(self._user, original_session_token)
+            interactive_authentication.renew_session(self._user)
             self.config.session_token = self._user.get_session_token()
             #  If there is once again an authentication fault, then it means
             # something else is going wrong and we will then simply rethrow

--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -128,7 +128,7 @@ class SessionUser(ShotgunUser):
         self._session_token = session_token
 
         self._try_save()
-        
+
     def get_login(self):
         """
         Returns the login name for this user.
@@ -245,7 +245,6 @@ class SessionUser(ShotgunUser):
             # next time.
             # FIXME: We should log something here however.
             pass
-
 
 
 class ScriptUser(ShotgunUser):

--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -195,27 +195,6 @@ class SessionUser(ShotgunUser):
         session_cache.delete_session_data(self.get_host(), self.get_login())
 
     @staticmethod
-    def get_saved_user(host, login, http_proxy):
-        """
-        Returns a user for a given host.
-
-        :param host: Host to retrieve the saved user from.
-        :param login: Saved user to retrieve from the host.
-        :param http_proxy: HTTP proxy to use with this host.
-
-        :returns: A SessionUser instance if a user was saved, None otherwise.
-        """
-        credentials = session_cache.get_session_data(host, login)
-        if credentials:
-            return SessionUser(
-                host=host,
-                http_proxy=http_proxy,
-                **credentials
-            )
-        else:
-            return None
-
-    @staticmethod
     def from_dict(payload):
         """
         Creates a user from a dictionary.

--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -119,8 +119,13 @@ class SessionUser(ShotgunUser):
 
         :param host: Host for this Shotgun user.
         :param login: Login name for the user.
-        :param session_token: Session token for the user.
+        :param session_token: Session token for the user. If session token is None
+            the session token will be looked for in the users file.
         :param http_proxy: HTTP proxy to use with this host. Defaults to None.
+
+        :raises IncompleteCredentials: If there was no session token on file for
+            login, this is raised.
+            login, this is raised.
         """
 
         super(SessionUser, self).__init__(host, http_proxy)
@@ -176,18 +181,6 @@ class SessionUser(ShotgunUser):
             self.get_host(), session_token=self.get_session_token(),
             http_proxy=self.get_http_proxy(),
             user=self
-        )
-
-    def save(self):
-        """
-        Saves a user's information in the local site cache.
-
-        :param user: Specifying a user to be the current user.
-        """
-        session_cache.cache_session_data(
-            self.get_host(),
-            self.get_login(),
-            self.get_session_token()
         )
 
     def clear_session_token(self):
@@ -250,7 +243,11 @@ class SessionUser(ShotgunUser):
         if it failed.
         """
         try:
-            self.save()
+            session_cache.cache_session_data(
+                self.get_host(),
+                self.get_login(),
+                self.get_session_token()
+            )
         except:
             # Do not break the running pass because somehow we couldn't
             # cache the credentials. We'll simply be asking them again

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -27,6 +27,7 @@ from tank_vendor.shotgun_authentication import ShotgunAuthenticator
 from tank_vendor.shotgun_authentication import AuthenticationError
 from tank_vendor.shotgun_authentication import ShotgunAuthenticationError
 from tank_vendor.shotgun_authentication import IncompleteCredentials
+from tank_vendor.shotgun_authentication import is_script_user
 from tank.platform import engine
 from tank import pipelineconfig_utils
 
@@ -447,11 +448,11 @@ def shotgun_run_action_auth(log, install_root, pipeline_config_root, is_localize
     core_dm = CoreDefaultsManager()
     sa = ShotgunAuthenticator(core_dm)
 
-    # first of all, if there is a default user defined, that takes precedence
-    # this is the case if there is a user defined in shotgun.yml
+    # first of all, if there is a default user and it's a script user,
+    # it takes precedence for backward compatibility reasons.
     default_user = sa.get_default_user()
-    if default_user:
-        # there is a default hard coded user - this takes presedence.
+    if is_script_user(default_user):
+        # there is a default hard script user - this takes presedence.
         tank.set_current_user(default_user)
 
     else:

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1317,7 +1317,7 @@ if __name__ == "__main__":
             core_dm = CoreDefaultsManager()
             sa = ShotgunAuthenticator(core_dm)
             # Clear the saved user.
-            user = sa.clear_saved_user()
+            user = sa.clear_default_user()
             if user:
                 logger.info("Succesfully logged out from %s." % user.get_host())
             else:

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -25,6 +25,7 @@ import unittest2 as unittest
 
 import sgtk
 import tank
+from tank_vendor import shotgun_authentication
 from tank import path_cache
 from tank_vendor import yaml
 
@@ -137,6 +138,10 @@ class TankTestBase(unittest.TestCase):
         self.tank_source_path = TANK_SOURCE_PATH
 
         self.init_cache_location = os.path.join(self.tank_temp, "init_cache.cache") 
+
+        shotgun_authentication.session_cache._get_cache_location = lambda: os.path.join(
+            self.tank_temp, "session_cache"
+        )
 
         def _get_cache_location_mock():
             return self.init_cache_location

--- a/tests/run_auth_tests.sh
+++ b/tests/run_auth_tests.sh
@@ -12,5 +12,7 @@
 ./run_tests.sh shotgun_authentication_tests.test_shotgun_wrapper &&
     ./run_tests.sh shotgun_authentication_tests.test_shotgun_authenticator &&
     ./run_tests.sh shotgun_authentication_tests.test_user &&
+    ./run_tests.sh shotgun_authentication_tests.test_session_cache &&
     ./run_tests.sh util_tests.test_login &&
+    ./run_tests.sh util_tests.test_shotgun &&
     ./run_tests.sh shotgun_authentication_tests.test_interactive_authentication --interactive

--- a/tests/shotgun_authentication_tests/test_interactive_authentication.py
+++ b/tests/shotgun_authentication_tests/test_interactive_authentication.py
@@ -108,7 +108,7 @@ class InteractiveTests(TankTestBase):
         self._print_message("We're about to fake an expired session. Hang tight!", test_console)
         # Test the session renewal code.
         tank_vendor.shotgun_authentication.interactive_authentication.renew_session(
-            sg_user, sg_user.get_session_token()
+            sg_user
         )
         self._print_message("Test successful", test_console)
 

--- a/tests/shotgun_authentication_tests/test_session_cache.py
+++ b/tests/shotgun_authentication_tests/test_session_cache.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
+
+from tank_test.tank_test_base import *
+
+from tank_vendor.shotgun_authentication import session_cache
+
+
+class SessionCacheTests(TankTestBase):
+
+    def test_current_host(self):
+        """
+        Makes sure current host is saved appropriately.
+        """
+        # Write the host and make sure we read it back.
+        host = "https://host.shotgunstudio.com"
+        session_cache.set_current_host(host)
+        self.assertEqual(session_cache.get_current_host(), host)
+
+        # Update the host and make sure we read it back.
+        other_host = "https://other_host.shotgunstudio.com"
+        session_cache.set_current_host(other_host)
+        self.assertEqual(session_cache.get_current_host(), other_host)
+
+    def test_current_user(self):
+        """
+        Makes sure the current user is saved appropriately for a given host.
+        """
+
+        host = "https://host.shotgunstudio.com"
+        user = "bob"
+
+        # Write the current user for a host and makes sure we get it back.
+        session_cache.set_current_user(host, user)
+        self.assertEqual(session_cache.get_current_user(host), user)
+
+        # Write the current user for a second host and make sure we get it
+        # back. Also make sure we are not updating the other host for some
+        # reason.
+        other_host = "https://other_host.shotgunstudio.com"
+        other_user = "alice"
+        session_cache.set_current_user(other_host, other_user)
+        self.assertEqual(session_cache.get_current_user(other_host), other_user)
+        self.assertEqual(session_cache.get_current_user(host), user)
+
+    def test_session_cache(self):
+        """
+        Makes sure that the user enabled sessions are stored properly.
+        """
+
+        # Make sure we stored the session token.
+        host = "https://host.shotgunstudio.com"
+        session_cache.cache_session_data(
+            host,
+            "bob",
+            "bob_session_token"
+        )
+        self.assertEqual(
+            session_cache.get_session_data(host, "bob")["session_token"], "bob_session_token"
+        )
+
+        # Make sure we can store a second one.
+        session_cache.cache_session_data(
+            host,
+            "alice",
+            "alice_session_token"
+        )
+        # We can see the old one
+        self.assertEqual(
+            session_cache.get_session_data(host, "bob")["session_token"], "bob_session_token"
+        )
+        # check for the new one
+        self.assertEqual(
+            session_cache.get_session_data(host, "alice")["session_token"], "alice_session_token"
+        )
+
+        session_cache.delete_session_data(host, "bob")
+
+        self.assertEqual(session_cache.get_session_data(host, "bob"), None)
+        self.assertEqual(
+            session_cache.get_session_data(host, "alice")["session_token"], "alice_session_token"
+        )

--- a/tests/shotgun_authentication_tests/test_shotgun_authenticator.py
+++ b/tests/shotgun_authentication_tests/test_shotgun_authenticator.py
@@ -56,7 +56,6 @@ class ShotgunAuthenticatorTests(TankTestBase):
         """
         Makes sure that create_script_user does correct input validation.
         """
-
         # No script name should throw
         with self.assertRaises(IncompleteCredentials):
             ShotgunAuthenticator(TestDefaultManager()).create_script_user("", "api_key")


### PR DESCRIPTION
- changed session cache format to yaml instead of plain old ini files.
- session cache for a site can now store credentials for as many users as needed
- introduced a single-sign-on like system in the defaults manager that tracks the most recently logged in site
- each site also tracks the most recently used user (what will be used in tank and shotgun studio for example)
- moved error handling deeper into the user classes to get a safer API.