### PR TITLE
For #29144, desktop backwards compatibility logic.

### DIFF
--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -31,7 +31,8 @@ from ... import pipelineconfig_factory
 
 # these are the items that need to be copied across
 # when a configuration is upgraded to contain a core API
-CORE_FILES_FOR_LOCALIZE = [ "shotgun.yml", 
+CORE_FILES_FOR_LOCALIZE = [ "shotgun.yml",
+                            "app_store.yml",
                            "interpreter_Darwin.cfg", 
                            "interpreter_Linux.cfg", 
                            "interpreter_Windows.cfg"]
@@ -187,8 +188,15 @@ def do_localize(log, pc_root_path, suppress_prompts, strip_toolkit_credentials):
             src = os.path.join(core_api_root, "config", "core", fn)
             tgt = os.path.join(pc_root_path, "config", "core", fn)
             log.debug("Copy %s -> %s" % (src, tgt))
-            shutil.copy(src, tgt)
-            
+            # If we're copying any other file than app_store.py, it is mandatory. If we're copying
+            # app_store.yml, only copy it if it exists This is because when you are localizing a
+            # core, app_store.yml might be present or not depending if you are migrating a core
+            # configured with a pre Shotgun 6 or post Shotgun 6 site. In the later, AppStore
+            # credentials can be retrieved using a session token and therefore we don't need the
+            # AppStore credentials to be saved on disk.
+            if fn != "app_store.yml" or os.path.exist(src):
+                shutil.copy(src, tgt)
+
     except Exception, e:
         raise TankError("Could not localize: %s" % e)
     finally:

--- a/python/tank/deploy/tank_commands/core_localize.py
+++ b/python/tank/deploy/tank_commands/core_localize.py
@@ -188,7 +188,7 @@ def do_localize(log, pc_root_path, suppress_prompts, strip_toolkit_credentials):
             src = os.path.join(core_api_root, "config", "core", fn)
             tgt = os.path.join(pc_root_path, "config", "core", fn)
             log.debug("Copy %s -> %s" % (src, tgt))
-            # If we're copying any other file than app_store.py, it is mandatory. If we're copying
+            # If we're copying any other file than app_store.yml, it is mandatory. If we're copying
             # app_store.yml, only copy it if it exists This is because when you are localizing a
             # core, app_store.yml might be present or not depending if you are migrating a core
             # configured with a pre Shotgun 6 or post Shotgun 6 site. In the later, AppStore


### PR DESCRIPTION
- app_store.yml is again copied by a localize, but only if it is there.