### PR TITLE
Fixes a bug in the pipeline configuration detection in the project setup wizard.

### DIFF
--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -281,7 +281,7 @@ class ProjectSetupParameters(object):
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
 
-        if not self._config_template.is_project_config():
+        if not self._config_template.is_local_config():
             return False
 
         field_name = {"win32": "windows_path", "linux2": "linux_path", "darwin": "mac_path"}[sys.platform]
@@ -793,7 +793,7 @@ class TemplateConfiguration(object):
     to which changes later on can be pushed or pulled.
     """
 
-    _PROJECT_CONFIG = "project"
+    _LOCAL = "local"
     
     def __init__(self, config_uri, sg, sg_app_store, script_user, log):
         """
@@ -1050,7 +1050,7 @@ class TemplateConfiguration(object):
                     return (self._process_config_zip(config_uri), "zip")
                 else:
                     self._log.info("Hang on, loading configuration...")
-                    return (self._process_config_dir(config_uri), self._PROJECT_CONFIG)
+                    return (self._process_config_dir(config_uri), self._LOCAL)
             else:
                 raise TankError("File path %s does not exist on disk!" % config_uri)    
         
@@ -1200,14 +1200,13 @@ class TemplateConfiguration(object):
         """
         return self._config_uri
 
-    def is_project_config(self):
+    def is_local_config(self):
         """
-        Returns if the configuration is from a configured project.
+        Returns if the configuration is on the local disk.
 
-        :returns: True if the configuration is from a project, False if it comes from the AppStore, GitHub or a zip
-                  file.
+        :returns: True if the configuration is on the local disk, False otherwise.
         """
-        return self._config_mode == self._PROJECT_CONFIG
+        return self._config_mode == self._LOCAL
 
     def get_pipeline_configuration(self):
         """
@@ -1219,7 +1218,7 @@ class TemplateConfiguration(object):
         :raises TankError: This exception is raised when the configuration was pulled from GitHub, AppStore or zip file,
             since no pipeline configuration can be associated with these.
         """
-        if not self.is_project_config():
+        if not self.is_local_config():
             raise TankError(
                 "Cannot resolve pipeline configuration for '%s' because it doesn't belong to an existing project!" %
                 self._config_uri

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -281,7 +281,7 @@ class ProjectSetupParameters(object):
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
 
-        if not self._config_template.is_configured_project():
+        if not self._config_template.is_project_config():
             return False
 
         field_name = {"win32": "windows_path", "linux2": "linux_path", "darwin": "mac_path"}[sys.platform]
@@ -793,7 +793,7 @@ class TemplateConfiguration(object):
     to which changes later on can be pushed or pulled.
     """
 
-    _CONFIGURED_PROJECT = "configured_project"
+    _PROJECT_CONFIG = "project"
     
     def __init__(self, config_uri, sg, sg_app_store, script_user, log):
         """
@@ -1050,7 +1050,7 @@ class TemplateConfiguration(object):
                     return (self._process_config_zip(config_uri), "zip")
                 else:
                     self._log.info("Hang on, loading configuration...")
-                    return (self._process_config_dir(config_uri), self._CONFIGURED_PROJECT)
+                    return (self._process_config_dir(config_uri), self._PROJECT_CONFIG)
             else:
                 raise TankError("File path %s does not exist on disk!" % config_uri)    
         
@@ -1200,14 +1200,14 @@ class TemplateConfiguration(object):
         """
         return self._config_uri
 
-    def is_configured_project(self):
+    def is_project_config(self):
         """
         Returns if the configuration is from a configured project.
 
         :returns: True if the configuration is from a project, False if it comes from the AppStore, GitHub or a zip
                   file.
         """
-        return self._config_mode == self._CONFIGURED_PROJECT
+        return self._config_mode == self._PROJECT_CONFIG
 
     def get_pipeline_configuration(self):
         """
@@ -1219,7 +1219,7 @@ class TemplateConfiguration(object):
         :raises TankError: This exception is raised when the configuration was pulled from GitHub, AppStore or zip file,
             since no pipeline configuration can be associated with these.
         """
