### PR TITLE
Added several retries when uploading thumbnail

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -17,7 +17,9 @@ import os
 import sys
 import urllib
 import urllib2
+import httplib
 import urlparse
+import time
 
 from tank_vendor.shotgun_api3 import Shotgun
 from tank_vendor import yaml
@@ -615,6 +617,31 @@ def get_published_file_entity_type(tk):
     """
     return tk.pipeline_configuration.get_published_file_entity_type()
 
+
+def upload_thumbnail(tk, entity_type, entity_id, thumbnail_path):
+    """
+    Upload a thumbnail to Shotgun, with a few retries.
+    """
+    retries = 5
+    index = 1
+    while True:
+        try:
+            tk.shotgun.upload_thumbnail(entity_type,
+                                        entity_id,
+                                        thumbnail_path)
+        except Exception as e:
+            # usually, we would send an error report at this point
+            # indicating the response from the server store in
+            # tk.shotgun._last_url_open_info
+            # retry after 1s
+            index += 1
+            if index == retries:
+                return False
+            time.sleep(1)
+        else:
+            return True
+
+
 def register_publish(tk, context, path, name, version_number, **kwargs):
     """
     Creates a Tank Published File in Shotgun.
@@ -738,23 +765,25 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     if thumbnail_path and os.path.exists(thumbnail_path):
 
         # publish
-        tk.shotgun.upload_thumbnail(published_file_entity_type, entity["id"], thumbnail_path)
+        upload_thumbnail(tk, published_file_entity_type, entity["id"], thumbnail_path)
+        # tk.shotgun.upload_thumbnail(published_file_entity_type, entity["id"], thumbnail_path)
 
         # entity
         if update_entity_thumbnail == True and context.entity is not None:
-            tk.shotgun.upload_thumbnail(context.entity["type"],
-                                        context.entity["id"],
-                                        thumbnail_path)
+            upload_thumbnail(tk,
+                             context.entity["type"],
+                             context.entity["id"],
+                             thumbnail_path)
 
         # task
         if update_task_thumbnail == True and task is not None:
-            tk.shotgun.upload_thumbnail("Task", task["id"], thumbnail_path)
+            upload_thumbnail(tk, "Task", task["id"], thumbnail_path)
 
     else:
         # no thumbnail found - instead use the default one
         this_folder = os.path.abspath(os.path.dirname(__file__))
         no_thumb = os.path.join(this_folder, "no_preview.jpg")
-        tk.shotgun.upload_thumbnail(published_file_entity_type, entity.get("id"), no_thumb)
+        upload_thumbnail(tk, published_file_entity_type, entity.get("id"), no_thumb)
 
 
     # register dependencies

--- a/python/tank_vendor/shotgun_api3/shotgun.py
+++ b/python/tank_vendor/shotgun_api3/shotgun.py
@@ -314,6 +314,9 @@ class Shotgun(object):
         self._connection = None
         self.__ca_certs = ca_certs
 
+        # for logging
+        self._last_url_open_info = None
+
         self.base_url = (base_url or "").lower()
         self.config.scheme, self.config.server, api_base, _, _ = \
             urlparse.urlsplit(self.base_url)
@@ -1153,6 +1156,7 @@ class Shotgun(object):
         try:
             resp = opener.open(url, params)
             result = resp.read()
+            self._last_url_open_info = str(resp.info()).splitlines()
             # response headers are in str(resp.info()).splitlines()
         except urllib2.HTTPError, e:
             if e.code == 500:
@@ -1249,7 +1253,10 @@ class Shotgun(object):
 
         # Perform the request
         try:
-            result = opener.open(url, params).read()
+            response = opener.open(url, params)
+            result = response.read()
+            self._last_url_open_info = str(response.info()).splitlines()
+            
         except urllib2.HTTPError, e:
             if e.code == 500:
                 raise ShotgunError("Server encountered an internal error. "


### PR DESCRIPTION
Code is quite basic but shows what should happen in a few places in toolkit, with proper error reporting of the server response.

Also, we usually add an extra error reporting to pipeline by email as this could indicate a serious error and we want to be informed as soon as possible (artists might not always report errors to us).
This would be good to have a general system for error reporting to pipeline, like a hook called whenever an error occurs. As dissussed in the catchup I tried to add this directly in TankError, to catastrophic results (a few thousand emails were sent just by launching an app because a TankError is raised by every template when trying to match any path).
