### PR TITLE
For #34259, case insensitive login

### DIFF
--- a/python/tank_vendor/shotgun_authentication/session_cache.py
+++ b/python/tank_vendor/shotgun_authentication/session_cache.py
@@ -80,7 +80,7 @@ def _get_site_cache_location(base_url):
     return os.path.join(
         _get_cache_location(),
         # get site only; https://www.foo.com:8080 -> www.foo.com
-        urlparse.urlparse(base_url)[1].split(":")[0]
+        urlparse.urlparse(base_url)[1].split(":")[0].lower()
     )
 
 

--- a/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
+++ b/python/tank_vendor/shotgun_authentication/shotgun_authenticator.py
@@ -197,7 +197,7 @@ class ShotgunAuthenticator(object):
 
         # There is no default user.
         if not credentials:
-            logger.debug("No default user not found.")
+            logger.debug("No default user found.")
             return None
 
         # If this looks like an api user, delegate to create_script_user.

--- a/tests/run_auth_tests.sh
+++ b/tests/run_auth_tests.sh
@@ -15,4 +15,4 @@
     ./run_tests.sh shotgun_authentication_tests.test_session_cache &&
     ./run_tests.sh util_tests.test_login &&
     ./run_tests.sh util_tests.test_shotgun &&
-    ./run_tests.sh shotgun_authentication_tests.test_interactive_authentication --interactive
+    ./run_tests.sh shotgun_authentication_tests.test_interactive_authentication $*


### PR DESCRIPTION
The session cache used to be case sensitive and preserving, now it's only case preserving.