### PR TITLE
Added the ability to use custom test schema with mockgun

### DIFF
--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -21,7 +21,7 @@ import inspect
 import tempfile
 
 from mockgun import Shotgun as MockGun_Shotgun 
-
+from mockgun import generate_schema
 import unittest2 as unittest
 
 import sgtk
@@ -32,7 +32,15 @@ from tank_vendor import yaml
 
 TANK_TEMP = None
 
-__all__ = ['setUpModule', 'TankTestBase', 'tank', 'interactive', 'skip_if_pyside_missing']
+__all__ = [
+    "setUpModule",
+    "TankTestBase",
+    "tank",
+    "interactive",
+    "skip_if_pyside_missing",
+    "MockGun_Shotgun",
+    "generate_schema",
+]
 
 
 def interactive(func):


### PR DESCRIPTION
Fixed real Shotgun API class being overriden by mockgun Shotgun in
generate_schema.
Exposed generate_schema and MockGun_Shotgun from tank_test_base.py.
Made schema files paths class attributes.
Added class method to change schema folder.
Added class method to retrieve schema files paths
Added load_schema method and call it in __init__
Converted a couple of single quotes to double quotes