### PR TITLE
For #34444, app store specific proxy

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -376,7 +376,7 @@ def create_sg_app_store_connection():
 
     # Connect to associated Shotgun site and retrieve the credentials to use to
     # connect to the app store site
-    config_data = __get_app_store_connection_information()
+    config_data = _get_app_store_connection_information()
 
     # get connection parameters
     sg = __create_sg_connection(config_data)
@@ -398,7 +398,7 @@ def create_sg_app_store_connection():
     return g_app_store_connection
 
 
-def __get_app_store_connection_information():
+def _get_app_store_connection_information():
     """
     Get app store connection information
     :returns: A dictionary with host, api_key, api_script and http_proxy
@@ -427,10 +427,10 @@ def __get_app_store_proxy_setting(connection):
     :returns: The http proxy connection string.
     """
     config_data = get_associated_sg_config_data()
-    if config_data:
+    if config_data and config_data.get("app_store_http_proxy"):
         return config_data["app_store_http_proxy"]
     else:
-        return client_site_sg.config.raw_http_proxy
+        return connection.config.raw_http_proxy
 
 
 def __get_app_store_key_from_shotgun(sg_connection):

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -416,31 +416,19 @@ def __get_app_store_connection_information():
     return config_data
 
 
-def __get_app_store_yml_settings():
-    # Check if there is an app_store.yml file associated with the 
-    # project. In that case, just use that.
-    core_cfg = __get_api_core_config_location()
-    app_store_yml_path = os.path.join(core_cfg, "app_store.yml")
-
-    if os.path.exists(app_store_yml_path):
-        # The file exists, so read the file expecting all values to be present.
-        return __get_sg_config_data_with_script_user(app_store_yml_path)
-    return {}
-
-
 def __get_app_store_proxy_setting(connection):
     """
-    Retrieve the app store proxy settings. Retrieves it from the app_store.yml
-    crendential file if present, otherwise retrieves it from an existing connection
-    object.
+    Retrieve the app store proxy settings. If the key
+    app_store_http_proxy is not found in the shotgun.yml file, the proxy
+    settings from the client site connection will be used.
 
     :param connection: A working connection to the site.
 
     :returns: The http proxy connection string.
     """
-    config_data = __get_app_store_yml_settings()
+    config_data = get_associated_sg_config_data()
     if config_data:
-        return config_data["http_proxy"]
+        return config_data["app_store_http_proxy"]
     else:
         return client_site_sg.config.raw_http_proxy
 
