### PR TITLE
(For #33456) Tank Command to Get Commands of an Entity 

### DIFF
--- a/python/tank/deploy/tank_command.py
+++ b/python/tank/deploy/tank_command.py
@@ -37,6 +37,7 @@ from .tank_commands import clone_configuration
 from .tank_commands import copy_apps
 from .tank_commands import unregister_folders
 from .tank_commands import desktop_migration
+from .tank_commands import get_entity_commands
 
 from ..platform import constants
 from ..platform.engine import start_engine, get_environment_from_context
@@ -71,7 +72,8 @@ BUILT_IN_ACTIONS = [setup_project.SetupProjectAction,
                     unregister_folders.UnregisterFoldersAction,
                     clone_configuration.CloneConfigAction,
                     copy_apps.CopyAppsAction,
-                    desktop_migration.DesktopMigration
+                    desktop_migration.DesktopMigration,
+                    get_entity_commands.GetEntityCommandsAction
                     ]
 
 

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -235,6 +235,8 @@ class GetEntityCommandsAction(Action):
                                 {
                                     "name":  unique name of the command
                                     "title": title to show for the command
+                                    "description": description of what the
+                                                   command does
                                     "icon":  path to the command's icon
                                 }
         """

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -80,9 +80,13 @@ class GetEntityCommandsAction(Action):
                                   command is a dictionary with the following
                                   format:
                                     {
-                                      "name":  command to execute
-                                      "title": title to display for the command
-                                      "icon":  path to the icon of this command
+                                      "name":        command to execute
+                                      "title":       title to display for the
+                                                     command
+                                      "description": description of what the
+                                                     command does
+                                      "icon":        path to the icon of this
+                                                     command
                                     }""",
                 "type":        "dict"
             }
@@ -269,7 +273,7 @@ class GetEntityCommandsAction(Action):
         for line in lines:
             tokens = line.split("$")
 
