### PR TITLE
for #22990 ensure context entities always have "name" key value

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -732,7 +732,7 @@ def from_entity(tk, entity_type, entity_id):
                     
         # make sure this was actually found in the cache
         # fall back on a shotgun lookup if not found
-        if entity_context["project"] is None:
+        if entity_context["entity"].get("name") is None:
             entity_context = _entity_from_sg(tk, entity_type, entity_id)
         
         context.update(entity_context)


### PR DESCRIPTION
If an entity hasn't had folders created yet, building the context for it will now correctly fall back on looking this information up in Shotgun. So now the `"name"` key will always be present in `context["entity"]`.

Previously we were checking for the existence of a `project` in the context which was incorrect. Now checking for the `"name"` key in `context.entity` seems better. 