-        if not self.is_configured_project():
+        if not self.is_project_config():
             raise TankError("Pipeline configuration uri only exists for configured projects!")
 
         # The config uri points to the config folder inside the pipeline configuration, so we'll have to step out

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -281,10 +281,13 @@ class ProjectSetupParameters(object):
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
 
+        if not self._config_template.is_local_configuration():
+            return False
+
         field_name = {"win32": "windows_path", "linux2": "linux_path", "darwin": "mac_path"}[sys.platform]
         
         data = self._sg.find_one("PipelineConfiguration", 
-                                 [[field_name, "is", self._config_template.get_uri()]],
+                                 [[field_name, "is", self._config_template.get_pipeline_configuration_uri()]],
                                  ["id", 
                                   "code", 
                                   "mac_path", 
@@ -1025,7 +1028,7 @@ class TemplateConfiguration(object):
         Returns a path to a config.
         
         :param config_uri: config path of some kind (git/appstore/local)
-        :returns: tuple with (tmp_path_to_config, config_type) where config_type is local/git/app_store
+        :returns: tuple with (tmp_path_to_config, config_type) where config_type is local/zip/git/app_store
         """
         # three cases:
         # tk-config-xyz
@@ -1042,7 +1045,7 @@ class TemplateConfiguration(object):
                 # either a folder or zip file!
                 if config_uri.endswith(".zip"):
                     self._log.info("Hang on, unzipping configuration...")
-                    return (self._process_config_zip(config_uri), "local")
+                    return (self._process_config_zip(config_uri), "zip")
                 else:
                     self._log.info("Hang on, loading configuration...")
                     return (self._process_config_dir(config_uri), "local")
@@ -1194,7 +1197,32 @@ class TemplateConfiguration(object):
         :returns: string
         """
         return self._config_uri
-        
+
+    def is_local_configuration(self):
+        """
+        Returns if the configuration is local.
+
+        :returns: True if the configuration is local, False if it comes from the AppStore, GitHub or a zip file.
+        """
+        return self._config_mode == "local"
+
+    def get_pipeline_configuration_uri(self):
+        """
+        Resolves the potential pipeline configuration based on the configuration uri. Potential is employed here because
+        there's no guarantee this folder is actually part of a pipeline configuration.
+
+        :returns: Path to the pipeline configuration associated with the configuration uri.
+
+        :raises TankError: This exception is raised when the configuration was pulled from GitHub, AppStore or zip file,
+            since no pipeline configuration can be associated with these.
+        """
+        if not self.is_local_configuration():
+            raise TankError("Pipeline configuration uri only exists for local paths!")
+
+        # The config uri points to the config folder inside the pipeline configuration, so we'll have to step out
+        # for this one.
+        return os.path.split(self._config_uri)[0]
+
     def get_readme_content(self):
         """
         Get associated readme content as a list.

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -1220,7 +1220,10 @@ class TemplateConfiguration(object):
             since no pipeline configuration can be associated with these.
         """
         if not self.is_project_config():
-            raise TankError("Pipeline configuration uri only exists for configured projects!")
+            raise TankError(
+                "Cannot resolve pipeline configuration for '%s' because it doesn't belong to an existing project!" %
+                self._config_uri
+            )
 
         # The config uri points to the config folder inside the pipeline configuration, so we'll have to step out
         # for this one.

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -641,4 +641,4 @@ class SetupProjectWizard(object):
             core_localize.do_localize(self._log, 
                                       self._params.get_configuration_location(sys.platform), 
                                       suppress_prompts=True,
-                                      strip_toolkit_credentials=self._is_session_based_authentication_supported())
+                                      strip_toolkit_credentials=False)


### PR DESCRIPTION
Configuration uris point to the 'config' folder on disk, but this path was used by the wizard to retrieve the pipeline configuration, so no matches were ever made.
To fix this I differentiated internaly (_config_mode) between local filesystem configs and everything else, so that when using local filesystem configs we could compute the path to the actual pipeline configuration and because of this get_configuration_shotgun_info now actually returns the right configuration.
