### PR TITLE
Enable use of env variables for project name, id, pc id and shotgun url

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -81,6 +81,9 @@ class PipelineConfiguration(object):
                             "Please contact support." % self._pc_root)
         self._project_name = data.get("project_name")
 
+        # In case project name is an env variable
+        self._project_name = os.path.expandvars(self._project_name)
+
         # cache fields lazily populated on getter access
         self._clear_cached_settings()
         
@@ -213,6 +216,9 @@ class PipelineConfiguration(object):
             if self._pc_id is None:
                 # not in metadata file on disk. Fall back on SG lookup
                 self._load_metadata_from_sg()
+            elif isinstance(self._pc_id, str):
+                # pc id is an env variable
+                self._pc_id = int(os.path.expandvars(self._pc_id))
 
         return self._pc_id
 
@@ -229,6 +235,9 @@ class PipelineConfiguration(object):
             if self._project_id is None:
                 # not in metadata file on disk. Fall back on SG lookup
                 self._load_metadata_from_sg()
+            elif isinstance(self._project_id, str):
+                # pc id is an env variable
+                self._project_id = int(os.path.expandvars(self._project_id))
 
         return self._project_id
 

--- a/python/tank_vendor/shotgun_api3/shotgun.py
+++ b/python/tank_vendor/shotgun_api3/shotgun.py
@@ -314,7 +314,7 @@ class Shotgun(object):
         self._connection = None
         self.__ca_certs = ca_certs
 
-        self.base_url = (base_url or "").lower()
+        self.base_url = os.path.expandvars(base_url or "").lower()
         self.config.scheme, self.config.server, api_base, _, _ = \
             urlparse.urlsplit(self.base_url)
         if self.config.scheme not in ("http", "https"):


### PR DESCRIPTION
These modifications are useful for studios with a lot of projects who do not wish to have a pipeline configuration for each project, but rather to have versions of the pipeline configuration assigned to each project. 
To be able to do that, you need to use environment variables, set in each project, then a same configuration can be used for several projects.
