### PR TITLE
(For #31592) Refactor the Flame Engine's Logic to Read Commands From Settings

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -668,8 +668,8 @@ class Engine(TankBundle):
             # add the commands if the name of the settings is ''
             # or the name matches
             matching_commands = [(instance_name, name, callback)
-                              for (name, callback) in instance_commands
-                              if not command_name or (command_name == name)]
+                                 for (name, callback) in instance_commands
+                                 if not command_name or (command_name == name)]
             ret_value.extend(matching_commands)
 
             # give feedback if no commands were found

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -633,6 +633,15 @@ class Engine(TankBundle):
         """
         Finds all the commands that match the given selectors.
 
+        Command selector structures are typically found in engine configurations 
+        and are typically defined on the following form in yaml:
+
+        menu_favourites:
+        - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
+        - {app_instance: tk-multi-snapshot,  name: Snapshot...}
+        - {app_instance: tk-multi-workfiles, name: Shotgun Save As...}
+        - {app_instance: tk-multi-publish,   name: Publish...}
+
         Note that selectors that do not match a command will output a warning.
 
         :param command_selectors: A list of command selectors, with each
@@ -675,9 +684,9 @@ class Engine(TankBundle):
             # give feedback if no commands were found
             if not matching_commands:
                 self._engine.log_warning(
-                    "The requested command '%s' from app '%s' could not be "
-                    "matched.\nPlease make sure that you have the app "
-                    "installed and that it is properly loaded." %
+                    "The requested command '%s' from app instance '%s' could "
+                    "not be matched.\nPlease make sure that you have the app "
+                    "installed and that it has successfully initialized." %
                     (command_name, instance_name))
 
         return ret_value

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -504,7 +504,8 @@ class Engine(TankBundle):
     def register_panel(self, callback, panel_name="main", properties=None):
         """
         Similar to register_command, but instead of registering a menu item in the form of a
-        command, this method registers a UI panel.
+        command, this method registers a UI panel. A register_panel call should
+        be used in conjunction with a register_command call.
         
         Panels need to be registered if they should persist between DCC sessions (e.g. 
         for example 'saved layouts').

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -676,7 +676,7 @@ class Engine(TankBundle):
             if not matching_commands:
                 self._engine.log_warning(
                     "The requested command '%s' from app '%s' could not be "
-                    "matched.\nPlease make sure that you have the app is "
+                    "matched.\nPlease make sure that you have the app "
                     "installed and that it is properly loaded." %
                     (command_name, instance_name))
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -655,7 +655,8 @@ class Engine(TankBundle):
             if app_instance is None:
                 continue
             instance_name = app_instance.instance_name
-            commands_by_instance.setdefault(instance_name, []).append((name, value["callback"]))
+            commands_by_instance.setdefault(
+                instance_name, []).append((name, value["callback"]))
 
         # go through the selectors and return any matching commands
         ret_value = []

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -655,8 +655,8 @@ class Engine(TankBundle):
             if app_instance is None:
                 continue
             instance_name = app_instance.instance_name
-            commands_by_instance.setdefault(
-                instance_name, []).append((name, value["callback"]))
+            commands_by_instance.setdefault(instance_name, []).append(
+                (name, value["callback"]))
 
         # go through the selectors and return any matching commands
         ret_value = []

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1273,7 +1273,6 @@ class Engine(TankBundle):
         # don't have ui so can't create an invoker!
         return None
 
-
     ##########################################################################################
     # private         
         

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -539,7 +539,7 @@ class Engine(TankBundle):
         # similar to register_command, track which app this request came from
         properties["app"] = current_app 
         
-        # now compose a unique id for a panel.
+        # now compose a unique id for this panel.
         # This is done based on the app instance name plus the given panel name.
         # By using the instance name rather than the app name, we support the
         # use case where more than one instance of an app exists within a

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -539,15 +539,8 @@ class Engine(TankBundle):
         properties["app"] = current_app 
         
         # now compose a unique id for this panel
-        # this is done based on the app instance name plus the given
-        # panel name. By using the instance name rather than the app name,
-        # we support the use case where more than one instance of an app exists 
-        # within a config.
-        panel_id = "%s_%s" % (current_app.instance_name, panel_name)
-        # to ensure the string is safe to use in most engines, 
-        # sanitize to simple alpha-numeric form
-        panel_id = re.sub("\W", "_", panel_id)
-        panel_id = panel_id.lower()
+        panel_id = self._generate_panel_id(current_app.instance_name,
+                                            panel_name)
          
         # add it to the list of registered panels
         self.__panels[panel_id] = {"callback": callback, "properties": properties}
@@ -1218,6 +1211,23 @@ class Engine(TankBundle):
 
         # don't have ui so can't create an invoker!
         return None
+
+    def _generate_panel_id(self, app_instance_name, panel_name):
+        """
+        Compose a unique id for a panel. This is done based on the app instance
+        name plus the given panel name. By using the instance name rather than
+        the app name, we support the use case where more than one instance of an
+        app exists within a config.
+        :param app_instance_name: Instance name of the current application.
+        :param panel_name:        Name that uniquely identifies a panel.
+        :returns:                 Id to give to the panel.
+        """
+        panel_id = "%s_%s" % (app_instance_name, panel_name)
+        # to ensure the string is safe to use in most engines,
+        # sanitize to simple alpha-numeric form
+        panel_id = re.sub("\W", "_", panel_id)
+        panel_id = panel_id.lower()
+        return panel_id
 
     ##########################################################################################
     # private         

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -633,7 +633,7 @@ class Engine(TankBundle):
         """
         Finds all the commands that match the given selectors.
 
-        Command selector structures are typically found in engine configurations 
+        Command selector structures are typically found in engine configurations
         and are typically defined on the following form in yaml:
 
         menu_favourites:


### PR DESCRIPTION
The *tk-flame* engine [currently has logic](https://github.com/shotgunsoftware/tk-flame/blob/master/engine.py#L154) to read a settings list with the following format:

```
    - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
    - {app_instance: tk-multi-snapshot, name: Snapshot...}
    - {app_instance: tk-multi-workfiles, name: Shotgun Save As...}
    - {app_instance: tk-multi-publish, name: Publish...}
```
(referred to as *command selectors* in the code of this PR)

and extracts all the commands that match the name for each specified app instance (e.g. the command with the name `"Shotgun File Manager..."` from *tk-multi-workfiles*).

Similar logic to this is also required to [read panels as tabs from the settings](https://github.com/shotgunsoftware/tk-desktop/blob/31592_config_tabs_registration/python/tk_desktop/desktop_engine_site_implementation.py#L70) in *tk-desktop*.

This PR refactors that logic in *tk-core*, through the help of a private method `__setting_get_matching_items` that does all the work. Note that it takes a functor as a parameter because `commands` and `panels` do not share the same logic to pick keys for their dictionaries (commands use the command-name with prefix on duplicates, panels compose an id from the instance-name and panel-name). The rest of the code is pretty much almost exactly taken from *tk-flame* (except some changes e.g. checking if there are no matching items for better error reporting).