### PR TITLE
#30632 update hook setting validation to handle inheritance

### DIFF
--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -550,7 +550,7 @@ class _SettingsValidator:
         for hook_name in hook_files:
             if hook_name.startswith("{self}"):
                 # assume that each app contains its correct hooks
-                # TODO: don't assume... check anyway. How do we get this to resolve to a path?
+                # TODO: don't assume... check anyway. 
                 continue
 
             elif hook_name.startswith("{config}"):

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -546,15 +546,12 @@ class _SettingsValidator:
             # assume that each app contains its correct hooks
             return
         
-        # multiple paths can be specified here setting up an inheritance chain in which case
-        # as long as at least one of these files exists, the validation passes.
-        print "validating hook paths '%s'" % settings_key
         hook_files = hook_name.split(":")
         for hook_name in hook_files:
             if hook_name.startswith("{self}"):
                 # assume that each app contains its correct hooks
                 # TODO: don't assume... check anyway. 
-                return
+                continue
 
             elif hook_name.startswith("{config}"):
                 # config hook 
@@ -566,28 +563,25 @@ class _SettingsValidator:
                 # lazy (runtime) validation for this - it may be beneficial
                 # not to actually set the environment variable until later
                 # in the life cycle of the engine 
-                return
+                continue
             
             elif hook_name.startswith("{") and "}" in hook_name:
                 # referencing other instances of items
                 # this cannot be easily validated at this point since
                 # no well defined runtime state exists at the time of validation
-                return
+                continue
 
             else:
                 # our standard case
                 hook_path = os.path.join(hooks_folder, "%s.py" % hook_name)
 
-            if os.path.exists(hook_path):
-                return
-        
-        # None of the paths exist on disk, raise an error!    
-        msg = ("Invalid configuration setting '%s' for %s: "
-               "The hook file '%s' located at '%s' does not exist." % (settings_key, 
-                                                                       self._display_name,
-                                                                       hook_name,
-                                                                       hook_path) ) 
-        raise TankError(msg)
+            if not os.path.exists(hook_path):
+                msg = ("Invalid configuration setting '%s' for %s: "
+                       "The hook file '%s' located at '%s' does not exist." % (settings_key, 
+                                                                               self._display_name,
+                                                                               hook_name,
+                                                                               hook_path) ) 
+                raise TankError(msg)
             
 
     def __validate_settings_config_path(self, settings_key, schema, config_value):


### PR DESCRIPTION
Checks all of the hook files specified in a hook setting in order to handle cases where users are using inheritance to override methods in multiple hook files (e.g. actions_hook: '{config}/multi-loader2/tk-multi_actions.py:{config}/multi-loader2/tk-houdini_actions.py'. The validation was previously assuming hook settings would only contain a single file path.