### PR TITLE
 #31482 Skip deferred user workspace folder before user validation

### DIFF
--- a/python/tank/folder/folder_types.py
+++ b/python/tank/folder/folder_types.py
@@ -1356,6 +1356,12 @@ class UserWorkspace(Entity):
         Inherited and wrapps base class implementation
         """
         
+        # first we need to check to see if folders should be created. if the
+        # folder creation is deferred, for example, until a specific engine
+        # is run. 
+        if not self._should_item_be_processed(engine, is_primary):
+            return
+        
         # wraps around the Entity.create_folders() method and adds
         # the current user to the filer query in case this has not already been done.
         # having this set up before the first call to create_folders rather than in the


### PR DESCRIPTION
* folder creation was failing when a user workspace with deferred creation was
  specified in the schema and the folder creation was happening via script.
* this fix moves the check to see if a user workpace folder should be created
  before the sg user validation