### PR TITLE
#34913 Support for sparse configs

### DIFF
--- a/python/tank/deploy/tank_commands/console_utils.py
+++ b/python/tank/deploy/tank_commands/console_utils.py
@@ -404,10 +404,13 @@ def _generate_settings_diff_recursive(parent_engine_name, old_schema, new_schema
             # found a new param:
             new_params[param_name] = {"description": param_desc, "type": param_type}
 
-            # attempt to resolve a default value from the new parameter def
+            # attempt to resolve a default value from the new parameter def.
+            # Use the fallback default with an unlikely to be used value to
+            # detect cases where there is no default value in the schema.
+            no_default_value = "__NO_DEFAULT_VALUE_IN_SCHEMA__"
             default_value = resolve_default_value(new_param_definition_dict,
-                engine_name=parent_engine_name)
-            if default_value is not None:
+                no_default_value, parent_engine_name)
+            if default_value is not no_default_value:
                 new_params[param_name]["value"] = default_value
 
         else:

--- a/python/tank/deploy/tank_commands/console_utils.py
+++ b/python/tank/deploy/tank_commands/console_utils.py
@@ -18,7 +18,7 @@ import os
 from ... import pipelineconfig_utils
 from ...platform import validation
 from ...platform import constants
-from ...errors import TankError
+from ...errors import TankError, TankNoDefaultValueError
 from ...util import shotgun
 from .. import util
 from ...platform.bundle import resolve_default_value