-            if len(tokens) < 5:
+            if len(tokens) < 6:
                 raise TankError("The cache is missing tokens on the line "
                                 "'%s'.\n"
                                 "Full cache:\n%s"
@@ -278,7 +282,9 @@ class GetEntityCommandsAction(Action):
             name = tokens[0]
             title = tokens[1]
             icon = tokens[4]
+            description = tokens[5]
 
-            commands.append({ "name": name, "title": title, "icon": icon })
+            commands.append({ "name": name, "title": title, "icon": icon,
+                              "description": description })
 
         return commands

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -10,7 +10,7 @@
 
 from .action_base import Action
 from ...errors import TankError
-from ..util import execute_toolkit_command, SubprocessCalledProcessError
+from ..util import execute_tank_command, SubprocessCalledProcessError
 
 import itertools
 import operator
@@ -142,7 +142,9 @@ class GetEntityCommandsAction(Action):
         Constructs the expected name for the cache file of a particular entity
         type.
 
-        :param platform:    platform that will use the cached information
+        :param platform:    platform that will use the cached information.
+                            This string is expected to be of the same format as
+                            sys.platform.
         :param entity_type: entity type that we want the cache for
         :returns:           name of the file containing the desired cached data
         """
@@ -189,23 +191,23 @@ class GetEntityCommandsAction(Action):
 
         # try to load the data right away if it is already cached
         try:
-            return execute_toolkit_command(pipeline_config_path,
-                                           "shotgun_get_actions",
-                                           [cache_name, env_name])
+            return execute_tank_command(pipeline_config_path,
+                                        "shotgun_get_actions",
+                                        [cache_name, env_name])
         except SubprocessCalledProcessError, e:
             # failed to load from cache - only OK if cache is missing or out
             # of date
             if e.returncode not in [self._ERROR_CODE_CACHE_OUT_OF_DATE,
                                     self._ERROR_CODE_CACHE_NOT_FOUND]:
-                raise TankError("Error while trying to get the caches's"
-                                "content.\nDetails: %s\nOutput: %s"
+                raise TankError("Error while trying to get the cache content."
+                                "\nDetails: %s\nOutput: %s"
                                 % (e, e.output))
 
         # cache is not up to date - update it
         try:
-            execute_toolkit_command(pipeline_config_path,
-                                    "shotgun_cache_actions",
-                                    [entity_type, cache_name])
+            execute_tank_command(pipeline_config_path,
+                                 "shotgun_cache_actions",
+                                 [entity_type, cache_name])
         except SubprocessCalledProcessError, e:
             # failed to update the cache
             raise TankError("Failed to update the cache.\n"
@@ -213,9 +215,9 @@ class GetEntityCommandsAction(Action):
 
         # now that the cache is updated, we can try to load the data again
         try:
-            return execute_toolkit_command(pipeline_config_path,
-                                           "shotgun_get_actions",
-                                           [cache_name, env_name])
+            return execute_tank_command(pipeline_config_path,
+                                        "shotgun_get_actions",
+                                        [cache_name, env_name])
         except SubprocessCalledProcessError, e:
             raise TankError("Failed to get the content of the updated cache.\n"
                             "Details: %s\nOutput: %s" % (e, e.output))

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -142,8 +142,20 @@ class GetEntityCommandsAction(Action):
         # advanced information about the commands (e.g. icon path).
         # Since this detailed cache can have different information from the
         # Shotgun one, we don't want to mix and match them and get different
-        # results based on which service asked for a cache update.
-        return "%s_%ss.txt" % (platform, entity_type.lower())
+        # results based on which service asked for a cache update. Therefore,
+        # different caches.
+
+        # get a platform name that follows the conventions of the shotgun cache
+        platform_name = platform
+        if platform == "darwin":
+            platform_name = "mac"
+        elif platform == "win32":
+            platform_name = "windows"
+        elif platform.startswith("linux"):
+            platform_name = "linux"
+
+        return ("shotgun_%s_%s_detailed.txt" %
+                (platform_name, entity_type)).lower()
 
     def _get_env_name(self, entity_type):
         """

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -192,8 +192,8 @@ class GetEntityCommandsAction(Action):
         # try to load the data right away if it is already cached
         try:
             return execute_tank_command(pipeline_config_path,
-                                        "shotgun_get_actions",
-                                        [cache_name, env_name])
+                                        ["shotgun_get_actions", cache_name,
+                                         env_name])
         except SubprocessCalledProcessError, e:
             # failed to load from cache - only OK if cache is missing or out
             # of date
@@ -206,8 +206,8 @@ class GetEntityCommandsAction(Action):
         # cache is not up to date - update it
         try:
             execute_tank_command(pipeline_config_path,
-                                 "shotgun_cache_actions",
-                                 [entity_type, cache_name])
+                                 ["shotgun_cache_actions", entity_type,
+                                  cache_name])
         except SubprocessCalledProcessError, e:
             # failed to update the cache
             raise TankError("Failed to update the cache.\n"
@@ -216,8 +216,8 @@ class GetEntityCommandsAction(Action):
         # now that the cache is updated, we can try to load the data again
         try:
             return execute_tank_command(pipeline_config_path,
-                                        "shotgun_get_actions",
-                                        [cache_name, env_name])
+                                        ["shotgun_get_actions", cache_name,
+                                         env_name])
         except SubprocessCalledProcessError, e:
             raise TankError("Failed to get the content of the updated cache.\n"
                             "Details: %s\nOutput: %s" % (e, e.output))

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -24,14 +24,14 @@ class GetEntityCommandsAction(Action):
     pipeline configuration.
 
     This is done by calling the tank command on the other pipeline
-    configuration and asking it for its cached entity commands (or asks it to
-    update its cache beforehand if needed).
+    configuration and asking for its cached entity commands (or ask to update
+    its cache beforehand if needed).
 
     It is used like this:
     >>> import tank
     # create our command object
     >>> cmd = tank.get_command("get_entity_commands")
-    # get the commands for tasks
+    # get the commands for tasks, but could mix and match with any other types
     >>> tasks = [("Task", 1234), ("Task", 1235)]
     >>> commands_by_task = cmd.execute({"pc_path": "/my/pc/path",
     >>>                                 "entities": tasks})
