### PR TITLE
#34369 Global bundle cache

### DIFF
--- a/python/tank/deploy/app_store_descriptor.py
+++ b/python/tank/deploy/app_store_descriptor.py
@@ -35,16 +35,18 @@ METADATA_FILE = ".metadata.json"
 class TankAppStoreDescriptor(VersionedSingletonDescriptor):
     """
     Represents an app store item.
-
-    Note: Construction of instances of this class can happen in two ways:
-
-    - via the factory method in descriptor.get_from_location()
-    - via the class method TankAppStoreDescriptor.find_latest_item()
-
     """
 
-    def __init__(self, pc_path, bundle_install_path, location_dict, bundle_type):
-        super(TankAppStoreDescriptor, self).__init__(pc_path, bundle_install_path, location_dict)
+    def __init__(self, bundle_install_path, location_dict, bundle_type):
+        """
+        Constructor
+
+        :param bundle_install_path: Location on disk where items are cached
+        :param location_dict: Location dictionary describing the bundle
+        :param bundle_type: Either AppDescriptor.APP, CORE, ENGINE or FRAMEWORK
+        :return: Descriptor instance
+        """
+        super(TankAppStoreDescriptor, self).__init__(bundle_install_path, location_dict)
 
         self._type = bundle_type
         self._name = location_dict.get("name")
@@ -118,27 +120,51 @@ class TankAppStoreDescriptor(VersionedSingletonDescriptor):
             version_entity = constants.TANK_ENGINE_VERSION_ENTITY
             link_field = "sg_tank_engine"
 
+        elif self._type == AppDescriptor.CORE:
+            bundle_entity = None
+            version_entity = constants.TANK_CORE_VERSION_ENTITY
+            link_field = None
+
         else:
             raise TankError("Illegal type value!")
 
         # connect to the app store
-        (sg, script_user) = shotgun.create_sg_app_store_connection()
+        (sg, _) = shotgun.create_sg_app_store_connection()
 
-        # first find the bundle level entity
-        bundle = sg.find_one(bundle_entity, [["sg_system_name", "is", self._name]], ["sg_status_list", "sg_deprecation_message"])
-        if bundle is None:
-            raise TankError("The App store does not contain an item named '%s'!" % self._name)
-
-        # now get the version
-        version = sg.find_one(version_entity,
-                              [[link_field, "is", bundle], ["code", "is", self._version]],
-                              ["description", 
-                               "sg_detailed_release_notes", 
-                               "sg_documentation",
-                               constants.TANK_CODE_PAYLOAD_FIELD])
-        if version is None:
-            raise TankError("The App store does not have a version "
-                            "'%s' of item '%s'!" % (self._version, self._name))
+        if self._type == AppDescriptor.CORE:
+            # special handling of core since it doesn't have a high-level
+            # 'bundle' entity
+            
+            bundle = None
+            
+            version = sg.find_one(constants.TANK_CORE_VERSION_ENTITY,
+                                  [["code", "is", self._version]],
+                                  ["description", 
+                                   "sg_detailed_release_notes", 
+                                   "sg_documentation",
+                                   constants.TANK_CODE_PAYLOAD_FIELD])
+            if version is None:
+                raise TankError("The App store does not have a version "
+                                "'%s' of Core!" % self._version)
+            
+            
+        else:
+        
+            # first find the bundle level entity
+            bundle = sg.find_one(bundle_entity, [["sg_system_name", "is", self._name]], ["sg_status_list", "sg_deprecation_message"])
+            if bundle is None:
+                raise TankError("The App store does not contain an item named '%s'!" % self._name)
+    
+            # now get the version
+            version = sg.find_one(version_entity,
+                                  [[link_field, "is", bundle], ["code", "is", self._version]],
+                                  ["description", 
+                                   "sg_detailed_release_notes", 
+                                   "sg_documentation",
+                                   constants.TANK_CODE_PAYLOAD_FIELD])
+            if version is None:
+                raise TankError("The App store does not have a version "
+                                "'%s' of item '%s'!" % (self._version, self._name))
 
         return {"bundle": bundle, "version": version}
 
@@ -162,278 +188,8 @@ class TankAppStoreDescriptor(VersionedSingletonDescriptor):
             # fail gracefully - this is only a cache!
             pass
 
-    ###############################################################################################
-    # class methods
-
-    @classmethod
-    def _find_latest_for_pattern(cls, pc_path, bundle_install_path, bundle_type, name, version_pattern):
-        """
-        Returns an TankAppStoreDescriptor object representing the latest version
-        of the sought after object. If no matching item is found, an
-        exception is raised.
-
-        This method is useful if you know the name of an app (after browsing in the
-        app store for example) and want to get a formal "handle" to it.
-
-        the version_pattern parameter can be on the following forms:
-        
-        - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
-        - v0.12.x - get the highest v0.12 version
-        - v1.x.x - get the highest v1 version 
-
-        :returns: TankAppStoreDescriptor instance
-        """
-
-        # connect to the app store
-        (sg, script_user) = shotgun.create_sg_app_store_connection()
-
-        # set up some lookup tables so we look in the right table in sg
-        main_entity_map = { AppDescriptor.APP: constants.TANK_APP_ENTITY,
-                            AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_ENTITY,
-                            AppDescriptor.ENGINE: constants.TANK_ENGINE_ENTITY }
-
-        version_entity_map = { AppDescriptor.APP: constants.TANK_APP_VERSION_ENTITY,
-                               AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_VERSION_ENTITY,
-                               AppDescriptor.ENGINE: constants.TANK_ENGINE_VERSION_ENTITY }
-
-        link_field_map = { AppDescriptor.APP: "sg_tank_app",
-                           AppDescriptor.FRAMEWORK: "sg_tank_framework",
-                           AppDescriptor.ENGINE: "sg_tank_engine" }
-
-        # find the main entry
-        bundle = sg.find_one(main_entity_map[bundle_type], 
-                             [["sg_system_name", "is", name]], 
-                             ["id", "sg_status_list"])
-        if bundle is None:
-            raise TankError("App store does not contain an item named '%s'!" % name)
-
-        # check if this has been deprecated in the app store
-        # in that case we should ensure that the cache is cleared later
-        is_deprecated = False
-        if bundle["sg_status_list"] == "dep":
-            is_deprecated = True
-
-        # now get all versions
-        
-        # get latest get the filter logic for what to exclude
-        if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
-            latest_filter = [["sg_status_list", "is_not", "bad" ]]
-        else:
-            latest_filter = [["sg_status_list", "is_not", "rev" ],
-                             ["sg_status_list", "is_not", "bad" ]]        
-        
-        link_field = link_field_map[bundle_type]
-        entity_type = version_entity_map[bundle_type]
-        sg_data = sg.find(entity_type, [[link_field, "is", bundle]] + latest_filter, ["code"])
-
-        if len(sg_data) == 0:
-            raise TankError("Cannot find any versions for %s in the App store!" % name)
-
-        # now put all version number strings which match the form
-        # vX.Y.Z into a nested dictionary where it is keyed by major,
-        # then minor then increment.
-        #
-        # For example, the following versions:
-        # v1.2.1, v1.2.2, v1.2.3, v1.4.3, v1.4.2, v1.4.1
-        # 
-        # Would generate the following:
-        # { "1": { "2": [1,2,3], "4": [3,2,1] } }
-        #  
-        
-        version_numbers = [x.get("code") for x in sg_data]
-        versions = {}
-        
-        for version_num in version_numbers:
-
-            try:
-                (major_str, minor_str, increment_str) = version_num[1:].split(".")
-                (major, minor, increment) = (int(major_str), int(minor_str), int(increment_str))
-            except:
-                # this version number was not on the form vX.Y.Z where X Y and Z are ints. skip.
-                continue
-            
-            if major not in versions:
-                versions[major] = {}
-            if minor not in versions[major]:
-                versions[major][minor] = []
-            if increment not in versions[major][minor]:
-                versions[major][minor].append(increment)
 
 
-        # now handle the different version strings
-        version_to_use = None
-        if "x" not in version_pattern:
-            # we are looking for a specific version
-            if version_pattern not in version_numbers:
-                raise TankError("Could not find requested version '%s' "
-                                "of '%s' in the App store!" % (version_pattern, name))
-            else:
-                # the requested version exists in the app store!
-                version_to_use = version_pattern 
-        
-        elif re.match("v[0-9]+\.x\.x", version_pattern):
-            # we have a v123.x.x pattern
-            (major_str, _, _) = version_pattern[1:].split(".")
-            major = int(major_str)
-            
-            if major not in versions:
-                raise TankError("%s does not have a version matching the pattern '%s'. "
-                                "Available versions are: %s" % (name, version_pattern, ", ".join(version_numbers)))
-            # now find the max version
-            max_minor = max(versions[major].keys())            
-            max_increment = max(versions[major][max_minor])
-            version_to_use = "v%s.%s.%s" % (major, max_minor, max_increment)
-            
-            
-        elif re.match("v[0-9]+\.[0-9]+\.x", version_pattern):
-            # we have a v123.345.x pattern
-            (major_str, minor_str, _) = version_pattern[1:].split(".")
-            major = int(major_str)
-            minor = int(minor_str)
-
-            # make sure the constraints are fulfilled
-            if (major not in versions) or (minor not in versions[major]):
-                raise TankError("%s does not have a version matching the pattern '%s'. "
-                                "Available versions are: %s" % (name, version_pattern, ", ".join(version_numbers)))
-            
-            # now find the max increment
-            max_increment = max(versions[major][minor])
-            version_to_use = "v%s.%s.%s" % (major, minor, max_increment)
-        
-        else:
-            raise TankError("Cannot parse version expression '%s'!" % version_pattern)
-
-        # make a location dict
-        location_dict = {"type": "app_store", "name": name, "version": version_to_use}
-
-        # and return a descriptor instance
-        desc = TankAppStoreDescriptor(pc_path, bundle_install_path, location_dict, bundle_type)
-        
-        # now if this item has been deprecated, meaning that someone has gone in to the app
-        # store and updated the record's deprecation status, we want to make sure we download
-        # all this info the next time it is being requested. So we force clear the metadata
-        # cache.
-        if is_deprecated:
-            desc._remove_app_store_metadata()
-        
-        return desc
-
-    
-    
-    @classmethod
-    def _find_latest(cls, pc_path, bundle_install_path, bundle_type, name):
-        """
-        Returns an TankAppStoreDescriptor object representing the latest version
-        of the sought after object. If no matching item is found, an
-        exception is raised.
-
-        This method is useful if you know the name of an app (after browsing in the
-        app store for example) and want to get a formal "handle" to it.
-
-        :returns: TankAppStoreDescriptor instance
-        """
-
-        # connect to the app store
-        (sg, script_user) = shotgun.create_sg_app_store_connection()
-
-        # get latest
-        # get the filter logic for what to exclude
-        if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
-            latest_filter = [["sg_status_list", "is_not", "bad" ]]
-        else:
-            latest_filter = [["sg_status_list", "is_not", "rev" ],
-                             ["sg_status_list", "is_not", "bad" ]]
-        
-        # set up some lookup tables so we look in the right table in sg
-        main_entity_map = { AppDescriptor.APP: constants.TANK_APP_ENTITY,
-                            AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_ENTITY,
-                            AppDescriptor.ENGINE: constants.TANK_ENGINE_ENTITY }
-
-        version_entity_map = { AppDescriptor.APP: constants.TANK_APP_VERSION_ENTITY,
-                               AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_VERSION_ENTITY,
-                               AppDescriptor.ENGINE: constants.TANK_ENGINE_VERSION_ENTITY }
-
-        link_field_map = { AppDescriptor.APP: "sg_tank_app",
-                           AppDescriptor.FRAMEWORK: "sg_tank_framework",
-                           AppDescriptor.ENGINE: "sg_tank_engine" }
-
-        # find the main entry
-        bundle = sg.find_one(main_entity_map[bundle_type], 
-                             [["sg_system_name", "is", name]], 
-                             ["id", "sg_status_list"])
-        if bundle is None:
-            raise TankError("App store does not contain an item named '%s'!" % name)
-
-        # check if this has been deprecated in the app store
-        # in that case we should ensure that the cache is cleared later
-        is_deprecated = False
-        if bundle["sg_status_list"] == "dep":
-            is_deprecated = True
-
-        # now get the version
-        link_field = link_field_map[bundle_type]
-        entity_type = version_entity_map[bundle_type]
-        sg_version_data = sg.find_one(entity_type,
-                                      filters = [[link_field, "is", bundle]] + latest_filter,
-                                      fields = ["code"],
-                                      order=[{"field_name": "created_at", "direction": "desc"}])
-        if sg_version_data is None:
-            raise TankError("Cannot find any versions for %s in the App store!" % name)
-
-
-
-        version_str = sg_version_data.get("code")
-        if version_str is None:
-            raise TankError("Invalid version number for %s" % sg_version_data)
-
-        # make a location dict
-        location_dict = {"type": "app_store", "name": name, "version": version_str}
-
-        # and return a descriptor instance
-        desc = TankAppStoreDescriptor(pc_path, bundle_install_path, location_dict, bundle_type)
-        
-        # now if this item has been deprecated, meaning that someone has gone in to the app
-        # store and updated the record's deprecation status, we want to make sure we download
-        # all this info the next time it is being requested. So we force clear the metadata
-        # cache.
-        if is_deprecated:
-            desc._remove_app_store_metadata()
-        
-        return desc
-
-    @classmethod
-    def find_latest_item(cls, pc_path, bundle_install_path, bundle_type, name, constraint_pattern=None):
-        """
-        Returns an TankAppStoreDescriptor object representing the latest version
-        of the sought after object. If no matching item is found, an
-        exception is raised. A constraint pattern can be specified if you want to search
-        a subset of the version space available.
-
-        This pattern can be on the following forms:
-
-        - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
-        - v0.12.x - get the highest v0.12 version
-        - v1.x.x - get the highest v1 version
-
-        This method is useful if you know the name of an app (after browsing in the
-        app store for example) and want to get a formal "handle" to it.
-
-        :returns: TankAppStoreDescriptor instance
-        """
-        return cls._find_latest_item_internal(
-            pc_path, bundle_install_path, bundle_type, name, constraint_pattern
-        )
-
-    @classmethod
-    def _find_latest_item_internal(cls, pc_path, bundle_install_path, bundle_type, name, constraint_pattern=None):
-        """
-        Actual implementation of find_latest_item. For parameter and return value information,
-        see find_latest_item for more details.
-        """
-        if constraint_pattern:
-            return cls._find_latest_for_pattern(pc_path, bundle_install_path, bundle_type, name, constraint_pattern)
-        else:
-            return cls._find_latest(pc_path, bundle_install_path, bundle_type, name)
 
 
     ###############################################################################################
@@ -592,24 +348,281 @@ class TankAppStoreDescriptor(VersionedSingletonDescriptor):
             data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
             sg.create("EventLogEntry", data)
 
+        elif self._type == AppDescriptor.CORE:
+            data = {}
+            data["description"] = "%s: Core %s %s was downloaded" % (local_sg.base_url, self._name, self._version)
+            data["event_type"] = "TankAppStore_Core_Download"
+            data["entity"] = version
+            data["user"] = script_user
+            data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
+            data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
+            sg.create("EventLogEntry", data)
+
         else:
             raise TankError("Invalid bundle type")
+
+
+    #############################################################################
+    # searching for other versions
 
     def find_latest_version(self, constraint_pattern=None):
         """
         Returns a descriptor object that represents the latest version.
         
-        :param constraint_pattern: If this is specified, the query will be constrained
-        by the given pattern. Version patterns are on the following forms:
+        This method is useful if you know the name of an app (after browsing in the
+        app store for example) and want to get a formal "handle" to it.
         
-            - v1.2.3 (means the descriptor returned will inevitably be same as self)
-            - v1.2.x 
-            - v1.x.x
+        :param constraint_pattern: If this is specified, the query will be constrained
+               by the given pattern. Version patterns are on the following forms:
+        
+                - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
+                - v0.12.x - get the highest v0.12 version
+                - v1.x.x - get the highest v1 version
 
         :returns: descriptor object
         """
-        return self._find_latest_item_internal(self._pipeline_config_path, self._bundle_install_path, self._type, self._name, constraint_pattern)
+        if constraint_pattern:
+            return self._find_latest_for_pattern(constraint_pattern)
+        else:
+            return self._find_latest()
+
+    def _find_latest_for_pattern(self, name, version_pattern):
+        """
+        Returns an TankAppStoreDescriptor object representing the latest version
+        of the sought after object. If no matching item is found, an
+        exception is raised.
+
+        the version_pattern parameter can be on the following forms:
         
+        - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
+        - v0.12.x - get the highest v0.12 version
+        - v1.x.x - get the highest v1 version 
+
+        :returns: TankAppStoreDescriptor instance
+        """
+
+        # connect to the app store
+        (sg, _) = shotgun.create_sg_app_store_connection()
+
+        # set up some lookup tables so we look in the right table in sg
+        main_entity_map = { AppDescriptor.APP: constants.TANK_APP_ENTITY,
+                            AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_ENTITY,
+                            AppDescriptor.ENGINE: constants.TANK_ENGINE_ENTITY }
+
+        version_entity_map = { AppDescriptor.APP: constants.TANK_APP_VERSION_ENTITY,
+                               AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_VERSION_ENTITY,
+                               AppDescriptor.ENGINE: constants.TANK_ENGINE_VERSION_ENTITY }
+
+        link_field_map = { AppDescriptor.APP: "sg_tank_app",
+                           AppDescriptor.FRAMEWORK: "sg_tank_framework",
+                           AppDescriptor.ENGINE: "sg_tank_engine" }
+
+        # find the main entry
+        bundle = sg.find_one(main_entity_map[self._type], 
+                             [["sg_system_name", "is", self._name]], 
+                             ["id", "sg_status_list"])
+        if bundle is None:
+            raise TankError("App store does not contain an item named '%s'!" % self._name)
+
+        # check if this has been deprecated in the app store
+        # in that case we should ensure that the cache is cleared later
+        is_deprecated = False
+        if bundle["sg_status_list"] == "dep":
+            is_deprecated = True
+
+        # now get all versions
         
