### PR TITLE
For #30564 - frameworks loaded from Hooks can now be shared.

### DIFF
--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -194,10 +194,12 @@ def load_framework(engine_obj, env, fw_instance_name):
     :param env:                 The environment containing the framework instance to load
     :param fw_instance_name:    The instance name of the framework (e.g. tk-framework-foo_v0.x.x)
     :returns:                   An initialized framework object.
+    :raises:                    TankError if the framework can't be found, has an invalid
+                                configuration or fails to initialize.
     """
     # see if we have a shared instance of the framework:
     fw = engine_obj._get_shared_framework(fw_instance_name)
-    if fw is not None:
+    if fw:
         # win!
         return fw
 

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -186,57 +186,72 @@ def setup_frameworks(engine_obj, parent_obj, env, parent_descriptor):
 
 def load_framework(engine_obj, env, fw_instance_name):
     """
-    Validates, loads and initializes a framework.
-    Returns an initialized framework object.
+    Validates, loads and initializes a framework.  If the framework is available from the list of 
+    shared frameworks maintained by the engine then the shared framework is returned, otherwise a 
+    new instance of the framework will be returned.
+
+    :param engine_obj:          The engine instance to use when loading the framework
+    :param env:                 The environment containing the framework instance to load
+    :param fw_instance_name:    The instance name of the framework (e.g. tk-framework-foo_v0.x.x)
+    :returns:                   An initialized framework object.
     """
-    
-    # now get the app location and resolve it into a version object
+    # see if we have a shared instance of the framework:
+    fw = engine_obj._get_shared_framework(fw_instance_name)
+    if fw is not None:
+        # win!
+        return fw
+
+    # get the framework descriptor
     descriptor = env.get_framework_descriptor(fw_instance_name)
     if not descriptor.exists_local():
         raise TankError("Cannot load Framework! %s does not exist on disk." % descriptor)
-    
-    # Load settings for app - skip over the ones that don't validate
-    try:
 
+    # Load the settings for the framework and validate them
+    try:
         # check that the context contains all the info that the app needs
         validation.validate_context(descriptor, engine_obj.context)
-        
+
         # make sure the current operating system platform is supported
-        validation.validate_platform(descriptor)        
-        
+        validation.validate_platform(descriptor)
+
         # get the app settings data and validate it.
         fw_schema = descriptor.get_configuration_schema()
-                
+
         fw_settings = env.get_framework_settings(fw_instance_name)
         validation.validate_settings(fw_instance_name, 
                                      engine_obj.tank, 
                                      engine_obj.context, 
                                      fw_schema, 
                                      fw_settings)
-                            
+
     except TankError, e:
         # validation error - probably some issue with the settings!
         raise TankError("Framework configuration Error for %s: %s" % (fw_instance_name, e))
-    
+
     except Exception:
         # code execution error in the validation. 
         raise TankError("Could not validate framework %s: %s" % (fw_instance_name, e))
-    
-    
+
     # load the framework
     try:
         # initialize fw class
         fw = _create_framework_instance(engine_obj, descriptor, fw_settings, env)
-        
+
         # load any frameworks required by the framework :)
         setup_frameworks(engine_obj, fw, env, descriptor)
-        
+
         # and run the init
         fw.init_framework()
-        
+
+        # if it's a shared framework then add it to the engine so we can re-use it
+        # again in the future if needed:
+        if fw.is_shared:
+            # register this framework for reuse by other bundles
+            engine_obj._register_shared_framework(fw_instance_name, fw)
+
     except Exception, e:
         raise TankError("Framework %s failed to initialize: %s" % (descriptor, e))
-    
+
     return fw
 
 


### PR DESCRIPTION
Previously, shared frameworks loaded via Hook.load_framework() were not registered as shared frameworks so a new instance was loaded and created each time.  This change means they are now registered correctly