### PR TITLE
For #31336, fix regression with default template key

### DIFF
--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -92,6 +92,15 @@ class TemplateKey(object):
         else:
             return self._default
 
+    @default.setter
+    def default(self, value):
+        """
+        Sets the default value for this key.
+
+        :param value: New default value for the key. Can be None.
+        """
+        self._default = value
+
     @property
     def choices(self):
         """

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -17,10 +17,24 @@ from __future__ import with_statement
 from tank import TankError
 import copy
 import datetime
-import time
 from mock import patch
 from tank_test.tank_test_base import *
-from tank.templatekey import TemplateKey, StringKey, IntegerKey, SequenceKey, TimestampKey, make_keys
+from tank.templatekey import StringKey, IntegerKey, SequenceKey, TimestampKey, make_keys
+
+
+class TestTemplateKey(TankTestBase):
+    """
+    Tests functionality common to all key classes.
+    """
+
+    def test_override_default_at_runtime(self):
+        """
+        Makes sure that a key's default can be overriden at runtime.
+        """
+        sk = SequenceKey("sequencekey", format_spec="04")
+        self.assertEquals(sk.default, "%04d")
+        sk.default = "%03d"
+
 
 class TestStringKey(TankTestBase):
     def setUp(self):


### PR DESCRIPTION
- Brings back a way to set the default value for a key programmatically.
- Added unit test.