### PR TITLE
#29996 #29998 Improved path cache syncing

### DIFF
--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -771,7 +771,7 @@ class PathCache(object):
             try:
                 root_name, relative_path = self._separate_root(local_os_path)
             except TankError, e:
-                self._log_debug(log, "Could resolve storages - skipping: %s" % e)
+                self._log_debug(log, "Could not resolve storages - skipping: %s" % e)
                 continue
             
             # all validation checks seem ok - go ahead and make the changes.
@@ -916,7 +916,6 @@ class PathCache(object):
                            the high level folder creation request.
                            
         """        
-        
         if self._path_cache_disabled:
             raise TankError("You are currently running a configuration which does not have any "
                             "capabilities of storing path entry lookups. There is no path cache "

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -626,6 +626,8 @@ class PathCache(object):
         
         self._log_debug(log, "The following FilesystemLocation ids need replaying: %s" % created_folder_ids)
         
+        # run the actual sync - and at the end, inser the event_log_sync data marker
+        # into the database to show where to start syncing from next time.
         return self._replay_folder_entities(cursor, log, max_event_log_id, created_folder_ids)
 
 
@@ -635,6 +637,9 @@ class PathCache(object):
         to the path cache. If ids is None, this indicates a full sync, and 
         the path cache db table is cleared first. If not, the table
         is appended to.
+        
+        Lastly, this method updates the event_log_sync marker in the sqlite database
+        that tracks what the most recent event log id was being synced.
 
         :param cursor: Sqlite database cursor
         :param log: Std python logger or None if logging is not required. 

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -922,7 +922,9 @@ class PathCache(object):
                     d["path_cache_row_id"] = new_rowid
                     
                 
-            
+            # now, if there were any FilesystemLocation records created,
+            # create an event log entry that links back to those entries.
+            # This is then used by the incremental path cache syncer. 
             if self._sync_with_sg and len(data_for_sg) > 0:
 
                 # first, a summary of what we are up to for the event log description

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -486,7 +486,7 @@ class PathCache(object):
         # now register the created ids in the event log
         # this will later on be read by the synchronization            
         # now, based on the entities we just created, assemble a metadata chunk that 
-        # the sync calls can use later on.
+        # the sync calls can use later on.        
         meta = {}
         # the api version used is always useful to know
         meta["core_api_version"] = self._tk.version
@@ -923,7 +923,7 @@ class PathCache(object):
                     
                 
             
-            if self._sync_with_sg:
+            if self._sync_with_sg and len(data_for_sg) > 0:
 
                 # first, a summary of what we are up to for the event log description
                 entity_ids = ", ".join([str(x) for x in entity_ids])

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -515,17 +515,18 @@ class TestShotgunSync(TankTestBase):
         # now have project / seq / shot / step 
         self.assertEqual(len(self.tk.shotgun.find(tank.path_cache.SHOTGUN_ENTITY, [])), 4)
         self.assertEqual( len(self._get_path_cache()), 4)
-        path_cache_contents_1 = self._get_path_cache()
         
         # now replace our path cache file with with snap1
         # so that we have a not-yet-up to date path cache file. 
         shutil.copy("%s.snap1" % pcl, pcl)
+        self.assertEqual( len(self._get_path_cache()), 2)
         
         # now we run the sync - and this sync should be incremental 
         log = sync_path_cache(self.tk)
         # make sure the log mentions an incremental sync
         self.assertTrue( "Doing an incremental sync" in log )
-
+        # and make sure the sync generated new records
+        self.assertEqual( len(self._get_path_cache()), 4)
 
 
     def test_missing_roots_mapping(self):

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -432,10 +432,33 @@ class TestShotgunSync(TankTestBase):
         
         
         
+    def test_no_new_folders_created(self):
+        """
+        Test the case when folder creation is running for an already existing path 
+        """        
         
+        # we should have one Toolkit_Folders_Create record in the path cache,
+        # coming from the project setup
+        folder_events = self.tk.shotgun.find("EventLogEntry", [["event_type", "is", "Toolkit_Folders_Create"]])
+        self.assertEqual(len(folder_events), 1)
         
+        folder.process_filesystem_structure(self.tk,
+                                            self.seq["type"], 
+                                            self.seq["id"],
+                                            preview=False,
+                                            engine=None)        
         
-        
+        # a seq should have been added to the path cache and we should have two events
+        folder_events = self.tk.shotgun.find("EventLogEntry", [["event_type", "is", "Toolkit_Folders_Create"]])
+        self.assertEqual(len(folder_events), 2)
 
-        
+        # running this again, no folders should be created and no events should be generated
+        folder.process_filesystem_structure(self.tk,
+                                            self.seq["type"], 
+                                            self.seq["id"],
+                                            preview=False,
+                                            engine=None)        
+
+        folder_events = self.tk.shotgun.find("EventLogEntry", [["event_type", "is", "Toolkit_Folders_Create"]])
+        self.assertEqual(len(folder_events), 2)
         


### PR DESCRIPTION
Handles edge cases and fixes bugs around path cache syncing.

- FilesystemLocation records in Shotgun whose paths do not fit inside any of the storages defined in the `roots.yml` are now ignored in the sync (a log message is generated). This is an edge case that you'll hit if your roots.yml file is not the same as your local storage def in Shotgun (a setup which we strongly advise against having).
- Fixed a bug causing a full path cache sync to kick in every single time folder creation was running. It turns out that when running on multiple machines, with different people creating folders, the cache sync would always fall back onto a full sync. Fixing this bug will mean a big improvement in app launch speed and users will stop seeing the "hang on, toolkit is generating folders"
- Changed the behaviour so that `Toolkit_Folder_Create` event log records are only created when items were actually added to the `FilesystemLocation` table in Shotgun. Previously, it would always add a record (with an empty list of folder references), resulting in unnecessary syncing and event log records.
- Added unit tests for all cases above and improved some of the other tests slightly.
- Added better logging to the sync process.