### PR TITLE
Session token validation from web launch

### DIFF
--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -66,6 +66,14 @@ class ShotgunUser(object):
         """
         return self._impl.create_sg_connection()
 
+    def are_credentials_valid(self):
+        """
+        Checks if the credentials for the user are valid.
+
+        :returns: True if the credentials are valid, False otherwise.
+        """
+        return self._impl.are_credentials_valid()
+
     @property
     def impl(self):
         """

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -492,6 +492,8 @@ def shotgun_run_action_auth(log, install_root, pipeline_config_root, is_localize
             # no password given from shotgun. Try to use a stored session token
             try:
                 user = sa.create_session_user(login)
+                if not user.are_credentials_valid():
+                    raise IncompleteCredentials("Session token is expired.")
             except IncompleteCredentials:
                 # report back to the Shotgun javascript integration
                 # this error message will trigger the javascript to


### PR DESCRIPTION
Makes sure that the command ran to launch from Shotgun validates that session token is valid when launching from a cached session.