### PR TITLE
#34399 fixes bugs in git locator caches

### DIFF
--- a/python/tank/deploy/descriptor.py
+++ b/python/tank/deploy/descriptor.py
@@ -436,7 +436,7 @@ class VersionedSingletonDescriptor(AppDescriptor):
     """
     _instances = dict()
 
-    def __new__(cls, pc_path, bundle_install_path, location_dict, *args, **kwargs):
+    def __new__(cls, pc_path, bundle_cache_root, location_dict, *args, **kwargs):
         """
         Executed prior to all __init__s. Handles singleton caching of descriptors.
 
@@ -448,42 +448,31 @@ class VersionedSingletonDescriptor(AppDescriptor):
         required name and version key as part of their location dict. These
         keys are used by the class to uniquely identify objects.
 
-        :param bundle_install_path: Location on disk where items are cached
+        :param bundle_cache_root: Root location for bundle cache
         :param location_dict: Location dictionary describing the bundle
         :return: Descriptor instance
         """
-
-        # We will cache based on the bundle install path, name of the
-        # app/engine/framework, and version number.
         instance_cache = cls._instances
-        name = location_dict.get("name")
-        version = location_dict.get("version")
 
-        if name is None or version is None:
-            raise TankError("Cannot process location '%s'. Name and version keys required." % location_dict)
+        # The cache is keyed based on the location dict and the bundle install root
+        cache_key = (bundle_cache_root, str(location_dict))
 
         # Instantiate and cache if we need to, otherwise just return what we
         # already have stored away.
-        if (bundle_install_path not in instance_cache or
-            name not in instance_cache[bundle_install_path] or
-            version not in instance_cache[bundle_install_path][name]):
+        if cache_key not in instance_cache:
             # If the bundle install path isn't in the cache, then we are
             # starting fresh. Otherwise, check to see if the app (by name)
             # is cached, and if not initialize its specific cache. After
             # that we instantiate and store by version.
-            if bundle_install_path not in instance_cache:
-                instance_cache[bundle_install_path] = dict()
-            if name not in instance_cache[bundle_install_path]:
-                instance_cache[bundle_install_path][name] = dict()
-            instance_cache[bundle_install_path][name][version] = super(VersionedSingletonDescriptor, cls).__new__(
+            instance_cache[cache_key] = super(VersionedSingletonDescriptor, cls).__new__(
                 cls,
                 pc_path,
-                bundle_install_path,
+                bundle_cache_root,
                 location_dict,
                 *args, **kwargs
             )
 
-        return instance_cache[bundle_install_path][name][version]
+        return instance_cache[cache_key]
 
 
 ################################################################################################

--- a/tests/deploy_tests/test_descriptors.py
+++ b/tests/deploy_tests/test_descriptors.py
@@ -17,9 +17,9 @@ from tank.errors import TankError
 
 class TestDescriptors(TankTestBase):
 
-    def _test_name_based_descriptor_location(self, bundle_type, bundle_location, descriptor_type):
+    def _test_app_store_descriptor_location(self, bundle_type, bundle_location):
         """
-        Tests an appstore descriptor bundle path for the given bundle type and location.
+        Tests an app store descriptor bundle path for the given bundle type and location.
 
         :param bundle_type: One of descriptor.AppDescriptor.{APP,ENGINE,FRAMEWORK}
         :param bundle_location: Location in the pipeline configuration where bundles of the given
@@ -29,17 +29,61 @@ class TestDescriptors(TankTestBase):
         desc = descriptor.get_from_location(
             bundle_type,
             self.tk.pipeline_configuration,
-            {"type": descriptor_type, "version": "v0.1.2", "name": "tk-bundle"}
+            {"type": "app_store", "version": "v0.1.2", "name": "tk-bundle"}
         )
         self.assertEqual(
             desc.get_path(),
             os.path.join(
                 bundle_location,
-                descriptor_type,
+                "app_store",
                 "tk-bundle",
                 "v0.1.2"
             )
         )
+
+        # test caching
+        desc2 = descriptor.get_from_location(
+            bundle_type,
+            self.tk.pipeline_configuration,
+            {"type": "app_store", "version": "v0.1.2", "name": "tk-bundle"}
+        )
+        # note that we don't use the equality operator here but using 'is' to
+        # make sure we are getting the same instance back
+        self.assertTrue(desc is desc2)
+
+        desc3 = descriptor.get_from_location(
+            bundle_type,
+            self.tk.pipeline_configuration,
+            {"type": "app_store", "version": "v0.1.3", "name": "tk-bundle"}
+        )
+        # note that we don't use the equality operator here but using 'is' to
+        # make sure we are getting the same instance back
+        self.assertTrue(desc is not desc3)
+
+    def _test_manual_descriptor_location(self, bundle_type, bundle_location):
+        """
+        Tests a manual descriptor bundle path for the given bundle type and location.
+
+        :param bundle_type: One of descriptor.AppDescriptor.{APP,ENGINE,FRAMEWORK}
+        :param bundle_location: Location in the pipeline configuration where bundles of the given
+            type get installed.
+        """
+
+        desc = descriptor.get_from_location(
+            bundle_type,
+            self.tk.pipeline_configuration,
+            {"type": "manual", "version": "v0.1.2", "name": "tk-bundle"}
+        )
+        self.assertEqual(
+            desc.get_path(),
+            os.path.join(
+                bundle_location,
+                "manual",
+                "tk-bundle",
+                "v0.1.2"
+            )
+        )
+
 
     def _test_dev_descriptor_location(self, bundle_type, bundle_location):
         """
@@ -93,6 +137,25 @@ class TestDescriptors(TankTestBase):
             )
         )
 
+        # test caching
+        desc2 = descriptor.get_from_location(
+            bundle_type,
+            self.tk.pipeline_configuration,
+            {"type": "git", "path": repo, "version": "v0.1.2"}
+        )
+        # note that we don't use the equality operator here but using 'is' to
+        # make sure we are getting the same instance back
+        self.assertTrue(desc is desc2)
+
+        desc3 = descriptor.get_from_location(
+            bundle_type,
+            self.tk.pipeline_configuration,
+            {"type": "git", "path": repo, "version": "v0.1.3"}
+        )
+        # note that we don't use the equality operator here but using 'is' to
+        # make sure we are getting the same instance back
+        self.assertTrue(desc is not desc3)
+
     def _test_git_descriptor_location(self, bundle_type, bundle_location):
         """
         Tests a git descriptor bundle path for the given bundle type and location for all
@@ -127,15 +190,13 @@ class TestDescriptors(TankTestBase):
             descriptor.AppDescriptor.FRAMEWORK: os.path.join(self.tk.pipeline_configuration.get_install_location(), "install", "frameworks")
         }
         for bundle_type, bundle_location in bundle_types.iteritems():
-            self._test_name_based_descriptor_location(
+            self._test_app_store_descriptor_location(
                 bundle_type,
-                bundle_location,
-                "app_store"
+                bundle_location
             )
-            self._test_name_based_descriptor_location(
+            self._test_manual_descriptor_location(
                 bundle_type,
-                bundle_location,
-                "manual"
+                bundle_location
             )
             self._test_dev_descriptor_location(
                 bundle_type,


### PR DESCRIPTION
Locator cache is now generic, keying off the locator dict, assuming that two locators having the same dict can be represented by the same locator instance (and point at the same code).

Added unit tests for cache.