+        # get latest get the filter logic for what to exclude
+        if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
+            latest_filter = [["sg_status_list", "is_not", "bad" ]]
+        else:
+            latest_filter = [["sg_status_list", "is_not", "rev" ],
+                             ["sg_status_list", "is_not", "bad" ]]        
+        
+        link_field = link_field_map[self._type]
+        entity_type = version_entity_map[self._type]
+        sg_data = sg.find(entity_type, [[link_field, "is", bundle]] + latest_filter, ["code"])
+
+        if len(sg_data) == 0:
+            raise TankError("Cannot find any versions for %s in the App store!" % self._name)
+
+        # now put all version number strings which match the form
+        # vX.Y.Z into a nested dictionary where it is keyed by major,
+        # then minor then increment.
+        #
+        # For example, the following versions:
+        # v1.2.1, v1.2.2, v1.2.3, v1.4.3, v1.4.2, v1.4.1
+        # 
+        # Would generate the following:
+        # { "1": { "2": [1,2,3], "4": [3,2,1] } }
+        #  
+        
+        version_numbers = [x.get("code") for x in sg_data]
+        versions = {}
+        
+        for version_num in version_numbers:
+
+            try:
+                (major_str, minor_str, increment_str) = version_num[1:].split(".")
+                (major, minor, increment) = (int(major_str), int(minor_str), int(increment_str))
+            except:
+                # this version number was not on the form vX.Y.Z where X Y and Z are ints. skip.
+                continue
+            
+            if major not in versions:
+                versions[major] = {}
+            if minor not in versions[major]:
+                versions[major][minor] = []
+            if increment not in versions[major][minor]:
+                versions[major][minor].append(increment)
+
+
+        # now handle the different version strings
+        version_to_use = None
+        if "x" not in version_pattern:
+            # we are looking for a specific version
+            if version_pattern not in version_numbers:
+                raise TankError("Could not find requested version '%s' "
+                                "of '%s' in the App store!" % (version_pattern, self._name))
+            else:
+                # the requested version exists in the app store!
+                version_to_use = version_pattern 
+        
+        elif re.match("v[0-9]+\.x\.x", version_pattern):
+            # we have a v123.x.x pattern
+            (major_str, _, _) = version_pattern[1:].split(".")
+            major = int(major_str)
+            
+            if major not in versions:
+                raise TankError("%s does not have a version matching the pattern '%s'. "
+                                "Available versions are: %s" % (self._name, version_pattern, ", ".join(version_numbers)))
+            # now find the max version
+            max_minor = max(versions[major].keys())            
+            max_increment = max(versions[major][max_minor])
+            version_to_use = "v%s.%s.%s" % (major, max_minor, max_increment)
+            
+            
+        elif re.match("v[0-9]+\.[0-9]+\.x", version_pattern):
+            # we have a v123.345.x pattern
+            (major_str, minor_str, _) = version_pattern[1:].split(".")
+            major = int(major_str)
+            minor = int(minor_str)
+
+            # make sure the constraints are fulfilled
+            if (major not in versions) or (minor not in versions[major]):
+                raise TankError("%s does not have a version matching the pattern '%s'. "
+                                "Available versions are: %s" % (self._name, version_pattern, ", ".join(version_numbers)))
+            
+            # now find the max increment
+            max_increment = max(versions[major][minor])
+            version_to_use = "v%s.%s.%s" % (major, minor, max_increment)
+        
+        else:
+            raise TankError("Cannot parse version expression '%s'!" % version_pattern)
+
+        # make a location dict
+        location_dict = {"type": "app_store", "name": self._name, "version": version_to_use}
+
+        # and return a descriptor instance
+        desc = TankAppStoreDescriptor(self._bundle_install_path, location_dict, self._type)
+        
+        # now if this item has been deprecated, meaning that someone has gone in to the app
+        # store and updated the record's deprecation status, we want to make sure we download
+        # all this info the next time it is being requested. So we force clear the metadata
+        # cache.
+        if is_deprecated:
+            desc._remove_app_store_metadata()
+        
+        return desc
+
+    def _find_latest(self):
+        """
+        Returns an TankAppStoreDescriptor object representing the latest version
+        of the sought after object. If no matching item is found, an
+        exception is raised.
+
+        :returns: TankAppStoreDescriptor instance
+        """
+
+        # connect to the app store
+        (sg, _) = shotgun.create_sg_app_store_connection()
+
+        # get latest
+        # get the filter logic for what to exclude
+        if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
+            latest_filter = [["sg_status_list", "is_not", "bad" ]]
+        else:
+            latest_filter = [["sg_status_list", "is_not", "rev" ],
+                             ["sg_status_list", "is_not", "bad" ]]
+        
+        # set up some lookup tables so we look in the right table in sg
+        main_entity_map = { AppDescriptor.APP:       constants.TANK_APP_ENTITY,
+                            AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_ENTITY,
+                            AppDescriptor.ENGINE:    constants.TANK_ENGINE_ENTITY}
+
+        version_entity_map = { AppDescriptor.APP:       constants.TANK_APP_VERSION_ENTITY,
+                               AppDescriptor.FRAMEWORK: constants.TANK_FRAMEWORK_VERSION_ENTITY,
+                               AppDescriptor.ENGINE:    constants.TANK_ENGINE_VERSION_ENTITY}
+
+        link_field_map = { AppDescriptor.APP:       "sg_tank_app",
+                           AppDescriptor.FRAMEWORK: "sg_tank_framework",
+                           AppDescriptor.ENGINE:    "sg_tank_engine"}
+
+        is_deprecated = False
+        
+        if self._type != AppDescriptor.CORE:
+            # items other than core have a main entity that represents
+            # app/engine/etc.
+            
+            # find the main entry
+            bundle = sg.find_one(main_entity_map[self._type], 
+                                 [["sg_system_name", "is", self._name]], 
+                                 ["id", "sg_status_list"])
+            if bundle is None:
+                raise TankError("App store does not contain an item named '%s'!" % self._name)
+    
+            # check if this has been deprecated in the app store
+            # in that case we should ensure that the cache is cleared later    
+            if bundle["sg_status_list"] == "dep":
+                is_deprecated = True
+
+            # now get the version
+            link_field = link_field_map[self._type]
+            entity_type = version_entity_map[self._type]
+            sg_version_data = sg.find_one(entity_type,
+                                          filters = [[link_field, "is", bundle]] + latest_filter,
+                                          fields = ["code"],
+                                          order=[{"field_name": "created_at", "direction": "desc"}])
+            
+        else:
+            # core API
+            sg_version_data = sg.find_one(constants.TANK_CORE_VERSION_ENTITY,
+                                          filters = latest_filter,
+                                          fields = ["code"],
+                                          order=[{"field_name": "created_at", "direction": "desc"}])
+        
+        if sg_version_data is None:
+            raise TankError("Cannot find any versions for %s in the App store!" % self._name)
+
+        version_str = sg_version_data.get("code")
+        if version_str is None:
+            raise TankError("Invalid version number for %s" % sg_version_data)
+
+        # make a location dict
+        location_dict = {"type": "app_store", 
+                         "name": self._name, 
+                         "version": version_str}
+
+        # and return a descriptor instance
+        desc = TankAppStoreDescriptor(self._bundle_install_path, location_dict, self._type)
+        
+        # now if this item has been deprecated, meaning that someone has gone in to the app
+        # store and updated the record's deprecation status, we want to make sure we download
+        # all this info the next time it is being requested. So we force clear the metadata
+        # cache.
+        if is_deprecated:
+            desc._remove_app_store_metadata()
+        
+        return desc
 
 

--- a/python/tank/deploy/descriptor.py
+++ b/python/tank/deploy/descriptor.py
@@ -13,6 +13,7 @@ Functionality for managing versions of apps.
 """
 
 import os
+import sys
 import copy
 import sys
 
@@ -30,7 +31,7 @@ class AppDescriptor(object):
     It also knows how to access metadata such as documentation, descriptions etc.
 
     Several AppDescriptor classes exists, all deriving from this base class, and the
-    factory method get_from_location() manufactures the correct descriptor object
+    factory method descriptor_factory() manufactures the correct descriptor object
     based on a location dict, that is found inside of the environment config.
 
     Different App Descriptor implementations typically handle different source control
@@ -42,10 +43,9 @@ class AppDescriptor(object):
     # constants and helpers
 
     # constants describing the type of item we are describing
-    APP, ENGINE, FRAMEWORK = range(3)
+    APP, ENGINE, FRAMEWORK, CORE = range(4)
 
-    def __init__(self, pipeline_config_path, bundle_install_path, location_dict):
-        self._pipeline_config_path = pipeline_config_path
+    def __init__(self, bundle_install_path, location_dict):
         self._bundle_install_path = bundle_install_path
         self._location_dict = location_dict
         self.__manifest_data = None
@@ -77,6 +77,8 @@ class AppDescriptor(object):
             root = os.path.join(self._bundle_install_path, "engines")
         elif app_type == AppDescriptor.FRAMEWORK:
             root = os.path.join(self._bundle_install_path, "frameworks")
+        elif app_type == AppDescriptor.CORE:
+            root = os.path.join(self._bundle_install_path, "cores")
         else:
             raise TankError("Don't know how to figure out the local storage root - unknown type!")
         return os.path.join(root, descriptor_name, name, version)
@@ -406,11 +408,13 @@ class AppDescriptor(object):
                     sg_field_name = field["system_name"]
                     self.__ensure_sg_field_exists(sg, sg_entity_type, sg_field_name, sg_data_type)
 
-    def run_post_install(self):
+    def run_post_install(self, tk):
         """
         If a post install hook exists in a descriptor, execute it. In the
         hooks directory for an app or engine, if a 'post_install.py' hook
         exists, the hook will be executed upon each installation.
+        
+        :param tk: Tk API instance associated with this item
         """
         
         post_install_hook_path = os.path.join(self.get_path(), "hooks",
@@ -418,7 +422,7 @@ class AppDescriptor(object):
         try:
             hook.execute_hook(post_install_hook_path, 
                               parent=None,
-                              pipeline_configuration=self._pipeline_config_path,
+                              pipeline_configuration=tk.pipeline_configuration.get_path(),
                               path=self.get_path())
         except TankFileDoesNotExistError:
             pass
@@ -436,12 +440,31 @@ class VersionedSingletonDescriptor(AppDescriptor):
     """
     _instances = dict()
 
-    def __new__(cls, pc_path, bundle_install_path, location_dict, *args, **kwargs):
+    def __new__(cls, bundle_install_path, location_dict, *args, **kwargs):
+        """
+        Executed prior to all __init__s. Handles singleton caching of descriptors.
+
+        Since all our normal descriptors are immutable - they represent a specific,
+        readonly and cached version of an app, engine or framework on disk, we can
+        also cache their wrapper objects.
+
+        All descriptor types deriving from this caching class need to have a
+        required name and version key as part of their location dict. These
+        keys are used by the class to uniquely identify objects.
+
+        :param bundle_install_path: Location on disk where items are cached
+        :param location_dict: Location dictionary describing the bundle
+        :return: Descriptor instance
+        """
+
         # We will cache based on the bundle install path, name of the
         # app/engine/framework, and version number.
         instance_cache = cls._instances
         name = location_dict.get("name")
         version = location_dict.get("version")
+
+        if name is None or version is None:
+            raise TankError("Cannot process location '%s'. Name and version keys required." % location_dict)
 
         # Instantiate and cache if we need to, otherwise just return what we
         # already have stored away.