@@ -119,7 +119,8 @@ class GetEntityCommandsAction(Action):
                     pipeline_config_path, entity_type, entities_of_type)
                 commands = self._parse_cached_commands(cache_content)
 
-                # the commands are the same for all entities of that type
+                # at the moment, the commands are the same for all entities of
+                # that type
                 for entity in entities_of_type:
                     commands_per_entity[entity] = commands
             except TankError as e:
@@ -201,8 +202,9 @@ class GetEntityCommandsAction(Action):
             # of date
             if e.returncode not in [self._ERROR_CODE_CACHE_OUT_OF_DATE,
                                     self._ERROR_CODE_CACHE_NOT_FOUND]:
-                raise TankError("Error while trying to get the cache content."
-                                "\nDetails: %s\nOutput: %s" % (e, e.output))
+                raise TankError("Error while trying to get the caches's"
+                                "content.\nDetails: %s\nOutput: %s"
+                                % (e, e.output))
 
         # cache is not up to date - update it
         try:
@@ -213,8 +215,8 @@ class GetEntityCommandsAction(Action):
             # So, we first try with the new method and fallback to the old one
             # if it fails.
 
-            # since the commands are the same for all the entities of that type,
-            # pick the ID of any entity
+            # since the commands are currently the same for all the entities
+            # of that type, pick the ID of any entity
             entity_id = entities[0][1]
             execute_toolkit_command(pipeline_config_path,
                                     "shotgun_cache_actions",
@@ -222,13 +224,13 @@ class GetEntityCommandsAction(Action):
 
         except SubprocessCalledProcessError as e:
             # failed to update the cache with the new method, revert to the old
-            # method.
+            # method
             try:
                 execute_toolkit_command(pipeline_config_path,
                                         "shotgun_cache_actions",
                                         [entity_type, cache_name])
             except SubprocessCalledProcessError as e:
-                # failed to update the cache, even with the old method.
+                # failed to update the cache, even with the old method
                 raise TankError("Failed to update the cache.\n"
                                 "Details: %s\nOutput: %s" % (e, e.output))
 
@@ -244,7 +246,7 @@ class GetEntityCommandsAction(Action):
     def _parse_cached_commands(self, commands_data):
         """
         Parses raw commands data into a structured list of dictionaries
-        representing the available commands in a cache.
+        representing the available commands in the cache.
 
         :raises:              will raise a TankError if the cache does not
                               have the expected format

--- a/python/tank/deploy/tank_commands/get_entity_commands.py
+++ b/python/tank/deploy/tank_commands/get_entity_commands.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from .action_base import Action
+from ...errors import TankError
+
+
+class GetEntityCommandsAction(Action):
+    """
+    Gets the commands that can be launched on certain entities for another
+    pipeline configuration.
+
+    This is done by calling the tank command on the other pipeline
+    configuration and asking it for its cached entity commands (or asks it to
+    update its cache beforehand if needed).
+
+    It is used like this:
+    >>> import tank
+    # create our command object
+    >>> cmd = tank.get_command("get_entity_commands")
+    # get the commands for tasks
+    >>> tasks = [("Task", 1234), ("Task", 1235)]
+    >>> commands_by_task = cmd.execute({"pc_path": "/my/pc/path",
+    >>>                                 "entities": tasks})
+    # extract the commands of a specific task
+    >>> commands = commands_by_task[tasks[0]]
+    """
+    def __init__(self):
+        Action.__init__(self,
+                        "get_entity_commands",
+                        Action.GLOBAL,
+                        ("Gets the available commands that can be executed "
+                         "for specified entities from another pipeline "
+                         "configuration"),
+                        "API")
+
+        # no tank command support for this one because it returns an object
+        self.supports_tank_command = False
+
+        # this method can be executed via the API
+        self.supports_api = True
+
+        self.parameters = {
+            "pc_path": {
+                "description": "Path to the pipeline configuration associated "
+                               "with the entities.",
+                "type":        "str"
+            },
+
+            "entities": {
+                "description": """List of entities to fetch the actions for.
+                                  Every entity should be a tuple with the
+                                  following format:
+                                    (entity_type, entity_id)""",
+                "type":        "list"
+            },
+
+            "return_value": {
+                "description": """Dictionary of the commands by entity, with
+                                  the (entity_type, entity_id) tuple used as a
+                                  key. Each value is a list of commands. A
+                                  command is a dictionary with the following
+                                  format:
+                                    {
+                                      "name":  command to execute
+                                      "title": title to display for the command
+                                      "icon":  path to the icon of this command
+                                    }""",
+                "type":        "dict"
+            }
+        }
+
+    def run_interactive(self, log, args):
+        """
+        Tank command accessor
+
+        :param log: std python logger
+        :param args: command line args
+        """
+        raise TankError("This Action does not support command line access")
+
+    def run_noninteractive(self, log, parameters):
+        """
+        Tank command API accessor.
+        Called when someone runs a tank command through the core API.
+
+        :param log: std python logger
+        :param parameters: dictionary with tank command parameters
+        """
+        pc_path = parameters["pc_path"]
+        entities = parameters["entities"]
+
+        commands_per_entity = {}
+
+        for entity in entities:
+            commands_per_entity[entity] = {
+                "name":  "TODO",
+                "title": "work in progress",
+                "icon":  ""
+            }
+
+        return commands_per_entity

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -38,7 +38,7 @@ def execute_git_command(cmd):
     if status != 0:
         raise TankError("Error executing git operation. The git command '%s' returned error code %s." % (cmd, status))     
 
-def execute_tank_command(pipeline_config_path, tank_command, args):
+def execute_tank_command(pipeline_config_path, args):
     """
     Wrapper around execution of the tank command of a specified pipeline
     configuration.
@@ -49,7 +49,6 @@ def execute_tank_command(pipeline_config_path, tank_command, args):
              executed.
     :param pipeline_config_path: the path to the pipeline configuration that
                                  contains the tank command
-    :param tank_command:         tank command to execute
     :param args:                 list of arguments to pass to the tank command
     :returns:                    text output of the command
     """
@@ -64,7 +63,7 @@ def execute_tank_command(pipeline_config_path, tank_command, args):
         raise TankError("Could not find the tank command on disk: %s"
                         % command_path)
 
-    return subprocess_check_output([command_path, tank_command] + args)
+    return subprocess_check_output([command_path] + args)
 
 def _get_tank_command_name():
     """ Returns the name of the tank command executable. """

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -38,8 +38,6 @@ def execute_git_command(cmd):
     if status != 0:
         raise TankError("Error executing git operation. The git command '%s' returned error code %s." % (cmd, status))     
 
-_TOOLKIT_COMMAND_NAME = "tank"
-
 def execute_toolkit_command(pipeline_config_path, command, args):
     """
     Wrapper around execution of the tank command of a specified pipeline
@@ -54,18 +52,24 @@ def execute_toolkit_command(pipeline_config_path, command, args):
     :param command:              toolkit command to execute
     :param args:                 list of arguments to pass to the toolkit
                                  command
+    :returns:                    text output of the command
     """
     if not os.path.isdir(pipeline_config_path):
         raise TankError("Could not find the Pipeline Configuration on disk: %s"
                         % pipeline_config_path)
 
-    command_path = os.path.join(pipeline_config_path, _TOOLKIT_COMMAND_NAME)
+    command_path = os.path.join(pipeline_config_path,
+                                _get_toolkit_command_name())
 
     if not os.path.isfile(command_path):
         raise TankError("Could not find the Toolkit command on disk: %s"
                         % command_path)
 
     return subprocess_check_output([command_path, command] + args)
+
+def _get_toolkit_command_name():
+    """ Returns the name of the toolkit command executable. """
+    return "tank" if sys.platform != "win32" else "tank.bat"
 
 def _copy_folder(log, src, dst, skip_list=None): 
     """

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -38,6 +38,35 @@ def execute_git_command(cmd):
     if status != 0:
         raise TankError("Error executing git operation. The git command '%s' returned error code %s." % (cmd, status))     
 
+_TOOLKIT_COMMAND_NAME = "tank"
+
+def execute_toolkit_command(pipeline_config_path, command, args):
+    """
+    Wrapper around execution of the tank command of a specified pipeline
+    configuration.
+
+    :raises: Will raise a SubprocessCalledProcessError if the toolkit command
+             returns a non-zero error code.
+             Will raise a TankError if the toolkit command could not be
+             executed.
+    :param pipeline_config_path: the path to the pipeline configuration that
+                                 contains the toolkit command
+    :param command:              toolkit command to execute
+    :param args:                 list of arguments to pass to the toolkit
+                                 command
+    """
+    if not os.path.isdir(pipeline_config_path):
+        raise TankError("Could not find the Pipeline Configuration on disk: %s"
+                        % pipeline_config_path)
+
+    command_path = os.path.join(pipeline_config_path, _TOOLKIT_COMMAND_NAME)
+
+    if not os.path.isfile(command_path):
+        raise TankError("Could not find the Toolkit command on disk: %s"
+                        % command_path)
+
+    return subprocess_check_output([command_path, command] + args)
+
 def _copy_folder(log, src, dst, skip_list=None): 
     """
     Alternative implementation to shutil.copytree

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -38,7 +38,7 @@ def execute_git_command(cmd):
     if status != 0:
         raise TankError("Error executing git operation. The git command '%s' returned error code %s." % (cmd, status))     
 
-def execute_toolkit_command(pipeline_config_path, command, args):
+def execute_toolkit_command(pipeline_config_path, toolkit_command, args):
     """
     Wrapper around execution of the tank command of a specified pipeline
     configuration.
@@ -49,7 +49,7 @@ def execute_toolkit_command(pipeline_config_path, command, args):
              executed.
     :param pipeline_config_path: the path to the pipeline configuration that
                                  contains the toolkit command
-    :param command:              toolkit command to execute
+    :param toolkit_command:      toolkit command to execute
     :param args:                 list of arguments to pass to the toolkit
                                  command
     :returns:                    text output of the command
@@ -65,7 +65,7 @@ def execute_toolkit_command(pipeline_config_path, command, args):
         raise TankError("Could not find the Toolkit command on disk: %s"
                         % command_path)
 
-    return subprocess_check_output([command_path, command] + args)
+    return subprocess_check_output([command_path, toolkit_command] + args)
 
 def _get_toolkit_command_name():
     """ Returns the name of the toolkit command executable. """

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -38,20 +38,19 @@ def execute_git_command(cmd):
     if status != 0:
         raise TankError("Error executing git operation. The git command '%s' returned error code %s." % (cmd, status))     
 
-def execute_toolkit_command(pipeline_config_path, toolkit_command, args):
+def execute_tank_command(pipeline_config_path, tank_command, args):
     """
     Wrapper around execution of the tank command of a specified pipeline
     configuration.
 
-    :raises: Will raise a SubprocessCalledProcessError if the toolkit command
+    :raises: Will raise a SubprocessCalledProcessError if the tank command
              returns a non-zero error code.
-             Will raise a TankError if the toolkit command could not be
+             Will raise a TankError if the tank command could not be
              executed.
     :param pipeline_config_path: the path to the pipeline configuration that
-                                 contains the toolkit command
-    :param toolkit_command:      toolkit command to execute
-    :param args:                 list of arguments to pass to the toolkit
-                                 command
+                                 contains the tank command
+    :param tank_command:         tank command to execute
+    :param args:                 list of arguments to pass to the tank command
     :returns:                    text output of the command
     """
     if not os.path.isdir(pipeline_config_path):
@@ -59,16 +58,16 @@ def execute_toolkit_command(pipeline_config_path, toolkit_command, args):
                         % pipeline_config_path)
 
     command_path = os.path.join(pipeline_config_path,
-                                _get_toolkit_command_name())
+                                _get_tank_command_name())
 
     if not os.path.isfile(command_path):
