### PR TITLE
#30136 Style sheet handling by core

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -142,6 +142,32 @@ class TankBundle(object):
         return self.__descriptor.get_icon_256()
 
     @property
+    def style_constants(self):
+        """
+        Returns a dictionary of style constants. These can be used to build
+        UIs using standard colors and other style components. All keys returned
+        in this dictionary can also be used inside a style.qss that lives 
+        at the root level of the app/engine for framework. Use a 
+        {{DOUBLE_BACKET}} syntax in the stylesheet file, for example:
+        
+            QWidget
+            { 
+                color: {{SG_FOREGROUND_COLOR}};
+            }
+        
+        This property returns the values for all constants, for example:
+        
+            { 
+              "SG_HIGHLIGHT_COLOR": "#18A7E3",
+              "SG_ALERT_COLOR": "#FC6246",
+              "SG_FOREGROUND_COLOR": "#C8C8C8"
+            }
+        
+        :returns: Dictionary. See above for example 
+        """
+        return constants.SG_STYLESHEET_CONSTANTS    
+
+    @property
     def documentation_url(self):
         """
         Return the relevant documentation url for this item.

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -115,7 +115,7 @@ ENVIRONMENT_LOCATION_KEY = "location"
 APP_FILE = "app.py"
 
 # an optional stylesheet that can be defined by bundles
-BUNDLE_STYLESHEET_FILE = "custom.qss"
+BUNDLE_STYLESHEET_FILE = "style.qss"
 
 # define the standard "shotgun blue"
 SG_HIGHLIGHT_COLOR = "#30A7E3"

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -115,7 +115,13 @@ ENVIRONMENT_LOCATION_KEY = "location"
 APP_FILE = "app.py"
 
 # an optional stylesheet that can be defined by bundles
-BUNDLE_STYLESHEET_FILE = "style.css"
+BUNDLE_STYLESHEET_FILE = "custom.qss"
+
+# define the standard "shotgun blue"
+SG_HIGHLIGHT_COLOR = "#30A7E3"
+
+# define the standard stylesheet replacements 
+QSS_REPLACEMENTS = { "SG_HIGHLIGHT_COLOR": SG_HIGHLIGHT_COLOR }
 
 # the storage name that is treated to be the primary storage for tank
 PRIMARY_STORAGE_NAME = "primary"

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -114,6 +114,9 @@ ENVIRONMENT_LOCATION_KEY = "location"
 # the file to look for that defines and bootstraps an app
 APP_FILE = "app.py"
 
+# an optional stylesheet that can be defined by bundles
+BUNDLE_STYLESHEET_FILE = "style.css"
+
 # the storage name that is treated to be the primary storage for tank
 PRIMARY_STORAGE_NAME = "primary"
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -118,7 +118,7 @@ APP_FILE = "app.py"
 BUNDLE_STYLESHEET_FILE = "style.qss"
 
 # define our standard stylesheet constants 
-SG_STYLESHEET_CONSTANTS = { "SG_HIGHLIGHT_COLOR": "#1B95DB",
+SG_STYLESHEET_CONSTANTS = { "SG_HIGHLIGHT_COLOR": "#18A7E3",
                             "SG_ALERT_COLOR": "#FC6246",
                             "SG_FOREGROUND_COLOR": "#C8C8C8"}
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -117,12 +117,10 @@ APP_FILE = "app.py"
 # an optional stylesheet that can be defined by bundles
 BUNDLE_STYLESHEET_FILE = "style.qss"
 
-# define the standard "shotgun blue"
-SG_HIGHLIGHT_COLOR = "#30A7E3"
-
-# define the standard stylesheet replacements 
-QSS_REPLACEMENTS = { "SG_HIGHLIGHT_COLOR": SG_HIGHLIGHT_COLOR,
-                     "SG_ALERT_COLOR": "#FC6246"}
+# define our standard stylesheet constants 
+SG_STYLESHEET_CONSTANTS = { "SG_HIGHLIGHT_COLOR": "#1B95DB",
+                            "SG_ALERT_COLOR": "#FC6246",
+                            "SG_FOREGROUND_COLOR": "#C8C8C8"}
 
 # the storage name that is treated to be the primary storage for tank
 PRIMARY_STORAGE_NAME = "primary"

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -121,7 +121,8 @@ BUNDLE_STYLESHEET_FILE = "custom.qss"
 SG_HIGHLIGHT_COLOR = "#30A7E3"
 
 # define the standard stylesheet replacements 
-QSS_REPLACEMENTS = { "SG_HIGHLIGHT_COLOR": SG_HIGHLIGHT_COLOR }
+QSS_REPLACEMENTS = { "SG_HIGHLIGHT_COLOR": SG_HIGHLIGHT_COLOR,
+                     "SG_ALERT_COLOR": "#FC6246"}
 
 # the storage name that is treated to be the primary storage for tank
 PRIMARY_STORAGE_NAME = "primary"

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -668,6 +668,9 @@ class Engine(TankBundle):
         # create the widget:
         widget = self._create_widget(widget_class, *args, **kwargs)
         
+        # apply style sheet
+        self._apply_external_styleshet(bundle, widget)        
+        
         # create the dialog:
         dialog = self._create_dialog(title, bundle, widget, parent)
         return (dialog, widget)
@@ -797,6 +800,37 @@ class Engine(TankBundle):
         
         # lastly, return the instantiated widget
         return (status, widget)
+    
+    def _apply_external_styleshet(self, bundle, widget):
+        """
+        Apply an std external stylesheet, associated with a bundle, to a widget.
+        
+        This will check if a standard style.css file exists in the
+        app/engine/framework root location on disk and if so load it from 
+        disk and apply to the given widget. The style sheet is cascading, meaning 
+        that it will affect all children of the given widget. Typically this is used
+        at window creation in order to allow newly created dialogs to apply app specific
+        styles easily.
+        
+        :param bundle: app/engine/framework instance to load style sheet from
+        :param widget: widget to apply stylesheet to 
+        """
+        css_file = os.path.join(bundle.disk_location, constants.BUNDLE_STYLESHEET_FILE)
+
+        if os.path.exists(css_file):
+            self.log_debug("Detected style sheet file '%s' - applying to widget %s" % (css_file, widget))
+            try:
+                # Read css file
+                f = open(css_file, "rt")
+                css_data = f.read()
+                # apply style sheet to widget
+                widget.setStyleSheet(css_data)
+            except Exception, e:
+                # catch-all and issue a warning and continue.
+                self._app.log_warning( "Could not apply stylesheet '%s': %s" % (css_file, e) )
+            finally:
+                f.close()
+    
     
     def _define_qt_base(self):
         """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -812,7 +812,7 @@ class Engine(TankBundle):
         :returns: Stylesheet string with replacements applied
         """
         processed_style_sheet = style_sheet
-        for (token, value) in constants.QSS_REPLACEMENTS.iteritems():
+        for (token, value) in constants.SG_STYLESHEET_CONSTANTS.iteritems():
             processed_style_sheet = processed_style_sheet.replace("{{%s}}" % token, value)
         return processed_style_sheet
     
@@ -933,7 +933,10 @@ class Engine(TankBundle):
             fh.close()
             
             # set the std selection bg color to be 'shotgun blue'
-            self._dark_palette.setBrush(QtGui.QPalette.Highlight, QtGui.QBrush(QtGui.QColor(constants.SG_HIGHLIGHT_COLOR)))
+            highlight_color = QtGui.QBrush(QtGui.QColor(constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]))
+            self._dark_palette.setBrush(QtGui.QPalette.Highlight, highlight_color)
+            
+            
             self._dark_palette.setBrush(QtGui.QPalette.HighlightedText, QtGui.QBrush(QtGui.QColor("#FFFFFF")))
             
             # and associate it with the qapplication

--- a/python/tank/platform/qt/dark_palette.css
+++ b/python/tank/platform/qt/dark_palette.css
@@ -51,7 +51,7 @@ QWidget
 QTreeView, QTableView, QListView, QTreeWidget, QTableWidget, QListWidget, QColumnView
 {
     /* Certain widgets don't pick up the selection bg color properly from the palette */
-    selection-background-color: #30A7E3;
+    selection-background-color: {{SG_HIGHLIGHT_COLOR}};
     selection-color: #FFFFFF;
 }
 

--- a/python/tank/platform/qt/dark_palette.css
+++ b/python/tank/platform/qt/dark_palette.css
@@ -45,7 +45,7 @@ QWidget
     from the stylesheet. Adding this color directive seems to gracefully
     resolve this
     */
-    color: #c8c8c8;
+    color: {{SG_FOREGROUND_COLOR}};
 }
 
 QTreeView, QTableView, QListView, QTreeWidget, QTableWidget, QListWidget, QColumnView


### PR DESCRIPTION
@sgsteph @alandann @jfboismenu-adsk curious to hear your thoughts about this. 
This adds logic to the engine so that every time a dialog is opened, core will look for a `style.css` file in the app's root directory, and if present, apply this to the top level dialog widget. This makes it really easy to drop in a css file into any app. And if you have made changes and want to reload, just re-open the dialog. No need to restart the engine.

Thoughts?