### PR TITLE
#33061 Toolkit metrics logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.py[co]
 
+# Ignore vim temporary and swap files
+*~
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
 
 # Packages
 *.egg

--- a/hooks/log_metrics.py
+++ b/hooks/log_metrics.py
@@ -19,7 +19,27 @@ class LogMetrics(Hook):
         """Called when Toolkit logs a user metric.
         
         :param list metrics: list of dictionaries with logged data.
-        
+
+        The metrics dictionaries will take one of two forms:
+
+        1. A user attribute metric. These typically log the version of
+           an app, engine, framework, DCC, etc.
+
+        {
+            "type": "user_attribute",
+            "attr_name": <attr name>
+            "attr_value": <attr value>
+        }
+
+        2. A user activity metric. These metrics are more common and
+           log the usage of a particular api, hook, engine, app, framework,
+           method, etc.
+
+        {
+            "type": "user_activity",
+            "module": <module name>
+            "action": <action name>
+        }
+
         """
         pass
-

--- a/hooks/log_metrics.py
+++ b/hooks/log_metrics.py
@@ -15,13 +15,11 @@ from tank import Hook
 
 class LogMetrics(Hook):
     
-    def execute(self, tk, metrics):
+    def execute(self, metrics):
         """Called when Toolkit logs a user metric.
         
-        :param tk: Toolkit instance 
-        :param list metrics: list of `ToolkitMetric` objects that were logged.
+        :param list metrics: list of dictionaries with logged data.
         
         """
         pass
-
 

--- a/hooks/log_metrics.py
+++ b/hooks/log_metrics.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-"""Hook that gets executed every time Toolkit logs a user metric."""
+"""Hook that gets executed every time Toolkit logs user metrics."""
 
 from tank import Hook
  
@@ -16,7 +16,7 @@ from tank import Hook
 class LogMetrics(Hook):
     
     def execute(self, metrics):
-        """Called when Toolkit logs a user metric.
+        """Called when Toolkit logs user metrics.
         
         :param list metrics: list of dictionaries with logged data.
 
@@ -40,6 +40,11 @@ class LogMetrics(Hook):
             "module": <module name>
             "action": <action name>
         }
+
+        Please note that this hook will be executed within one or more
+        dedicated metrics logging worker threads and not in the main thread.
+        Overriding this hook may require additional care to avoid issues
+        related to accessing shared resources across multiple threads.
 
         """
         pass

--- a/hooks/log_metrics.py
+++ b/hooks/log_metrics.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""Hook that gets executed every time Toolkit logs a user metric."""
+
+from tank import Hook
+ 
+
+class LogMetrics(Hook):
+    
+    def execute(self, tk, metrics):
+        """Called when Toolkit logs a user metric.
+        
+        :param tk: Toolkit instance 
+        :param list metrics: list of `ToolkitMetric` objects that were logged.
+        
+        """
+        pass
+
+

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -23,6 +23,7 @@ from .errors import TankError
 from .path_cache import PathCache
 from .template import read_templates
 from .platform import constants as platform_constants
+from .util import log_user_activity_metric
 from . import pipelineconfig
 from . import pipelineconfig_utils
 from . import pipelineconfig_factory
@@ -220,6 +221,19 @@ class Tank(object):
 
     ##########################################################################################
     # public methods
+
+    def log_core_metric(self, action):
+        """Log a core metric.
+
+        :param action: Action string to log, e.g. 'Init'
+
+        Logs a user activity metric as performed within core. This is
+        a convenience method that auto-populates the module portion of 
+        `tank.util.log_user_activity_metric()`
+
+        """
+        log_user_activity_metric('tk-core', action)
+
 
     def list_commands(self):
         """

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -125,6 +125,22 @@ class Tank(object):
                                                                              parent=self, 
                                                                              **kwargs)
 
+    def log_metric(self, action):
+        """Log a core metric.
+
+        :param action: Action string to log, e.g. 'Init'
+
+        Logs a user activity metric as performed within core. This is
+        a convenience method that auto-populates the module portion of
+        `tank.util.log_user_activity_metric()`
+
+        Internal Use Only - We provide no guarantees that this method
+        will be backwards compatible.
+
+        """
+        log_user_activity_metric('tk-core', action)
+
+
     ################################################################################################
     # properties
 
@@ -221,19 +237,6 @@ class Tank(object):
 
     ##########################################################################################
     # public methods
-
-    def log_core_metric(self, action):
-        """Log a core metric.
-
-        :param action: Action string to log, e.g. 'Init'
-
-        Logs a user activity metric as performed within core. This is
-        a convenience method that auto-populates the module portion of 
-        `tank.util.log_user_activity_metric()`
-
-        """
-        log_user_activity_metric('tk-core', action)
-
 
     def list_commands(self):
         """

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -138,7 +138,8 @@ class Tank(object):
         will be backwards compatible.
 
         """
-        log_user_activity_metric('tk-core', action)
+        full_action = "%s %s" % ('tk-core', action)
+        log_user_activity_metric('tk-core', full_action)
 
 
     ################################################################################################

--- a/python/tank/deploy/tank_command.py
+++ b/python/tank/deploy/tank_command.py
@@ -304,6 +304,8 @@ class SgtkSystemCommand(object):
                        is the value you want to pass. You can query which parameters
                        can be passed in via the parameters property.
         """