-        raise TankError("Could not find the Toolkit command on disk: %s"
+        raise TankError("Could not find the tank command on disk: %s"
                         % command_path)
 
-    return subprocess_check_output([command_path, toolkit_command] + args)
+    return subprocess_check_output([command_path, tank_command] + args)
 
-def _get_toolkit_command_name():
-    """ Returns the name of the toolkit command executable. """
+def _get_tank_command_name():
+    """ Returns the name of the tank command executable. """
     return "tank" if sys.platform != "win32" else "tank.bat"
 
 def _copy_folder(log, src, dst, skip_list=None): 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1551,7 +1551,7 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
     return app_settings
     
 
-def start_shotgun_engine(tk, entity_type, context=None):
+def start_shotgun_engine(tk, entity_type, context):
     """
     Special, internal method that handles the shotgun engine.
     """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1554,6 +1554,17 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
 def start_shotgun_engine(tk, entity_type, context):
     """
     Special, internal method that handles the shotgun engine.
+
+    :param tk:          tank instance
+    :param entity_type: type of the entity to use as a target for picking our
+                        shotgun environment
+    :param context:     context to use for the shotgun engine and its apps.
+
+                        If some apps require a specific context to extract
+                        information (e.g. they call a pick_environment hook to
+                        get the environment to use based on the context), this
+                        should be set to something other than the empty
+                        context.
     """
 
     # bypass the get_environment hook and use a fixed set of environments

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -343,7 +343,12 @@ def _write_shotgun_cache(tk, entity_type, cache_file_name):
         entry = [ cmd_name, title, deny, str(supports_multiple_sel),
                   icon, description ]
 
-        res.append("$".join(entry))
+        # sanitize the fields to make sure that they do not break the cache
+        # format
+        sanitized = [ token.replace("\n", " ").replace("$", "_")
+                      for token in entry ]
+
+        res.append("$".join(sanitized))
 
     data = "\n".join(res)
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -32,6 +32,7 @@ from tank_vendor.shotgun_authentication import IncompleteCredentials
 from tank_vendor import yaml
 from tank.platform import engine
 from tank import pipelineconfig_utils
+from tank import context
 
 
 
@@ -294,7 +295,7 @@ def _run_shotgun_command(log, tk, action_name, entity_type, entity_ids):
                     "initializing it.")
 
 
