### PR TITLE
#35198 Adds an optional flag to log_metric for apps to log the app version

### DIFF
--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -21,7 +21,7 @@ from . import constants
 
 from ..errors import TankError
 from .bundle import TankBundle
-from ..util import log_user_activity_metric
+from ..util import log_user_activity_metric, log_user_attribute_metric
 
 class Application(TankBundle):
     """
@@ -166,14 +166,19 @@ class Application(TankBundle):
     ##########################################################################################
     # internal API
 
-    def log_metric(self, action):
+    def log_metric(self, action, log_version=False):
         """Logs an app metric.
 
         :param action: Action string to log, e.g. 'Execute Action'
+        :param log_version: If True, also log a user attribute metric for the
+            version of the app. Default is `False`.
 
         Logs a user activity metric as performed within an app. This is a
         convenience method that auto-populates the module portion of
         `tank.util.log_user_activity_metric()`.
+
+        If the optional `log_version` flag is set to True, this method will
+        also log a user attribute metric for the current version of the app.
 
         Internal Use Only - We provide no guarantees that this method
         will be backwards compatible.
@@ -185,6 +190,9 @@ class Application(TankBundle):
         full_action = "(%s) %s %s" % (self.engine.name, self.name, action)
         log_user_activity_metric(self.name, full_action)
 
+        if log_version:
+            # log the app version as a user attribute
+            log_user_attribute_metric("%s version" % (self.name,), self.version)
 
 def get_application(engine, app_folder, descriptor, settings, instance_name, env):
     """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -692,13 +692,8 @@ class Engine(TankBundle):
 
             if properties.get("app"):
                 # track which app command is being launched
-                properties["app"].log_metric("'%s'" % name)
+                properties["app"].log_metric("'%s'" % name, log_version=True)
 
-                # specify which app version is being used
-                log_user_attribute_metric(
-                    "%s version" % properties["app"].name,
-                    properties["app"].version
-                )
             # run the actual payload callback
             return callback(*args, **kwargs)
 


### PR DESCRIPTION
Since we're often logging the app version when we log a metric for app execution, this change adds an optional flag to take care of both with one call. 