@@ -458,7 +481,6 @@ class VersionedSingletonDescriptor(AppDescriptor):
                 instance_cache[bundle_install_path][name] = dict()
             instance_cache[bundle_install_path][name][version] = super(VersionedSingletonDescriptor, cls).__new__(
                 cls,
-                pc_path,
                 bundle_install_path,
                 location_dict,
                 *args, **kwargs
@@ -470,31 +492,78 @@ class VersionedSingletonDescriptor(AppDescriptor):
 ################################################################################################
 # factory method for app descriptors
 
+def preprocess_location(location_dict, pipeline_config):
+    """
+    Preprocess location dict to resolve config-specific constants and directives.
+    
+    This is only relevant if the locator system is used in conjunction with 
+    a toolkit configuration. For example, the keyword {PIPELINE_CONFIG} is
+    only meaningful if used in the context of a configuration.
+    
+    Location dictionaries defined and used outside of the scope of a 
+    pipeline configuration do not support such keywords (since no 
+    pipeline configuration exists at that point). 
+    
+    :param location_dict: Location dict to operate on
+    :param pipeline_config: Pipeline Config object
+    :returns: location dict with any directives resolved.
+    """
+
+    if location_dict.get("type") == "dev":
+        
+        # platform specific location support
+        platform_key = {"linux2": "linux_path", "darwin": "mac_path", "win32": "windows_path"}[sys.platform]
+        if platform_key in location_dict:
+            location_dict[platform_key] = location_dict[platform_key].replace("{PIPELINE_CONFIG}", pipeline_config.get_path())
+
+        if "path" in location_dict:
+            location_dict["path"] = location_dict["path"].replace("{PIPELINE_CONFIG}", pipeline_config.get_path())
+
+    return location_dict
+
+
+def descriptor_factory(descriptor_type, app_cache_root, location_dict):
+    """
+    Factory method.
+
+    :param descriptor_type: Either AppDescriptor.APP, CORE, ENGINE or FRAMEWORK
+    :param app_cache_root: Root path to where downloaded apps are cached
+    :param location_dict: A std location dictionary
+    :returns: Descriptor object
+    """
+    return get_from_location_and_paths(descriptor_type, None, app_cache_root, location_dict)
+
+################################################################################################
+# legacy methods - do not use.
 
 def get_from_location(app_or_engine, pipeline_config, location_dict):
     """
     Factory method.
+    
+    LEGACY - Use pipelineconfiguration.get_app|engine|framework_descriptor() 
+             instead.
 
-    :param app_or_engine: Either AppDescriptor.APP AppDescriptor.ENGINE or FRAMEWORK
+    :param app_or_engine: Either AppDescriptor.APP ENGINE CORE or FRAMEWORK
     :param pipeline_config: Pipeline Configuration Object
     :param location_dict: A tank location dict
     :returns: an AppDescriptor object
     """
-
     return get_from_location_and_paths(
         app_or_engine,
-        pipeline_config.get_path(),
-        pipeline_config.get_bundles_location(),
+        None,
+        pipeline_config._get_bundles_location(), #TODO - fix this
         location_dict
     )
-
 
 def get_from_location_and_paths(app_or_engine, pc_path, bundle_install_path, location_dict):
     """
     Factory method.
+    
+    LEGACY - Use descriptor_factory() instead.
 
-    :param app_or_engine: Either AppDescriptor.APP AppDescriptor.ENGINE or FRAMEWORK
-    :param pc_path: Path to the root of the pipeline configuration
+    :param app_or_engine: Either AppDescriptor.APP ENGINE CORE or FRAMEWORK
+    :param pc_path: Path to the root of the pipeline configuration. 
+                    Legacy parameter and no longer used. This value will be ignored.
     :param bundle_install_path: Path to the root of the apps, frameworks and engines bundles.
     :param location_dict: A tank location dict
     :returns: an AppDescriptor object
@@ -505,29 +574,27 @@ def get_from_location_and_paths(app_or_engine, pc_path, bundle_install_path, loc
     from .git_descriptor import TankGitDescriptor
     from .manual_descriptor import TankManualDescriptor
 
-    # temporary implementation. Todo: more error checks!
-
     # tank app store format
     # location: {"type": "app_store", "name": "tk-nukepublish", "version": "v0.5.0"}
     if location_dict.get("type") == "app_store":
-        return TankAppStoreDescriptor(pc_path, bundle_install_path, location_dict, app_or_engine)
+        return TankAppStoreDescriptor(bundle_install_path, location_dict, app_or_engine)
 
     # manual format
     # location: {"type": "manual", "name": "tk-nukepublish", "version": "v0.5.0"}
     elif location_dict.get("type") == "manual":
-        return TankManualDescriptor(pc_path, bundle_install_path, location_dict, app_or_engine)
+        return TankManualDescriptor(bundle_install_path, location_dict, app_or_engine)
 
     # git repo
     # location: {"type": "git", "path": "/path/to/repo.git", "version": "v0.2.1"}
     elif location_dict.get("type") == "git":
-        return TankGitDescriptor(pc_path, bundle_install_path, location_dict, app_or_engine)
+        return TankGitDescriptor(bundle_install_path, location_dict, app_or_engine)
 
     # local dev format
     # location: {"type": "dev", "path": "/path/to/app"}
     # or
     # location: {"type": "dev", "windows_path": "c:\\path\\to\\app", "linux_path": "/path/to/app", "mac_path": "/path/to/app"}
     elif location_dict.get("type") == "dev":
-        return TankDevDescriptor(pc_path, bundle_install_path, location_dict)
+        return TankDevDescriptor(bundle_install_path, location_dict)
 
     else:
         raise TankError("%s: Invalid location dict '%s'" % (app_or_engine, location_dict))

--- a/python/tank/deploy/dev_descriptor.py
+++ b/python/tank/deploy/dev_descriptor.py
@@ -26,8 +26,8 @@ class TankDevDescriptor(AppDescriptor):
     into the local storage, you interact with it directly.
     """
     
-    def __init__(self, pc_path, bundle_install_path, location_dict):
-        super(TankDevDescriptor, self).__init__(pc_path, bundle_install_path, location_dict)
+    def __init__(self, bundle_install_path, location_dict):
+        super(TankDevDescriptor, self).__init__(bundle_install_path, location_dict)
 
         # platform specific location support
         system = sys.platform
@@ -42,9 +42,6 @@ class TankDevDescriptor(AppDescriptor):
             raise TankError("Invalid dev descriptor! Could not find a path or a %s entry in the "
                             "location dict %s." % (platform_key, location_dict))
 
-        # replace magic token {PIPELINE_CONFIG} with path to pipeline configuration
-        self._path = self._path.replace("{PIPELINE_CONFIG}", self._pipeline_config_path)
-        
         # lastly, resolve environment variables
         self._path = os.path.expandvars(self._path)
         

--- a/python/tank/deploy/git_descriptor.py
+++ b/python/tank/deploy/git_descriptor.py
@@ -37,8 +37,8 @@ class TankGitDescriptor(VersionedSingletonDescriptor):
     /full/path/to/local/repo.git
     """
 
-    def __init__(self, pc_path, bundle_install_path, location_dict, type):
-        super(TankGitDescriptor, self).__init__(pc_path, bundle_install_path, location_dict)
+    def __init__(self, bundle_install_path, location_dict, type):
+        super(TankGitDescriptor, self).__init__(bundle_install_path, location_dict)
 
         self._type = type
         self._path = location_dict.get("path")
@@ -324,7 +324,7 @@ class TankGitDescriptor(VersionedSingletonDescriptor):
         new_loc_dict = copy.deepcopy(self._location_dict)
         new_loc_dict["version"] = latest_version
 
-        return TankGitDescriptor(self._pipeline_config_path, self._bundle_install_path, new_loc_dict, self._type)
+        return TankGitDescriptor(self._bundle_install_path, new_loc_dict, self._type)
 
     def __clone_repo(self, target_path):
         """

--- a/python/tank/deploy/manual_descriptor.py
+++ b/python/tank/deploy/manual_descriptor.py
@@ -23,8 +23,8 @@ class TankManualDescriptor(AppDescriptor):
     Represents a manually installed item
     """
 
-    def __init__(self, pc_path, bundle_install_path, location_dict, bundle_type):
-        super(TankManualDescriptor, self).__init__(pc_path, bundle_install_path, location_dict)
+    def __init__(self, bundle_install_path, location_dict, bundle_type):
+        super(TankManualDescriptor, self).__init__(bundle_install_path, location_dict)
         self._type = bundle_type
         self._name = location_dict.get("name")
         self._version = location_dict.get("version")

--- a/python/tank/deploy/tank_command.py
+++ b/python/tank/deploy/tank_command.py
@@ -47,9 +47,9 @@ from ..errors import TankError
 ###############################################################################################
 # Built in actions (all in the tank_commands sub module)
 
-BUILT_IN_ACTIONS = [setup_project.SetupProjectAction, 
+BUILT_IN_ACTIONS = [setup_project.SetupProjectAction,
                     setup_project_wizard.SetupProjectFactoryAction,
-                    core_upgrade.CoreUpgradeAction, 
+                    core_upgrade.CoreUpgradeAction,
                     core_localize.CoreLocalizeAction,
                     core_localize.ShareCoreAction,
                     core_localize.AttachToCoreAction,

--- a/python/tank/deploy/tank_commands/cache_apps.py
+++ b/python/tank/deploy/tank_commands/cache_apps.py
@@ -19,7 +19,7 @@ class CacheAppsAction(Action):
         Action.__init__(self, 
                         "cache_apps", 
                         Action.TK_INSTANCE, 
-                        ("Toolkit manages an app cache to ensure that all versions of apps and "
+                        ("Toolkit manages a bundle cache to ensure that all versions of apps and "
                         "engines that are specified in the environments exists locally. This "
                         "cache is normally automatically managed by the update and install "
                         "commands, but if you are manually editing version numbers inside "

--- a/python/tank/deploy/tank_commands/console_utils.py
+++ b/python/tank/deploy/tank_commands/console_utils.py
@@ -330,14 +330,18 @@ def ensure_frameworks_installed(log, tank_api_instance, file_location, descripto
         # - minor: v1.x.x
         # - increment: v1.2.x
 
-        # get the latest version from the app store...
-        fw_descriptor = TankAppStoreDescriptor.find_latest_item(
-            tank_api_instance.pipeline_configuration.get_path(),
-            tank_api_instance.pipeline_configuration.get_bundles_location(),
-            AppDescriptor.FRAMEWORK,
-            name,
-            version_pattern)
-
+        # get the latest version from the app store by 
+        # first getting a stub and then looking for latest.
+        location_stub = {"type": "app_store", 
+                         "version": "v0.0.0", 
+                         "name": name}
+        
+        pc = tank_api_instance.pipeline_configuration
+        
+        descriptor_stub = pc.get_framwork_descriptor(location_stub)
+        
+        fw_descriptor = descriptor_stub.find_latest_version(version_pattern)
+                
         installed_fw_descriptors.append(fw_descriptor)
 
         # and now process this framework
@@ -361,7 +365,7 @@ def ensure_frameworks_installed(log, tank_api_instance, file_location, descripto
         fw_descriptor.ensure_shotgun_fields_exist()
 
         # run post install hook
-        fw_descriptor.run_post_install()
+        fw_descriptor.run_post_install(tank_api_instance)
 
         # now get data for all new settings values in the config
         params = get_configuration(log, tank_api_instance, fw_descriptor, None, suppress_prompts, None)

--- a/python/tank/deploy/tank_commands/install.py
+++ b/python/tank/deploy/tank_commands/install.py
@@ -13,7 +13,6 @@ from . import console_utils
 from .action_base import Action
 
 from ..descriptor import AppDescriptor
-from ..descriptor import get_from_location
 from ..app_store_descriptor import TankAppStoreDescriptor 
 
 
@@ -211,30 +210,23 @@ class InstallAppAction(Action):
             # run descriptor factory method
             log.info("Connecting to git...")
             location = {"type": "git", "path": app_name, "version": "v0.0.0"}
-            tmp_descriptor = get_from_location(AppDescriptor.APP, 
-                                               self.tk.pipeline_configuration, 
-                                               location)
-            # now find latest
+            tmp_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
             app_descriptor = tmp_descriptor.find_latest_version()
-            log.info("Latest version in repository '%s' is %s." % (app_name, 
+            log.info("Latest tag in repository '%s' is %s." % (app_name, 
                                                                    app_descriptor.get_version()))
             
         elif "/" in app_name or "\\" in app_name:
             # this is a local path on disk, meaning that we should set up a dev descriptor!
             log.info("Looking for a locally installed app in '%s'..." % app_name) 
             location = {"type": "dev", "path": app_name}
-            app_descriptor = get_from_location(AppDescriptor.APP, 
-                                               self.tk.pipeline_configuration, 
-                                               location)
+            app_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
         
         else:
             # this is an app store app!
-            log.info("Connecting to the Toolkit App Store...")
-            app_descriptor = TankAppStoreDescriptor.find_latest_item(
-                self.tk.pipeline_configuration.get_path(),
-                self.tk.pipeline_configuration.get_bundles_location(),
-                AppDescriptor.APP, app_name
-            )
+            log.info("Connecting to the Toolkit App Store...")            
+            location = {"type": "app_store", "name": app_name, "version": "v0.0.0"}
+            tmp_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
+            app_descriptor = tmp_descriptor.find_latest_version()
             log.info("Latest approved App Store Version is %s." % app_descriptor.get_version())
         
         # note! Some of these methods further down are likely to pull the apps local
@@ -271,7 +263,7 @@ class InstallAppAction(Action):
         app_descriptor.ensure_shotgun_fields_exist()
     
         # run post install hook
-        app_descriptor.run_post_install()
+        app_descriptor.run_post_install(self.tk)
     
         # find the name of the engine
         engine_system_name = env.get_engine_descriptor(engine_instance_name).get_system_name()
@@ -469,30 +461,23 @@ class InstallEngineAction(Action):
             # run descriptor factory method
             log.info("Connecting to git...")
             location = {"type": "git", "path": engine_name, "version": "v0.0.0"}
-            tmp_descriptor = get_from_location(AppDescriptor.ENGINE, 
-                                               self.tk.pipeline_configuration, 
-                                               location)
-            # now find latest
+            tmp_descriptor = self.tk.pipeline_configuration.get_engine_descriptor(location)
             engine_descriptor = tmp_descriptor.find_latest_version()
-            log.info("Latest version in repository '%s' is %s." % (engine_name, engine_descriptor.get_version()))
+            log.info("Latest tag in repository '%s' is %s." % (engine_name, engine_descriptor.get_version()))
             
         elif "/" in engine_name or "\\" in engine_name:
             # this is a local path on disk, meaning that we should set up a dev descriptor!
             log.info("Looking for a locally installed engine in '%s'..." % engine_name) 
             location = {"type": "dev", "path": engine_name}
-            engine_descriptor = get_from_location(AppDescriptor.ENGINE, 
-                                                  self.tk.pipeline_configuration, 
-                                                  location)
+            engine_descriptor = self.tk.pipeline_configuration.get_engine_descriptor(location)
             
         else:
             # this is an app store app!
             log.info("Connecting to the Toolkit App Store...")
-            engine_descriptor = TankAppStoreDescriptor.find_latest_item(
-                self.tk.pipeline_configuration.get_path(),
-                self.tk.pipeline_configuration.get_bundles_location(),
-                AppDescriptor.ENGINE, 
-                engine_name)
-        log.info("Latest approved App Store Version is %s." % engine_descriptor.get_version())
+            location = {"type": "app_store", "name": engine_name, "version": "v0.0.0"}
+            tmp_descriptor = self.tk.pipeline_configuration.get_engine_descriptor(location)
+            engine_descriptor = tmp_descriptor.find_latest_version()
+            log.info("Latest approved App Store Version is %s." % engine_descriptor.get_version())
         
         log.info("")
     
@@ -531,7 +516,7 @@ class InstallEngineAction(Action):
         engine_descriptor.ensure_shotgun_fields_exist()
     
         # run post install hook
-        engine_descriptor.run_post_install()
+        engine_descriptor.run_post_install(self.tk)
     
         # now get data for all new settings values in the config
         params = console_utils.get_configuration(log, self.tk, engine_descriptor, None, suppress_prompts, None)

--- a/python/tank/deploy/tank_commands/setup_project_core.py
+++ b/python/tank/deploy/tank_commands/setup_project_core.py
@@ -17,7 +17,7 @@ from ...errors import TankError
 from ... import pipelineconfig_factory
 
 from tank_vendor import yaml
-    
+
 def run_project_setup(log, sg, sg_app_store, sg_app_store_script_user, setup_params):
     """
     Execute the project setup.
@@ -48,13 +48,13 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     """
     log.info("")
     log.info("Starting project setup.")
-    
+
     # get the location of the configuration
     config_location_curr_os = setup_params.get_configuration_location(sys.platform)
     config_location_mac = setup_params.get_configuration_location("darwin")
     config_location_linux = setup_params.get_configuration_location("linux2")
     config_location_win = setup_params.get_configuration_location("win32")
-    
+
     # project id
     project_id = setup_params.get_project_id()
     if project_id:
@@ -64,12 +64,12 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
 
     # get all existing pipeline configurations
     setup_params.report_progress_from_installer("Checking Pipeline Configurations...")
-    
-    pcs = sg.find(constants.PIPELINE_CONFIGURATION_ENTITY, 
+
+    pcs = sg.find(constants.PIPELINE_CONFIGURATION_ENTITY,
                   [["project", "is", sg_project_link]],
                   ["code", "linux_path", "windows_path", "mac_path"])
-    
-    
+
+
     if len(pcs) > 0:
         if setup_params.get_force_setup():
             # if we have the force flag enabled, remove any pipeline configurations
@@ -78,11 +78,11 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
                 sg.delete(constants.PIPELINE_CONFIGURATION_ENTITY, x["id"])
 
         elif not setup_params.get_auto_path_mode():
-            # this is a normal setup, e.g. not with the force flag on 
+            # this is a normal setup, e.g. not with the force flag on
             # nor an auto-path where each machine effectively manages its own config
             # for this case, we don't allow the process to proceed if a config exists
             raise TankError("Cannot set up this project! Pipeline configuration entries already exist in Shotgun.")
-        
+
         else:
             # auto path mode
             # make sure that all PCs have empty paths set, either None values or ""
@@ -90,16 +90,16 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
                 if x["linux_path"] or x["windows_path"] or x["mac_path"]:
                     raise TankError("Cannot set up this project! Non-auto-path style pipeline "
                                     "configuration entries already exist in Shotgun.")
-            
+
     # first do disk structure setup, this is most likely to fail.
     setup_params.report_progress_from_installer("Creating main folder structure...")
     log.info("Installing configuration into '%s'..." % config_location_curr_os )
     if not os.path.exists(config_location_curr_os):
         # note that we have already validated that creation is possible
         os.makedirs(config_location_curr_os, 0775)
-    
-    # create pipeline config base folder structure            
-    _make_folder(log, os.path.join(config_location_curr_os, "cache"), 0777)    
+
+    # create pipeline config base folder structure
+    _make_folder(log, os.path.join(config_location_curr_os, "cache"), 0777)
     _make_folder(log, os.path.join(config_location_curr_os, "config"), 0775)
     _make_folder(log, os.path.join(config_location_curr_os, "install"), 0775)
     _make_folder(log, os.path.join(config_location_curr_os, "install", "core"), 0777)
@@ -108,7 +108,7 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     _make_folder(log, os.path.join(config_location_curr_os, "install", "engines"), 0777, True)
     _make_folder(log, os.path.join(config_location_curr_os, "install", "apps"), 0777, True)
     _make_folder(log, os.path.join(config_location_curr_os, "install", "frameworks"), 0777, True)
-        
+
     # copy the configuration into place
     setup_params.report_progress_from_installer("Setting up template configuration...")
     setup_params.create_configuration(os.path.join(config_location_curr_os, "config"))
@@ -123,22 +123,22 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
         tgt_file = os.path.join(config_location_curr_os, file_name)
         shutil.copy(src_file, tgt_file)
         os.chmod(tgt_file, 0775)
-    
+
     # copy the python stubs
     log.debug("Copying python stubs...")
     tank_proxy = os.path.join(core_api_root, "setup", "tank_api_proxy")
     _copy_folder(log, tank_proxy, os.path.join(config_location_curr_os, "install", "core", "python"))
-        
+
     # specify the parent files in install/core/core_PLATFORM.cfg
     log.debug("Creating core redirection config files...")
     setup_params.report_progress_from_installer("Writing configuration files...")
-    
+
     core_path = os.path.join(config_location_curr_os, "install", "core", "core_Darwin.cfg")
     core_location = setup_params.get_associated_core_path("darwin")
     fh = open(core_path, "wt")
     fh.write(core_location if core_location else "undefined")
     fh.close()
-    
+
     core_path = os.path.join(config_location_curr_os, "install", "core", "core_Linux.cfg")
     core_location = setup_params.get_associated_core_path("linux2")
     fh = open(core_path, "wt")
@@ -150,10 +150,10 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     fh = open(core_path, "wt")
     fh.write(core_location if core_location else "undefined")
     fh.close()
-    
+
     # write a file location file for our new setup
     sg_code_location = os.path.join(config_location_curr_os, "config", "core", "install_location.yml")
-    
+
     # if we are basing our setup on an existing project setup, make sure we can write to the file.
     if os.path.exists(sg_code_location):
         os.chmod(sg_code_location, 0666)
@@ -165,34 +165,34 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     fh.write("# configuration defined for this project.\n")
     fh.write("\n")
     fh.write("Windows: '%s'\n" % config_location_win)
-    fh.write("Darwin: '%s'\n" % config_location_mac)    
-    fh.write("Linux: '%s'\n" % config_location_linux)                    
+    fh.write("Darwin: '%s'\n" % config_location_mac)
+    fh.write("Linux: '%s'\n" % config_location_linux)
     fh.write("\n")
     fh.write("# End of file.\n")
     fh.close()
-        
+
     # update the roots.yml file in the config to match our settings
     # resuffle list of associated local storages to be a dict keyed by storage name
     # and with keys mac_path/windows_path/linux_path
 
     log.debug("Writing %s..." % constants.STORAGE_ROOTS_FILE)
     roots_path = os.path.join(config_location_curr_os, "config", "core", constants.STORAGE_ROOTS_FILE)
-    
+
     roots_data = {}
     for storage_name in setup_params.get_required_storages():
-    
+
         roots_data[storage_name] = {"windows_path": setup_params.get_storage_path(storage_name, "win32"),
                                     "linux_path": setup_params.get_storage_path(storage_name, "linux2"),
                                     "mac_path": setup_params.get_storage_path(storage_name, "darwin")}
-    
+
     try:
         fh = open(roots_path, "wt")
         # using safe_dump instead of dump ensures that we
         # don't serialize any non-std yaml content. In particular,
         # this causes issues if a unicode object containing a 7-bit
-        # ascii string is passed as part of the data. in this case, 
-        # dump will write out a special format which is later on 
-        # *loaded in* as a unicode object, even if the content doesn't  
+        # ascii string is passed as part of the data. in this case,
+        # dump will write out a special format which is later on
+        # *loaded in* as a unicode object, even if the content doesn't
         # need unicode handling. And this causes issues down the line
         # in toolkit code, assuming strings:
         #
@@ -200,36 +200,36 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
         # "{foo: !!python/unicode 'bar'}\n"
         # >>> yaml.safe_dump({"foo": u"bar"})
         # '{foo: bar}\n'
-        #        
+        #
         yaml.safe_dump(roots_data, fh)
         fh.close()
     except Exception, exp:
         raise TankError("Could not write to roots file %s. "
                         "Error reported: %s" % (roots_path, exp))
-    
+
     # now ensure there is a tank folder in every storage
     setup_params.report_progress_from_installer("Setting up project storage folders...")
     for storage_name in setup_params.get_required_storages():
-        
+
         log.info("Setting up %s storage..." % storage_name )
-        
+
         # get the project path for this storage
         current_os_path = setup_params.get_project_path(storage_name, sys.platform)
         log.debug("Project path: %s" % current_os_path )
-                        
-    
+
+
     # Create Project.tank_name and PipelineConfiguration records in Shotgun
     #
     # This logic has some special complexity when the auto_path mode is in use.
-    
+
     setup_params.report_progress_from_installer("Registering in Shotgun...")
-    
+
     if setup_params.get_auto_path_mode():
         # first, check the project name. If there is no project name in Shotgun, populate it
         # with the project name which is specified via the project name parameter.
         # if there isn't yet an entry, create it.
-        # This is consistent with the anticipated future behaviour we expect when we 
-        # switch from auto_path to a zip file based approach. 
+        # This is consistent with the anticipated future behaviour we expect when we
+        # switch from auto_path to a zip file based approach.
 
         project_name = setup_params.get_project_disk_name()
 
@@ -254,13 +254,13 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
 
         log.info("Creating Pipeline Configuration in Shotgun...")
         # this is an auto-path project, meaning that shotgun doesn't store the location
-        # to the pipeline configuration. Because an auto-path location is often set up 
+        # to the pipeline configuration. Because an auto-path location is often set up
         # on multiple machines, check first if the entry exists and in that case skip creation
         data = sg.find_one(constants.PIPELINE_CONFIGURATION_ENTITY,
                            [["code", "is", constants.PRIMARY_PIPELINE_CONFIG_NAME],
                             ["project", "is", sg_project_link]],
                            ["id"])
-        
+
         if data is None:
             log.info("Creating Pipeline Configuration in Shotgun...")
             data = {"project": sg_project_link, "code": constants.PRIMARY_PIPELINE_CONFIG_NAME}
@@ -269,7 +269,7 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
             log.debug("Created data: %s" % pc_entity)
         else:
             pipeline_config_id = data["id"]
-        
+
     else:
         # normal mode.
         if project_id:
@@ -277,44 +277,44 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
             project_name = setup_params.get_project_disk_name()
             log.debug("Shotgun: Setting Project.tank_name to %s" % project_name)
             sg.update("Project", project_id, {"tank_name": project_name})
-        
+
         log.info("Creating Pipeline Configuration in Shotgun...")
         data = {"project": sg_project_link,
                 "linux_path": config_location_linux,
                 "windows_path": config_location_win,
                 "mac_path": config_location_mac,
                 "code": constants.PRIMARY_PIPELINE_CONFIG_NAME}
-    
+
         # create pipeline configuration record
         pc_entity = sg.create(constants.PIPELINE_CONFIGURATION_ENTITY, data)
-        pipeline_config_id = pc_entity["id"] 
+        pipeline_config_id = pc_entity["id"]
         log.debug("Created data: %s" % pc_entity)
-    
+
     # write the record to disk
     pipe_config_sg_id_path = os.path.join(config_location_curr_os, "config", "core", "pipeline_configuration.yml")
     log.debug("Writing to pc cache file %s" % pipe_config_sg_id_path)
-    
+
     # determine the entity type to use for Published Files:
     pf_entity_type = _get_published_file_entity_type(log, sg)
-    
+
     data = {}
     data["project_name"] = project_name
     data["pc_id"] = pipeline_config_id
     data["project_id"] = project_id
-    data["pc_name"] = constants.PRIMARY_PIPELINE_CONFIG_NAME 
+    data["pc_name"] = constants.PRIMARY_PIPELINE_CONFIG_NAME
     data["published_file_entity_type"] = pf_entity_type
-    
+
     # all 0.15+ projects are pushing folders to Shotgun by default
-    data["use_shotgun_path_cache"] = True 
-    
+    data["use_shotgun_path_cache"] = True
+
     try:
         fh = open(pipe_config_sg_id_path, "wt")
         # using safe_dump instead of dump ensures that we
         # don't serialize any non-std yaml content. In particular,
         # this causes issues if a unicode object containing a 7-bit
-        # ascii string is passed as part of the data. in this case, 
-        # dump will write out a special format which is later on 
-        # *loaded in* as a unicode object, even if the content doesn't  
+        # ascii string is passed as part of the data. in this case,
+        # dump will write out a special format which is later on
+        # *loaded in* as a unicode object, even if the content doesn't
         # need unicode handling. And this causes issues down the line
         # in toolkit code, assuming strings:
         #
@@ -328,7 +328,7 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     except Exception, exp:
         raise TankError("Could not write to pipeline configuration cache file %s. "
                         "Error reported: %s" % (pipe_config_sg_id_path, exp))
-    
+
     if sg_app_store:
         # we have an app store connection
         # write a custom event to the shotgun event log
@@ -339,48 +339,50 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
         data["user"] = sg_app_store_script_user
         data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
         sg_app_store.create("EventLogEntry", data)
-    
-    
+
+
     ##########################################################################################
     # install apps
-    
+
     # We now have a fully functional tank setup! Time to start it up...
-    pc = pipelineconfig_factory.from_path(config_location_curr_os)
-    
+    tk = sgtk_from_path(config_location_curr_os)
+    log.debug("Instantiated tk instance: %s" % tk)
+    pc = tk.pipeline_configuration
+
     # each entry in the config template contains instructions about which version of the app
     # to use. First loop over all environments and gather all descriptors we should download,
-    # then go ahead and download and post-install them 
-    
+    # then go ahead and download and post-install them
+
     log.info("Downloading and installing apps...")
-    
-    # pass 1 - populate list of all descriptors    
+
+    # pass 1 - populate list of all descriptors
     descriptors = []
     for env_name in pc.get_environments():
-        
+
         env_obj = pc.get_environment(env_name)
-        
+
         for engine in env_obj.get_engines():
             descriptors.append( env_obj.get_engine_descriptor(engine) )
-            
+
             for app in env_obj.get_apps(engine):
                 descriptors.append( env_obj.get_app_descriptor(engine, app) )
-                
+
         for framework in env_obj.get_frameworks():
             descriptors.append( env_obj.get_framework_descriptor(framework) )
-                
+
     # pass 2 - download all apps
     num_descriptors = len(descriptors)
     for idx, descriptor in enumerate(descriptors):
-        
+
         # note that we push percentages here to the progress bar callback
         # going from 0 to 100
         progress = (int)((float)(idx)/(float)(num_descriptors)*100)
         setup_params.report_progress_from_installer("Downloading apps...", progress)
-        
+
         if not descriptor.exists_local():
-            log.info("Downloading %s to the local Toolkit install location..." % descriptor)            
+            log.info("Downloading %s to the local Toolkit install location..." % descriptor)
             descriptor.download_local()
-            
+
         else:
             log.info("Item %s is already locally installed." % descriptor)
 
@@ -389,12 +391,12 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     for descriptor in descriptors:
         descriptor.ensure_shotgun_fields_exist()
         # run post install hook
-        descriptor.run_post_install()
-        
+        descriptor.run_post_install(tk)
+
 
     ##########################################################################################
     # post processing of the install
-    
+
     # run after project create script if it exists
     setup_params.report_progress_from_installer("Running post-setup scripts...")
     after_script_path = os.path.join(config_location_curr_os, "config", "after_project_create.py")
@@ -408,9 +410,9 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
         except Exception, e:
             if ("API read() invalid/missing string entity" in e.__str__()
                 and "\"type\"=>\"TankType\"" in e.__str__()):
-                # Handle a specific case where an old version of the 
+                # Handle a specific case where an old version of the
                 # after_project_create script set up TankType entities which
-                # are now disabled following the migration to the 
+                # are now disabled following the migration to the
                 # new PublishedFileType entity
                 log.info("")
                 log.warning("The post install script failed to complete.  This is most likely because it "
@@ -420,7 +422,7 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
                 log.info("")
                 log.error("The post install script failed to complete: %s" % e)
         else:
-            log.info("Post install phase complete!")            
+            log.info("Post install phase complete!")
         finally:
             sys.path.pop(0)
 
@@ -429,22 +431,22 @@ def _project_setup_internal(log, sg, sg_app_store, sg_app_store_script_user, set
     log.info("")
 
 
-    
-    
+
+
 
 ########################################################################################
 # helper methods
-       
+
 
 def _make_folder(log, folder, permissions, create_placeholder_file = False):
     """
     Create folder helper method
-    
+
     :param log: std log handle
     :param folder: path to folder
     :param permissions: chmod int (e.g. 0777)
-    :param create_placeholder_file: if true, a file named placeholder will be created. 
-                                    this is to make the config more compatible with file 
+    :param create_placeholder_file: if true, a file named placeholder will be created.
+                                    this is to make the config more compatible with file
                                     based SCMs such as perforce and git, where empty folders
                                     are not handled by the system
     """
@@ -454,45 +456,45 @@ def _make_folder(log, folder, permissions, create_placeholder_file = False):
         ph_path = os.path.join(folder, "placeholder")
         fh = open(ph_path, "wt")
         fh.write("This placeholder file was automatically generated by Toolkit.\n\n")
-        
+
         fh.write("The placeholder file is needed when managing toolkit configurations\n")
         fh.write("in source control packages such as git and perforce. These systems\n")
         fh.write("do not handle empty folders so a placeholder file is required for the \n")
         fh.write("folder to be tracked and managed properly.\n")
         fh.close()
-    
 
-def _copy_folder(log, src, dst): 
+
+def _copy_folder(log, src, dst):
     """
     Alternative implementation to shutil.copytree
     Copies recursively with very open permissions.
     Creates folders if they don't already exist.
     """
-    
+
     if not os.path.exists(dst):
         log.debug("Creating folder %s..." % dst)
         os.mkdir(dst, 0775)
 
-    names = os.listdir(src)     
-    for name in names: 
-        
-        # get rid of system files
-        if name in [".svn", ".git", ".gitignore", "__MACOSX"]: 
-            continue
-        
-        srcname = os.path.join(src, name) 
-        dstname = os.path.join(dst, name) 
+    names = os.listdir(src)
+    for name in names:
 
-        try: 
-            if os.path.isdir(srcname): 
-                _copy_folder(log, srcname, dstname)             
-            else: 
+        # get rid of system files
+        if name in [".svn", ".git", ".gitignore", "__MACOSX"]:
+            continue
+
+        srcname = os.path.join(src, name)
+        dstname = os.path.join(dst, name)
+
+        try:
+            if os.path.isdir(srcname):
+                _copy_folder(log, srcname, dstname)
+            else:
                 log.debug("Copying %s --> %s" % (srcname, dstname))
-                shutil.copy(srcname, dstname) 
-        
-        except (IOError, os.error), why: 
-            raise TankError("Can't copy %s to %s: %s" % (srcname, dstname, str(why))) 
-        
+                shutil.copy(srcname, dstname)
+
+        except (IOError, os.error), why:
+            raise TankError("Can't copy %s to %s: %s" % (srcname, dstname, str(why)))
+
     
 def _get_published_file_entity_type(log, sg):
     """

--- a/python/tank/deploy/tank_commands/setup_project_params.py
+++ b/python/tank/deploy/tank_commands/setup_project_params.py
@@ -32,86 +32,86 @@ from tank_vendor import yaml
 class ProjectSetupParameters(object):
     """
     Class that holds all the various parameters needed to run a project setup.
-    
-    This class allows for various forms of validation and inspection of all the data required 
+
+    This class allows for various forms of validation and inspection of all the data required
     to set up a project.
-    
+
     Parameters are typically set in this order:
-    
-    - get some information about the configuration 
+
+    - get some information about the configuration
     - set the template configuration you want to use - set_config_uri()
-    
+
     - set the project id - set_project_id()
     - get a suggested project name - get_default_project_disk_name()
     - set project disk name - set_project_disk_name() (can validate on beforehand using validate_project_disk_name())
-    
+
     - set the configuration location - set_configuration_location()
-    
+
     - validate using pre_setup_validation
-    
+
     - run project setup!
-    
+
     """
-    
+
     def __init__(self, log, sg, sg_app_store, sg_app_store_script_user):
         """
         Constructor
-        
+
         :param log: python logger
         :param sg: shotgun connection
         :param sg_app_store: shotgun app store connection
-        :param sg_app_store_script_user: sg-style link dict representing the script user used to 
+        :param sg_app_store_script_user: sg-style link dict representing the script user used to
                                          connect to the app store
         """
-        
+
         # set up handles
         self._sg = sg
         self._log = log
         self._sg_app_store = sg_app_store
         self._sg_app_store_script_user = sg_app_store_script_user
-        
+
         # initialize data members - config
         self._cached_config_templates = {}
         self._config_template = None
         self._config_name = None
         self._config_description = None
         self._config_path = None
-        
+
         # expert setting auto path mode
         self._auto_path = False
-        
+
         # initialize data members - project
         self._force_setup = False
         self._project_id = None
         self._project_disk_name = None
-    
+
         # where to pick up the core from
         self._core_path = None
-        
+
         # progress callback
         self._progress_callback = None
-    
+
     def set_progress_callback(self, fp):
         """
-        Specify a function which should be called during project setup 
+        Specify a function which should be called during project setup
         whenever there is an update to the progress.
-        
-        The callback function should have the following 
+
+        The callback function should have the following
         signature:
-        
+
         def callback(chapter_str, percent_progress_int)
-        
+
         The installer will run through several "chapters" throughout the install
         and each of these will have a separate progress calculation. Some chapters
-        are fast and/or difficult to quantify into steps - in this case, the 
+        are fast and/or difficult to quantify into steps - in this case, the
         percent_progress_int parameter will be passed None. For such chapters,
         the callback will be called only once.
-        
+
         For chapters which report progress, the callback will be called multiple times,
         each time with an incremented progress. This is an int value in percent.
-        
+
         For example
-        
+
         callback("Setting up base storages", None)
         callback("Making folders", None)
         callback("Downloading apps", 1)
@@ -119,38 +119,38 @@ class ProjectSetupParameters(object):
         callback("Downloading apps", 56)
         callback("Downloading apps", 93)
         callback("Finalizing", None)
-    
-        :param fp: Function object representing a progress callback    
+
+        :param fp: Function object representing a progress callback
         """
         self._progress_callback = fp
-        
-        
+
+
     def report_progress_from_installer(self, chapter, progress=None):
         """
         This method is executed from the setup core as it is executing the setup.
         If a progress callback has been defined, this is being called.
         For details, see set_progress_callback()
-        
+
         :param chapter: String defining the current chapter
-        :param progress: Int or None indicating progress, in percent 
+        :param progress: Int or None indicating progress, in percent
         """
         if self._progress_callback:
             self._progress_callback(chapter, progress)
-        
+
     ################################################################################################################
-    # Configuration template related logic     
-    
+    # Configuration template related logic
+
     def validate_config_uri(self, config_uri):
         """
         Validates a configuration template to check if it is compatible with the current Shotgun setup.
-        This will download the config, validate it to ensure that it is compatible with the 
-        constraints (versions of core and shotgun) of this system. 
-        
+        This will download the config, validate it to ensure that it is compatible with the
+        constraints (versions of core and shotgun) of this system.
+
         If locating, downloading, or validating the config fails, exceptions will be raised.
-        
+
         Once the config exists and is compatible, the storage situation is reviewed against shotgun.
         A dictionary with a breakdown of all storages required by the configuration is returned:
-        
+
         {
           "primary" : { "description": "Description",
                         "exists_on_disk": False,
@@ -158,50 +158,50 @@ class ProjectSetupParameters(object):
                         "darwin": "/mnt/foo",
                         "win32": "z:\mnt\foo",
                         "linux2": "/mnt/foo"},
-                                     
+
           "textures" : { "description": None,
                          "exists_on_disk": False,
                          "defined_in_shotgun": True,
                          "darwin": None,
                          "win32": "z:\mnt\foo",
-                         "linux2": "/mnt/foo"}                                    
+                         "linux2": "/mnt/foo"}
          }
-        
+
         :param config_uri: Configuration uri representing the location of a config
         :returns: dictionary with storage data, see above.
         """
-        
+
         # see if we got it cached
         if config_uri not in self._cached_config_templates:
             # first download, read and parse the configuration template
             # this call may mean downloading stuff from the internet.
-            config_template = TemplateConfiguration(config_uri, 
-                                                    self._sg, 
-                                                    self._sg_app_store, 
-                                                    self._sg_app_store_script_user, 
+            config_template = TemplateConfiguration(config_uri,
+                                                    self._sg,
+                                                    self._sg_app_store,
+                                                    self._sg_app_store_script_user,
                                                     self._log)
             self._cached_config_templates[config_uri] = config_template
 
         return self._cached_config_templates[config_uri].resolve_storages()
 
-        
-        
+
+
     def set_config_uri(self, config_uri, check_storage_path=True):
         """
         Sets the configuration uri to use for this project.
         As part of this command, a template configuration may be downloaded over the network,
         either from git or from the toolkit app store.
         Raises exceptions in case the configuration is not compatible with the current shotgun setup.
-        
+
         :param config_uri: Configuration uri representing the location of a config
         :param check_storage_path: Validate that storage paths exists on disk
         """
-        
+
         # cache, get storage breakdown and run basic validation
         storage_data = self.validate_config_uri(config_uri)
-        
+
         # now validate storages
-        #        
+        #
         # {
         #   "primary" : { "description": "Description",
         #                 "exists_on_disk": False,
@@ -209,17 +209,17 @@ class ProjectSetupParameters(object):
         #                 "darwin": "/mnt/foo",
         #                 "win32": "z:\mnt\foo",
         #                 "linux2": "/mnt/foo"},
-        #                              
+        #
         #   "textures" : { "description": None,
         #                  "exists_on_disk": False,
         #                  "defined_in_shotgun": True,
         #                  "darwin": None,
         #                  "win32": "z:\mnt\foo",
-        #                  "linux2": "/mnt/foo"}                                    
+        #                  "linux2": "/mnt/foo"}
         #  }
-                
+
         for storage_name in storage_data:
-            
+
             if not storage_data[storage_name]["defined_in_shotgun"]:
                 raise TankError("The storage '%s' required by the configuration has not been defined in Shotgun. "
                                 "In order to fix this, please navigate to the Site Preferences in Shotgun "
@@ -228,54 +228,54 @@ class ProjectSetupParameters(object):
             elif storage_data[storage_name][sys.platform] is None:
                 raise TankError("The Shotgun Local File Storage '%s' does not have a path defined "
                                 "for the current operating system!" % storage_name)
-            
+
             elif check_storage_path and not storage_data[storage_name]["exists_on_disk"]:
                 local_path = storage_data[storage_name][sys.platform]
                 raise TankError("The path on disk '%s' defined in the Shotgun Local File Storage '%s' does "
-                                "not exist!" % (local_path, storage_name))                            
-        
+                                "not exist!" % (local_path, storage_name))
+
         # all checks passed! Populate official variables
         # note that the validate_config_uri method cached the config for us
         # so can just assign the object from the cache.
         self._config_template = self._cached_config_templates[config_uri]
         self._storage_data = storage_data
-        
+
     def get_configuration_display_name(self):
         """
         Returns the display name of the configuration template
-        
+
         :returns: Configuration display name string, none if not defined
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
-        return self._config_template.get_name() 
-        
+
+        return self._config_template.get_name()
+
     def get_configuration_description(self):
         """
         Returns the description of the associated configuration template
-        
+
         :returns: Configuration description string, None if not defined
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         return self._config_template.get_description()
-    
+
     def get_configuration_shotgun_info(self):
         """
         Returns information about how the config relates to shotgun.
         Returns a dictionary with shotgun pipelineconfig information,
-        including the fields 
-        
+        including the fields
+
         - id
         - code
         - mac_path
-        - windows_path 
-        - linux_path 
+        - windows_path
+        - linux_path
         - project
         - project.Project.tank_name (the disk name for the project)
-        
+
         :returns: dict or None if no sg association could be found
         """
         if self._config_template is None:
@@ -285,86 +285,86 @@ class ProjectSetupParameters(object):
             return False
 
         field_name = {"win32": "windows_path", "linux2": "linux_path", "darwin": "mac_path"}[sys.platform]
-        
-        data = self._sg.find_one("PipelineConfiguration", 
+
+        data = self._sg.find_one("PipelineConfiguration",
                                  [[field_name, "is", self._config_template.get_pipeline_configuration()]],
-                                 ["id", 
-                                  "code", 
-                                  "mac_path", 
-                                  "windows_path", 
-                                  "linux_path", 
-                                  "project", 
+                                 ["id",
+                                  "code",
+                                  "mac_path",
+                                  "windows_path",
+                                  "linux_path",
+                                  "project",
                                   "project.Project.tank_name"])
-        
+
         return data
-    
+
     def get_configuration_readme(self):
         """
         Returns the contents of a configuration README file, if such a file
-        exists. 
-        
+        exists.
+
         :returns: list of strings or empty list if readme doesn't exist
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         return self._config_template.get_readme_content()
-        
-    
+
+
     def get_required_storages(self):
         """
         Returns a list of storage names which are required for this project.
-        
+
         :returns: list of strings
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         return self._storage_data.keys()
 
     def get_storage_description(self, storage_name):
         """
         Returns the description of a storage required by a configuration
-        
+
         :param storage_name: Storage name
         :returns: Storage description string, None if not defined
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         if storage_name not in self._storage_data:
-            raise TankError("Configuration template does not contain a storage with name '%s'!" % storage_name) 
-        
+            raise TankError("Configuration template does not contain a storage with name '%s'!" % storage_name)
+
         return self._storage_data.get(storage_name).get("description")
-        
+
     def get_storage_path(self, storage_name, platform):
-        """    
+        """
         Returns the storage root path given a platform and a storage, as defined in Shotgun
         Note that this path has not been cleaned up, and may for example contain slashes at the end.
-        
+
         :param storage_name: Storage name
-        :param platform: operating system, sys.platform syntax 
+        :param platform: operating system, sys.platform syntax
         :returns: path
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         if storage_name not in self._storage_data:
-            raise TankError("Configuration template does not contain a storage with name '%s'!" % storage_name) 
-        
+            raise TankError("Configuration template does not contain a storage with name '%s'!" % storage_name)
+
         return self._storage_data.get(storage_name).get(platform)
 
     def create_configuration(self, target_path):
         """
         Sets up the associated template configuration. Copies files.
-        
-        :param target_path: Location where the config should be set up. 
+
+        :param target_path: Location where the config should be set up.
         """
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
-        
+
         return self._config_template.create_configuration(target_path)
-        
+
     ################################################################################################################
     # Project related logic
 
@@ -392,34 +392,34 @@ class ProjectSetupParameters(object):
     def get_default_project_disk_name(self):
         """
         Returns the default folder name for a project
-        
+
         :returns: project name string. This may contain slashes if the project name spans across
                   more than one folder.
         """
-        
+
         if self._project_id is None:
             raise TankError("No project id specified!")
-        
+
         # see if there is a hook to procedurally evaluate this
         project_name_hook = shotgun.get_project_name_studio_hook_location()
         if os.path.exists(project_name_hook):
             # custom hook is available!
-            suggested_folder_name = hook.execute_hook(project_name_hook, 
-                                                      parent=None, 
-                                                      sg=self._sg, 
+            suggested_folder_name = hook.execute_hook(project_name_hook,
+                                                      parent=None,
+                                                      sg=self._sg,
                                                       project_id=self._project_id)
         else:
             # construct a valid name - replace white space with underscore and lower case it.
             proj = self._sg.find_one("Project", [["id", "is", self._project_id]], ["name"])
             suggested_folder_name = re.sub("\W", "_", proj.get("name")).lower()
-        
+
         return suggested_folder_name
-        
+
     def validate_project_disk_name(self, project_name):
         """
         Validates that the given project disk name is valid.
         Raises exceptions in case the name is not valid.
-        
+
         :param project_name: project disk name
         """
         if project_name.startswith("/"):
@@ -427,23 +427,23 @@ class ProjectSetupParameters(object):
 
         if project_name.endswith("/"):
             raise TankError("A project disk name cannot end with a slash!")
-        
+
         # basic validation of folder name
         # note that the value can contain slashes and span across multiple folders
         if re.match("^[\./a-zA-Z0-9_-]+$", project_name) is None:
             raise TankError("Invalid project folder '%s'! Please use alphanumerics, "
                             "underscores and dashes." % project_name)
-        
+
     def preview_project_path(self, storage_name, project_name, platform):
         """
         Returns a full project path for a given storage. Returns None if the project name is not valid.
         A configuration template must have been specified prior to executing this command.
         The path returned may not exist on disk but never ends with a path separator.
-        
+
         :param storage_name: Name of storage for which to preview the project path
         :param project_name: Project disk name to preview
         :param platform: Os platform as a string, sys.platform style (e.g. linux2/win32/darwin)
-        
+
         :returns: full path
         """
         if self._config_template is None:
@@ -455,13 +455,13 @@ class ProjectSetupParameters(object):
         except TankError:
             # validation failed!
             return None
-        
+
         # get the storage path
         storage_path = self.get_storage_path(storage_name, platform)
-        
+
         if storage_path is None:
             return None
-        
+
         # get rid of any trailing slashes
         storage_path = storage_path.rstrip("/\\")
         # append the project name
@@ -473,19 +473,19 @@ class ProjectSetupParameters(object):
         else:
             # ensure slashes all the way
             storage_path = storage_path.replace("\\", "/")
-        
+
         return storage_path
 
     def set_project_disk_name(self, project_name):
         """
         Sets a project disk name to use for this configuration.
         May raise exception if the name is not valid.
-        
+
         :param project_name: name of project
         """
         self.validate_project_disk_name(project_name)
         self._project_disk_name = project_name
-    
+
     def get_project_id(self):
         """
         Returns the project id for the project to be set up.
@@ -493,66 +493,66 @@ class ProjectSetupParameters(object):
         :returns: Shotgun project id as int or None if the id is not set.
         """
         return self._project_id
-        
+
     def get_force_setup(self):
         """
         Should setup be forced?
-        
+
         :returns: a boolean flag indicating whether the setup should be forced or not.
         """
         return self._force_setup
-        
+
     def get_project_disk_name(self):
         """
-        Returns the disk name to be given to the project. This may be a simple name 
+        Returns the disk name to be given to the project. This may be a simple name
         "test_project" or may contain slashes "test/project" for project names
         which span across multiple folder levels, however it never starts or ends
         with a slash.
-        
+
         :returns: project name as a string
         """
         if self._project_disk_name is None:
             raise TankError("No project name specified!")
 
         return self._project_disk_name
-    
+
     def get_project_path(self, storage_name, platform):
-        """    
+        """
         Returns the project path given a platform and a storage. Can be None for undefined storages.
         The path returned may not exist on disk but never ends with a path separator.
-        
+
         :param storage_name: Name of storage for which to preview the project path
         :param platform: Os platform as a string, sys.platform style (e.g. linux2/win32/darwin)
-        
+
         :returns: full path
         """
         if self._project_disk_name is None:
             raise TankError("No project name specified!")
-        
+
         if self._config_template is None:
             raise TankError("Please specify a configuration template!")
 
         return self.preview_project_path(storage_name, self._project_disk_name, platform)
-            
-    
+
+
     ################################################################################################################
-    # Configuration template related logic     
-    
+    # Configuration template related logic
+
     def set_auto_path_mode(self, status):
         """
         Defines if auto-path should be on or off.
         Auto-path means that the pipeline configuration entry in
         Shotgun does not actually encode the path to where the configuration
         is located on disk - this is instead purely kept on the disk side
-        
+
         :param status: boolean indicating if auto path should be used
         """
         self._auto_path = status
-        
+
     def get_auto_path_mode(self):
         """
         Returns the auto-path status. See set_auto_path for details.
-        
+
         :returns: boolean indicating if auto path should be used
         """
         return self._auto_path
@@ -562,47 +562,47 @@ class ProjectSetupParameters(object):
         Performs basic I/O checks to ensure that the given configuration location is valid.
         Raises exceptions in case of validation problems.
 
-        :param linux_path: Path on linux 
+        :param linux_path: Path on linux
         :param windows_path: Path on windows
         :param macosx_path: Path on mac
         """
-        
+
         config_path = {}
         config_path["linux2"] = linux_path
         config_path["win32"] = windows_path
         config_path["darwin"] = macosx_path
-        
+
         # validate that the config name contains valid characters. The range of valid characters
         # is similar to the one used to validate the project name.
         CONFIG_NAME_VALIDATION_REGEX = "^[a-zA-Z0-9_-]+$"
-        
+
         # for paths which are not None and not empty, validate their name.
-        # (note how we don't use os.path.sep because we have to check 
+        # (note how we don't use os.path.sep because we have to check
         #  windows paths on a linux system and vice versa).
         if linux_path and linux_path != "":
-            base_name = linux_path.split("/")[-1]            
+            base_name = linux_path.split("/")[-1]
             if re.match(CONFIG_NAME_VALIDATION_REGEX, base_name) is None:
                 raise TankError("Invalid Linux configuration folder name '%s'! Please use alphanumerics, "
                                 "underscores and dashes." % base_name)
 
         if windows_path and windows_path != "":
-            base_name = windows_path.split("\\")[-1]            
+            base_name = windows_path.split("\\")[-1]
             if re.match(CONFIG_NAME_VALIDATION_REGEX, base_name) is None:
                 raise TankError("Invalid Windows configuration folder name '%s'! Please use alphanumerics, "
                                 "underscores and dashes." % base_name)
 
         if macosx_path and macosx_path != "":
-            base_name = macosx_path.split("/")[-1]            
+            base_name = macosx_path.split("/")[-1]
             if re.match(CONFIG_NAME_VALIDATION_REGEX, base_name) is None:
                 raise TankError("Invalid Mac configuration folder name '%s'! Please use alphanumerics, "
                                 "underscores and dashes." % base_name)
-        
+
         # get the location of the configuration
-        config_path_current_os = config_path[sys.platform] 
-        
+        config_path_current_os = config_path[sys.platform]
+
         if config_path_current_os is None or config_path_current_os == "":
             raise TankError("Please specify a configuration path for your current operating system!")
-                
+
         # validate that the config location is not taken
         if os.path.exists(config_path_current_os):
             # pc location already exists - make sure it doesn't already contain an install
@@ -614,19 +614,19 @@ class ProjectSetupParameters(object):
             if not os.access(config_path_current_os, os.W_OK|os.R_OK|os.X_OK):
                 raise TankError("The permissions setting for '%s' is too strict. The current user "
                                 "cannot create files or folders in this location." % config_path_current_os)
-            
+
         else:
-            # path does not exist! 
+            # path does not exist!
             # make sure parent path exists and is writable
             # (the setup process will create the path automatically)
             #
             # however, ensure that the parent path exists
             parent_config_path_current_os = os.path.dirname(config_path_current_os)
-        
+
             if not os.path.exists(parent_config_path_current_os):
                 raise TankError("The folder '%s' does not exist! Please create "
                                 "it before proceeding!" % parent_config_path_current_os)
-                    
+
             # and make sure we can create a folder in it
             if not os.access(parent_config_path_current_os, os.W_OK|os.R_OK|os.X_OK):
                 raise TankError("Cannot create a project configuration in location '%s'! "
@@ -640,12 +640,12 @@ class ProjectSetupParameters(object):
         """
         Sets the desired path to a pipeline configuration.
         Paths can be None, indicating that the path is not defined on a platform.
-        
-        :param linux_path: Path on linux 
+
+        :param linux_path: Path on linux
         :param windows_path: Path on windows
         :param macosx_path: Path on mac
         """
-        
+
         # validate
         self.validate_configuration_location(linux_path, windows_path, macosx_path)
 
@@ -654,18 +654,18 @@ class ProjectSetupParameters(object):
         self._config_path["linux2"] = linux_path
         self._config_path["win32"] = windows_path
         self._config_path["darwin"] = macosx_path
-        
+
     def get_configuration_location(self, platform):
-        """    
+        """
         Returns the path to the configuration for a given platform.
         The path returned has not been validated and may not be correct nor exist.
-        
+
         :param platform: Os platform as a string, sys.platform style (e.g. linux2/win32/darwin)
         :returns: path to pipeline configuration.
         """
         if self._config_path is None:
             raise TankError("No configuration location has been set!")
-        
+
         return self._config_path[platform]
 
 
@@ -676,18 +676,18 @@ class ProjectSetupParameters(object):
         """
         Sets the desired core API to use.
         Paths can be None, indicating that the path is not defined on a platform.
-        
-        :param linux_path: Path on linux 
+
+        :param linux_path: Path on linux
         :param windows_path: Path on windows
         :param macosx_path: Path on mac
         """
-        
+
         # and set member variables
         self._core_path = {}
         self._core_path["linux2"] = linux_path
         self._core_path["win32"] = windows_path
         self._core_path["darwin"] = macosx_path
-    
+
     def get_associated_core_path(self, platform):
         """
         Return the location of the currently running API, given an os platform.
@@ -701,69 +701,69 @@ class ProjectSetupParameters(object):
 
 
     ################################################################################################################
-    # Validation     
-    
+    # Validation
+
     def pre_setup_validation(self):
         """
         Performs basic validation checks on all the specified data together.
         This method should be executed prior to running the setup projet logic to ensure
-        that the process will succeed.         
+        that the process will succeed.
         """
-        
+
         if self._core_path is None:
-            raise TankError("Need to define a core location!") 
-        
+            raise TankError("Need to define a core location!")
+
         if self._core_path[sys.platform] is None:
             raise TankError("The core API you are trying to use in conjunction with this project "
                             "has not been set up to operate on the current operating system. Please update "
                             "the install_location.yml file and try again.")
-        
+
         # make sure all parameters have been specified
         if self._config_template is None:
             raise TankError("Configuration template has not been specified!")
-        
+
         if self._config_path is None:
             raise TankError("Path to the target configuration install has not been specified!")
-        
+
         if self._project_disk_name is None:
             raise TankError("Project disk name has not been specified!")
-            
+
         # get the location of the configuration
-        config_path_current_os = self.get_configuration_location(sys.platform) 
-        
+        config_path_current_os = self.get_configuration_location(sys.platform)
+
         # validate the local storages
         for storage_name in self.get_required_storages():
-            
+
             # get the project path for this storage
             # note! at this point, the storage root has been checked and exists on disk.
             project_path_local_os = self.get_project_path(storage_name, sys.platform)
-                            
+
             # make sure that the storage location is not the same folder
             # as the pipeline config location. That will confuse tank.
             if config_path_current_os == project_path_local_os:
                 raise TankError("Your configuration location '%s' has been set to the same "
                                 "as one of the storage locations. This is not supported!" % config_path_current_os)
-            
+
             if not os.path.exists(project_path_local_os):
                 raise TankError("The Project path %s for storage %s does not exist on disk! "
                                 "Please create it and try again!" % (project_path_local_os, storage_name))
-        
-        # check if the config template has required minimum core version and make sure that 
+
+        # check if the config template has required minimum core version and make sure that
         # the core we are trying to marry up with the config is recent enough
         required_core_version = self._config_template.get_required_core_version()
         if required_core_version:
-            
+
             # now figure out the version of the desired API
             api_location = self.get_associated_core_path(sys.platform)
             curr_core_version = pipelineconfig_utils.get_core_api_version(api_location)
-    
-            if deploy_util.is_version_newer(required_core_version, curr_core_version):        
+
+            if deploy_util.is_version_newer(required_core_version, curr_core_version):
                 raise TankError("This configuration requires Toolkit Core version %s "
                                 "but you are running version %s" % (required_core_version, curr_core_version))
             else:
                 self._log.debug("Config requires Toolkit Core %s. "
                                 "You are running %s which is fine." % (required_core_version, curr_core_version))
-        
+
 
 
 
@@ -772,21 +772,21 @@ class ProjectSetupParameters(object):
 class TemplateConfiguration(object):
     """
     Functionality for handling installation and validation of tank configs.
-    This class abstracts download and resolve of various config URLs, such as 
-    
+    This class abstracts download and resolve of various config URLs, such as
+
     - app store based configs
     - git based configs
     - file system configs
     - configs copied across from other projects
-    
+
     The constructor is initialized with a config_uri which can have the following syntax:
-    
+
     - toolkit app store syntax:    tk-config-default
     - git syntax (ends with .git): git@github.com:shotgunsoftware/tk-config-default.git
                                    https://github.com/shotgunsoftware/tk-config-default.git
                                    /path/to/bare/repo.git
     - file system location:        /path/to/config
-    
+
     For the app store, the config is downloaded and unpacked into the project location
     For the file system uri, the config folder is copied into the project location
     For git, the git repo is cloned into the config location, therefore being a live repository
@@ -794,22 +794,22 @@ class TemplateConfiguration(object):
     """
 
     _LOCAL = "local"
-    
+
     def __init__(self, config_uri, sg, sg_app_store, script_user, log):
         """
         Constructor
-        
+
         :param config_uri: location of config (see constructor docs for details)
         :param sg: Shotgun site API instance
         :param sg_app_store: Shotgun app store API instance
         :param script_user: The app store script entity used to connect. Dictionary with type and id.
-        :param log: Log channel 
+        :param log: Log channel
         """
         self._sg = sg
         self._sg_app_store = sg_app_store
         self._script_user = script_user
         self._log = log
-        
+
         # now extract the cfg and validate
         old_umask = os.umask(0)
         try:
@@ -832,7 +832,7 @@ class TemplateConfiguration(object):
             for line in fh:
                 self._readme_content.append(line.strip())
             fh.close()
-        
+
         # validate that we are running recent enough versions of core and shotgun
         info_yml = os.path.join(self._cfg_folder, constants.BUNDLE_METADATA_FILE)
         if not os.path.exists(info_yml):
@@ -849,23 +849,23 @@ class TemplateConfiguration(object):
                     file_data.close()
             except Exception, e:
                 raise TankError("Cannot load configuration manifest '%s'. Error: %s" % (info_yml, e))
-    
+
             # perform checks
             if "requires_shotgun_version" in self._manifest:
                 # there is a sg min version required - make sure we have that!
-                
+
                 required_version = self._manifest["requires_shotgun_version"]
-        
+
                 # get the version for the current sg site as a string (1.2.3)
                 sg_version_str = ".".join([ str(x) for x in self._sg.server_info["version"]])
-        
+
                 if deploy_util.is_version_newer(required_version, sg_version_str):
                     raise TankError("This configuration requires Shotgun version %s "
                                     "but you are running version %s" % (required_version, sg_version_str))
                 else:
                     self._log.debug("Config requires shotgun %s. "
                                     "You are running %s which is fine." % (required_version, sg_version_str))
-                    
+
 
     ################################################################################################
     # Helper methods
@@ -874,13 +874,13 @@ class TemplateConfiguration(object):
         """
         Read, validate and return the roots data from the config.
         Example return data structure:
-        
+
         { "primary": {"description":  "desc",
                       "mac_path":     "/asd",
                       "linux_path":   None,
                       "windows_path": "/asd" }
         }
-        
+
         :returns: A dictionary for keyed by storage
         """
         # get the roots definition
@@ -892,7 +892,7 @@ class TemplateConfiguration(object):
                 roots_data = yaml.load(root_file) or {}
             finally:
                 root_file.close()
-            
+
             # validate it
             for x in roots_data:
                 if "mac_path" not in roots_data[x]:
@@ -901,23 +901,23 @@ class TemplateConfiguration(object):
                     roots_data[x]["linux_path"] = None
                 if "windows_path" not in roots_data[x]:
                     roots_data[x]["windows_path"] = None
-            
-        else: 
+
+        else:
             # set up default roots data
-            roots_data = { constants.PRIMARY_STORAGE_NAME: 
+            roots_data = { constants.PRIMARY_STORAGE_NAME:
                             { "description": "A location where the primary data is located.",
-                              "mac_path": "/studio/projects", 
-                              "linux_path": "/studio/projects", 
+                              "mac_path": "/studio/projects",
+                              "linux_path": "/studio/projects",
                               "windows_path": "\\\\network\\projects"
-                            },                          
+                            },
                           }
-            
+
         return roots_data
-        
+
     def _process_config_zip(self, zip_path):
         """
         unpacks a zip config into a temp location.
-        
+
         :param zip_path: path to zip file to unpack
         :returns: tmp location on disk where config now resides
         """
@@ -930,37 +930,37 @@ class TemplateConfiguration(object):
             if item not in template_items:
                 raise TankError("Config zip '%s' is missing a %s folder!" % (zip_path, item))
         self._log.debug("Configuration looks valid!")
-        
+
         return zip_unpack_tmp
-    
+
     def _process_config_app_store(self, config_name):
         """
         Downloads a config zip from the app store and unzips it.
-        
+
         :param config_name: App store config bundle name
-        :returns: tmp location on disk where config now resides 
+        :returns: tmp location on disk where config now resides
         """
-        
+
         if self._sg_app_store is None:
             raise TankError("Cannot download config - you are not connected to the app store!")
-        
+
         # try download from app store...
-        parent_entity = self._sg_app_store.find_one(constants.TANK_CONFIG_ENTITY, 
+        parent_entity = self._sg_app_store.find_one(constants.TANK_CONFIG_ENTITY,
                                               [["sg_system_name", "is", config_name ]],
-                                              ["code"]) 
+                                              ["code"])
         if parent_entity is None:
             raise Exception("Cannot find a config in the app store named %s!" % config_name)
-        
+
         # get latest code
-        latest_cfg = self._sg_app_store.find_one(constants.TANK_CONFIG_VERSION_ENTITY, 
+        latest_cfg = self._sg_app_store.find_one(constants.TANK_CONFIG_VERSION_ENTITY,
                                            filters = [["sg_tank_config", "is", parent_entity],
                                                       ["sg_status_list", "is_not", "rev" ],
-                                                      ["sg_status_list", "is_not", "bad" ]], 
+                                                      ["sg_status_list", "is_not", "bad" ]],
                                            fields=["code", constants.TANK_CODE_PAYLOAD_FIELD],
                                            order=[{"field_name": "created_at", "direction": "desc"}])
         if latest_cfg is None:
             raise Exception("It looks like this configuration doesn't have any versions uploaded yet!")
-        
+
         # now have to get the attachment id from the data we obtained. This is a bit hacky.
         # data example for the payload field, as returned by the query above:
         # {'url': 'http://tank.shotgunstudio.com/file_serve/attachment/21', 'name': 'tank_core.zip',
@@ -972,16 +972,16 @@ class TemplateConfiguration(object):
             attachment_id = int(latest_cfg[constants.TANK_CODE_PAYLOAD_FIELD]["url"].split("/")[-1])
         except:
             raise TankError("Could not extract attachment id from data %s" % latest_cfg)
-    
+
         self._log.debug("Downloading Config %s %s from the App Store..." % (config_name, latest_cfg["code"]))
-        
+
         zip_tmp = os.path.join(tempfile.gettempdir(), "%s_tank_cfg.zip" % uuid.uuid4().hex)
-    
+
         bundle_content = self._sg_app_store.download_attachment(attachment_id)
         fh = open(zip_tmp, "wb")
         fh.write(bundle_content)
         fh.close()
-    
+
         # and write a custom event to the shotgun event log to indicate that a download
         # has happened.
         data = {}
@@ -992,10 +992,10 @@ class TemplateConfiguration(object):
         data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
         data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
         self._sg_app_store.create("EventLogEntry", data)
-    
+
         # got a zip! Pass to zip extractor...
         return self._process_config_zip(zip_tmp)
-    
+
     def _process_config_dir(self, dir_path):
         """
         Validates that the directory contains a tank config
@@ -1006,29 +1006,29 @@ class TemplateConfiguration(object):
                 raise TankError("Config location '%s' missing a %s folder!" % (dir_path, item))
         self._log.debug("Configuration looks valid!")
         return dir_path
-        
+
     def _process_config_git(self, git_repo_str):
         """
         Validate that a git repo is correct, download it to a temp location
-        
+
         :param git_repo_str: Git repository string
         :returns: tmp location on disk where config now resides
         """
-        
+
         self._log.debug("Attempting to clone git uri '%s' into a temp location "
                         "for introspection..." % git_repo_str)
-        
+
         clone_tmp = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
         self._log.info("Attempting to clone git repository '%s'..." % git_repo_str)
         self._clone_git_repo(git_repo_str, clone_tmp)
-        
+
         return clone_tmp
-        
+
     def _process_config(self, config_uri):
         """
         Looks at the starter config string and tries to convert it into a folder
         Returns a path to a config.
-        
+
         :param config_uri: config path of some kind (git/appstore/configured_project)
         :returns: tuple with (tmp_path_to_config, config_type) where config_type is configured_project/zip/git/app_store
         """
@@ -1040,7 +1040,7 @@ class TemplateConfiguration(object):
             # this is a git repository!
             self._log.info("Hang on, loading configuration from git...")
             return (self._process_config_git(config_uri), "git")
-            
+
         elif os.path.sep in config_uri:
             # probably a file path!
             if os.path.exists(config_uri):
@@ -1052,40 +1052,40 @@ class TemplateConfiguration(object):
                     self._log.info("Hang on, loading configuration...")
                     return (self._process_config_dir(config_uri), self._LOCAL)
             else:
-                raise TankError("File path %s does not exist on disk!" % config_uri)    
-        
+                raise TankError("File path %s does not exist on disk!" % config_uri)
+
         elif config_uri.startswith("tk-"):
             # app store!
             self._log.info("Hang on, loading configuration from the app store...")
             return (self._process_config_app_store(config_uri), "app_store")
-        
+
         else:
             raise TankError("Don't know how to handle config '%s'" % config_uri)
-        
+
     def _clone_git_repo(self, repo_path, target_path):
         """
         Clone the specified git repo into the target path
-        
+
         :param repo_path:   The git repo path to clone
         :param target_path: The target path to clone the repo to
         :raises:            TankError if the clone command fails
         """
-        # Note: git doesn't like paths in single quotes when running on 
+        # Note: git doesn't like paths in single quotes when running on
         # windows - it also prefers to use forward slashes!
         sanitized_repo_path = repo_path.replace(os.path.sep, "/")
         cmd = "clone \"%s\" \"%s\"" % (sanitized_repo_path, target_path)
         deploy_util.execute_git_command(cmd)
-        
-    
+
+
     ################################################################################################
     # Public interface
-    
+
     def resolve_storages(self):
         """
         Validate that the roots exist in shotgun. Communicates with Shotgun.
-        
+
         Returns the root paths from shotgun for each storage.
-        
+
         {
           "primary" : { "description": "Description",
                         "exists_on_disk": False,
@@ -1094,21 +1094,21 @@ class TemplateConfiguration(object):
                         "darwin": "/mnt/foo",
                         "win32": "z:\mnt\foo",
                         "linux2": "/mnt/foo"},
-                                    
+
           "textures" : { "description": None,
                          "exists_on_disk": False,
                          "defined_in_shotgun": True,
                          "shotgun_id": 14,
                          "darwin": None,
                          "win32": "z:\mnt\foo",
-                         "linux2": "/mnt/foo"}                                    
+                         "linux2": "/mnt/foo"}
         }
-        
+
         The main dictionary is keyed by storage name. It will contain one entry
         for each local storage which is required by the configuration template.
         Each sub-dictionary contains the following items:
-        
-        - description: Description what the storage is used for. This comes from the 
+
+        - description: Description what the storage is used for. This comes from the
           configuration template and can be used to help a user to explain the purpose
           of a particular storage required by a configuration.
         - defined_in_shotgun: If false, no local storage with this name exists in Shotgun.
@@ -1117,69 +1117,69 @@ class TemplateConfiguration(object):
         - darwin/win32/linux: Paths to storages, as defined in Shotgun. These values can be
           None if a storage has not been defined.
         - exists_on_disk: Flag if the path defined for the current operating system exists on
-          disk or not. 
-        
-        :returns: dictionary with storage breakdown, see example above.                                  
+          disk or not.
+
+        :returns: dictionary with storage breakdown, see example above.
         """
-        
+
         return_data = {}
-        
+
         self._log.debug("Checking so that all the local storages are registered...")
-        sg_storage = self._sg.find("LocalStorage", 
-                                   [], 
+        sg_storage = self._sg.find("LocalStorage",
+                                   [],
                                    fields=["id", "code", "linux_path", "mac_path", "windows_path"])
 
         # make sure that there is a storage in shotgun matching all storages for this config
         sg_storage_codes = [x.get("code") for x in sg_storage]
         cfg_storages = self._roots_data.keys()
-                
+
         for s in cfg_storages:
-            
+
             return_data[s] = { "description": self._roots_data[s].get("description"),
                                "shotgun_id": None,
                                "darwin": None,
                                "win32": None,
                                "linux2": None}
-            
+
             if s not in sg_storage_codes:
                 return_data[s]["defined_in_shotgun"] = False
                 return_data[s]["exists_on_disk"] = False
             else:
                 return_data[s]["defined_in_shotgun"] = True
-                            
+
                 # find the sg storage paths and add to return data
                 for x in sg_storage:
-                    
+
                     if x.get("code") == s:
-                        
+
                         # copy the storage paths across
                         return_data[s]["darwin"] = x.get("mac_path")
                         return_data[s]["linux2"] = x.get("linux_path")
                         return_data[s]["win32"] = x.get("windows_path")
                         return_data[s]["shotgun_id"] = x.get("id")
-                        
+
                         # get the local path
-                        lookup_dict = {"linux2": "linux_path", "win32": "windows_path", "darwin": "mac_path" }                        
+                        lookup_dict = {"linux2": "linux_path", "win32": "windows_path", "darwin": "mac_path" }
                         local_storage_path = x.get( lookup_dict[sys.platform] )
 
                         if local_storage_path is None:
                             # shotgun has no path for our local storage
                             return_data[s]["exists_on_disk"] = False
-                            
+
                         elif not os.path.exists(local_storage_path):
                             # path is defined but cannot be found
                             return_data[s]["exists_on_disk"] = False
-                            
+
                         else:
                             # path exists! yay!
                             return_data[s]["exists_on_disk"] = True
-                                    
+
         return return_data
 
     def get_required_core_version(self):
         """
         Returns the required core version, as a string
-        
+
         :returns: str, e.g. 'v0.2.3' or None if not defined
         """
         return self._manifest.get("requires_core_version")
@@ -1187,15 +1187,15 @@ class TemplateConfiguration(object):
     def get_name(self):
         """
         Returns the display name of this config, as defined in the manifest
-        
+
         :returns: string
         """
         return self._manifest.get("display_name")
-        
+
     def get_uri(self):
         """
         Returns the config URI associated with this config
-        
+
         :returns: string
         """
         return self._config_uri
@@ -1232,15 +1232,15 @@ class TemplateConfiguration(object):
         """
         Get associated readme content as a list.
         If not readme exists, an empty list is returned
-        
+
         :returns: list of strings
         """
         return self._readme_content
-        
+
     def get_description(self):
         """
         Returns the description of the config, as defined in the manifest
-        
+
         :returns string
         """
         return self._manifest.get("description")

--- a/python/tank/deploy/tank_commands/setup_project_wizard.py
+++ b/python/tank/deploy/tank_commands/setup_project_wizard.py
@@ -24,57 +24,57 @@ from .setup_project_params import ProjectSetupParameters
 class SetupProjectFactoryAction(Action):
     """
     Special handling of Project setup.
-    
+
     This is a more complex alternative to the simple setup_project command.
-    
+
     This class exposes a setup_project_factory command to the API only (no tank command support)
-    which returns a factory command object which can then in turn construct project setup wizard instances which 
+    which returns a factory command object which can then in turn construct project setup wizard instances which
     can be used to build interactive wizard-style project setup processes.
-    
+
     it is used like this:
-    
+
     >>> import tank
     # create our factory object
     >>> factory = tank.get_command("setup_project_factory")
     # the factory can spit out set up wizards
     >>> setup_wizard = factory.execute({})
     # now set up various parameters etc on the project wizard
-    # this can be an interactive process which includes validation etc. 
+    # this can be an interactive process which includes validation etc.
     >>> wizard.set_parameters(....)
     # lastly, execute the actual setup.
     >>> wizard.execute()
-    
-    """    
+
+    """
     def __init__(self):
-        Action.__init__(self, 
-                        "setup_project_factory", 
-                        Action.GLOBAL, 
+        Action.__init__(self,
+                        "setup_project_factory",
+                        Action.GLOBAL,
                         ("Returns a factory object which can be used to construct setup wizards. These wizards "
-                         "can then be used to run an interactive setup process."), 
+                         "can then be used to run an interactive setup process."),
                         "Configuration")
-        
+
         # no tank command support for this one because it returns an object
         self.supports_tank_command = False
-        
+
         # this method can be executed via the API
         self.supports_api = True
-        
+
         self.parameters = {}
-                
+
     def run_interactive(self, log, args):
         """
         Tank command accessor
-        
+
         :param log: std python logger
         :param args: command line args
         """
         raise TankError("This Action does not support command line access")
-        
+
     def run_noninteractive(self, log, parameters):
         """
-        Tank command API accessor. 
+        Tank command API accessor.
         Called when someone runs a tank command through the core API.
-        
+
         :param log: std python logger
         :param parameters: dictionary with tank command parameters
         """
@@ -82,23 +82,23 @@ class SetupProjectFactoryAction(Action):
         (sg, sg_app_store, sg_app_store_script_user) = self._shotgun_connect(log)
         # return a wizard object
         return SetupProjectWizard(log, sg, sg_app_store, sg_app_store_script_user)
-                    
+
     def _shotgun_connect(self, log):
         """
         Connects to the App store and to the associated shotgun site.
         Logging in to the app store is optional and in the case this fails,
-        the app store parameters will return None. 
-        
+        the app store parameters will return None.
+
         The method returns a tuple with three parameters:
-        
+
         - sg is an API handle associated with the associated site
         - sg_app_store is an API handle associated with the app store
-        - sg_app_store_script_user is a sg dict (with name, id and type) 
+        - sg_app_store_script_user is a sg dict (with name, id and type)
           representing the script user used to connect to the app store.
-        
+
         :returns: (sg, sg_app_store, sg_app_store_script_user) - see above.
         """
-        
+
         # now connect to shotgun
         try:
             log.info("Connecting to Shotgun...")
@@ -107,7 +107,7 @@ class SetupProjectFactoryAction(Action):
             log.debug("Connected to target Shotgun server! (v%s)" % sg_version)
         except Exception, e:
             raise TankError("Could not connect to Shotgun server: %s" % e)
-    
+
         try:
             log.info("Connecting to the App Store...")
             (sg_app_store, script_user) = shotgun.create_sg_app_store_connection()
@@ -120,50 +120,50 @@ class SetupProjectFactoryAction(Action):
             log.debug("The following error was raised: %s" % e)
             sg_app_store = None
             script_user = None
-        
+
         return (sg, sg_app_store, script_user)
-                
+
 
 
 class SetupProjectWizard(object):
     """
     A class which wraps around the project setup functionality in toolkit.
     """
-    
+
     def __init__(self, log, sg, sg_app_store, sg_app_store_script_user):
         """
-        Constructor. 
-        """        
+        Constructor.
+        """
         self._log = log
         self._sg = sg
         self._sg_app_store = sg_app_store
         self._sg_app_store_script_user = sg_app_store_script_user
-        self._params = ProjectSetupParameters(self._log, 
-                                              self._sg, 
-                                              self._sg_app_store, 
+        self._params = ProjectSetupParameters(self._log,
+                                              self._sg,
+                                              self._sg_app_store,
                                               self._sg_app_store_script_user)
-                
+
     def set_progress_callback(self, cb):
         """
-        Specify a function which should be called during project setup 
+        Specify a function which should be called during project setup
         whenever there is an update to the progress.
-        
-        The callback function should have the following 
+
+        The callback function should have the following
         signature:
-        
+
         def callback(chapter_str, percent_progress_int)
-        
+
         The installer will run through several "chapters" throughout the install
         and each of these will have a separate progress calculation. Some chapters
-        are fast and/or difficult to quantify into steps - in this case, the 
+        are fast and/or difficult to quantify into steps - in this case, the
         percent_progress_int parameter will be passed None. For such chapters,
         the callback will be called only once.
-        
+
         For chapters which report progress, the callback will be called multiple times,
         each time with an incremented progress. This is an int value in percent.
-        
+
         For example
-        
+
         callback("Setting up base storages", None)
         callback("Making folders", None)
         callback("Downloading apps", 1)
@@ -171,31 +171,31 @@ class SetupProjectWizard(object):
         callback("Downloading apps", 56)
         callback("Downloading apps", 93)
         callback("Finalizing", None)
-    
+
         :param fp: Function object representing a progress callback
         """
         self._params.set_progress_callback(cb)
-        
+
     def set_project(self, project_id, force=False):
         """
         Specify which project that should be set up.
-        
+
         :param project_id: Shotgun id for the project that should be set up.
         :param force: Allow for the setting up of existing projects.
         """
-        self._params.set_project_id(project_id, force)     
-        
+        self._params.set_project_id(project_id, force)
+
     def validate_config_uri(self, config_uri):
         """
         Validates a configuration template to check if it is compatible with the current Shotgun setup.
-        This will download the configuration, validate it to ensure that it is compatible with the 
-        constraints (versions of core and shotgun) of this system. 
-        
+        This will download the configuration, validate it to ensure that it is compatible with the
+        constraints (versions of core and shotgun) of this system.
+
         If locating, downloading, or validating the configuration fails, exceptions will be raised.
-        
+
         Once the configuration exists and is compatible, the storage situation is reviewed against shotgun.
         A dictionary with a breakdown of all storages required by the configuration is returned:
-                
+
         {
           "primary" : { "description": "This is where work files and scene publishes are located.",
                         "exists_on_disk": False,
@@ -204,14 +204,14 @@ class SetupProjectWizard(object):
                         "darwin": "/mnt/data",
                         "win32": "z:\mnt\data",
                         "linux2": "/mnt/data"},
-                                    
+
           "textures" : { "description": "All texture are located on this storage",
                          "exists_on_disk": False,
                          "defined_in_shotgun": False,
                          "shotgun_id": None,
                          "darwin": None,
                          "win32": None,
-                         "linux2": None}    
+                         "linux2": None}
 
           "renders" : { "description": None,
                         "exists_on_disk": False,
@@ -220,12 +220,12 @@ class SetupProjectWizard(object):
                         "win32": "z:\mnt\renders",
                         "linux2": "/mnt/renders"}
         }
-        
+
         The main dictionary is keyed by storage name. It will contain one entry
         for each local storage which is required by the configuration template.
         Each sub-dictionary in turn contains the following items:
-        
-        - description: Description what the storage is used for. This comes from the 
+
+        - description: Description what the storage is used for. This comes from the
           configuration template and can be used to help a user to explain the purpose
           of a particular storage required by a configuration.
         - defined_in_shotgun: If false, no local storage with this name exists in Shotgun.
@@ -234,17 +234,17 @@ class SetupProjectWizard(object):
         - darwin/win32/linux: Paths to storages, as defined in Shotgun. These values can be
           None if a storage has not been defined.
         - exists_on_disk: Flag if the path defined for the current operating system exists on
-          disk or not. 
-        
+          disk or not.
+
         :param config_uri: Configuration uri representing the location of a config
         :returns: dictionary with storage data, see above.
         """
         return self._params.validate_config_uri(config_uri)
-        
+
     def set_config_uri(self, config_uri):
         """
-        Validate and set a configuration uri to use with this setup wizard. 
-        
+        Validate and set a configuration uri to use with this setup wizard.
+
         In order to proceed with further functions, such as setting a project name,
         the config uri needs to be set.
 
@@ -259,12 +259,12 @@ class SetupProjectWizard(object):
         """
         Returns a metadata dictionary for the config that has been associated with the wizard.
         Returns a dictionary with information. Currently returns the following keys:
-        
+
         - display_name: The display name for the configuration, e.g. 'Default Config'
         - description: A short description of the configuraiton.
         - readme: readme content associated with the config, in the form of list of strings.
                   if no readme exists, an empty list is returned.
-        
+
         :returns: dictionary with display_name, readme and description keys
         """
         d = {}
@@ -276,45 +276,45 @@ class SetupProjectWizard(object):
     def get_default_project_disk_name(self):
         """
         Returns a default project name from toolkit.
-        
+
         Before you call this method, a config and a project must have been set.
-        
+
         This will execute hooks etc and given the selected project id will
         return a suggested project name.
-        
+
         :returns: string with a suggested project name
         """
         return self._params.get_default_project_disk_name()
-        
+
     def validate_project_disk_name(self, project_disk_name):
         """
         Validate the project disk name.
         Raises Exceptions if the project disk name is not valid.
-        
+
         :param project_disk_name: string with a project name.
         """
         self._params.validate_project_disk_name(project_disk_name)
-        
+
     def preview_project_paths(self, project_disk_name):
         """
         Return preview project paths given a project name.
-        
-        { "primary": { "darwin": "/foo/bar/project_name", 
+
+        { "primary": { "darwin": "/foo/bar/project_name",
                        "linux2": "/foo/bar/project_name",
                        "win32" : "c:\foo\bar\project_name"},
-          "textures": { "darwin": "/textures/project_name", 
+          "textures": { "darwin": "/textures/project_name",
                         "linux2": "/textures/project_name",
                         "win32" : "c:\textures\project_name"}}
-        
+
         The operating systems are enumerated using sys.platform jargon.
         If a path doesn't have a valid storage path defined in Shotgun,
         it will be returned as None. If the project name is not valid,
         None values will be returned for all paths.
-        
+
         It is recommended that you execute validate_project_disk_name()
-        to check the validity of the project name prior to executing this 
-        method. 
-        
+        to check the validity of the project name prior to executing this
+        method.
+
         :param project_disk_name: string with a project name.
         :returns: Dictionary, see above.
         """
@@ -323,37 +323,37 @@ class SetupProjectWizard(object):
             return_data[s] = {}
             return_data[s]["darwin"] = self._params.preview_project_path(s, project_disk_name, "darwin")
             return_data[s]["win32"] = self._params.preview_project_path(s, project_disk_name, "win32")
-            return_data[s]["linux2"] = self._params.preview_project_path(s, project_disk_name, "linux2") 
-        
+            return_data[s]["linux2"] = self._params.preview_project_path(s, project_disk_name, "linux2")
+
         return return_data
-        
+
     def set_project_disk_name(self, project_disk_name, create_folders=True):
         """
         Set the desired name of the project. May raise exception if the name is not valid.
         By default, this method also attempts to ensure that folders exists for all
         storages associated with this configuration and project name.
-        
+
         It is recommended that you execute validate_project_disk_name()
-        to check the validity of the project name prior to executing this 
-        method. 
-        
+        to check the validity of the project name prior to executing this
+        method.
+
         :param project_disk_name: string with a project name
         :param create_folders: if set to true, the wizard will attempt to create project root folders
-                               if these don't already exist. 
+                               if these don't already exist.
         """
 
         # by default, the wizard will also try to help out with the creation of
-        # the project root folder if it doesn't already exist! 
+        # the project root folder if it doesn't already exist!
         if create_folders:
-            
+
             # make sure name is valid before starting to create directories...
             self._params.validate_project_disk_name(project_disk_name)
             self._log.debug("Will try to create project folders on disk...")
             for s in self._params.get_required_storages():
-                
+
                 # get the full path
                 proj_path = self._params.preview_project_path(s, project_disk_name, sys.platform)
-                
+
                 if not os.path.exists(proj_path):
                     self._log.info("Creating project folder '%s'..." % proj_path)
                     old_umask = os.umask(0)
@@ -362,21 +362,21 @@ class SetupProjectWizard(object):
                     finally:
                         os.umask(old_umask)
                     self._log.debug("...done!")
-                
+
                 else:
                     self._log.debug("Storage '%s' - project folder '%s' - already exists!" % (s, proj_path))
-        
+
         # lastly, register the name in shotgun
         self._params.set_project_disk_name(project_disk_name)
-            
+
     def get_default_configuration_location(self):
         """
         Returns default suggested location for configurations.
         Returns a dictionary with sys.platform style keys linux2/win32/darwin, e.g.
-        
-        { "darwin": "/foo/bar/project_name", 
+
+        { "darwin": "/foo/bar/project_name",
           "linux2": "/foo/bar/project_name",
-          "win32" : "c:\foo\bar\project_name"}        
+          "win32" : "c:\foo\bar\project_name"}
 
         :returns: dictionary with paths
         """
@@ -389,12 +389,12 @@ class SetupProjectWizard(object):
         # now check the shotgun data
         new_proj_disk_name = self._params.get_project_disk_name() # e.g. 'foo/bar_baz'
         new_proj_disk_name_win = new_proj_disk_name.replace("/", "\\")  # e.g. 'foo\bar_baz'
-         
+
         data = self._params.get_configuration_shotgun_info()
-        
+
         if not data:
             # we are not based on an existing project. Instead pick the last primary config
-            data = self._sg.find_one("PipelineConfiguration", 
+            data = self._sg.find_one("PipelineConfiguration",
                                      [["code", "is", "primary"]],
                                      ["id", 
                                       "mac_path", 

--- a/python/tank/deploy/tank_commands/switch.py
+++ b/python/tank/deploy/tank_commands/switch.py
@@ -11,8 +11,7 @@
 from ...errors import TankError
 from . import console_utils
 from .action_base import Action
-from ..descriptor import AppDescriptor 
-from ..descriptor import get_from_location
+from ..descriptor import AppDescriptor
 from ..app_store_descriptor import TankAppStoreDescriptor 
 
 import os
@@ -148,12 +147,11 @@ class SwitchAppAction(Action):
         
         if mode == "app_store":
             
-            new_descriptor = TankAppStoreDescriptor.find_latest_item(
-                self.tk.pipeline_configuration.get_path(),
-                self.tk.pipeline_configuration.get_bundles_location(),
-                AppDescriptor.APP,
-                descriptor.get_system_name()
-            )
+            location = {"type": "app_store", 
+                        "name": descriptor.get_system_name(), 
+                        "version": "v0.0.0"}
+            tmp_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
+            new_descriptor = tmp_descriptor.find_latest_version()            
         
         elif mode == "dev":
 
@@ -162,22 +160,14 @@ class SwitchAppAction(Action):
 
             # run descriptor factory method
             location = {"type": "dev", "path": path}
-            new_descriptor = get_from_location(AppDescriptor.APP, 
-                                                          self.tk.pipeline_configuration, 
-                                                          location)
-
-
+            new_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
 
         elif mode == "git":
             
             # run descriptor factory method
             location = {"type": "git", "path": path, "version": "v0.0.0"}
-            tmp_descriptor = get_from_location(AppDescriptor.APP, 
-                                               self.tk.pipeline_configuration, 
-                                               location)
-            # now find latest
-            new_descriptor = tmp_descriptor.find_latest_version()
-            
+            tmp_descriptor = self.tk.pipeline_configuration.get_app_descriptor(location)
+            new_descriptor = tmp_descriptor.find_latest_version()            
         
         else:
             raise TankError("Unknown mode!")
@@ -210,7 +200,7 @@ class SwitchAppAction(Action):
         new_descriptor.ensure_shotgun_fields_exist()
     
         # run post install hook
-        new_descriptor.run_post_install()
+        new_descriptor.run_post_install(self.tk)
     
         # ensure that all required frameworks have been installed
         # find the file where our item is being installed
@@ -231,22 +221,3 @@ class SwitchAppAction(Action):
                                 new_descriptor.get_location())
         
         log.info("Switch complete!")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/python/tank/deploy/tank_commands/update.py
+++ b/python/tank/deploy/tank_commands/update.py
@@ -425,7 +425,7 @@ def _update_item(log, suppress_prompts, tk, env, old_descriptor, new_descriptor,
     new_descriptor.ensure_shotgun_fields_exist()
 
     # run post install hook
-    new_descriptor.run_post_install()
+    new_descriptor.run_post_install(tk)
 
     # ensure that all required frameworks have been installed
     # find the file where our item is being installed

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -21,6 +21,7 @@ from tank_vendor import yaml
 
 from .errors import TankError, TankUnreadableFileError
 from .deploy import util
+from .deploy import descriptor
 from .platform import constants
 from .platform.environment import Environment, WritableEnvironment
 from .util import shotgun, yaml_cache
@@ -34,10 +35,6 @@ class PipelineConfiguration(object):
     Use the factory methods below to construct this object, do not
     create directly via constructor.
     """
-
-    # Since the project id can be None for site configurations, we have to
-    # initialize _project_id to an invalid value different from None.
-    _UNDEFINED_PROJECT_ID = -1
 
     def __init__(self, pipeline_configuration_path):
         """
@@ -83,14 +80,17 @@ class PipelineConfiguration(object):
         self._roots = pipelineconfig_utils.get_roots_metadata(self._pc_root)
 
         # get the project tank disk name (Project.tank_name), stored in the PC metadata file.
-        data = pipelineconfig_utils.get_metadata(self._pc_root)
-        if data.get("project_name") is None:
-            raise TankError("Project name not defined in config metadata for config %s! "
-                            "Please contact support." % self._pc_root)
-        self._project_name = data.get("project_name")
-
-        # cache fields lazily populated on getter access
-        self._clear_cached_settings()
+        pipeline_config_metadata = self._get_metadata()
+        self._project_name = pipeline_config_metadata.get("project_name")
+        self._project_id = pipeline_config_metadata.get("project_id")
+        self._pc_id = pipeline_config_metadata.get("pc_id")
+        self._pc_name = pipeline_config_metadata.get("pc_name")
+        self._published_file_entity_type = pipeline_config_metadata.get("published_file_entity_type", "TankPublishedFile")        
+        self._use_shotgun_path_cache = pipeline_config_metadata.get("use_shotgun_path_cache", False)
+        self._use_global_bundle_cache = pipeline_config_metadata.get("use_global_bundle_cache", False)
+        
+        # lazily loaded member variables
+        self._bundles_location = None
 
         # Populate the global yaml_cache if we find a pickled cache
         # on disk.
@@ -98,40 +98,89 @@ class PipelineConfiguration(object):
         # the global pickled cache stored in the config down to
         # local storage to speed up reading in subsequent sessions.
         self._populate_yaml_cache()
-        
+
+        # run init hook
         self.execute_core_hook_internal(constants.PIPELINE_CONFIGURATION_INIT_HOOK_NAME, parent=self)
 
     def __repr__(self):
         return "<Sgtk Configuration %s>" % self._pc_root
 
-    def _clear_cached_settings(self):
+    ########################################################################################
+    # handling pc metadata
+    
+    def _get_metadata(self):
         """
-        Force the pc object to reread its settings from disk.
-        Call this if you have made changes to config files and 
-        want these to be picked up. The next time settings are needed,
-        these will be automatically re-read from disk.
+        Loads the pipeline config metadata (the pipeline_configuration.yml) file from disk.
+        
+        :param pipeline_config_path: path to a pipeline configuration root folder
+        :returns: deserialized content of the file in the form of a dict.
         """
-        self._project_id = self._UNDEFINED_PROJECT_ID
-        self._pc_id = None
-        self._pc_name = None
-        self._published_file_entity_type = None
-        self._cache_folder = None
-        self._path_cache_path = None
-        self._use_shotgun_path_cache = None
+    
+        # now read in the pipeline_configuration.yml file
+        cfg_yml = os.path.join(self.get_config_location(), 
+                               "core", 
+                               "pipeline_configuration.yml")
+    
+        if not os.path.exists(cfg_yml):
+            raise TankError("Configuration metadata file '%s' missing! "
+                            "Please contact support." % cfg_yml)
+    
+        fh = open(cfg_yml, "rt")
+        try:
+            data = yaml.load(fh)
+            if data is None:
+                raise Exception("File contains no data!")
+        except Exception, e:
+            raise TankError("Looks like a config file is corrupt. Please contact "
+                            "support! File: '%s' Error: %s" % (cfg_yml, e))
+        finally:
+            fh.close()
+    
+        return data
+    
+    def _update_pipeline_config(self, updates):
+        """
+        Updates the pipeline configuration on disk with the passed in values.
 
-    def _load_metadata_from_sg(self):
+        :param updates: Dictionary of values to update in the pipeline configuration
         """
-        Caches PC metadata from shotgun.
-        """
-        sg = shotgun.get_sg_connection()
-        platform_lookup = {"linux2": "linux_path", "win32": "windows_path", "darwin": "mac_path" }
-        sg_path_field = platform_lookup[sys.platform]
-        data = sg.find_one(constants.PIPELINE_CONFIGURATION_ENTITY,
-                           [[sg_path_field, "is", self._pc_root]],
-                           ["id", "project", "code"])
-        if data is None:
-            raise TankError("Cannot find a Pipeline configuration in Shotgun that has its %s "
-                            "set to '%s'!" % (sg_path_field, self._pc_root))
+        # get current settings
+        curr_settings = self._get_metadata()
+        
+        # add path cache setting
+        curr_settings.update(updates)
+        
+        # write the record to disk
+        pipe_config_sg_id_path = os.path.join(self.get_config_location(), 
+                                              "core", 
+                                              "pipeline_configuration.yml")        
+        
+        old_umask = os.umask(0)
+        try:
+            os.chmod(pipe_config_sg_id_path, 0666)
+            # and write the new file
+            fh = open(pipe_config_sg_id_path, "wt")
+            # using safe_dump instead of dump ensures that we
+            # don't serialize any non-std yaml content. In particular,
+            # this causes issues if a unicode object containing a 7-bit
+            # ascii string is passed as part of the data. in this case, 
+            # dump will write out a special format which is later on 
+            # *loaded in* as a unicode object, even if the content doesn't  
+            # need unicode handling. And this causes issues down the line
+            # in toolkit code, assuming strings:
+            #
+            # >>> yaml.dump({"foo": u"bar"})
+            # "{foo: !!python/unicode 'bar'}\n"
+            # >>> yaml.safe_dump({"foo": u"bar"})
+            # '{foo: bar}\n'
+            #            
+            yaml.safe_dump(curr_settings, fh)
+        except Exception, exp:
+            raise TankError("Could not write to configuration file '%s'. "
+                            "Error reported: %s" % (pipe_config_sg_id_path, exp))
+        finally:
+            fh.close()
+            os.umask(old_umask)            
 
         self._project_id = data.get("project").get("id")
         self._pc_id = data.get("id")
@@ -178,24 +227,14 @@ class PipelineConfiguration(object):
     def get_name(self):
         """
         Returns the name of this PC.
-        May connect to Shotgun to retrieve this.
         """
-        if self._pc_name is None:
-            # try to get it from the cache file
-            data = pipelineconfig_utils.get_metadata(self._pc_root)
-            self._pc_name = data.get("pc_name")
-
-
-            if self._pc_name is None:
-                # not in metadata file on disk. Fall back on SG lookup
-                self._load_metadata_from_sg()
-
         return self._pc_name
 
     def is_auto_path(self):
         """
         Returns true if this config was set up with auto path mode.
-        This method will connect to shotgun in order to determine the auto path status.
+        This method will connect to shotgun in order to determine the 
+        auto path status.
         
         :returns: boolean indicating auto path state
         """
@@ -236,35 +275,14 @@ class PipelineConfiguration(object):
 
     def get_shotgun_id(self):
         """
-        Returns the shotgun id for this PC. 
-        May connect to Shotgun to retrieve this.
+        Returns the shotgun id for this PC.
         """
-        if self._pc_id is None:
-            # try to get it from the cache file
-            data = pipelineconfig_utils.get_metadata(self._pc_root)
-            self._pc_id = data.get("pc_id")
-
-            if self._pc_id is None:
-                # not in metadata file on disk. Fall back on SG lookup
-                self._load_metadata_from_sg()
-
         return self._pc_id
 
     def get_project_id(self):
         """
-        Returns the shotgun id for the project associated with this PC. 
-        May connect to Shotgun to retrieve this.
+        Returns the shotgun id for the project associated with this PC.
         """
-        if self._project_id == self._UNDEFINED_PROJECT_ID:
-            # try to get it from the cache file
-            data = pipelineconfig_utils.get_metadata(self._pc_root)
-
-            if "project_id" not in data:
-                # not in metadata file on disk. Fall back on SG lookup
-                self._load_metadata_from_sg()
-            else:
-                self._project_id = data.get("project_id")
-
         return self._project_id
 
     def is_site_configuration(self):
@@ -294,22 +312,20 @@ class PipelineConfiguration(object):
         Returns the type of entity being used
         for the 'published file' entity
         """
-        if self._published_file_entity_type is None:
-            # try to get it from the cache file
-            data = pipelineconfig_utils.get_metadata(self._pc_root)
-            self._published_file_entity_type = data.get("published_file_entity_type")
-
-            if self._published_file_entity_type is None:
-                # fall back to legacy type:
-                self._published_file_entity_type = "TankPublishedFile"
-
         return self._published_file_entity_type
+
+    def use_global_bundle_cache(self):
+        """
+        Returns true if a global bundle cache should be used to store projects.
+        """
+        return self._use_global_bundle_cache
 
     def convert_to_site_config(self):
         """
         Converts the pipeline configuration into the site configuration.
         """
         self._update_pipeline_config({"project_id": None})
+        self._project_id = None
 
     ########################################################################################
     # path cache
@@ -320,17 +336,8 @@ class PipelineConfiguration(object):
         This should only ever return False for setups created before 0.15.
         All projects created with 0.14+ automatically sets this to true.
         """
-        if self._use_shotgun_path_cache is None:
-            # try to get it from the cache file
-            data = pipelineconfig_utils.get_metadata(self._pc_root)
-            self._use_shotgun_path_cache = data.get("use_shotgun_path_cache")
-
-            if self._use_shotgun_path_cache is None:
-                # if not defined assume it is off
-                self._use_shotgun_path_cache = False
-
         return self._use_shotgun_path_cache
-
+    
     def turn_on_shotgun_path_cache(self):
         """
         Updates the pipeline configuration settings to have the shotgun based (v0.15+)
@@ -343,51 +350,8 @@ class PipelineConfiguration(object):
             raise TankError("Shotgun based path cache already turned on!")
                 
         self._update_pipeline_config({"use_shotgun_path_cache": True})
+        self._use_shotgun_path_cache = True
 
-    def _update_pipeline_config(self, updates):
-        """
-        Updates the pipeline configuration on disk with the passed in values.
-
-        :param updates: Dictionary of values to update in the pipeline configuration
-        """
-        # get current settings
-        curr_settings = pipelineconfig_utils.get_metadata(self._pc_root)
-        
-        # add path cache setting
-        curr_settings.update(updates)
-        
-        # write the record to disk
-        pipe_config_sg_id_path = os.path.join(self._pc_root, "config", "core", "pipeline_configuration.yml")        
-        
-        old_umask = os.umask(0)
-        try:
-            os.chmod(pipe_config_sg_id_path, 0666)
-            # and write the new file
-            fh = open(pipe_config_sg_id_path, "wt")
-            # using safe_dump instead of dump ensures that we
-            # don't serialize any non-std yaml content. In particular,
-            # this causes issues if a unicode object containing a 7-bit
-            # ascii string is passed as part of the data. in this case, 
-            # dump will write out a special format which is later on 
-            # *loaded in* as a unicode object, even if the content doesn't  
-            # need unicode handling. And this causes issues down the line
-            # in toolkit code, assuming strings:
-            #
-            # >>> yaml.dump({"foo": u"bar"})
-            # "{foo: !!python/unicode 'bar'}\n"
-            # >>> yaml.safe_dump({"foo": u"bar"})
-            # '{foo: bar}\n'
-            #            
-            yaml.safe_dump(curr_settings, fh)
-        except Exception, exp:
-            raise TankError("Could not write to pipeline configuration settings file %s. "
-                            "Error reported: %s" % (pipe_config_sg_id_path, exp))
-        finally:
-            fh.close()
-            os.umask(old_umask)             
-            
-        # update settings in memory
-        self._clear_cached_settings()      
         
     ########################################################################################
     # storage roots related
@@ -458,7 +422,6 @@ class PipelineConfiguration(object):
                 proj_roots[storage_name][platform] = storage_path
                 
         return proj_roots
-
     
     def get_data_roots(self):
         """
@@ -485,7 +448,6 @@ class PipelineConfiguration(object):
           
         :returns: the project disk name properly concatenated onto the root_value
         """
-        
         # get the valid separator for this path
         separators = {"linux2": "/", "win32": "\\", "darwin": "/" }
         separator = separators[os_name] 
@@ -559,54 +521,103 @@ class PipelineConfiguration(object):
         
         return core_api_root
 
-    def get_bundles_location(self):
-        """
-        Returns the location where all apps/frameworks/engines are stored in subfolders
-        
-        :returns: path string
-        """
-        return os.path.join(self.get_install_location(), "install")
-
-    def get_apps_location(self):
-        """
-        Returns the location where apps are stored
-        
-        Note! This method has been deprecated and will be removed at 
-        some point in the future. Please do not use it.
-        
-        :returns: path string        
-        """
-        return os.path.join(self.get_bundles_location(), "apps")
-
-    def get_engines_location(self):
-        """
-        Returns the location where engines are stored
-        
-        Note! This method has been deprecated and will be removed at 
-        some point in the future. Please do not use it.
-        
-        :returns: path string        
-        """
-        return os.path.join(self.get_bundles_location(), "engines")
-
-    def get_frameworks_location(self):
-        """
-        Returns the location where frameworks are stored
-        
-        Note! This method has been deprecated and will be removed at 
-        some point in the future. Please do not use it.
-        
-        :returns: path string        
-        """
-        return os.path.join(self.get_bundles_location(), "frameworks")
-
     def get_core_python_location(self):
         """
         Returns the python root for this install.
         
         :returns: path string
         """
-        return os.path.join(self.get_bundles_location(), "core", "python")
+        return os.path.join(self.get_install_location(), "install", "core", "python")
+
+
+    ########################################################################################
+    # accessing cached code
+
+    def _get_bundles_location(self):
+        """
+        Returns the location where all apps/frameworks/engines are stored in subfolders.
+        
+        Note: if you want to find the location to where the core API is stored,
+              use the get_core_python_location() method.
+        
+        :returns: path string
+        """
+        if self._bundles_location is None:
+            # have not calculated and cached the global bundles root yet
+            if self.use_global_bundle_cache():
+                # global location as per core hook
+                self._bundles_location = self.execute_core_hook_method_internal(
+                    constants.CACHE_LOCATION_HOOK_NAME, 
+                    "global_bundle_cache",
+                    self)
+            else:
+                # traditional location relative to core install
+                self._bundles_location = os.path.join(self.get_install_location(), "install")
+
+        return self._bundles_location
+
+
+    def get_app_descriptor(self, location):
+        """
+        Convenience method that returns a descriptor for an app
+        that is associated with this pipeline configuration.
+        
+        :param location: Location dictionary describing the app source location
+        :returns:        Descriptor object
+        """
+        # resolve any config specific aspects of location dict
+        pp_location = descriptor.preprocess_location(location, self)
+        return descriptor.descriptor_factory(descriptor.AppDescriptor.APP, 
+                                             self._get_bundles_location(), 
+                                             pp_location)
+        
+    def get_engine_descriptor(self, location):
+        """
+        Convenience method that returns a descriptor for an engine
+        that is associated with this pipeline configuration.
+        
+        :param location: Location dictionary describing the engine source location
+        :returns:        Descriptor object
+        """
+        # resolve any config specific aspects of location dict
+        pp_location = descriptor.preprocess_location(location, self)
+        return descriptor.descriptor_factory(descriptor.AppDescriptor.ENGINE, 
+                                             self._get_bundles_location(), 
+                                             pp_location)
+        
+    def get_framework_descriptor(self, location):
+        """
+        Convenience method that returns a descriptor for a framework
+        that is associated with this pipeline configuration.
+        
+        :param location: Location dictionary describing the framework source location
+        :returns:        Descriptor object
+        """
+        # resolve any config specific aspects of location dict
+        pp_location = descriptor.preprocess_location(location, self)
+        return descriptor.descriptor_factory(descriptor.AppDescriptor.FRAMEWORK, 
+                                             self._get_bundles_location(), 
+                                             pp_location)
+
+    def get_core_descriptor(self, location):
+        """
+        Convenience method that returns a descriptor for core
+        that is associated with this pipeline configuration.
+        
+        Note! While Engines, Apps and Frameworks descriptors point
+        at code that is typically used at runtime, a core descriptor
+        is typically not used at runtime but instead at deploy time, 
+        to cache a series of cores locally in the bundle cache and then
+        choose one to deploy into a configuration.
+        
+        :param location: Location dictionary describing the core source location
+        :returns:        Descriptor object
+        """
+        # resolve any config specific aspects of location dict
+        pp_location = descriptor.preprocess_location(location, self)
+        return descriptor.descriptor_factory(descriptor.AppDescriptor.CORE, 
+                                             self._get_bundles_location(), 
+                                             pp_location)
 
     ########################################################################################
     # configuration disk locations
@@ -702,7 +713,6 @@ class PipelineConfiguration(object):
             data = dict()
 
         return data
-
 
     ########################################################################################
     # helpers and internal

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -685,6 +685,11 @@ def _get_cache_location():
     Get the location of the initializtion lookup cache.
     Just computes the path, no I/O.
 
+    NOTE! This logic is duplicated in the default cache core hook.
+    The hook should be used whenever possible. This method
+    is inteded for edge cases where a config has not yet been 
+    established and therefore a hook cannot be run. 
+
     :returns: A path on disk to the cache file
     """
 
@@ -707,7 +712,17 @@ def _get_cache_location():
 
     # get site only; https://www.foo.com:8080 -> www.foo.com
     base_url = urlparse.urlparse(sg_base_url)[1].split(":")[0]
-
+    
+    # in order to apply further shortcuts to avoid hitting 
+    # MAX_PATH on windows, strip shotgunstudio.com from all
+    # hosted sites
+    #
+    # mysite.shotgunstudio.com -> mysite
+    # shotgun.internal.int     -> shotgun.internal.int
+    #
+    if base_url.endswith("shotgunstudio.com"):
+        base_url = base_url[:-len(".shotgunstudio.com")]
+    
     # now structure things by site, project id, and pipeline config id
     return os.path.join(root, base_url, constants.SITE_INIT_CACHE_FILE_NAME)
 

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -46,7 +46,7 @@ def is_pipeline_config(pipeline_config_path):
     # probe by looking for the existence of a key config file.
     pc_file = os.path.join(pipeline_config_path, "config", "core", constants.STORAGE_ROOTS_FILE)
     return os.path.exists(pc_file)
-    
+
 def get_metadata(pipeline_config_path):
     """
     Loads the pipeline config metadata (the pipeline_configuration.yml) file from disk.

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -290,9 +290,7 @@ class Environment(object):
                             "key for engine %s" % (self._env_path, framework_name))
 
         # get the descriptor object for the location
-        d = descriptor.get_from_location(descriptor.AppDescriptor.FRAMEWORK,
-                                         self.__pipeline_config,
-                                         location_dict)
+        d = self.__pipeline_config.get_framework_descriptor(location_dict)
 
         return d
 
@@ -306,9 +304,7 @@ class Environment(object):
                             "key for engine %s" % (self._env_path, engine_name))
 
         # get the descriptor object for the location
-        d = descriptor.get_from_location(descriptor.AppDescriptor.ENGINE,
-                                         self.__pipeline_config,
-                                         location_dict)
+        d = self.__pipeline_config.get_engine_descriptor(location_dict)
 
         return d
 
@@ -317,15 +313,13 @@ class Environment(object):
         Returns the descriptor object for an app.
         """
 
-        location_dict = self.__engine_locations.get( (engine_name, app_name) )
+        location_dict = self.__engine_locations.get((engine_name, app_name))
         if location_dict is None:
             raise TankError("The environment %s does not have a valid location "
                             "key for app %s.%s" % (self._env_path, engine_name, app_name))
 
         # get the version object for the location
-        d = descriptor.get_from_location(descriptor.AppDescriptor.APP,
-                                         self.__pipeline_config,
-                                         location_dict)
+        d = self.__pipeline_config.get_app_descriptor(location_dict)
 
         return d
 

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -381,8 +381,6 @@ def create_sg_app_store_connection():
     # get connection parameters
     sg = __create_sg_connection(config_data)
 
-    script_user = None
-
     # determine the script user running currently
     # get the API script user ID from shotgun
     script_user = sg.find_one(


### PR DESCRIPTION
**This is still work in progress**

Implements a new, more configurable location for where apps, engines and frameworks can be stored. This can be used in alongside the current `install` folder that is currently used.

If the `pipeline_configuration.yml` file specifies `use_global_bundle_cache: true`, this feature is turned on. Instead of caching downloads in the `install` folder relative to the core installation, it will query the cache hook to find a location to store things. In addition, a number of smaller changes are included:

- Cores are also natively supported by the deploy system
- The code has been restructured so that it is largely independent of tk core, with a view to move it out into a separate module shortly
- Interfaces have been cleaned up and improved in order to make the deploy module more separate.
- The cache hook default implementation uses shorter paths (to mitigate `MAXPATH` on windows)

