### PR TITLE
#30142 Added tk.shotgun_url property

### DIFF
--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -97,7 +97,7 @@ class CacheLocation(HookBaseClass):
             root = os.path.expanduser("~/.shotgun")
 
         # get site only; https://www.foo.com:8080 -> www.foo.com
-        base_url = urlparse.urlparse(tk.shotgun.base_url)[1].split(":")[0]
+        base_url = urlparse.urlparse(tk.shotgun_url)[1].split(":")[0]
         
         # now structure things by site, project id, and pipeline config id
         cache_root = os.path.join(root, 

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -146,6 +146,15 @@ class Tank(object):
         return self.__pipeline_config.get_data_roots()
 
     @property
+    def shotgun_url(self):
+        """
+        The shotgun url associated with this API session.
+        
+        :returns: url as string, for example 'https://mysite.shotgunstudio.com'
+        """
+        return shotgun.get_associated_sg_base_url()
+
+    @property
     def shotgun(self):
         """
         Lazily create a Shotgun API handle.

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -320,16 +320,16 @@ class Context(object):
         # walk up task -> entity -> project -> site
         
         if self.task is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Task", self.task["id"])            
+            return "%s/detail/%s/%d" % (self.__tk.shotgun_url, "Task", self.task["id"])            
         
         if self.entity is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, self.entity["type"], self.entity["id"])            
+            return "%s/detail/%s/%d" % (self.__tk.shotgun_url, self.entity["type"], self.entity["id"])            
 
         if self.project is not None:
-            return "%s/detail/%s/%d" % (self.__tk.shotgun.base_url, "Project", self.project["id"])            
+            return "%s/detail/%s/%d" % (self.__tk.shotgun_url, "Project", self.project["id"])            
         
         # fall back on just the site main url
-        return self.__tk.shotgun.base_url
+        return self.__tk.shotgun_url
         
     @property
     def filesystem_locations(self):

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -391,6 +391,18 @@ class TestApiProperties(TankTestBase):
         """
         self.assertEquals(self.tk.documentation_url, None)
 
+    def test_shotgun_url_property(self):
+        """
+        test api.shotgun_url property
+        """
+        self.assertEquals(self.tk.shotgun_url, "http://unit_test_mock_sg")
+
+    def test_shotgun_property(self):
+        """
+        test api.shotgun property
+        """
+        self.assertEquals(self.tk.shotgun.__class__.__name__, "Shotgun")
+
     def test_configuration_name_property(self):
         """
         test api.configuration_name property


### PR DESCRIPTION
Adds a `shotgun_url` property to the tk API. We use `tk.shotgun.base_url` in a bunch of places which isn't great because it may create an sg API instance just to find out the shotgun url. Instead, the new  `tk.shotgun_url` can now be used for fast and straight forward lookup.