### PR TITLE
Adding ShotgunUser.__repr__ for easier debugging.

### DIFF
--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -104,6 +104,14 @@ class ShotgunUser(object):
         # will take care of the session renewal.
         self.create_sg_connection().find_one("HumanUser", [])
 
+    def __repr__(self):
+        """
+        Returns a string reprensentation of the user.
+
+        :returns: A string reprensentation of the user.
+        """
+        return repr(self.impl)
+
     @property
     def impl(self):
         """

--- a/python/tank_vendor/shotgun_authentication/user.py
+++ b/python/tank_vendor/shotgun_authentication/user.py
@@ -104,6 +104,14 @@ class ShotgunUser(object):
         # will take care of the session renewal.
         self.create_sg_connection().find_one("HumanUser", [])
 
+    def __str__(self):
+        """
+        Returns the name of the user.
+
+        :returns: The user's name string.
+        """
+        return str(self.impl)
+
     def __repr__(self):
         """
         Returns a string reprensentation of the user.

--- a/python/tank_vendor/shotgun_authentication/user_impl.py
+++ b/python/tank_vendor/shotgun_authentication/user_impl.py
@@ -233,6 +233,14 @@ class SessionUser(ShotgunUserImpl):
         except AuthenticationFault:
             return True
 
+    def __repr__(self):
+        """
+        Returns a string reprensentation of the user.
+
+        :returns: A string containing login and site.
+        """
+        return "Human User %s @ %s" % (self._login, self._host)
+
     @staticmethod
     def from_dict(payload):
         """
@@ -344,6 +352,14 @@ class ScriptUser(ShotgunUserImpl):
         data["api_script"] = self.get_script()
         data["api_key"] = self.get_key()
         return data
+
+    def __repr__(self):
+        """
+        Returns a string reprensentation of the user.
+
+        :returns: A string containing script name and site.
+        """
+        return "Script User %s @ %s" % (self._api_script, self._host)
 
     @staticmethod
     def from_dict(payload):

--- a/python/tank_vendor/shotgun_authentication/user_impl.py
+++ b/python/tank_vendor/shotgun_authentication/user_impl.py
@@ -239,7 +239,15 @@ class SessionUser(ShotgunUserImpl):
 
         :returns: A string containing login and site.
         """
-        return "Human User %s @ %s" % (self._login, self._host)
+        return "<SessionUser %s @ %s>" % (self._login, self._host)
+
+    def __str__(self):
+        """
+        Returns the name of the user.
+
+        :returns: A string.
+        """
+        return self._login
 
     @staticmethod
     def from_dict(payload):
@@ -359,7 +367,15 @@ class ScriptUser(ShotgunUserImpl):
 
         :returns: A string containing script name and site.
         """
-        return "Script User %s @ %s" % (self._api_script, self._host)
+        return "<ScriptUser %s @ %s>" % (self._api_script, self._host)
+
+    def __str__(self):
+        """
+        Returns the name of the user.
+
+        :returns: A string.
+        """
+        return self._api_script
 
     @staticmethod
     def from_dict(payload):


### PR DESCRIPTION
Desktop prints the current user for debugging, but because the ShotgunUser now proxies the implementation we can't know what type of user we actually have based on the class information. This will provide useful information about the user.