### PR TITLE
#35280 Fix for shotgun app regression in 0.17.1

### DIFF
--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -89,6 +89,10 @@ TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST = [
     "pick_environment",
 ]
 
+# flag to indicate that an app command is a legacy style
+# shotgun multi select action
+LEGACY_MULTI_SELECT_ACTION_FLAG = "shotgun_multi_select_action"
+
 # hook that is executed whenever a PipelineConfiguration instance initializes.
 PIPELINE_CONFIGURATION_INIT_HOOK_NAME = "pipeline_configuration_init"
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -24,6 +24,7 @@ from tank.deploy import tank_command
 from tank.deploy.tank_commands.core_upgrade import TankCoreUpgrader
 from tank.deploy.tank_commands.action_base import Action
 from tank.util import shotgun, CoreDefaultsManager
+from tank.platform import constants
 from tank_vendor.shotgun_authentication import ShotgunAuthenticator
 from tank_vendor.shotgun_authentication import AuthenticationError
 from tank_vendor.shotgun_authentication import ShotgunAuthenticationError
@@ -266,17 +267,17 @@ def _run_shotgun_command(log, tk, action_name, entity_type, entity_ids):
     cmd = e.commands.get(action_name)
     if cmd:
         callback = cmd["callback"]
-        # introspect and get number of args for this fn
-        arg_count = callback.func_code.co_argcount
 
         # check if we are running a pre-013 engine
         # (this can be removed at a later point)
         if hasattr(e, "execute_old_style_command"):
             # 013 compliant engine!
-            # choose between simple style callbacks or complex style
-            # special shotgun callbacks - these always take two
-            # params entity_type and entity_ids
-            if arg_count > 1:
+            #
+            # choose between std style callbacks or special
+            # shotgun (legacy) multi select callbacks
+            # this is detected by register_command and a special
+            # flag is set for the multi select ones
+            if constants.LEGACY_MULTI_SELECT_ACTION_FLAG in cmd["properties"]:
                 # old style shotgun app launch - takes entity_type and ids as args
                 e.execute_old_style_command(action_name, entity_type, entity_ids)
             else:


### PR DESCRIPTION
This fixes an issue where shotgun apps which supports the (legacy) multi select property wouldn't execute. This includes "create folders" in Shotgun and several others so while it's a legacy edge case, it does affect people.

Multi select apps have a special (legacy) callback structure that we unfortunately haven't gotten around to standardizing (it would be a little tricky!). All other app commands execute an empty callback, but the multi select callback passes a list of items.

The logic for choosing which style of callback to use is based around introspection of args. This was causing the bug. I have basically moved that introspection logic into `register_command` that looks for the special multi-select signature and in case it finds it, sets a flag. This flag is used by the tank command (rather than args introspection), meaning that the error goes away and a generic callback can be used everywhere.