-def _write_shotgun_cache(tk, entity_type, cache_file_name):
+def _write_shotgun_cache(tk, credentials, entity_type, cache_file_name):
     """
     Writes a shotgun cache menu file to disk.
     The cache is per type and per operating system
@@ -302,8 +303,21 @@ def _write_shotgun_cache(tk, entity_type, cache_file_name):
 
     cache_path = os.path.join(tk.pipeline_configuration.get_shotgun_menu_cache_location(), cache_file_name)
 
+    context = tk.context_empty()
+
+    # if the user passes a specific entity, we load it as our context
+    # TODO generalize to any entity
+    if entity_type.lower() == "task":
+        # loading the specific entity requires authentication
+        ensure_authenticated(
+            credentials.get("script-name"),
+            credentials.get("script-key")
+        )
+        #TODO use the passed entity type and id instead
+        context = tank.context.from_entity(tk, "Task", 329)
+
     # start the shotgun engine, load the apps
-    e = engine.start_shotgun_engine(tk, entity_type)
+    e = engine.start_shotgun_engine(tk, entity_type, context)
 
     # get list of actions
     engine_commands = e.commands
@@ -376,7 +390,7 @@ def _write_shotgun_cache(tk, entity_type, cache_file_name):
         raise TankError("Could not write to cache file %s: %s" % (cache_path, e))
 
 
-def shotgun_cache_actions(log, pipeline_config_root, args):
+def shotgun_cache_actions(log, pipeline_config_root, credentials, args):
     """
     Executes the special shotgun cache actions command
     """
@@ -405,7 +419,7 @@ def shotgun_cache_actions(log, pipeline_config_root, args):
 
     num_log_messages_before = log.handlers[0].formatter.get_num_items()
     try:
-        _write_shotgun_cache(tk, entity_type, cache_file_name)
+        _write_shotgun_cache(tk, credentials, entity_type, cache_file_name)
     except TankError, e:
         log.error("Error writing shotgun cache file: %s" % e)
     except Exception, e:
@@ -1525,7 +1539,8 @@ if __name__ == "__main__":
         # special case when we are called from shotgun
         elif cmd_line[0] == "shotgun_cache_actions":
             # note: this pathway does not require authentication
-            exit_code = shotgun_cache_actions(logger, pipeline_config_root, cmd_line[1:])
+            exit_code = shotgun_cache_actions(logger, pipeline_config_root,
+                                              credentials, cmd_line[1:])
 
         else:
             # these choices remain:

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -309,7 +309,7 @@ def _write_shotgun_cache(tk, entity_type, cache_file_name):
     engine_commands = e.commands
 
     # insert special system commands
-    if entity_type == "Project":
+    if entity_type.lower() == "project":
         engine_commands["__core_info"] = { "properties": {"title": "Check for Core Upgrades...",
                                                           "deny_permissions": ["Artist"] } }
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -342,22 +342,13 @@ def _write_shotgun_cache(tk, credentials, entity_type, cache_file_name):
                 # deny this platform! :)
                 continue
 
-        if "title" in cmd_params["properties"]:
-            title = cmd_params["properties"]["title"]
-        else:
-            title = cmd_name
+        title = cmd_params["properties"].get("title", cmd_name)
+        supports_multiple_sel = cmd_params["properties"].get(
+            "supports_multiple_selection", False)
+        deny = ",".join(cmd_params["properties"].get("deny_permissions", []))
+        icon = cmd_params["properties"].get("icon", "")
 
-        if "supports_multiple_selection" in cmd_params["properties"]:
-            supports_multiple_sel = cmd_params["properties"]["supports_multiple_selection"]
-        else:
-            supports_multiple_sel = False
-
-        if "deny_permissions" in cmd_params["properties"]:
-            deny = ",".join(cmd_params["properties"]["deny_permissions"])
-        else:
-            deny = ""
-
-        entry = [ cmd_name, title, deny, str(supports_multiple_sel) ]
+        entry = [ cmd_name, title, deny, str(supports_multiple_sel), icon ]
 
         res.append("$".join(entry))
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -402,7 +402,7 @@ def shotgun_cache_actions(log, pipeline_config_root, credentials, args):
         raise TankError("Could not instantiate an Sgtk API Object! Details: %s" % e )
 
     # params: entity_type, cache_file_name
-    if len(args) != 2:
+    if len(args) < 2:
         raise TankError("Invalid arguments! Pass entity_type, cache_file_name")
 
     entity_type = args[0]

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -303,7 +303,7 @@ def _write_shotgun_cache(tk, credentials, entity_type, entity_id,
 
     :param tk:              toolkit API instance
     :param credentials:     credentials dictionary that potentially has a
-                            script-name and script-key set
+                            'script-name' and 'script-key' set
     :param entity_type:     type of the entity that we want to write the cache
                             for
     :param entity_id:       sample ID of an entity from the specified type.

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -361,8 +361,10 @@ def _write_shotgun_cache(tk, credentials, entity_type, entity_id,
             "supports_multiple_selection", False)
         deny = ",".join(cmd_params["properties"].get("deny_permissions", []))
         icon = cmd_params["properties"].get("icon", "")
+        description = cmd_params["properties"].get("description", "")
 
-        entry = [ cmd_name, title, deny, str(supports_multiple_sel), icon ]
+        entry = [ cmd_name, title, deny, str(supports_multiple_sel),
+                  icon, description ]
 
         res.append("$".join(entry))
 


### PR DESCRIPTION
(note: the scope of this PR changed - see later comments for details)

This PR needs a bit of context. I will document it here so that we can keep history of the reasoning behind it. The original intent was to do the following:
- add a new tank command that does the job done by [`process_manager`](https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/b7b2936bba261371e8c21b1209ca54e99e0d745b/python/tk_framework_desktopserver/process_manager.py#L211), which is to run `shotgun_get_actions` (along with `shotgun_cache_actions` if needed) on another pipeline config. This would allow an app to get the commands from another pipeline config, just like the Shotgun website does to get the commands for an entity.
- add the *icon_path* to the entity cache (the icon specified by the *applaunchers*). The shotgun website does not check the amount of tokens in the cache per command, so that would not have broken the website portion of it if the field was *appended* to the cache format.

Tried it. :boom:.

It turns out that not all icons were fetched. Specifically, all the applaunchers that would specify a path with a `{target_engine}` token would fail to resolve the path. The reason for that is that, when updating the cache, we launched a `tk-shotgun` engine with a context set to `None`. This then initializes the proper *applaunchers*. Some of them will have a `{target_engine}` token in their path and will try to resolve them through a `tank.platform.get_engine_path` call. This call will eventually call the `pick_environment` hook to know where to fetch the engine data from. The hook will rely on the context to choose which environment to use. It does so by checking e.g. `context.project` and `context.entity`.

`context` is `None`. :boom:.

We can set the context to be an empty context, but then no environment can be picked (how could it know since the context is always empty?). We thus want to set a proper context associated to the entity type that we want to get the commands for. This can be done by passing *one* of the IDs of the entity type that we want the commands for. However, due to the nature of how the Shotgun website asks for commands (preloading them without having information about *what* entities are about to be shown), we can't have this information passed to us. Doing a Shotgun query to get *any* entity of the type we're fetching (as in, going the hacky way of querying the first entity of that type) really is not a nice solution to that problem.

Fundamentally, we want to ask commands for *specific* entities, not entity types as a whole. It is reasonable to think that different entities *could* have different commands (e.g. an Asset task vs a Shot task). While this is not the case at the moment, the API should reflect this flexibility. Therefore, we should pass an entity ID when we have one. I have modified `shotgun_cache_actions` in this PR to accept an entity ID and setup a specific context when it can.

Now, this means that there are two ways to call `shotgun_cache_actions`: one *without* an ID (the old way) that uses an empty context, one *with* an ID (the new way) that uses a specific context. Both  result in *different* information in the cache (one that can resolve all icon paths, the other that can't)... :bomb:.

To avoid conflicts, this PR introduces the concept of "detailed" caches, which are caches that are created by calling `shotgun_cache_actions` the new way (by passing an entity ID). When using the new tank command `get_entity_commands`, the `shotgun_{platform}_{entity}_detailed.txt` cache is used.


The old cache with missing icon paths (see Maya for example):
![screen shot 2015-11-27 at 4 22 41 pm](https://cloud.githubusercontent.com/assets/1843555/11448296/4e0f9978-9523-11e5-9081-2e2e06de72ee.png)

The new cache with all the icon paths:
![screen shot 2015-11-27 at 4 22 52 pm](https://cloud.githubusercontent.com/assets/1843555/11448299/59466d12-9523-11e5-9ccc-2a240c4f0264.png)

Shotgun website commands still work:
![screen shot 2015-11-27 at 4 23 21 pm](https://cloud.githubusercontent.com/assets/1843555/11448307/6ab5af04-9523-11e5-83d6-dbfe35682ba8.png)

Icon paths work:
![screen shot 2015-11-27 at 4 23 33 pm](https://cloud.githubusercontent.com/assets/1843555/11448311/702404d6-9523-11e5-9363-d6ba9dc3fdee.png)

BONUS! Fixed a regression (see that the Project has "Check for App Upgrades" and "Check for Core Upgrades"):
![screen shot 2015-11-27 at 4 24 03 pm](https://cloud.githubusercontent.com/assets/1843555/11448319/908b0a12-9523-11e5-9022-3fc7ae866542.png)
The reason is that [we compare the entity_type with the `"Project"` string](https://github.com/shotgunsoftware/tk-core/blob/d7e7f89dc77ea6590cb52ea94cb17d342fe8f72a/scripts/tank_cmd.py#L312), but [we extract the entity_type from the path of the `yml` environment filenames](https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/b7b2936bba261371e8c21b1209ca54e99e0d745b/python/tk_framework_desktopserver/process_manager.py#L242) (that's when we're using the websockets server)... which are lowercase. `"project" != "Project"` :boom:.