### PR TITLE
Improved caching of descriptors

### DIFF
--- a/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
@@ -35,53 +35,7 @@ class IODescriptorBase(object):
     Different App Descriptor implementations typically handle different source control
     systems: There may be an app descriptor which knows how to communicate with the
     Tank App store and one which knows how to handle the local file system.
-
-    A descriptor is immutable in the sense that it always points at the same code -
-    this may be a particular frozen version out of that toolkit app store that
-    will not change or it may be a dev area where the code can change. Given this,
-    descriptors are cached and only constructed once for a given descriptor URL.
     """
-
-    # @todo - need a way to clear this cache (for example when switching tk APIs)
-    #         we should look at a general cache system (maybe part of shotgun_base)
-    #         where we can keep better track of globals in general.
-    _instances = dict()
-
-    def __new__(cls, descriptor_dict, *args, **kwargs):
-        """
-        Handles caching of descriptors.
-
-        Executed prior to __init__ being executed.
-
-        Since all our normal descriptors are immutable - they represent a specific,
-        read only and cached version of an app, engine or framework on disk, we can
-        also cache their wrapper objects.
-
-        :param bundle_cache_root: Root location for bundle cache
-        :param descriptor_dict: descriptor dictionary describing the bundle
-        :returns: Descriptor instance
-        """
-        instance_cache = cls._instances
-
-        # The cache is keyed based on the descriptor dict
-        cache_key = str(descriptor_dict)
-
-        # Instantiate and cache if we need to, otherwise just return what we
-        # already have stored away.
-        if cache_key not in instance_cache:
-            # If the bundle install path isn't in the cache, then we are
-            # starting fresh. Otherwise, check to see if the app (by name)
-            # is cached, and if not initialize its specific cache. After
-            # that we instantiate and store by version.
-            instance_cache[cache_key] = super(IODescriptorBase, cls).__new__(
-                cls,
-                descriptor_dict,
-                *args,
-                **kwargs
-            )
-
-        return instance_cache[cache_key]
-
     def __init__(self, descriptor_dict):
         """
         Constructor

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/factory.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/factory.py
@@ -46,6 +46,13 @@ def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fa
     from .git_branch import IODescriptorGitBranch
     from .manual import IODescriptorManual
 
+    # resolve into both dict and uri form
+    if isinstance(dict_or_uri, basestring):
+        descriptor_dict = IODescriptorBase.dict_from_uri(dict_or_uri)
+        descriptor_uri = dict_or_uri
+    else:
+        descriptor_dict = dict_or_uri
+        descriptor_uri = IODescriptorBase.uri_from_dict(dict_or_uri)
 
     # first check if we already have this in our cache
     # Since all our normal descriptors are immutable - they represent a specific,
@@ -57,21 +64,13 @@ def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fa
     # and it doesn't matter where we are fetching it from. If <core appstore v1.2.3>
     # is available in multiple different locations on disk, the content of each location
     # should be identical
-
-    cache_key = str(dict_or_uri)
-
-    if cache_key in g_cached_instances:
+    if descriptor_uri in g_cached_instances:
         # cache hit
-        return g_cached_instances[cache_key]
+        return g_cached_instances[descriptor_uri]
 
-    # no cache hit, construct the object manually
 
-    # first resolve any uri
-    if isinstance(dict_or_uri, basestring):
-        # translate uri to dict
-        descriptor_dict = IODescriptorBase.dict_from_uri(dict_or_uri)
-    else:
-        descriptor_dict = dict_or_uri
+    # at this point we didn't have a cache hit,
+    # so construct the object manually
 
     # factory logic
     if descriptor_dict.get("type") == "app_store":
@@ -108,7 +107,7 @@ def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fa
 
     # Now see if we should cache it. Only cache descriptors that represent immutable
     if descriptor.is_immutable():
-        g_cached_instances[cache_key] = descriptor
+        g_cached_instances[descriptor_uri] = descriptor
 
     return descriptor
 

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/factory.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/factory.py
@@ -13,9 +13,19 @@ from .. import constants
 from .. import util
 log = util.get_shotgun_deploy_logger()
 