+
+        self.__internal_action_obj.tk.log_metric(self.name)
         return self.__internal_action_obj.run_noninteractive(self.__log, params)
         
         
@@ -459,6 +461,10 @@ def run_action(log, tk, ctx, command, args):
         log.info("Command: %s" % found_action.name.replace("_", " ").capitalize())
         log.info("-" * 70)
         log.info("")
+
+        if not isinstance(found_action, ShellEngineAction):
+            found_action.tk.log_metric(found_action.name)
+
         return found_action.run_interactive(log, args)
 
 

--- a/python/tank/deploy/tank_commands/clone_configuration.py
+++ b/python/tank/deploy/tank_commands/clone_configuration.py
@@ -90,6 +90,8 @@ class CloneConfigAction(Action):
                          computed_params["path_mac"], 
                          computed_params["path_win"])
 
+        self.tk.log_metric("clone config")
+
         return data["id"]
     
     def run_interactive(self, log, args):

--- a/python/tank/deploy/tank_commands/clone_configuration.py
+++ b/python/tank/deploy/tank_commands/clone_configuration.py
@@ -90,8 +90,6 @@ class CloneConfigAction(Action):
                          computed_params["path_mac"], 
                          computed_params["path_win"])
 
-        self.tk.log_metric("clone config")
-
         return data["id"]
     
     def run_interactive(self, log, args):

--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -169,9 +169,7 @@ class SetupProjectAction(Action):
                                       params.get_configuration_location(sys.platform), 
                                       suppress_prompts=True)
 
-        self.tk.log_metric("project setup")
 
-                        
     def run_interactive(self, log, args):
         """
         Tank command accessor
@@ -267,9 +265,7 @@ class SetupProjectAction(Action):
         log.info("https://support.shotgunsoftware.com")
         log.info("")
 
-        self.tk.log_metric("project setup (interactive)")
-        
-        
+
     def _shotgun_connect(self, log):
         """
         Connects to the App store and to the associated shotgun site.

--- a/python/tank/deploy/tank_commands/setup_project.py
+++ b/python/tank/deploy/tank_commands/setup_project.py
@@ -168,8 +168,9 @@ class SetupProjectAction(Action):
             core_localize.do_localize(log, 
                                       params.get_configuration_location(sys.platform), 
                                       suppress_prompts=True)
-                        
-                        
+
+        self.tk.log_metric("project setup")
+
                         
     def run_interactive(self, log, args):
         """
@@ -264,7 +265,9 @@ class SetupProjectAction(Action):
         log.info("")
         log.info("For more Apps, Support, Documentation and the Toolkit Community, go to")
         log.info("https://support.shotgunsoftware.com")
-        log.info("")        
+        log.info("")
+
+        self.tk.log_metric("project setup (interactive)")
         
         
     def _shotgun_connect(self, log):

--- a/python/tank/deploy/tank_commands/update.py
+++ b/python/tank/deploy/tank_commands/update.py
@@ -74,8 +74,6 @@ class AppUpdatesAction(Action):
         if computed_params["app_filter"] == "ALL":
             computed_params["app_filter"] = None
 
-        self.tk.log_metric("updates")
-
         return check_for_updates(log,
                                  self.tk,
                                  computed_params["environment_filter"], 
@@ -213,8 +211,6 @@ class AppUpdatesAction(Action):
                           external=external_path,
                           preserve_yaml=preserve_yaml)    
 
-        self.tk.log_metric("updates (interactive)")
-            
 
 ################################################################################################
 # helper methods for update

--- a/python/tank/deploy/tank_commands/update.py
+++ b/python/tank/deploy/tank_commands/update.py
@@ -73,8 +73,10 @@ class AppUpdatesAction(Action):
             computed_params["engine_filter"] = None
         if computed_params["app_filter"] == "ALL":
             computed_params["app_filter"] = None
-        
-        return check_for_updates(log, 
+
+        self.tk.log_metric("updates")
+
+        return check_for_updates(log,
                                  self.tk,
                                  computed_params["environment_filter"], 
                                  computed_params["engine_filter"],
@@ -210,7 +212,8 @@ class AppUpdatesAction(Action):
                           app_instance_name=app_filter,
                           external=external_path,
                           preserve_yaml=preserve_yaml)    
-        
+
+        self.tk.log_metric("updates (interactive)")
             
 
 ################################################################################################
@@ -237,7 +240,7 @@ def check_for_updates(log,
     :param preserve_yaml: If True, a comment preserving yaml parser is used. 
     :param external: Path to external config to operate on
     """
-    
+
     pc = tk.pipeline_configuration
     
     processed_items = []

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -742,7 +742,9 @@ class PipelineConfiguration(object):
             hooks_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "hooks"))
             hook_path = os.path.join(hooks_path, file_name)
         else:
-            parent.log_metric("custom core hook")
+            # some hooks are always custom. ignore those and log the rest.
+            if hook_name not in ["pick_environment"]:
+                parent.log_metric("custom hook %s" % (hook_name,))
 
         return hook.execute_hook(hook_path, parent, **kwargs)
 
