### PR TITLE
#33467 correctly detect Windows platform when on Windows 10

### DIFF
--- a/scripts/tank_cmd.sh
+++ b/scripts/tank_cmd.sh
@@ -20,7 +20,7 @@
 
 uname_os_str=`uname`
 
-if [[ "$uname_os_str" == MINGW32_NT* ]];
+if [[ "$uname_os_str" == MINGW64_NT* ]] || [[ "$uname_os_str" == MINGW32_NT* ]];
 then
 	curr_platform="Windows"
 	# see http://stackoverflow.com/questions/12015348/msys-path-conversion-or-cygpath-for-msys/12063651#12063651

--- a/scripts/tank_cmd_login.sh
+++ b/scripts/tank_cmd_login.sh
@@ -26,7 +26,7 @@
 
 uname_os_str=`uname`
 
-if [[ "$uname_os_str" == MINGW32_NT* ]];
+if [[ "$uname_os_str" == MINGW64_NT* ]] || [[ "$uname_os_str" == MINGW32_NT* ]];
 then
 	curr_platform="Windows"
 	# see http://stackoverflow.com/questions/12015348/msys-path-conversion-or-cygpath-for-msys/12063651#12063651

--- a/setup/root_binaries/tank
+++ b/setup/root_binaries/tank
@@ -82,7 +82,8 @@ else
    # so try and get the parent and call its tank script
    # the parent location is stored in a config file
    curr_platform=`uname`
-   if [[ "${curr_platform}" == MINGW32_NT* ]] || [[ "${curr_platform}" ==  CYGWIN_NT* ]];
+   if [[ "${curr_platform}" == MINGW64_NT* ]] || [[ "${curr_platform}" == MINGW32_NT* ]] ||
+        [[ "${curr_platform}" ==  CYGWIN_NT* ]];
    then
        curr_platform="Windows"
    fi


### PR DESCRIPTION
In the Git shell on Windows 10, `umask` returns `MINGW64_NT-10.0` which we don't correctly detect as Windows in our `tank` shell scripts. This means that Toolkit won't be able to find the correct python interpreter to use and will generate an error.

This change adds logic to include the `MINGW64_NT*` family of values as belonging to the Windows platform so that the the correct interpreter will be found in `config/core/interpreter_windows.cfg`