@@ -455,8 +443,14 @@ def __get_app_store_key_from_shotgun(sg_connection):
                           app store credentials should be retrieved.
     :returns: tuple of strings with contents (script_name, script_key)
     """
-    config_data = __get_app_store_yml_settings()
-    if config_data:
+    # first check if there is an app_store.yml file associated with the 
+    # project. In that case, just use that.
+    core_cfg = __get_api_core_config_location()
+    app_store_yml_path = os.path.join(core_cfg, "app_store.yml")
+
+    if os.path.exists(app_store_yml_path):
+        # The file exists, so read the file expecting all values to be present.
+        config_data = __get_sg_config_data_with_script_user(app_store_yml_path)
         # we got two values from the app store file!
         return config_data["api_script"], config_data["api_key"]
 

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -11,14 +11,16 @@
 from __future__ import with_statement
 import os
 import datetime
+import unittest2 as unittest
 
 from mock import patch
 
 import tank
 from tank import context, errors
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase, setUpModule
 from tank.template import TemplatePath
 from tank.templatekey import SequenceKey
+from tank_vendor.shotgun_authentication import ShotgunAuthenticator, DefaultsManager
 
 
 class TestShotgunFindPublish(TankTestBase):
@@ -427,6 +429,118 @@ class TestGetSgConfigData(TankTestBase):
 
 # Class decorators don't exist on Python2.5
 TestGetSgConfigData = patch("tank.util.shotgun.__get_api_core_config_location", TestGetSgConfigData)
+
+
+class LegacyAuthConnectionSettings(unittest.TestCase):
+    """
+    Tests proxy connection for site and appstore connections.
+    """
+
+    _SITE = "https://tank.shotgunstudio.com"
+    _SITE_PROXY = "127.0.0.1"
+    _STORE_PROXY = "127.0.0.2"
+
+    def _inject_shotgun_yaml_data(
+        self,
+        server_caps_mock,
+        get_api_core_config_location_mock,
+        get_sg_config_data_mock,
+        get_app_store_key_from_shotgun_mock,
+        shotgun_yml
+    ):
+        """
+        Bootstrap unit tests.
+        """
+        get_api_core_config_location_mock.return_value = "unknown_path_location"
+        get_sg_config_data_mock.return_value = shotgun_yml
+        get_app_store_key_from_shotgun_mock.return_value = ("abc", "123")
+        # no need to do anything for the server caps mock. It will not connect
+        # to Shotgun.
+
+    def setUp(self):
+        """
+        Clear cached appstore connection
+        """
+        tank.util.shotgun.g_sg_cached_connection = None
+        tank.util.shotgun.g_app_store_connection = None
+
+    def tearDown(self):
+        """
+        Clear cached appstore connection
+        """
+        tank.util.shotgun.g_sg_cached_connection = None
+        tank.util.shotgun.g_app_store_connection = None
+
+    @patch("tank.util.shotgun.__get_app_store_key_from_shotgun")
+    @patch("tank.util.shotgun.__get_api_core_config_location")
+    @patch("tank.util.shotgun.__get_sg_config_data")
+    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    def _test_site_connection_no_auth_user_internal(
+        self,
+        server_caps_mock,
+        get_sg_config_data_mock,
+        get_api_core_config_location_mock,
+        get_app_store_key_from_shotgun_mock,
+        source_proxy=None,
+        source_store_proxy=None,
+        expected_store_proxy=None
+    ):
+        """
+        No authenticated user, should be picking settings from shotgun.yml
+        """
+        self._inject_shotgun_yaml_data(
+            server_caps_mock,
+            get_api_core_config_location_mock,
+            get_sg_config_data_mock,
+            get_app_store_key_from_shotgun_mock,
+            {
+                "host": self._SITE,
+                "api_script": "1234",
+                "api_key": "1234",
+                "http_proxy": source_proxy,
+                "app_store_http_proxy": source_store_proxy
+            }
+        )
+
+        # Make sure that the site uses the host and proxy.
+        sg = tank.util.shotgun.create_sg_connection()
+        self.assertEqual(sg.base_url, self._SITE)
+        self.assertEqual(sg.config.raw_http_proxy, source_proxy)
+
+        config = tank.util.shotgun._get_app_store_connection_information()
+        self.assertEqual(config["host"], tank.platform.constants.SGTK_APP_STORE)
+        self.assertEqual(config["http_proxy"], expected_store_proxy)
+
+    def test_connections_no_proxy(self):
+        """
+        No proxies set, so everything should be None.
+        """
+        self._test_site_connection_no_auth_user_internal()
+
+    def test_connections_site_proxy(self):
+        """
+        When the http_proxy setting is set in shotgun.yml, both the site
+        connection and app store connections are expected to use the
+        proxy setting.
+        """
+        self._test_site_connection_no_auth_user_internal(source_proxy=self._SITE_PROXY, expected_store_proxy=self._SITE_PROXY)
+
+    def test_connections_store_proxy(self):
+        """
+        When the app_store_http_proxy setting is set in shotgun.yml, the app
+        store connections are expected to use the proxy setting.
+        """
+        self._test_site_connection_no_auth_user_internal(source_store_proxy=self._STORE_PROXY, expected_store_proxy=self._STORE_PROXY)
+
+    def test_connections_both_proxy(self):
+        """
+        When both proxy settings are set, each connection has its own proxy.
+        """
+        self._test_site_connection_no_auth_user_internal(
+            source_proxy=self._SITE_PROXY,
+            source_store_proxy=self._STORE_PROXY,
+            expected_store_proxy=self._STORE_PROXY
+        )
 
 
 class TestCalcPathCache(TankTestBase):

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -501,10 +501,22 @@ class ConnectionSettingsTestCases(object):
     @patch("tank.util.shotgun.__get_api_core_config_location")
     @patch("tank.util.shotgun.__get_app_store_key_from_shotgun")
     @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    def _run_test(self, *args, **kwargs):
+    def _run_test(
+        self,
+        server_caps_mock,
+        get_app_store_key_from_shotgun_mock,
+        get_api_core_config_location_mock,
+        site,
+        source_proxy,
+        source_store_proxy,
+        expected_store_proxy
+    ):
         """
         Should be implemented by derived classes in order to mock authentication
         for the test.
