### PR TITLE
Avoid use of a logging method introduced in Python 2.7 (2.6 compatibility)

### DIFF
--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -16,7 +16,7 @@ from .errors import IncompleteCredentials
 from .defaults_manager import DefaultsManager
 
 import logging
-logger = logging.getLogger("shotgun_auth").getChild("shotgun_authenticator")
+logger = logging.getLogger("shotgun_auth.shotgun_authenticator")
 
 
 class ShotgunAuthenticator(object):

--- a/python/tank_vendor/shotgun_authentication/user_impl.py
+++ b/python/tank_vendor/shotgun_authentication/user_impl.py
@@ -30,7 +30,7 @@ from .errors import IncompleteCredentials
 _shotgun_instance_factory = ShotgunWrapper
 
 import logging
-logger = logging.getLogger("shotgun_auth").getChild("user_impl")
+logger = logging.getLogger("shotgun_auth.user_impl")
 
 
 class ShotgunUserImpl(object):


### PR DESCRIPTION
This is for backwards compatibility with pipelines and studios still using Python 2.6, as we do in some applications/environments.

See: https://docs.python.org/2/library/logging.html#logging.Logger.getChild (introduced in Python 2.7)