+# for performance, we keep cached instances of
+# descriptors in a cache.
+g_cached_instances = {}
+
+
 def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fallback_roots):
     """
     Factory method. Use this method to construct all DescriptorIO instances.
+
+    A descriptor is immutable in the sense that it always points at the same code -
+    this may be a particular frozen version out of that toolkit app store that
+    will not change or it may be a dev area where the code can change. Given this,
+    descriptors are cached and only constructed once for a given descriptor URL.
 
     :param sg: Shotgun connection to associated site
     :param descriptor_type: Either AppDescriptor.APP, CORE, ENGINE or FRAMEWORK
@@ -36,12 +46,34 @@ def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fa
     from .git_branch import IODescriptorGitBranch
     from .manual import IODescriptorManual
 
+
+    # first check if we already have this in our cache
+    # Since all our normal descriptors are immutable - they represent a specific,
+    # read only and cached version of an app, engine or framework on disk, we can
+    # also cache their wrapper objects.
+    # NOTE! We are not keying the cache based on bundle_cache_root or
+    # fallback_roots -- the assumption here is that if you find for example
+    # <core appstore v1.2.3> this represents that particular version of some code
+    # and it doesn't matter where we are fetching it from. If <core appstore v1.2.3>
+    # is available in multiple different locations on disk, the content of each location
+    # should be identical
+
+    cache_key = str(dict_or_uri)
+
+    if cache_key in g_cached_instances:
+        # cache hit
+        return g_cached_instances[cache_key]
+
+    # no cache hit, construct the object manually
+
+    # first resolve any uri
     if isinstance(dict_or_uri, basestring):
         # translate uri to dict
         descriptor_dict = IODescriptorBase.dict_from_uri(dict_or_uri)
     else:
         descriptor_dict = dict_or_uri
 
+    # factory logic
     if descriptor_dict.get("type") == "app_store":
         descriptor = IODescriptorAppStore(descriptor_dict, sg, descriptor_type)
 
@@ -73,6 +105,10 @@ def create_io_descriptor(sg, descriptor_type, dict_or_uri, bundle_cache_root, fa
         log.debug("Latest keyword detected. Searching for latest version...")
         descriptor = descriptor.get_latest_version()
         log.debug("Resolved latest to be %r" % descriptor)
+
+    # Now see if we should cache it. Only cache descriptors that represent immutable
+    if descriptor.is_immutable():
+        g_cached_instances[cache_key] = descriptor
 
     return descriptor
 

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/git_branch.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/git_branch.py
@@ -53,13 +53,15 @@ class IODescriptorGitBranch(IODescriptorGit):
         :param descriptor_dict: descriptor dictionary describing the bundle
         :return: Descriptor instance
         """
-        super(IODescriptorGitBranch, self).__init__(descriptor_dict)
-
+        # make sure all required fields are there
         self._validate_descriptor(
             descriptor_dict,
             required=["type", "path", "version", "branch"],
             optional=[]
         )
+
+        # call base class
+        super(IODescriptorGitBranch, self).__init__(descriptor_dict)
 
         # path is handled by base class - all git descriptors
         # have a path to a repo

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/git_tag.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/git_tag.py
@@ -47,13 +47,15 @@ class IODescriptorGitTag(IODescriptorGit):
         :param bundle_type: The type of bundle. ex: Descriptor.APP
         :return: Descriptor instance
         """
-        super(IODescriptorGitTag, self).__init__(descriptor_dict)
-
+        # make sure all required fields are there
         self._validate_descriptor(
             descriptor_dict,
             required=["type", "path", "version"],
             optional=[]
         )
+
+        # call base class
+        super(IODescriptorGitTag, self).__init__(descriptor_dict)
 
         # path is handled by base class - all git descriptors
         # have a path to a repo


### PR DESCRIPTION
Improved the caching of descriptor objects - instead of having a `__new__` method to magically handle it behind the scenes, it is now instead just done as part of the factory method. This makes the code a bit easier to read and since we now have a factory method and a single point in the code where things are being instantiated, this is the natural place to handle any smarts around creation of new items.

This also resolves some bugs:

- `__init__` is no longer executed all the time. With the previous implementation it was always being called, even for cached objects which was confusing and led to bugs. (See http://stackoverflow.com/questions/674304/pythons-use-of-new-and-init for some info around that.).

- I think with the previous implementation, we were caching "latest" descriptors, which I think theoretically should be ok, but I can see this leading to potentially subtle future bugs. The factory based caching made it very straight forward to choose which descriptor types to cache, and latest and mutable descriptor types are now excluded from the cache.

@josh-t discovered this issue and did a quick fix in #244 - This PR is a slightly bigger change trying to resolve the same issue. Josh, could you take a look at this pull request? Having read that SO post, i felt moving the caching code into the factory is really the right move more long term. What do you think?