### PR TITLE
#29962 Support multiple values passed in for deferred creation

### DIFF
--- a/python/tank/folder/folder_types.py
+++ b/python/tank/folder/folder_types.py
@@ -255,13 +255,18 @@ class Folder(object):
             # defer create for all engine_strs!
             return True
         
-        if isinstance(dc_value, basestring) and dc_value == engine_str:
-            # defer_creation parameter is a string and this matches the engine_str!
-            return True
-        
-        if isinstance(dc_value, list) and engine_str in dc_value:
-            # defer_creation parameter is a list and the engine_str is contained in this list
-            return True
+        # multiple values can be provided in engine_str by delimiting them with a comma
+        # (eg. 'tk-nuke, tk-myApp'). Split them and remove whitespace (eg. ['tk-nuke', 'tk-myApp']) 
+        # then check each one for a match. If *any* of them match then return True to process!
+        engine_str_list = [x.strip() for x in engine_str.split(",")]
+        for engine_str_val in engine_str_list:
+            if isinstance(dc_value, basestring) and dc_value == engine_str_val:
+                # defer_creation parameter is a string and this matches the engine_str_val!
+                return True
+            
+            if isinstance(dc_value, list) and engine_str_val in dc_value:
+                # defer_creation parameter is a list and the engine_str_val is contained in this list
+                return True
         
         # for all other cases, no match!
         return False


### PR DESCRIPTION
Adds support for passing multiple defer keywords to folder creation as a comma-separated string. This is useful if you want to trigger the deferred folder creation for multiple keywords when using the Launcher app to launch a DCC.

For example, when you launch Nuke, the Launcher app automatically sends the engine name (`tk-nuke`) as the deferred keyword, so any folders in your schema definition that are configured with the setting `defer_creation: "tk-nuke"` will be created. However, if you wanted this to also trigger folder creation for additional keywords, previously this was not possible because when you specify a specific keyword in the Launcher settings (eg. `tk-myApp`), this will override the app's default behavior of sending the engine name and replace it with the value you provide. 

Now you can send a defer keyword like `"tk-nuke, tk-myApp"`. Toolkit will treat that as 2 separate keywords (`tk-nuke` and `tk-myApp`) and will compare each one to the defer_creation setting for the folder.