@@ -772,6 +774,7 @@ class PipelineConfiguration(object):
         hook_path = os.path.join(hook_folder, file_name)
         if os.path.exists(hook_path):
             hook_paths.append(hook_path)
-            
+            parent.log_metric("custom hook %s" % (hook_name,))
+
         return hook.execute_hook_method(hook_paths, parent, method_name, **kwargs)
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -741,6 +741,8 @@ class PipelineConfiguration(object):
             # of the core API.
             hooks_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "hooks"))
             hook_path = os.path.join(hooks_path, file_name)
+        else:
+            parent.log_metric("custom core hook")
 
         return hook.execute_hook(hook_path, parent, **kwargs)
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -743,7 +743,7 @@ class PipelineConfiguration(object):
             hook_path = os.path.join(hooks_path, file_name)
         else:
             # some hooks are always custom. ignore those and log the rest.
-            if hook_name not in ["pick_environment"]:
+            if hook_name not in constants.TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST:
                 parent.log_metric("custom hook %s" % (hook_name,))
 
         return hook.execute_hook(hook_path, parent, **kwargs)

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -162,14 +162,21 @@ class Application(TankBundle):
     def log_exception(self, msg):
         self.engine.log_exception(msg)
 
-    def log_app_metric(self, action):
+
+    ##########################################################################################
+    # internal API
+
+    def log_metric(self, action):
         """Logs an app metric.
 
         :param action: Action string to log, e.g. 'Execute Action'
 
-        Logs a user activity metric as performed within an app. This is a 
-        convenience method that auto-populates the module portion of 
+        Logs a user activity metric as performed within an app. This is a
+        convenience method that auto-populates the module portion of
         `tank.util.log_user_activity_metric()`.
+
+        Internal Use Only - We provide no guarantees that this method
+        will be backwards compatible.
 
         """
         # the action contains the engine and app name, e.g.

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -21,6 +21,7 @@ from . import constants
 
 from ..errors import TankError
 from .bundle import TankBundle
+from ..util import log_user_activity_metric
 
 class Application(TankBundle):
     """
@@ -160,6 +161,22 @@ class Application(TankBundle):
 
     def log_exception(self, msg):
         self.engine.log_exception(msg)
+
+    def log_app_metric(self, action):
+        """Logs an app metric.
+
+        :param action: Action string to log, e.g. 'Execute Action'
+
+        Logs a user activity metric as performed within an app. This is a 
+        convenience method that auto-populates the module portion of 
+        `tank.util.log_user_activity_metric()`.
+
+        """
+        # the action contains the engine and app name, e.g.
+        # module: tk-multi-loader2
+        # action: tk-multi-loader2 (tk-maya) - Execute 'Load...'
+        full_action = "%s - %s (%s)" % (self.name, action, self.engine.name)
+        log_user_activity_metric(self.name, full_action)
 
 
 def get_application(engine, app_folder, descriptor, settings, instance_name, env):

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -175,7 +175,7 @@ class Application(TankBundle):
         # the action contains the engine and app name, e.g.
         # module: tk-multi-loader2
         # action: tk-multi-loader2 (tk-maya) - Execute 'Load...'
-        full_action = "%s - %s (%s)" % (self.name, action, self.engine.name)
+        full_action = "%s (%s) - %s" % (self.name, self.engine.name, action)
         log_user_activity_metric(self.name, full_action)
 
 

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -181,8 +181,8 @@ class Application(TankBundle):
         """
         # the action contains the engine and app name, e.g.
         # module: tk-multi-loader2
-        # action: tk-multi-loader2 (tk-maya) - Execute 'Load...'
-        full_action = "%s (%s) - %s" % (self.name, self.engine.name, action)
+        # action: (tk-maya) tk-multi-loader2 - Load...
+        full_action = "(%s) %s - %s" % (self.engine.name, self.name, action)
         log_user_activity_metric(self.name, full_action)
 
 

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -182,7 +182,7 @@ class Application(TankBundle):
         # the action contains the engine and app name, e.g.
         # module: tk-multi-loader2
         # action: (tk-maya) tk-multi-loader2 - Load...
-        full_action = "(%s) %s - %s" % (self.engine.name, self.name, action)
+        full_action = "(%s) %s %s" % (self.engine.name, self.name, action)
         log_user_activity_metric(self.name, full_action)
 
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -84,6 +84,11 @@ TANK_BUNDLE_INIT_HOOK_NAME = "bundle_init"
 # hook to log metrics
 TANK_LOG_METRICS_HOOK_NAME = "log_metrics"
 
+# metrics logging custom hooks blacklist
+TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST = [
+    "pick_environment",
+]
+
 # hook that is executed whenever a PipelineConfiguration instance initializes.
 PIPELINE_CONFIGURATION_INIT_HOOK_NAME = "pipeline_configuration_init"
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -81,6 +81,9 @@ TANK_ENGINE_INIT_HOOK_NAME = "engine_init"
 # hook that is executed whenever a bundle has initialized
 TANK_BUNDLE_INIT_HOOK_NAME = "bundle_init"
 
