### PR TITLE
[minor] Tank command now prints out the current user

### DIFF
--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1250,6 +1250,8 @@ def run_engine_cmd(log, pipeline_config_root, context_items, command, using_cwd,
     log.debug("Sgtk API: %s" % tk)
     log.debug("Context: %s" % ctx)
 
+    log.info("- You are running as user '%s'" % tank.get_authenticated_user() )
+
     if tk is not None:
         log.info("- Using configuration '%s' and Core %s" % (tk.pipeline_configuration.get_name(), tk.version))
         # attach our logger to the tank instance

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1250,7 +1250,7 @@ def run_engine_cmd(log, pipeline_config_root, context_items, command, using_cwd,
     log.debug("Sgtk API: %s" % tk)
     log.debug("Context: %s" % ctx)
 
-    log.info("- You are running as user '%s'" % tank.get_authenticated_user() )
+    log.info("- Running as user '%s'" % tank.get_authenticated_user() )
 
     if tk is not None:
         log.info("- Using configuration '%s' and Core %s" % (tk.pipeline_configuration.get_name(), tk.version))


### PR DESCRIPTION
With this change, the current user is printed out when you start the `tank` command:

```
Mannes-MacBook-Pro-2:climp manne$ ./tank shell

Welcome to the Shotgun Pipeline Toolkit!
For documentation, see https://toolkit.shotgunsoftware.com
Starting Toolkit for your current path '/mnt/software/shotgun/climp'
- The path is not associated with any Shotgun object.
- Falling back on default project settings.
- Running as user 'manne'
- Using configuration 'Primary' and Core HEAD
- Setting the Context to Climp.
- Started Shell Engine version v0.4.1
- Environment: /mnt/software/shotgun/climp/config/env/project.yml.
- Running command shell...
```

I found this useful for my own dev work and I think it will help others!
