### PR TITLE
#31422 Makes frameworks shared by default and allows for cyclic includes.

### DIFF
--- a/python/tank/deploy/descriptor.py
+++ b/python/tank/deploy/descriptor.py
@@ -320,7 +320,8 @@ class AppDescriptor(object):
         shared = md.get("shared")
         # always return a bool
         if shared is None:
-            shared = False
+            # frameworks are now shared by default unless you opt out.
+            shared = True
         return shared
 
     ###############################################################################################

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -166,17 +166,9 @@ def setup_frameworks(engine_obj, parent_obj, env, parent_descriptor):
         
         engine_obj.log_debug("%s - loading framework %s" % (parent_obj, fw_inst_name))
         
-        # try to get a shared instance for this framework
-        fw_obj = engine_obj._get_shared_framework(fw_inst_name)
-
-        if fw_obj is None:
-            # load framework
-            # this only occurs once per instance name for shared frameworks
-            fw_obj = load_framework(engine_obj, env, fw_inst_name)
-
-            if fw_obj.is_shared:
-                # register this framework for reuse by other bundles
-                engine_obj._register_shared_framework(fw_inst_name, fw_obj)
+        # load framework
+        # this only occurs once per instance name for shared frameworks
+        fw_obj = load_framework(engine_obj, env, fw_inst_name)
         
         # note! frameworks are keyed by their code name, not their instance name
         parent_obj.frameworks[fw_obj.name] = fw_obj
@@ -239,17 +231,17 @@ def load_framework(engine_obj, env, fw_instance_name):
         # initialize fw class
         fw = _create_framework_instance(engine_obj, descriptor, fw_settings, env)
 
-        # load any frameworks required by the framework :)
-        setup_frameworks(engine_obj, fw, env, descriptor)
-
-        # and run the init
-        fw.init_framework()
-
         # if it's a shared framework then add it to the engine so we can re-use it
         # again in the future if needed:
         if fw.is_shared:
             # register this framework for reuse by other bundles
             engine_obj._register_shared_framework(fw_instance_name, fw)
+
+        # load any frameworks required by the framework :)
+        setup_frameworks(engine_obj, fw, env, descriptor)
+
+        # and run the init
+        fw.init_framework()
 
     except Exception, e:
         raise TankError("Framework %s failed to initialize: %s" % (descriptor, e))


### PR DESCRIPTION
This changes the loading and allocation behaviour for frameworks to improve performance and allow for cyclic dependencies. Previously, each app would load its individual framework code from disk, resulting in a very sandboxed set of functionality - an app could do deep introspection, runtime code rewrites etc in associated frameworks without affecting other apps. 

Alongside this approach, we also allowed for the possibility of a shared framework, where a single framework is loaded on the engine level and shared between apps.

This change makes everything shared by default with a couple of immediate benefits:

- Less loading of code from disk. This will affect users running on show file system setups.
- Less memory usage
- It's now possible to load a framework chain with cycles.

Frameworks needing explicit sandboxing can still opt in to this.