+# hook to log metrics
+TANK_LOG_METRICS_HOOK_NAME = "log_metrics"
+
 # hook that is executed whenever a PipelineConfiguration instance initializes.
 PIPELINE_CONFIGURATION_INIT_HOOK_NAME = "pipeline_configuration_init"
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -163,8 +163,8 @@ class Engine(TankBundle):
         self.log_metric("Init")
 
         # log the core and engine versions being used by the current user
-        log_user_attribute_metric("tk-core version" % (tk.version,))
-        log_user_attribute_metric("%s version" % (self.name, self.version))
+        log_user_attribute_metric("tk-core version", tk.version)
+        log_user_attribute_metric("%s version" % (self.name,), self.version)
 
         # check if there are any compatibility warnings:
         # do this now in case the engine fails to load!
@@ -315,6 +315,22 @@ class Engine(TankBundle):
         # action: tk-maya - Init
         full_action = "%s - %s" % (self.name, action)
         log_user_activity_metric(self.name, full_action)
+
+    def log_user_attribute_metric(self, attr_name, attr_value):
+        """Convenience class. Logs a user attribute metric.
+
+        :param attr_name: The name of the attribute to set for the user.
+        :param attr_value: The value of the attribute to set for the user.
+
+        This is a convenience wrapper around
+        `tank.util.log_user_activity_metric()` that prevents engine subclasses
+        from having to import from `tank.util`.
+
+        Internal Use Only - We provide no guarantees that this method
+        will be backwards compatible.
+
+        """
+        log_user_attribute_metric(attr_name, attr_value)
 
 
     ##########################################################################################
@@ -1812,9 +1828,6 @@ def start_engine(engine_name, tk, context):
     metrics_dispatch_queue = MetricsDispatchQueue()
     if engine.metrics_dispatch_allowed and not metrics_dispatch_queue.dispatching:
         metrics_dispatch_queue.start_dispatching(tk)
-
-        # while here, go ahead and log some metrics
-
 
     return engine
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -179,9 +179,10 @@ class Engine(TankBundle):
 
         # if the engine supports logging metrics, begin dispatching logged metrics
         if self.metrics_dispatch_allowed:
-            self._metrics_dispatcher = MetricsDispatcher(self, tk)
+            self._metrics_dispatcher = MetricsDispatcher(self)
+            self.log_debug("Starting metrics dispatcher...")
             self._metrics_dispatcher.start()