+
+        The actual parameters of this method are the following. The _mock parameters
+        are passed in via the @patch method and should not be passed by the caller.
 
         :param site: Site used for authentication
         :param source_proxy: proxy being returned by the authentication code for the site
@@ -512,18 +524,18 @@ class ConnectionSettingsTestCases(object):
         :param expected_store_proxy: actual proxy value
         """
         # Avoids crash because we're not in a pipeline configuration.
-        args[2].return_value = "unknown_path_location"
+        get_api_core_config_location_mock.return_value = "unknown_path_location"
         # Mocks app store credentials retrieval
-        args[1].return_value = ("abc", "123")
+        get_app_store_key_from_shotgun_mock.return_value = ("abc", "123")
 
         # Make sure that the site uses the host and proxy.
         sg = tank.util.shotgun.create_sg_connection()
         self.assertEqual(sg.base_url, self._SITE)
-        self.assertEqual(sg.config.raw_http_proxy, kwargs["source_proxy"])
+        self.assertEqual(sg.config.raw_http_proxy, source_proxy)
 
         config = tank.util.shotgun._get_app_store_connection_information()
         self.assertEqual(config["host"], tank.platform.constants.SGTK_APP_STORE)
-        self.assertEqual(config["http_proxy"], kwargs["expected_store_proxy"])
+        self.assertEqual(config["http_proxy"], expected_store_proxy)
 
 
 class LegacyAuthConnectionSettings(ConnectionSettingsTestCases, unittest.TestCase):

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -543,6 +543,7 @@ class LegacyAuthConnectionSettings(ConnectionSettingsTestCases, unittest.TestCas
         """
         See ConnectionSettingsTestCases._run_test
         """
+        # Mocks shotgun.yml content, which we use for authentication.
         get_sg_config_data_mock.return_value = {
             "host": site,
             "api_script": "1234",
@@ -565,10 +566,8 @@ class AuthConnectionSettings(ConnectionSettingsTestCases, unittest.TestCase):
     Tests proxy connection for site and appstore connections.
     """
 
-    _SITE = "https://test.shotgunstudio.com"
-
     @patch("tank.util.shotgun.__get_sg_config_data")
-    def _test_site_connection_no_auth_user_internal(
+    def _run_test(
         self,
         get_sg_config_data_mock,
         site,
@@ -579,8 +578,6 @@ class AuthConnectionSettings(ConnectionSettingsTestCases, unittest.TestCase):
         """
         No authenticated user, should be picking settings from shotgun.yml
         """
-
-
         # Mocks shotgun.yml content
         get_sg_config_data_mock.return_value = {
             # We're supposed to read only the proxy settings for the appstore
@@ -590,17 +587,22 @@ class AuthConnectionSettings(ConnectionSettingsTestCases, unittest.TestCase):
             "http_proxy": "123.234.345.456:7890",
             "app_store_http_proxy": source_store_proxy
         }
-
         # Mocks a user being authenticated.
         user = ShotgunUser(
             SessionUser(
                 login="test_user", session_token="abc1234",
-                host=self._SITE, http_proxy=source_proxy
+                host=site, http_proxy=source_proxy
             )
         )
         tank.set_authenticated_user(user)
 
-        self._run_test(source_proxy, source_store_proxy, expected_store_proxy)
+        ConnectionSettingsTestCases._run_test(
+            self,
+            site=site,
+            source_proxy=source_proxy,
+            source_store_proxy=source_store_proxy,
+            expected_store_proxy=expected_store_proxy
+        )
 
 
 class TestCalcPathCache(TankTestBase):


### PR DESCRIPTION
- Implements an app store specific proxy setting.
- Adds unit tests for both the original and new authentication logic