### PR TITLE
Adds simpler resolver logic to bootstrap

### DIFF
--- a/python/tank_vendor/shotgun_deploy/configuration.py
+++ b/python/tank_vendor/shotgun_deploy/configuration.py
@@ -177,7 +177,7 @@ class Configuration(object):
         self._bundle_cache_fallback_paths = bundle_cache_fallback_paths
 
     def __repr__(self):
-        return "<Config with id %s, project id %s and base %s>" % (
+        return "<Config with id %s, project id %s and base %r>" % (
             self._pipeline_config_id,
             self._project_id,
             self._descriptor
@@ -394,8 +394,6 @@ class Configuration(object):
             core_location,
             fallback_roots=self._bundle_cache_fallback_paths
         )
-
-        log.debug("Config will use Core %s" % core_descriptor)
 
         # make sure we have our core on disk
         core_descriptor.ensure_local()

--- a/python/tank_vendor/shotgun_deploy/manager.py
+++ b/python/tank_vendor/shotgun_deploy/manager.py
@@ -21,7 +21,7 @@ from . import constants
 from ..shotgun_base import ensure_folder_exists
 from .errors import ShotgunDeployError
 from .configuration import Configuration, create_managed_configuration
-from .resolver import BasicConfigurationResolver
+from .resolver import NoShotgunFallbackConfigurationResolver
 from .io_descriptor import location_dict_to_uri
 
 log = util.get_shotgun_deploy_logger()
@@ -214,7 +214,7 @@ class ToolkitManager(object):
         # separate file.
         self._report_progress("Resolving configuration...")
 
-        resolver = BasicConfigurationResolver(
+        resolver = NoShotgunFallbackConfigurationResolver(
             self._sg_connection,
             self._bundle_cache_fallback_paths
         )
@@ -326,7 +326,7 @@ class ToolkitManager(object):
         :param project_id: Project to retrieve configuration uri for.
         :return: toolkit config locator uri string
         """
-        resolver = BasicConfigurationResolver(
+        resolver = NoShotgunFallbackConfigurationResolver(
             self._sg_connection,
             self._bundle_cache_fallback_paths
         )

--- a/python/tank_vendor/shotgun_deploy/manager.py
+++ b/python/tank_vendor/shotgun_deploy/manager.py
@@ -21,7 +21,7 @@ from . import constants
 from ..shotgun_base import ensure_folder_exists
 from .errors import ShotgunDeployError
 from .configuration import Configuration, create_managed_configuration
-from .resolver import NoShotgunFallbackConfigurationResolver
+from .resolver import BaseConfigurationResolver
 from .io_descriptor import location_dict_to_uri
 
 log = util.get_shotgun_deploy_logger()
@@ -193,7 +193,7 @@ class ToolkitManager(object):
 
         If project_id is None, the method will bootstrap into the site
         config. This method will attempt to resolve the config according
-        to business logic set in the assocaited resolver class and based
+        to business logic set in the associated resolver class and based
         on this launch a configuration. This may involve downloading new
         apps from the toolkit app store and installing files on disk.
 
@@ -214,7 +214,7 @@ class ToolkitManager(object):
         # separate file.
         self._report_progress("Resolving configuration...")
 
-        resolver = NoShotgunFallbackConfigurationResolver(
+        resolver = BaseConfigurationResolver(
             self._sg_connection,
             self._bundle_cache_fallback_paths
         )
@@ -326,7 +326,7 @@ class ToolkitManager(object):
         :param project_id: Project to retrieve configuration uri for.
         :return: toolkit config locator uri string
         """
-        resolver = NoShotgunFallbackConfigurationResolver(
+        resolver = BaseConfigurationResolver(
             self._sg_connection,
             self._bundle_cache_fallback_paths
         )

--- a/python/tank_vendor/shotgun_deploy/resolver.py
+++ b/python/tank_vendor/shotgun_deploy/resolver.py
@@ -65,7 +65,7 @@ class ConfigurationResolver(object):
         raise NotImplementedError
 
 
-class NoShotgunFallbackConfigurationResolver(ConfigurationResolver):
+class BaseConfigurationResolver(ConfigurationResolver):
     """
     An simplistic resolver which is not aware of pipeline configurations
     in Shotgun. This will always resolve the base config location
@@ -79,7 +79,7 @@ class NoShotgunFallbackConfigurationResolver(ConfigurationResolver):
         :param sg_connection: Shotgun API instance
         :param bundle_cache_fallback_paths: List of additional paths where apps are cached.
         """
-        super(NoShotgunFallbackConfigurationResolver, self).__init__(
+        super(BaseConfigurationResolver, self).__init__(
             sg_connection,
             bundle_cache_fallback_paths
         )
@@ -95,8 +95,8 @@ class NoShotgunFallbackConfigurationResolver(ConfigurationResolver):
         Given a Shotgun project (or None for site mode), return a configuration
         object based on a particular set of resolution logic rules.
 
-        The NoShotgunFallbackConfigurationResolver is a simple and fast implementation
-        which does not take pipeline configuration entities in shotugn into account.
+        The BaseConfigurationResolver is a simple and fast implementation
+        which does not take pipeline configuration entities in Shotgun into account.
         It just returns the base configuration.
 
         Note: This implementation is expected to be replaced with the
@@ -146,9 +146,9 @@ class NoShotgunFallbackConfigurationResolver(ConfigurationResolver):
         )
 
 
-class BasicConfigurationResolver(ConfigurationResolver):
+class DefaultShotgunConfigurationResolver(ConfigurationResolver):
     """
-    Basic configuration resolves which implements the logic
+    Default Shotgun config resolver which implements the logic
     toolkit is using today. It first tries to find a Pipeline Configuration
     in Shotgun, if this fails, it falls back on the base configuration.
 
@@ -172,7 +172,7 @@ class BasicConfigurationResolver(ConfigurationResolver):
         :param sg_connection: Shotgun API instance
         :param bundle_cache_fallback_paths: List of additional paths where apps are cached.
         """
-        super(BasicConfigurationResolver, self).__init__(
+        super(DefaultShotgunConfigurationResolver, self).__init__(
             sg_connection,
             bundle_cache_fallback_paths
         )


### PR DESCRIPTION
A minor change, but extensive enough that I thought we should CR it! :)

This adds a new, more basic resolver to the bootstrap. 
The `BasicConfigurationResolver` that was used previously contains what is likely to be the eventual bootstrap resolve logic; the resolver looks in Shotgun to find a pipeline configuration matching the given namespace, project and pipeline config name ('branch'). It then looks for paths and if those are not found, it looks for a config uri in a field, tries to resolve the descriptor that this points at and use. In case no pipeline config is found, it falls back on the base config.

This resolver requires some changes to Shotgun; the likely introduction of a namespace field and supporting resolver logic so that we can distinguish between namespacs as part of the resolve (we may also do more complex operations in the future where several configs can be merged at runtime etc). It also assumes a config uri field. 

For the time being, I have added a simpler `NoShotgunFallbackConfigurationResolver` which fullfills the needs of the autonomous, plugin-based bootstrap that is currently needed. This resolver does not allow for any types of runtime overrides - it just returns the base configuration.