### PR TITLE
For #30050, setup project wizard shouldn't strip script key

### DIFF
--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -163,8 +163,7 @@ class SetupProjectAction(Action):
             log.info("Localizing Core...")
             core_localize.do_localize(log, 
                                       params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True,
-                                      strip_toolkit_credentials=False)
+                                      suppress_prompts=True)
                         
                         
                         
@@ -242,8 +241,7 @@ class SetupProjectAction(Action):
             log.info("Localizing Core...")
             core_localize.do_localize(log, 
                                       params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True,
-                                      strip_toolkit_credentials=False)        
+                                      suppress_prompts=True)
         
         # display readme etc.
         readme_content = params.get_configuration_readme()

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -640,5 +640,4 @@ class SetupProjectWizard(object):
         if core_settings["localize"]:
             core_localize.do_localize(self._log, 
                                       self._params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True,
-                                      strip_toolkit_credentials=False)
+                                      suppress_prompts=True)

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -641,4 +641,4 @@ class SetupProjectWizard(object):
             core_localize.do_localize(self._log, 
                                       self._params.get_configuration_location(sys.platform), 
                                       suppress_prompts=True,
-                                      strip_toolkit_credentials=self._is_session_based_authentication_supported())
+                                      strip_toolkit_credentials=False)


### PR DESCRIPTION
Fixes a regression that was introduced by the security work. Script users are not stripped from the shotgun.yml when configuring a project anymore.