### PR TITLE
Make sure tank <cmd> operates in a fully initialized context

### DIFF
--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1100,6 +1100,7 @@ def run_engine_cmd(log, pipeline_config_root, context_items, command, using_cwd,
             # In this case, initialize this to have the project context.
             # We do this by attempting to construct a context and probing it
 
+            tk.synchronize_filesystem_structure()
             ctx = tk.context_from_path(ctx_path)
             if ctx.project is None:
                 # context could not be determined based on the path


### PR DESCRIPTION
Prior to this, running tank <cmd> in a context created by another user would fail to initialize the full context object from the current filesystem location.

See: https://toolkit.shotgunsoftware.com/entries/88549058-Updating-to-v0-15-may-require-a-minor-update-to-some-scripts-
