### PR TITLE
For #28468, address feedback for login gui

### DIFF
--- a/python/tank_vendor/shotgun_authentication/login_dialog.py
+++ b/python/tank_vendor/shotgun_authentication/login_dialog.py
@@ -48,15 +48,6 @@ class LoginDialog(QtGui.QDialog):
         self.ui.site.setText(hostname)
         self.ui.login.setText(login)
 
-        # default focus
-        if self.ui.site.text():
-            if self.ui.login.text():
-                self.ui.password.setFocus(QtCore.Qt.OtherFocusReason)
-            else:
-                self.ui.login.setFocus(QtCore.Qt.OtherFocusReason)
-        else:
-            self.ui.site.setFocus(QtCore.Qt.OtherFocusReason)
-
         # set the logo
         self.ui.logo.setPixmap(QtGui.QPixmap(":/shotgun_authentication/shotgun_logo_light_medium.png"))
 
@@ -102,14 +93,6 @@ class LoginDialog(QtGui.QDialog):
             self.ui.message.setText(message)
             self.ui.message.show()
 
-    def show(self):
-        """
-        Shows the ui.
-        """
-        QtGui.QDialog.show(self)
-        self.activateWindow()
-        self.raise_()
-
     def exec_(self):
         """
         Displays the window modally.
@@ -119,6 +102,16 @@ class LoginDialog(QtGui.QDialog):
         # the trick of activating + raising does not seem to be enough for
         # modal dialogs. So force put them on top as well.
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint | self.windowFlags())
+
+        # Someone else is setting the focus between the init and
+        # the exec_, so set the focus appropriately at the very last minute.
+        if self.ui.site.text():
+            if self.ui.login.text():
+                self.ui.password.setFocus(QtCore.Qt.OtherFocusReason)
+            else:
+                self.ui.login.setFocus(QtCore.Qt.OtherFocusReason)
+        else:
+            self.ui.site.setFocus(QtCore.Qt.OtherFocusReason)
         return QtGui.QDialog.exec_(self)
 
     def result(self):

--- a/python/tank_vendor/shotgun_authentication/login_dialog.py
+++ b/python/tank_vendor/shotgun_authentication/login_dialog.py
@@ -52,27 +52,45 @@ class LoginDialog(QtGui.QDialog):
         # default focus
         if self.ui.site.text():
             if self.ui.login.text():
-                self.ui.password.setFocus()
+                self.ui.password.setFocus(QtCore.Qt.OtherFocusReason)
             else:
-                self.ui.login.setFocus()
+                self.ui.login.setFocus(QtCore.Qt.OtherFocusReason)
         else:
-            self.ui.site.setFocus()
+            self.ui.site.setFocus(QtCore.Qt.OtherFocusReason)
 
         # set the logo
         self.ui.logo.setPixmap(QtGui.QPixmap(":/shotgun_authentication/shotgun_logo_light_medium.png"))
 
+        if fixed_host:
+            self._disable_widget(
+                self.ui.site,
+                "You can't edit the host, your core is configured for this site."
+            )
+
         # Disable keyboard input in the site and login boxes if we are simply renewing the session.
-        self.ui.site.setReadOnly(is_session_renewal or fixed_host)
-        self.ui.login.setReadOnly(is_session_renewal)
+        # If the host is fixed, disable the site textbox.
+        if is_session_renewal:
+            self._disable_widget(
+                self.ui.site,
+                "You are renewing your session: you can't change your host.")
+            self._disable_widget(
+                self.ui.login,
+                "You are renewing your session: you can't change your login."
+            )
 
         if is_session_renewal:
-            self._set_error_message("Your session has expired. Please enter your Shotgun password.")
+            self._set_message("Your session has expired. Please enter your Shotgun password.")
         else:
             self._set_message("Please enter your Shotgun credentials.")
 
         # hook up signals
         self.ui.sign_in.clicked.connect(self._ok_pressed)
         self.ui.cancel.clicked.connect(self.reject)
+
+    def _disable_widget(self, widget, tooltip_text):
+        widget.setReadOnly(True)
+        widget.setEnabled(False)
+        widget.setToolTip(tooltip_text)
 
     def _set_message(self, message):
         """

--- a/python/tank_vendor/shotgun_authentication/resources/login_dialog.ui
+++ b/python/tank_vendor/shotgun_authentication/resources/login_dialog.ui
@@ -21,6 +21,7 @@
     selection-background-color: rgb(168, 123, 43);
     selection-color: rgb(230, 230, 230);
     font-size: 11px;
+    color: rgb(192, 192, 192);
 }
 
 QPushButton
@@ -44,7 +45,11 @@ QLineEdit
 QLineEdit:focus
 {
 	border: 1px solid rgb(48, 167, 227);
+}
 
+QLineEdit:Disabled {
+    background-color: rgb(60, 60, 60);
+    color: rgb(160, 160, 160);
 }</string>
   </property>
   <property name="modal">

--- a/python/tank_vendor/shotgun_authentication/ui/login_dialog.py
+++ b/python/tank_vendor/shotgun_authentication/ui/login_dialog.py
@@ -20,6 +20,7 @@ class Ui_LoginDialog(object):
 "    selection-background-color: rgb(168, 123, 43);\n"
 "    selection-color: rgb(230, 230, 230);\n"
 "    font-size: 11px;\n"
+"    color: rgb(192, 192, 192);\n"
 "}\n"
 "\n"
 "QPushButton\n"
@@ -43,7 +44,11 @@ class Ui_LoginDialog(object):
 "QLineEdit:focus\n"
 "{\n"
 "    border: 1px solid rgb(48, 167, 227);\n"
+"}\n"
 "\n"
+"QLineEdit:Disabled {\n"
+"    background-color: rgb(60, 60, 60);\n"
+"    color: rgb(160, 160, 160);\n"
 "}")
         LoginDialog.setModal(True)
         self.verticalLayout_2 = QtGui.QVBoxLayout(LoginDialog)


### PR DESCRIPTION
- Textbox is now fully disabled when not editable
- When session is expired, message is no longer is red but in gray.
- Focus is appropriately set to the next available empty QLineEdit