@@ -409,7 +409,7 @@ def _generate_settings_diff_recursive(parent_engine_name, old_schema, new_schema
             try:
                 default_value = resolve_default_value(new_param_definition_dict,
                     parent_engine_name, raise_if_missing=True)
-            except TankError:
+            except TankNoDefaultValueError:
                 # No default value exists. We won't add it to the dict.
                 # It will be prompted for later.
                 pass

--- a/python/tank/deploy/tank_commands/console_utils.py
+++ b/python/tank/deploy/tank_commands/console_utils.py
@@ -193,7 +193,8 @@ def _get_configuration_recursive(log, tank_api_instance, new_ver_descriptor, par
 
             if "value" in param_data:
                 # default value in param data, just log the info for the user
-                log.info("Using default value '%s'" % str(param_data["value"]))
+                default_value = param_data["value"]
+                log.info("Using default value '%s'" % (str(default_value),))
             else:
                 # no default value in the param_data, prompt the user
                 if suppress_prompts:

--- a/python/tank/deploy/tank_commands/console_utils.py
+++ b/python/tank/deploy/tank_commands/console_utils.py
@@ -406,12 +406,14 @@ def _generate_settings_diff_recursive(parent_engine_name, old_schema, new_schema
             new_params[param_name] = {"description": param_desc, "type": param_type}
 
             # attempt to resolve a default value from the new parameter def.
-            # Use the fallback default with an unlikely to be used value to
-            # detect cases where there is no default value in the schema.
-            no_default_value = "__NO_DEFAULT_VALUE_IN_SCHEMA__"
-            default_value = resolve_default_value(new_param_definition_dict,
-                no_default_value, parent_engine_name)
-            if default_value is not no_default_value:
+            try:
+                default_value = resolve_default_value(new_param_definition_dict,
+                    parent_engine_name, raise_if_missing=True)
+            except TankError:
+                # No default value exists. We won't add it to the dict.
+                # It will be prompted for later.
+                pass
+            else:
                 new_params[param_name]["value"] = default_value
 
         else:

--- a/python/tank/deploy/tank_commands/update.py
+++ b/python/tank/deploy/tank_commands/update.py
@@ -490,7 +490,7 @@ def _process_item(log, suppress_prompts, tk, env, engine_name=None, app_name=Non
         log.info("")
         log.info("-" * 70)
         log.info("Engine %s (Environment %s)" % (engine_name, env.name))
-        
+
 
     status = _check_item_update_status(env, engine_name, app_name, framework_name)
     item_was_updated = False
@@ -554,7 +554,7 @@ def _check_item_update_status(environment_obj, engine_name=None, app_name=None, 
     - can_update:    Can we update?
     - update_status: String with details describing the status.  
     """
-    
+
     parent_engine_desc = None
     
     if framework_name:

--- a/python/tank/deploy/tank_commands/validate_config.py
+++ b/python/tank/deploy/tank_commands/validate_config.py
@@ -125,7 +125,19 @@ class ValidateConfigAction(Action):
 g_templates = set()
 g_hooks = set()
 
-def _validate_bundle(log, tk, name, settings, descriptor, engine_name=None, app_name=None):
+def _validate_bundle(log, tk, name, settings, descriptor, engine_name=None):
+    """Validate the supplied bundle including the descriptor and all settings.
+
+    :param log: A logger instance for logging validation output.
+    :param tk: A toolkit api instance.
+    :param name: The bundle's name.
+    :param settings: The bundle's settings dict.
+    :param descriptor: A descriptor object for the bundle.
+    :param engine_name: The name of the containing engine or None.
+        This is used when the bundle is an app and needs to validate engine-
+        specific settings.
+
+    """
 
     log.info("")
     log.info("Validating %s..." % name)
@@ -152,7 +164,7 @@ def _validate_bundle(log, tk, name, settings, descriptor, engine_name=None, app_
 
     for s in manifest.keys():
 
-        default = bundle.resolve_default_value(manifest.get(s), engine_name=engine_name)
+        default = bundle.resolve_default_value(manifest[s], engine_name=engine_name)
 
         if s in settings:
             value = settings.get(s)
@@ -169,17 +181,13 @@ def _validate_bundle(log, tk, name, settings, descriptor, engine_name=None, app_
                 # no default value
                 # don't report this
                 pass
-                #log.info("  Parameter %s - OK [no default value specified in manifest]" % s)
 
             elif manifest[s].get("type") == "hook" and value == "default":
                 # don't display when default values are used.
                 pass
-                #log.info("  Parameter %s - OK [using hook 'default']" % s)
 
             elif default == value:
                 pass
-                # don't display when default values are used.
-                #log.info("  Parameter %s - OK [using default value]" % s)
 
             else:
                 log.info("  Parameter %s - OK [using non-default value]" % s)
@@ -194,6 +202,12 @@ def _validate_bundle(log, tk, name, settings, descriptor, engine_name=None, app_
 
                      
 def _process_environment(log, tk, env):
+    """Process an environment by validating each of its bundles.
+
+    :param log: A logger instance for logging validation output.
+    :param tk: A toolkit api instance.
+    :param env: An environment instance.
+    """
     
     log.info("Processing environment %s" % env)
 
@@ -206,9 +220,8 @@ def _process_environment(log, tk, env):
             s = env.get_app_settings(e, a)
             descriptor = env.get_app_descriptor(e, a)
             name = "%s / %s / %s" % (env.name, e, a)
-            _validate_bundle(log, tk, name, s, descriptor, engine_name=e,
-                app_name=a)
-    
+            _validate_bundle(log, tk, name, s, descriptor, engine_name=e)
+
     
     
      

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -64,3 +64,12 @@ class TankErrorProjectIsSetup(TankError):
         """
         super(TankErrorProjectIsSetup, self).__init__("You are trying to set up a project which has already been set up. "
                                                       "If you want to do this, make sure to set the force parameter.")
+
+class TankNoDefaultValueError(TankError):
+    """
+    Exception that can be raised when a default value is required but none is found.
+
+    Typically raised by `tank.platform.bundle.resolve_default_value()` when the
+    `raise_if_missing` flag is set to True.
+    """
+    pass

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -19,7 +19,7 @@ import sys
 import imp
 import uuid
 from .. import hook
-from ..errors import TankError, TankContextChangeNotSupportedError
+from ..errors import TankError, TankContextChangeNotSupportedError, TankNoDefaultValueError
 from . import constants
 
 class TankBundle(object):
@@ -856,8 +856,8 @@ def resolve_default_value(schema, default=None, engine_name=None,
     :param schema: The schema for the setting default to resolve
     :param default: Optional fallback default value.
     :param engine_name: Optional name of the current engine if there is one.
-    :param raise_if_missing: If True, raise TankError if no default value is
-        found.
+    :param raise_if_missing: If True, raise TankNoDefaultValueError if no
+        default value is found.
     :return: The resolved default value
     """
 
@@ -906,7 +906,7 @@ def resolve_default_value(schema, default=None, engine_name=None,
         # calling code requested an exception if no default value exists.
         # the value may have been overridden by one of the special cases above,
         # so only raise if the value is None.
-        raise TankError("No default value found.")
+        raise TankNoDefaultValueError("No default value found.")
 
     return value
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -881,7 +881,9 @@ def resolve_default_value(schema, default=None, engine_name=None):
 
     # special case handling for list params - check if
     # allows_empty == True, in that case set default value to []
-    if setting_type == "list" and value is None and schema.get("allows_empty"):
+    if (setting_type == "list" and
+        value in [None, constants.TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE] and
+        schema.get("allows_empty")):
         value = []
 
     if setting_type == "hook":

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -560,7 +560,7 @@ class TankBundle(object):
             #    default_value: maya_publish_file
             #
             resolved_hook_name = resolve_default_value(
-                manifest.get(settings_name), "undefined", engine_name)
+                manifest.get(settings_name), engine_name=engine_name)
 
             # get the full path for the resolved hook name:
             if resolved_hook_name.startswith("{self}"):
@@ -885,6 +885,13 @@ def resolve_default_value(schema, default=None, engine_name=None):
         value in [None, constants.TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE] and
         schema.get("allows_empty")):
         value = []
+
+    # special case handling for dict params - check if
+    # allows_empty == True, in that case set default value to {}
+    if (setting_type == "dict" and
+        value in [None, constants.TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE] and
+        schema.get("allows_empty")):
+        value = {}
 
     if setting_type == "hook":
         value = _resolve_default_hook_value(value, engine_name)

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -556,7 +556,6 @@ class TankBundle(object):
             # hook_publish_file:
             #    type: hook
             #    description: Called when a file is published, e.g. copied from a work area to a publish area.
-            #    parameters: [source_path, target_path]
             #    default_value: maya_publish_file
             #
             resolved_hook_name = resolve_default_value(

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -534,8 +534,10 @@ class TankBundle(object):
         if hook_expression == constants.TANK_BUNDLE_DEFAULT_HOOK_SETTING:
             # hook settings points to the default one.
             # find the name of the hook from the manifest
+
             manifest = self.__descriptor.get_configuration_schema()
-            #
+            engine_name = self._get_engine_name()
+
             # Entries are on the following form
             #            
             # hook_publish_file:
@@ -544,28 +546,9 @@ class TankBundle(object):
             #    parameters: [source_path, target_path]
             #    default_value: maya_publish_file
             #
-            default_hook_name = manifest.get(settings_name).get("default_value", "undefined")
-            
-            # special case - if the manifest default value contains the special token
-            # {engine_name}, replace this with the name of the associated engine.
-            # note that this bundle base class level has no notion of what an engine or app is
-            # so we basically do this duck-type style, basically see if there is an engine
-            # attribute and if so, attempt the replacement:
-            engine_name = None
-            resolved_hook_name = default_hook_name
-            if constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN in default_hook_name:
-                try:
-                    # note - this technically violates the generic nature of the bundle
-                    # base class implementation (because the engine member is not defined in bundle
-                    # but in App and Framework but NOT in the Engine class) - an engine trying to define
-                    # a hook using the {engine_name} construct will therefore get an error.
-                    engine_name = self.engine.name
-                except:
-                    raise TankError("%s: Failed to find the associated engine "
-                                    "when trying to access hook %s" % (self, hook_expression))
-                
-                resolved_hook_name = default_hook_name.replace(constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)
-                
+            resolved_hook_name = resolve_default_value(
+                manifest.get(settings_name), "undefined", engine_name)
+
             # get the full path for the resolved hook name:
             if resolved_hook_name.startswith("{self}"):
                 # new format hook: 
@@ -577,7 +560,7 @@ class TankBundle(object):
                 # old style hook: 
                 #  default_value: 'my_hook'
                 path = os.path.join(self.disk_location, "hooks", "%s.py" % resolved_hook_name)
-            
+
             # if the hook uses the engine name then output a more useful error message if a hook for 
             # the engine can't be found.
             if engine_name and not os.path.exists(path):
@@ -705,24 +688,14 @@ class TankBundle(object):
             default_value = None
             
             if settings_name:
-                default_value = manifest.get(settings_name).get("default_value")
-            
+                default_value = resolve_default_value(
+                    manifest.get(settings_name),
+                    engine_name=self._get_engine_name(),
+            )
+
             if default_value: # possible not to have a default value!
                 
-                if constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN in default_value:
-                    try:
-                        # note - this technically violates the generic nature of the bundle
-                        # base class implementation (because the engine member is not defined in bundle
-                        # but in App and Framework but NOT in the Engine class) - an engine trying to define
-                        # a hook using the {engine_name} construct will therefore get an error.
-                        engine_name = self.engine.name
-                    except:
-                        raise TankError("%s: Failed to find the associated engine "
-                                        "when trying to access hook %s" % (self, hook_expression))
-                    
-                    default_value = default_value.replace(constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)
-            
-                # expand the default value to be referenced from {self} and with the .py suffix 
+                # expand the default value to be referenced from {self} and with the .py suffix
                 # for backwards compatibility with the old syntax where the default value could
                 # just be 'hook_name' with implicit '{self}' and no suffix!
                 if not default_value.startswith("{self}"):
@@ -741,7 +714,7 @@ class TankBundle(object):
         
         # resolve paths into actual file paths
         resolved_hook_paths = [self.__resolve_hook_path(settings_name, x) for x in unresolved_hook_paths]
-                
+
         ret_value = hook.execute_hook_method(resolved_hook_paths, self, method_name, **kwargs)
         
         return ret_value
@@ -810,51 +783,130 @@ class TankBundle(object):
         to be resolved for settings derived outside of the 
         app.
 
-        :param settings: the settings source
+        :param settings: the settings dictionary source
         :param key: setting name
         :param default: a default value to use for the setting
         """
 
-        # start with the supplied default value in case we need to short circuit
-        # before checking against the schema
+        # The post processing code requires the schema to introspect the
+        # setting's types, defaults, etc. An old use case exists whereby the key
+        # does not exist in the config schema so we need to account for that.
+        schema_exists = key in self.__descriptor.get_configuration_schema()
+
+        # Get the value for the supplied key
+        if key in settings:
+            # Value provided by the settings
+            value = settings[key]
+        elif schema_exists:
+            schema = self.__descriptor.get_configuration_schema().get(key)
+
+            # Resolve a default value from the schema. This checks various
+            # legacy default value forms in the schema keys.
+            value = resolve_default_value(schema, default,
+                self._get_engine_name())
+
+            # We have a value of some kind and a schema. Allow the post
+            # processing code to further resolve the value.
+            if value:
+                value = self.__post_process_settings_r(key, value, schema)
+        else:
+            # Nothing in the settings, no schema, fallback to the supplied
+            # default value
+            value = default
+
+        return value
+
+    def _get_engine_name(self):
+        """Returns the bundle's engine name if available. None otherwise.
+
+        Convenience method to avoid try/except everywhere.
+
+        :return: The engine name or None
+        """
+
+        try:
+            engine_name = self.engine.name
+        except:
+            engine_name = None
+
+        return engine_name
+
+def resolve_default_value(schema, default=None, engine_name=None):
+    """
+    Extract a default value from the supplied schema.
+
+    Fall back on the supplied default value if no default could be
+    determined from the schema.
+
+    :param schema: The schema for the setting default to resolve
+    :param default: Optional fallback default value.
+    :param engine_name: Optional name of the current engine if there is one.
+    :return:
+    """
+
+    # Engine-specific default value keys are allowed (ex:
+    # "default_value_tk-maya"). If an engine name was supplied,
+    # build the corresponding engine-specific default value key.
+    if engine_name:
+        engine_default_key = "%s_%s" % (constants.TANK_SCHEMA_DEFAULT_VALUE_KEY,
+            engine_name)
+    else:
+        engine_default_key = None
+
+    # Now look for a default value to use.
+    if engine_default_key and engine_default_key in schema:
+        # An engine specific key exists, use it.
+        value = schema[engine_default_key]
+    elif constants.TANK_SCHEMA_DEFAULT_VALUE_KEY in schema:
+        # The standard default value key
+        value = schema[constants.TANK_SCHEMA_DEFAULT_VALUE_KEY]
+    else:
+        # No default value found, fall back on the supplied default.
         value = default
 
-        # attempt to get the value from the settings.
-        if key in settings:
-            value = settings[key]
+    # ---- type specific checks
 
-        # try to get the type for the setting (may fail if the key does not
-        # exist in the schema. an old use case we need to support now...)
-        try:
-            schema = self.__descriptor.get_configuration_schema().get(key)
-        except:
-            schema = None
+    setting_type = schema.get("type")
 
-        if not schema:
-            # No schema, can't post process or retrieve a default. Just return
-            # the value we have.
-            return value
+    # special case handling for list params - check if
+    # allows_empty == True, in that case set default value to []
+    if setting_type == "list" and value is None and schema.get("allows_empty"):
+        value = []
 
-        # Schema exists. If the key wasn't in the settings, fallback to the
-        # default value in the manifest.
-        if key not in settings:
+    if setting_type == "hook":
+        value = _resolve_default_hook_value(value, engine_name)
 
-            if schema.get("type") == "hook":
-                # Hooks already have the concept of a default value. Just
-                # use that special default hook string and allow the post
-                # process to resolve the value correctly based on the
-                # default value in the manifest. Because the hooks have a
-                # bit of legacy path evaluation code, if we just use the
-                # value from the manifest here, we aren't guaranteed to get
-                # the expected path.
-                value = constants.TANK_BUNDLE_DEFAULT_HOOK_SETTING
-            else:
-                # Use the default value from the manifest
-                value = schema.get("default_value", default)
+    return value
 
-        # If the value is None, no need to post process.
-        if value is None:
-            return value
 
-        # post process against schema
-        return self.__post_process_settings_r(key, value, schema)
+def _resolve_default_hook_value(value, engine_name=None):
+    """
+    Given a hook value, evaluate any special keys or legacy values.
+
+    :param value: The unresolved default value for the hook
+    :param engine_name: The name of the engine for engine-specific hook values
+    :return: The resolved hook default value.
+
+    :raises: TankError - if an engine name token is found in the supplied
+        value, but no engine name is provided.
+    """
+
+    # Replace the engine reference token if it exists.
+    if constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN in value:
+        if not engine_name:
+            raise TankError(
+                "Cannot resolve dynamic engine token in setting: %s!" %
+                (value,)
+            )
+        value = value.replace(
+            constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)
+
+    if not value.startswith("{"):
+        # This is an old-style hook. In order to maintain backward
+        #  compatibility, return the value in the new style.
+        value = "{self}/%s.py" % (value,)
+
+    # the remaining tokens ({self}, {config}, {tk-framework-...}) will be
+    # resolved at runtime just before the hook is executed.
+    return value
+

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -847,11 +847,12 @@ def resolve_default_value(schema, default=None, engine_name=None):
     # Engine-specific default value keys are allowed (ex:
     # "default_value_tk-maya"). If an engine name was supplied,
     # build the corresponding engine-specific default value key.
+    engine_default_key = None
     if engine_name:
-        engine_default_key = "%s_%s" % (constants.TANK_SCHEMA_DEFAULT_VALUE_KEY,
-            engine_name)
-    else:
-        engine_default_key = None
+        engine_default_key = "%s_%s" % (
+            constants.TANK_SCHEMA_DEFAULT_VALUE_KEY,
+            engine_name
+        )
 
     # Now look for a default value to use.
     if engine_default_key and engine_default_key in schema:
@@ -891,13 +892,12 @@ def _resolve_default_hook_value(value, engine_name=None):
         value, but no engine name is provided.
     """
 
-    # Replace the engine reference token if it exists.
-    if constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN in value:
-        if not engine_name:
-            raise TankError(
-                "Cannot resolve dynamic engine token in setting: %s!" %
-                (value,)
-            )
+    # Replace the engine reference token if it exists and there is an engine.
+    # In some instances, such as during engine startup, as apps are being
+    # validated, the engine instance name may not be available. This is ok
+    # since hooks are actually validated just before they are executed. We'll
+    # simply return the value with the engine name token.
+    if engine_name and constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN in value:
         value = value.replace(
             constants.TANK_HOOK_ENGINE_REFERENCE_TOKEN, engine_name)
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -888,8 +888,6 @@ def _resolve_default_hook_value(value, engine_name=None):
     :param engine_name: The name of the engine for engine-specific hook values
     :return: The resolved hook default value.
 
-    :raises: TankError - if an engine name token is found in the supplied
-        value, but no engine name is provided.
     """
 
     # Replace the engine reference token if it exists and there is an engine.

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -115,6 +115,11 @@ CONFIG_BACK_MAPPING_FILE = "tank_configs.yml"
 # default value for hooks
 TANK_BUNDLE_DEFAULT_HOOK_SETTING = "default"
 
+# the key name used to identify default values in a manifest file. used as both
+# the actual key as well as the prefix for engine-specific default value keys.
+# example: "default_value_tk-maya".
+TANK_SCHEMA_DEFAULT_VALUE_KEY = "default_value"
+
 # default method to execute on hooks
 DEFAULT_HOOK_METHOD = "execute"
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -120,6 +120,10 @@ TANK_BUNDLE_DEFAULT_HOOK_SETTING = "default"
 # example: "default_value_tk-maya".
 TANK_SCHEMA_DEFAULT_VALUE_KEY = "default_value"
 
+# A (hopefully) not used value used to test against a missing default value
+# in the schema. This allows None/null to be acceptable as a default value.
+TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE = "XXX_NO_DEFAULT_VALUE_XXX"
+
 # default method to execute on hooks
 DEFAULT_HOOK_METHOD = "execute"
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -120,10 +120,6 @@ TANK_BUNDLE_DEFAULT_HOOK_SETTING = "default"
 # example: "default_value_tk-maya".
 TANK_SCHEMA_DEFAULT_VALUE_KEY = "default_value"
 
-# A (hopefully) not used value used to test against a missing default value
-# in the schema. This allows None/null to be acceptable as a default value.
-TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE = "XXX_NO_DEFAULT_VALUE_XXX"
-
 # default method to execute on hooks
 DEFAULT_HOOK_METHOD = "execute"
 

--- a/python/tank/platform/qt/config_item.py
+++ b/python/tank/platform/qt/config_item.py
@@ -17,6 +17,8 @@ import sys
 from . import QtCore, QtGui
 from .ui_item import Ui_Item
 from .. import constants
+from tank.platform.bundle import resolve_default_value
+from tank.platform.engine import current_engine
 
 class ConfigItem(QtGui.QWidget):
     """
@@ -29,7 +31,11 @@ class ConfigItem(QtGui.QWidget):
         self.ui = Ui_Item() 
         self.ui.setupUi(self)
 
-        default_val = params.get("default_value")
+        engine_name = None
+        if current_engine():
+            engine_name = current_engine().name
+
+        default_val = resolve_default_value(params, engine_name=engine_name)
         param_type = params.get("type")
 
         self.ui.name.setText("Setting %s" % setting)

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -322,7 +322,7 @@ class TankQDialog(TankDialogBase):
             else:
                 # enumerate configuration items            
                 for setting, params in self._bundle.descriptor.get_configuration_schema().items():        
-                    value = self._bundle.settings.get(setting)
+                    value = self._bundle.get_setting(setting, None)
                     self._add_settings_item(setting, params, value)
 
         ########################################################################################

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -402,10 +402,10 @@ class _SettingsValidator:
             else:
                 # Use the fallback default with an unlikely to be used value to
                 # detect cases where there is no default value in the schema.
-                no_default_value = constants.TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE
-                settings_value = resolve_default_value(value_schema,
-                    no_default_value)
-                if settings_value == no_default_value:
+                try:
+                    settings_value = resolve_default_value(value_schema,
+                        raise_if_missing=True)
+                except TankError:
                     # could not identify a default value. that may be because
                     # the default is engine-specific and there is no regular
                     # "default_value". See if there are any engine-specific
@@ -418,8 +418,9 @@ class _SettingsValidator:
                         continue
                     else:
                         raise TankError(
-                            "Could not determine value for key '%s' in settings! "
-                            "No specified value and no default value." % settings_key
+                            "Could not determine value for key '%s' in "
+                            "settings! No specified value and no default value."
+                            % (settings_key,)
                         )
 
             self.__validate_settings_value(settings_key, value_schema, settings_value)

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -402,7 +402,7 @@ class _SettingsValidator:
             else:
                 # Use the fallback default with an unlikely to be used value to
                 # detect cases where there is no default value in the schema.
-                no_default_value = "__NO_DEFAULT_VALUE_IN_SCHEMA__"
+                no_default_value = constants.TANK_SCHEMA_NO_DEFAULT_VALUE_TEST_VALUE
                 settings_value = resolve_default_value(value_schema,
                     no_default_value)
                 if settings_value == no_default_value:

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -401,6 +401,8 @@ class _SettingsValidator:
                 # value exists in the settings. use it.
                 settings_value = settings[settings_key]
             else:
+                # Use the fallback default with an unlikely to be used value to
+                # detect cases where there is no default value in the schema.
                 no_default_value = "__NO_DEFAULT_VALUE_IN_SCHEMA__"
                 settings_value = resolve_default_value(value_schema,
                     no_default_value)

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -305,13 +305,12 @@ class _SchemaValidator:
 
             if not _validate_expected_data_type(data_type, default_value):
                 params = (
-                    default_value_key,
                     settings_key,
                     self._display_name,
                     type(default_value).__name__,
                     data_type
                 )
-                err_msg = "Invalid type for '%s' in schema '%s' for '%s' - found '%s', expected '%s'" % params
+                err_msg = "Invalid type for default value in schema '%s' for '%s' - found '%s', expected '%s'" % params
                 raise TankError(err_msg)
 
         if data_type == "list":

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -17,7 +17,7 @@ import re
 import sys
 
 from . import constants
-from ..errors import TankError
+from ..errors import TankError, TankNoDefaultValueError
 from ..template import TemplateString
 from .bundle import resolve_default_value
 
@@ -405,7 +405,7 @@ class _SettingsValidator:
                 try:
                     settings_value = resolve_default_value(value_schema,
                         raise_if_missing=True)
-                except TankError:
+                except TankNoDefaultValueError:
                     # could not identify a default value. that may be because
                     # the default is engine-specific and there is no regular
                     # "default_value". See if there are any engine-specific

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -405,13 +405,13 @@ class _SettingsValidator:
                     # string and allow the validation code do its thing.
                     settings_value = constants.TANK_BUNDLE_DEFAULT_HOOK_SETTING
                 else:
-                    settings_value = value_schema.get("default_value", None)
-
-            # if no value, then can't validate the setting. raise.
-            if settings_value is None:
-                raise TankError(
-                    "Could not determine value for key '%s' in settings!"
-                    "No specified value and no default value." % settings_key)
+                    if "default_value" not in value_schema:
+                        # if no value, then can't validate the setting. raise.
+                        raise TankError(
+                            "Could not determine value for key '%s' in settings!"
+                            "No specified value and no default value." % settings_key)
+                    else:
+                        settings_value = value_schema.get("default_value", None)
 
             self.__validate_settings_value(settings_key, value_schema, settings_value)
     

--- a/tests/fixtures/config/bundles/test_app/hooks/test_hook-test_engine.py
+++ b/tests/fixtures/config/bundles/test_app/hooks/test_hook-test_engine.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class TestHook(Hook):
+    
+    def execute(self, dummy_param):
+        return True
+        

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -119,7 +119,13 @@ configuration:
         type: list
         values:
             type: str
-    
+
+    test_allow_empty_list:
+        type: list
+        allows_empty: True
+        values:
+            type: str
+
     test_complex_list:
         type: list
         values:

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -126,6 +126,12 @@ configuration:
         values:
             type: str
 
+    test_allow_empty_dict:
+        type: dict
+        allows_empty: True
+        values:
+            type: str
+
     test_complex_list:
         type: list
         values:
@@ -176,6 +182,10 @@ configuration:
     test_bool_sparse:
         type: bool
         default_value: true
+
+    test_empty_str_sparse:
+        type: str
+        default_value: ""
 
     test_template_sparse:
         type: template

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -74,16 +74,21 @@ configuration:
     test_hook_new_style_config_old_style_hook:
         type: hook
         default_value: "test_hook"
-    
+
+    test_hook_new_style_config_old_style_engine_specific_hook:
+        type: hook
+
     test_default_syntax_with_new_style_hook:
         type: hook
         default_value: "{self}/test_hook.py"
-    
+
+    test_default_syntax_with_new_style_engine_specific_hook:
+        type: hook
+
     test_default_syntax_missing_implementation:
         type: hook
         default_value: "{self}/thisfiledoesnotexist.py"
-    
-    
+
     test_icon:
         type: config_path
 
@@ -144,6 +149,80 @@ configuration:
                             test_str:
                                 type: str
 
+    # ---- sparse config
+
+    # these values mimic those found in the test environment file test.yml.
+    # the unit tests should behave identially to the unit tests checking the
+    # values in the environment.
+
+    test_str_sparse:
+        type: str
+        default_value: a
+
+    test_int_sparse:
+        type: int
+        default_value: 1
+
+    test_float_sparse:
+        type: float
+        default_value: 1.1
+
+    test_bool_sparse:
+        type: bool
+        default_value: true
+
+    test_template_sparse:
+        type: template
+        required_fields: [name,version]
+        default_value: maya_publish_name
+
+    test_hook_std_sparse:
+        type: hook
+        default_value: "{config}/config_test_hook.py"
+
+    test_hook_default_sparse:
+        type: hook
+        default_value: "test_hook"
+        # this will be resolved to "{self}/test_hook.py"
+
+    test_hook_env_var_sparse:
+        type: hook
+        default_value: "{$TEST_ENV_VAR}/test_env_var_hook.py"
+
+    test_hook_self_sparse:
+        type: hook
+        default_value: "{self}/test_hook.py"
+
+    # engine-specific sparse hooks
+
+    test_hook_new_style_config_old_style_engine_specific_hook_sparse:
+        type: hook
+        default_value: "test_hook-{engine_name}"
+
+    test_default_syntax_with_new_style_engine_specific_hook_sparse:
+        type: hook
+        default_value: "{self}/test_hook-{engine_name}.py"
+
+    # default value testing
+
+    test_engine_specific_default:
+        type: str
+        default_value_test_engine: "foobar"
+        default_value: "barfoo"
+
+    test_engine_specific_multi:
+        type: str
+        default_value_test_engine: "foobar"
+        default_value_test_engine2: "bazoo"
+        default_value: "barfoo"
+
+    test_engine_specific_default_only:
+        type: str
+        default_value_test_engine: "foobar"
+
+    test_engine_specific_default_wrong:
+        type: str
+        default_value_tk-maya: "foobar"
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -35,6 +35,8 @@ engines:
                 test_default_syntax_with_new_style_engine_specific_hook: "{self}/test_hook-{engine_name}.py"
                 test_default_syntax_missing_implementation: "{config}/no_app_implementation.py"
 
+                test_no_schema: 1234.5678
+
                 test_simple_dictionary:
                     test_str: a
                     test_int: 1

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -30,8 +30,9 @@ engines:
                 test_hook_inheritance_old_style_fails: "{self}/inheritance_old_style_fails.py"
                 
                 test_hook_new_style_config_old_style_hook: "{config}/config_test_hook.py"
+                test_hook_new_style_config_old_style_engine_specific_hook: "{config}/config_test_hook-{engine_name}.py"
                 test_default_syntax_with_new_style_hook: default
-                
+                test_default_syntax_with_new_style_engine_specific_hook: "{self}/test_hook-{engine_name}.py"
                 test_default_syntax_missing_implementation: "{config}/no_app_implementation.py"
 
                 test_simple_dictionary:

--- a/tests/fixtures/config/hooks/config_test_hook-test_engine.py
+++ b/tests/fixtures/config/hooks/config_test_hook-test_engine.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class TestHook(Hook):
+    
+    def execute(self, dummy_param):
+        return True
+        
+    def second_method(self, another_dummy_param):
+        return True

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -120,6 +120,7 @@ class TestGetSetting(TestApplication):
         self.assertEqual(1, self.app.get_setting("test_int_sparse"))
         self.assertEqual(1.1, self.app.get_setting("test_float_sparse"))
         self.assertEqual(True, self.app.get_setting("test_bool_sparse"))
+        self.assertEqual("", self.app.get_setting("test_empty_str_sparse"))
 
         tmpl_sparse = self.app.get_template("test_template_sparse")
         self.assertEqual("maya_publish_name", tmpl.name)
@@ -128,8 +129,9 @@ class TestGetSetting(TestApplication):
         # test legacy case where a setting has no schema
         self.assertEqual(1234.5678, self.app.get_setting("test_no_schema"))
 
-        # test empty list without default
+        # test allow empty types with no default
         self.assertEqual([], self.app.get_setting("test_allow_empty_list"))
+        self.assertEqual({}, self.app.get_setting("test_allow_empty_dict"))
 
         # test the default values of sparse hooks
         self.assertEqual(

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -125,7 +125,42 @@ class TestGetSetting(TestApplication):
         self.assertEqual("maya_publish_name", tmpl.name)
         self.assertIsInstance(tmpl_sparse, Template)
 
+        # test legacy case where a setting has no schema
+        self.assertEqual(1234.5678, self.app.get_setting("test_no_schema"))
 
+        # test empty list without default
+        self.assertEqual([], self.app.get_setting("test_allow_empty_list"))
+
+        # test the default values of sparse hooks
+        self.assertEqual(
+            "{config}/config_test_hook.py",
+            self.app.get_setting("test_hook_std_sparse")
+        )
+
+        self.assertEqual(
+            "{self}/test_hook.py",
+            self.app.get_setting("test_hook_default_sparse")
+        )
+
+        self.assertEqual(
+            "{$TEST_ENV_VAR}/test_env_var_hook.py",
+            self.app.get_setting("test_hook_env_var_sparse")
+        )
+
+        self.assertEqual(
+            "{self}/test_hook.py",
+            self.app.get_setting("test_hook_self_sparse")
+        )
+
+        self.assertEqual(
+            "{self}/test_hook-test_engine.py",
+            self.app.get_setting("test_hook_new_style_config_old_style_engine_specific_hook_sparse")
+        )
+
+        self.assertEqual(
+            "{self}/test_hook-test_engine.py",
+            self.app.get_setting("test_default_syntax_with_new_style_engine_specific_hook_sparse")
+        )
 
 class TestExecuteHookByName(TestApplication):
     

--- a/tests/platform_tests/test_validation.py
+++ b/tests/platform_tests/test_validation.py
@@ -188,7 +188,7 @@ class TestValidateSettings(TankTestBase):
         key = "some_name"
         schema = {key:{"type":"str"}}
 
-        expected_msg = "Missing required key '%s' in settings!" % key 
+        expected_msg = "Could not determine value for key '%s' in settings! No specified value and no default value." % key
         self.check_error_message(TankError, expected_msg, validate_settings, self.app_name, self.tk, self.context, schema, settings)
 
     def test_hook_does_not_exist(self):


### PR DESCRIPTION
These changes eliminate the requirement that all bundle settings must be explicitly specified in an environment. The new behavior uses the `default_value` specified in the bundle's `info.yml` manifest as a fallback at runtime when not specified in the environment file.

Any `tank` commands (`update`, `install`, etc) that modify environment files will no longer populate new settings and set their values to the manifest's corresponding default value. Settings with no default value will still be added to the environment after prompting the user for a value. It should be pointed out that no existing settings will be removed from environment files with the changes. 