-            self.log_debug("Metrics dispatching started.")
+            self.log_debug("Metrics dispatcher started.")
         
     def __repr__(self):
         return "<Sgtk Engine 0x%08x: %s, env: %s>" % (id(self),  
@@ -500,8 +501,9 @@ class Engine(TankBundle):
 
         # halt metrics dispatching
         if self._metrics_dispatcher and self._metrics_dispatcher.dispatching:
+            self.log_debug("Stopping metrics dispatcher.")
             self._metrics_dispatcher.stop()
-            self.log_debug("Metrics dispatching stopped.")
+            self.log_debug("Metrics dispatcher stopped.")
 
     def destroy_engine(self):
         """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -26,6 +26,8 @@ from .. import hook
 from ..errors import TankError, TankEngineInitError, TankContextChangeNotSupportedError
 from ..deploy import descriptor
 from ..deploy.dev_descriptor import TankDevDescriptor
+from ..util import log_user_activity_metric, log_user_attribute_metric
+from ..util.metrics import MetricsDispatchQueueSingleton as MetricsQueue
 
 from . import application
 from . import constants
@@ -156,9 +158,13 @@ class Engine(TankBundle):
         
         # emit an engine started event
         tk.execute_core_hook(constants.TANK_ENGINE_INIT_HOOK_NAME, engine=self)
-        
+
         self.log_debug("Init complete: %s" % self)
-        
+        self.log_engine_metric("Init")
+
+        # log the engine version being used by the current user
+        log_user_attribute_metric("%s Version" % self.name, self.version)
+
         # check if there are any compatibility warnings:
         # do this now in case the engine fails to load!
         messages = black_list.compare_against_black_list(descriptor)
@@ -590,9 +596,30 @@ class Engine(TankBundle):
                 name = "%s:%s" % (prefix, name)
                 # also add a prefix key in the properties dict
                 properties["prefix"] = prefix
-            
-        self.__commands[name] = { "callback": callback, "properties": properties }
-        
+
+        # wrapper that logs app and usage metrics before executing the
+        # callback.
+        def callback_wrapper(*args, **kwargs):
+
+            if properties.get("app"):
+
+                # track which app command is being launched
+                properties["app"].log_app_metric("'%s'" % name)
+
+                # specify which app version is being used
+                log_user_attribute_metric(
+                    "%s version" % properties["app"].name,
+                    properties["app"].version
+                )
+
+            return callback(*args, **kwargs)
+
+        self.__commands[name] = {
+            "callback": callback_wrapper,
+            "properties": properties,
+        }
+
+
     def register_panel(self, callback, panel_name="main", properties=None):
         """
         Similar to register_command, but instead of registering a menu item in the form of a
@@ -839,7 +866,26 @@ class Engine(TankBundle):
         message.extend(traceback_str.split("\n"))
         
         self.log_error("\n".join(message))
-        
+
+
+    def log_engine_metric(self, action):
+        """Log an engine metric.
+
+        :param action: Action string to log, e.g. 'Init'
+
+        Logs a user activity metric as performed within an engine. This is
+        a convenience method that auto-populates the module portion of 
+        `tank.util.log_user_activity_metric()`
+
+        """
+
+        # the action contains the engine and app name, e.g.
+        # module: tk-maya
+        # action: tk-maya - Init
+        full_action = "%s - %s" % (self.name, action)
+        log_user_activity_metric(self.name, full_action)
+
+
     ##########################################################################################
     # debug for tracking Qt Widgets & Dialogs created by the provided methods      
 
@@ -1740,6 +1786,11 @@ def start_engine(engine_name, tk, context):
 
     # register this engine as the current engine
     set_current_engine(obj)
+
+    # ensure the metrics queue is initialized (dispatchers are running)
+    metrics_queue = MetricsQueue()
+    if not metrics_queue.initialized:
+        metrics_queue.init(tk)
 
     return obj
 

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -166,7 +166,7 @@ class Framework(TankBundle):
         # the action contains the engine and framework name, e.g.
         # module: tk-framework-perforce
         # action: (tk-maya) tk-framework-perforce - Connected
-        full_action = "(%s) %s - %s" % (self.engine.name, self.name, action)
+        full_action = "(%s) %s %s" % (self.engine.name, self.name, action)
         log_user_activity_metric(self.name, full_action)
 
 

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -22,6 +22,7 @@ from . import constants
 from ..errors import TankError
 from .bundle import TankBundle
 from . import validation
+from ..util import log_user_activity_metric
 
 # global variable that holds a stack of references to
 # a current bundle object - this variable is populated
@@ -144,6 +145,29 @@ class Framework(TankBundle):
 
     def log_exception(self, msg):
         self.engine.log_exception(msg)
+
+
+    ##########################################################################################
+    # internal API
+
+    def log_metric(self, action):
+        """Logs a framework metric.
+
+        :param action: Action string to log, e.g. 'Execute Action'
+
+        Logs a user activity metric as performed within framework code. This is
+        a convenience method that auto-populates the module portion of
+        `tank.util.log_user_activity_metric()`.
+
+        Internal Use Only - We provide no guarantees that this method
+        will be backwards compatible.
+
+        """
+        # the action contains the engine and framework name, e.g.
+        # module: tk-framework-perforce
+        # action: (tk-maya) tk-framework-perforce - Connected
+        full_action = "(%s) %s - %s" % (self.engine.name, self.name, action)
+        log_user_activity_metric(self.name, full_action)
 
 
 

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -23,3 +23,6 @@ from .path import prepend_path_to_env_var
 from .login import get_shotgun_user
 from .login import get_current_user
 
+from .metrics import log_user_activity_metric
+from .metrics import log_user_attribute_metric
+

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -290,8 +290,7 @@ class MetricsDispatchWorkerThread(Thread):
             pass
 
         # execute the log_metrics core hook
-        self._engine.execute_in_main_thread(
-            self._engine.tank.execute_core_hook,
+        self._engine.tank.execute_core_hook(
             platform_constants.TANK_LOG_METRICS_HOOK_NAME,
             metrics=[m.data for m in metrics]
         )

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""Classes and functions for logging Toolkit metrics."""
+
+
+###############################################################################
+# imports
+
+from threading import Thread
+from Queue import Queue
+
+import urllib
+import urllib2
+
+
+###############################################################################
+# Metrics dispatch Thread and Queue classes
+
+class MetricsDispatchWorkerThread(Thread):
+    """Worker thread for dispatching metrics to sg registration endpoint.
+
+    Given a queue where metrics are logged in the client code, once started,
+    this worker will dispatch them to the shotgun api endpoint as they
+    arrive. 
+
+    This thread runs as a `daemon` in order to prevent process shutdown
+    from waiting until all metrics are processed.
+    
+    """
+
+    def __init__(self, tk, metrics_queue, log=None):
+        """Initialize the worker thread.
+
+        :params tk: Toolkit api instance.
+        :params queue.Queue metrics_queue: FIFO queue for metrics to dispatch.
+        :params logging.Logger log: Logger for debugging purposes.
+
+        """
+
+        super(MetricsDispatchWorkerThread, self).__init__()
+
+        self._tk = tk
+        self._log = log
+        self._metrics_queue = metrics_queue
+
+        # don't wait for this thread to exit 
+        self.daemon = True
+
+
+    def run(self):
+        """Runs a loop to dispatch metrics as they're added to the queue."""
+
+        # if metrics are not supported, then no reason to process the queue
+        if not self._metrics_supported():
+            return
+
+        # The thread is a daemon. Let it run for the duration of the process
+        while True:
+
+            # get the next available metric and dispatch it
+            try:
+                metric = self._metrics_queue.get(block=True)
+                self._dispatch(metric)
+            except Exception as e:
+                if self._log:
+                    self._log.error("Error dispatching metric: %s" % (e,))
+            finally:
+                # success or fail, we don't want to reprocess this metric
+                self._metrics_queue.task_done()
+
+
+    def _dispatch(self, metric):
+        """Dispatch the supplied metric to the sg api registration endpoint.
+
+        :param Metric metric: The Toolkit metric to dispatch.
+
+        """
+
+        # get this thread's sg connection via tk api
+        sg_connection = self._tk.shotgun
+
+        # handle proxy setup by pulling the proxy details from the main
+        # shotgun connection
+        if sg_connection.config.proxy_handler:
+            opener = urllib2.build_opener(
+                sg_connection.config.proxy_handler)
+            urllib2.install_opener(opener)
+
+        # get the session token and add it to the metrics payload
+        session_token = sg_connection.get_session_token()
+        metric.data["session_token"] = session_token
+
+        # format the url based on the sg connection and post the data
+        url = "%s/%s" % (sg_connection.base_url, metric.API_ENDPOINT)
+        #res = urllib2.urlopen(url, urllib.urlencode(metric.data)) # XXX uncomment
+
+        # remove the session token so that it doesn't show up in the log
+        del metric.data["session_token"]
+
+        if self._log:
+            self._log.debug("Logged metric: %s" % (metric,))
+
+
+    def _metrics_supported(self):
+        """Returns True if server supports the metrics api endpoint."""
+
+        if not hasattr(self, '_metrics_ok'):
+
+            sg_connection = self._tk.shotgun
+            self._metrics_ok = (
+                sg_connection.server_caps.version and 
+                sg_connection.server_caps.version >= (6, 2, 0)
+                # XXX update the version number once metric endpoint available
+            )
+            
+        self._metrics_ok = True # XXX remove after tsting
+
+        return self._metrics_ok
+
+
+class MetricsDispatchQueueSingleton(object):
+    """A FIFO queue for logging metrics to dispatch via worker thread(s).
+
+    This is a singleton class, so any instantiation will return the same object
+    instance within the current process.
+
+    The `init()` method must be called in order to create and start the 
+    worker threads. Metrics can be added before or after `init()` is called 
+    and they will be processed in order.
+
+    """
+
+    # keeps track of the single instance of the class
+    __instance = None
+
+
+    def __new__(cls, *args, **kwargs):
+        """Ensures only one instance of the metrics queue exists."""
+
+        # create the queue instance if it hasn't been created already
+        if not cls.__instance:
+
+            # remember the instance so that no more are created
+            metrics_queue = super(
+                MetricsDispatchQueueSingleton, cls).__new__(
+                    cls, *args, **kwargs)
+
+            # False until init() is called
+            metrics_queue._initialized = False
+
+            # The underlying Queue.Queue instance
+            metrics_queue._queue = Queue()
+
+            cls.__instance = metrics_queue
+
+        return cls.__instance
+
+
+    def init(self, tk, workers=1, log=None):
+        """Initialize the Queue by starting up the workers.
+
+        :param tk: Toolkit api instance to use for sg connection.
+            Forwarded to the worker threads.
+        :param int workers: Number of worker threads to start.
+        :param loggin.Logger log: Optional logger for debugging.
+            Forwarded to the worker threads.
+
+        Creates and starts worker threads for dispatching metrics. Only
+        callable once. Subsequent calls are a no-op.
+
+        """
+
+        # Uncomment these lines to debug metrics
+        import logging
+        log = logging.getLogger('tk.metrics')
+        log.addHandler(logging.StreamHandler())
+        log.setLevel(logging.DEBUG)
+
+        if self._initialized:
+            if log:
+                log.debug("Metrics queue already initialized. Doing nothing.")
+            return
+
+        # start the dispatch workers to use this queue
+        for i in range(workers):
+            worker = MetricsDispatchWorkerThread(tk, self._queue, log)
+            worker.start()
+            if log:
+                log.debug("Added worker thread: %s" % (worker,))
+
+        self._initialized = True
+
+
+    def log(self, metric):
+        """Add the metric to the queue for dispatching.
+
+        :param ToolkitMetric metric: The metric to log.
+
+        """
+        self._queue.put(metric)
+
+
+    @property
+    def initialized(self):
+        """True if the queue has been initialized."""
+        return self._initialized
+
+
+###############################################################################
+# ToolkitMetric classes and subclasses
+
+class ToolkitMetric(object):
+    """Simple class representing tk metric data and destination endpoint."""
+
+    API_ENDPOINT = "api3/register_metric"
+    """Endpoint for registering metrics. Could be overridden by subclasses."""
+
+    def __init__(self, data):
+        """Initialize the object with a dictionary of metric data.
+        
+        :param dict data: A dictionary of metric data.
+        
+        """
+        self._data = data
+
+    def __str__(self):
+        """Readable representation of the metric."""
+        return "%s: %s" % (self.__class__, self._data)
+
+    @property
+    def data(self):
+        """The underlying data this metric represents."""
+        return self._data
+
+
+class UserActivityMetric(ToolkitMetric):
+    """Convenience class for a user activity metric."""
+
+    def __init__(self, module, action):
+        """Initialize the metric with the module and action information.
+        
+        :param str module: Name of the module in which action was performed.
+        :param str action: The action that was performed.
+        
+        """
+        super(UserActivityMetric, self).__init__({
+            "mode": "user_activity",
+            "module": module,
+            "action": action,
+        })
+
+
+class UserAttributeMetric(ToolkitMetric):
+    """Convenience class for a user attribute metric."""
+
+    def __init__(self, attr_name, attr_value):
+        """Initialize the metric with the attribute name and value.
+        
+        :param str attr_name: Name of the attribute.
+        :param str attr_value: The value of the attribute.
+
+        """
+        super(UserAttributeMetric, self).__init__({
+            "mode": "user_attribute",
+            "attr_name": attr_name,
+            "attr_value": attr_value,
+        })
+
+
+###############################################################################
+# metrics logging convenience functions
+
+def log_metric(metric):
+    """Log a Toolkit metric.
+    
+    :param ToolkitMetric metric: The metric to log.
+
+    This method simply adds the metric to the dispatch queue.
+    
+    """
+    MetricsDispatchQueueSingleton().log(metric)
+
+
+def log_user_activity_metric(module, action):
+    """Convenience method for logging a user activity metric.
+
+    :param str module: The module the activity occured in.
+    :param str action: The action the user performed.
+
+    """
+    log_metric(UserActivityMetric(module, action))
+
+    
+def log_user_attribute_metric(attr_name, attr_value):
+    """Convenience method for logging a user attribute metric.
+
+    :param str attr_name: The name of the attribute.
+    :param str attr_value: The value of the attribute to log.
+
+    """
+    log_metric(UserAttributeMetric(attr_name, attr_value))
+
+

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -78,14 +78,14 @@ class TestMetricsDispatchQueueSingleton(TankTestBase):
 
     # TODO: figure out why server_caps not being patched as in other tests.
     #@patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    #def test_initialized(self, server_caps_mock):
-    #    """Initialized/workers properties set properly when `init` is called."""
+    #def test_dispatching(self, server_caps_mock):
+    #    """dispatching/workers properties set properly when `start_dispatching` is called."""
     #
     #    obj = MetricsDispatchQueueSingleton()
-    #    self.assertFalse(obj.initialized)
+    #    self.assertFalse(obj.dispatching)
     #    self.assertEquals(obj.workers, [])
-    #    obj.init(self.tk)
-    #    self.assertTrue(obj.initialized)
+    #    obj.start_dispatching(self.tk)
+    #    self.assertTrue(obj.dispatchign)
     #    self.assertNotEqual(obj.workers, [])
 
 

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from mock import patch
+
+from tank.util.metrics import (
+    MetricsDispatchQueueSingleton,
+    ToolkitMetric,
+    UserAttributeMetric,
+    UserActivityMetric,
+    log_metric,
+    log_user_activity_metric,
+    log_user_attribute_metric,
+)
+
+from tank_test.tank_test_base import *
+
+class TestToolkitMetric(TankTestBase):
+    """Cases testing tank.util.metrics.ToolkitMetric class"""
+
+    def test_data_property(self):
+        """Object has a data dictionary that matches args."""
+
+        in_data = {
+            "type": "user_activity",
+            "module": "Tank Metrics Unit Test",
+            "action": "ToolkitMetric.data property test",
+        }
+        obj = ToolkitMetric(in_data)
+        self.assertTrue(hasattr(obj, 'data'))
+        self.assertIsInstance(obj.data, type(in_data))
+
+class TestUserAttributeMetric(TankTestBase):
+    """Cases testing tank.util.metrics.UserAttributeMetric class"""
+
+    def test_data_property(self):
+        """Object has a data dictionary that matches args."""
+
+        obj = UserAttributeMetric(
+            "Test Attribute",
+            "UserAttributeMetric.data property test",
+        )
+        self.assertTrue(hasattr(obj, 'data'))
+        self.assertIsInstance(obj.data, dict)
+
+
+class TestUserActivityMetric(TankTestBase):
+    """Cases testing tank.util.metrics.UserActivityMetric class"""
+
+    def test_data_property(self):
+        """Object has a data dictionary that matches args."""
+
+        obj = UserActivityMetric(
+            "Tank Metrics Unit Test",
+            "UserActivityMetric.data property test",
+        )
+        self.assertTrue(hasattr(obj, 'data'))
+        self.assertIsInstance(obj.data, dict)
+
+
+class TestMetricsDispatchQueueSingleton(TankTestBase):
+    """Cases testing tank.util.metrics.MetricsDispatchQueueSingleton class."""
+
+    def test_singleton(self):
+        """Multiple instantiations return same instance."""
+
+        obj1 = MetricsDispatchQueueSingleton()
+        obj2 = MetricsDispatchQueueSingleton()
+        obj3 = MetricsDispatchQueueSingleton()
+        self.assertTrue(obj1 == obj2 == obj3)
+
+    # TODO: figure out why server_caps not being patched as in other tests.
+    #@patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    #def test_initialized(self, server_caps_mock):
+    #    """Initialized/workers properties set properly when `init` is called."""
+    #
+    #    obj = MetricsDispatchQueueSingleton()
+    #    self.assertFalse(obj.initialized)
+    #    self.assertEquals(obj.workers, [])
+    #    obj.init(self.tk)
+    #    self.assertTrue(obj.initialized)
+    #    self.assertNotEqual(obj.workers, [])
+
+
+class TestMetricsFunctions(TankTestBase):
+    """Cases testing tank.util.metrics functions"""
+
+    def test_log_metric(self):
+        good_metrics = [
+            UserActivityMetric(
+                "Tank Metrics Unit Test",
+                "tk_metrics.log_metric test",
+            ),
+            UserAttributeMetric(
+                "Test Attribute",
+                "tk_metrics.log_metric test",
+            ),
+        ]
+        bad_metrics = [
+            UserActivityMetric(None, "UserActivityMetric.data property test"),
+            UserActivityMetric("Tank Metrics Unit Test", None),
+            UserActivityMetric(None, None),
+            UserActivityMetric({}, {}),
+            UserActivityMetric([], []),
+            UserAttributeMetric(None, "Test Value"),
+            UserAttributeMetric("Test Attribute", None),
+            UserAttributeMetric(None, None),
+            UserAttributeMetric({}, {}),
+            UserAttributeMetric([], []),
+        ]
+
+        # make sure no exceptions on good metrics
+        for metric in good_metrics:
+            try:
+                log_metric(metric)
+            except Exception, e:
+                self.fail(
+                    "log_metric() failed unexpectedly on good metric (%s): %s",
+                    (metric, e)
+                )
+
+        # make sure no exceptions on bad metrics
+        for metric in bad_metrics:
+            try:
+                log_metric(metric)
+            except Exception, e:
+                self.fail(
+                    "log_metric() failed unexpectedly on bad metric (%s): %s",
+                    (metric, e)
+                )
+
+    def test_log_user_activity_metric(self):
+
+        try:
+            log_user_activity_metric(
+                "Tank Metrics Unit Test",
+                "tk_metrics.log_user_activity_metric test",
+            )
+            log_user_activity_metric(
+                None, "tk_metrics.log_user_activity_metric test")
+            log_user_activity_metric("Tank Metrics Unit Test", None)
+            log_user_activity_metric(None, None)
+            log_user_activity_metric({}, {})
+            log_user_activity_metric([], [])
+        except Exception, e:
+            self.fail(
+                "log_user_activity_metric() failed unexpectedly: %s" % (e,))
+
+    def test_log_user_attribute_metric(self):
+
+        try:
+            log_user_attribute_metric(
+                "Test Attribute",
+                "tk_metrics.log_user_attribute_metric test",
+            )
+            log_user_attribute_metric(
+                None, "tk_metrics.log_user_attribute_metric test")
+            log_user_attribute_metric("Test Attribute", None)
+            log_user_attribute_metric(None, None)
+            log_user_attribute_metric({}, {})
+            log_user_attribute_metric([], [])
+        except Exception, e:
+            self.fail(
+                "log_user_attribute_metric() failed unexpectedly: %s" % (e,))
+
+

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -11,7 +11,8 @@
 from mock import patch
 
 from tank.util.metrics import (
-    MetricsDispatchQueueSingleton,
+    MetricsQueueSingleton,
+    MetricsDispatcher,
     ToolkitMetric,
     UserAttributeMetric,
     UserActivityMetric,
@@ -65,29 +66,16 @@ class TestUserActivityMetric(TankTestBase):
         self.assertIsInstance(obj.data, dict)
 
 
-class TestMetricsDispatchQueueSingleton(TankTestBase):
-    """Cases testing tank.util.metrics.MetricsDispatchQueueSingleton class."""
+class TestMetricsQueueSingleton(TankTestBase):
+    """Cases testing tank.util.metrics.MetricsQueueSingleton class."""
 
     def test_singleton(self):
         """Multiple instantiations return same instance."""
 
-        obj1 = MetricsDispatchQueueSingleton()
-        obj2 = MetricsDispatchQueueSingleton()
-        obj3 = MetricsDispatchQueueSingleton()
+        obj1 = MetricsQueueSingleton()
+        obj2 = MetricsQueueSingleton()
+        obj3 = MetricsQueueSingleton()
         self.assertTrue(obj1 == obj2 == obj3)
-
-    # TODO: figure out why server_caps not being patched as in other tests.
-    #@patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    #def test_dispatching(self, server_caps_mock):
-    #    """dispatching/workers properties set properly when `start_dispatching` is called."""
-    #
-    #    obj = MetricsDispatchQueueSingleton()
-    #    self.assertFalse(obj.dispatching)
-    #    self.assertEquals(obj.workers, [])
-    #    obj.start_dispatching(self.tk)
-    #    self.assertTrue(obj.dispatchign)
-    #    self.assertNotEqual(obj.workers, [])
-
 
 class TestMetricsFunctions(TankTestBase):
     """Cases testing tank.util.metrics functions"""


### PR DESCRIPTION
These changes add the ability to dispatch metrics to the sg server. A queue of metrics is processed by one (the default) or more worker threads which upload the metrics to a metrics registration endpoint on the sg side. 