### PR TITLE
for our discussion: generic logging to disk

### DIFF
--- a/python/tank_vendor/shotgun_base/__init__.py
+++ b/python/tank_vendor/shotgun_base/__init__.py
@@ -12,8 +12,8 @@ from .paths import get_pipeline_config_cache_root, get_cache_bundle_folder_name
 from .paths import get_legacy_pipeline_config_cache_root, get_legacy_bundle_install_folder
 from .paths import get_cache_root, get_site_cache_root, get_logs_root
 from .utils import copy_folder, move_folder, copy_file
-from .utils import touch_file, ensure_folder_exists
+from .utils import touch_file, ensure_folder_exists, create_valid_filename
 from .utils import append_folder_to_path, safe_delete_file, get_shotgun_storage_key, sanitize_path
 from .errors import ShotgunBaseError
-from .log import get_sgtk_logger
+from .log import get_sgtk_logger, initialize_base_file_logger
 

--- a/python/tank_vendor/shotgun_base/log.py
+++ b/python/tank_vendor/shotgun_base/log.py
@@ -9,9 +9,22 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import logging
+import logging.handlers
+import os
+
+from .paths import get_logs_root
 
 sgtk_root_logger = logging.getLogger("sgtk")
 sgtk_root_logger.propagate = False
+# the basic logger object has its message throughput
+# level set to DEBUG. Individual handlers attaching
+# to this logger should then individually adjust
+# their preferred display level.
+sgtk_root_logger.setLevel(logging.DEBUG)
+
+# a global and standard rotating log file handler
+# for writing generic toolkit logs to disk
+std_file_handler = None
 
 def get_sgtk_logger(name=None):
     """
@@ -48,3 +61,54 @@ def get_shotgun_base_logger():
     :return: Python logger
     """
     return get_sgtk_logger("base")
+
+def initialize_base_file_logger(log_name):
+    """
+    Create a standard handler and attach it to the stgk base logger.
+    This will write a file to disk in a standard location and will capture
+    all log messsages pass through the stgk log hierarchy.
+
+    In order to avoid writing out the same log information
+    in multiple files, this method ensures that only one
+    base file logger can exist at one time. If this method
+    is called multiple times with different log names, only
+    the last one will be active.
+
+    :param log_name: Name of logger to create. This will form the
+                     filename of the log file.
+    """
+    # avoid cyclic imports
+    from . import ensure_folder_exists
+    from . import create_valid_filename
+
+    global std_file_handler
+
+    if std_file_handler:
+        # there is already a log handler.
+        # terminate previous one
+        get_shotgun_base_logger().removeHandler(std_file_handler)
+        std_file_handler = None
+
+    # set up logging root folder
+    log_folder = get_logs_root()
+    ensure_folder_exists(log_folder)
+
+    # generate log path
+    log_file = os.path.join(
+        log_folder,
+        "%s.log" % create_valid_filename(log_name)
+    )
+
+    std_file_handler = logging.handlers.RotatingFileHandler(
+        log_file,
+        maxBytes=1024*1024,
+        backupCount=5)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(process)-5d %(levelname)-7s] %(name)s - %(message)s"
+    )
+    std_file_handler.setFormatter(formatter)
+    get_shotgun_base_logger().addHandler(std_file_handler)
+
+    # log the fact that we set up the log file :)
+    log = get_shotgun_base_logger()
+    log.debug("Writing to log standard log file %s" % log_file)

--- a/python/tank_vendor/shotgun_base/paths.py
+++ b/python/tank_vendor/shotgun_base/paths.py
@@ -12,12 +12,13 @@ import os
 import sys
 import urlparse
 
+
 def get_cache_root():
     """
     Returns a cache root suitable for all Shotgun related data,
-    regardless of site.
+    regardless of Shotgun site.
 
-    The following paths will be generated:
+    The following paths will be computed:
 
     - macosx: ~/Library/Caches/Shotgun
     - windows: %APPDATA%\Shotgun
@@ -29,13 +30,13 @@ def get_cache_root():
         root = os.path.expanduser("~/Library/Caches/Shotgun")
 
     elif sys.platform == "win32":
-        root = os.path.join(os.environ["APPDATA"], "Shotgun")
+        root = os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun")
 
     elif sys.platform.startswith("linux"):
         root = os.path.expanduser("~/.shotgun")
 
     else:
-        raise RuntimeError("Unsupported operating system!")
+        raise NotImplementedError("Unknown platform: %s" % sys.platform)
 
     return root
 
@@ -132,22 +133,27 @@ def get_cache_bundle_folder_name(bundle):
 
 def get_logs_root():
     """
-    Returns the platform specific location of the logfiles.
+    Returns a root folder suitable for all shotgun log files,
+    regardless of Shotgun site.
 
-    :returns: Path to the logfile.
+    The following paths will be computed:
+
+    - macosx: ~/Library/Logs/Shotgun
+    - windows: %APPDATA%\Shotgun\logs
+    - linux: ~/.shotgun/logs
+
+    :returns: The calculated location for the cache root
+
     """
     if sys.platform == "darwin":
-        fname = os.path.join(os.path.expanduser("~"), "Library", "Logs", "Shotgun")
+        root = os.path.join(os.path.expanduser("~"), "Library", "Logs", "Shotgun")
     elif sys.platform == "win32":
-        fname = os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun")
+        root = os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun", "logs")
     elif sys.platform.startswith("linux"):
-        fname = os.path.join(os.path.expanduser("~"), ".shotgun", "logs")
+        root = os.path.join(os.path.expanduser("~"), ".shotgun", "logs")
     else:
         raise NotImplementedError("Unknown platform: %s" % sys.platform)
-    return fname
-
-
-# ---- legacy path methods
+    return root
 
 
 def get_legacy_pipeline_config_cache_root(site_url, project_id, pipeline_configuration_id):

--- a/python/tank_vendor/shotgun_base/utils.py
+++ b/python/tank_vendor/shotgun_base/utils.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import re
 import sys
 import errno
 import stat
@@ -330,3 +331,27 @@ def move_folder(src, dst, folder_permissions=0775):
                 os.remove(f)
             except Exception, e:
                 log.error("Could not delete file %s: %s" % (f, e))
+
+
+def create_valid_filename(value):
+    """
+    Create a sanitized file name given a string.
+    Replaces spaces and other characters with underscores
+
+    'my lovely name ' -> 'my_lovely_name'
+
+    :param value: String value to sanitize
+    :returns: sanitized string
+    """
+    # regex to find non-word characters - in ascii land, that is [^A-Za-z0-9_]
+    # note that we use a unicode expression, meaning that it will include other
+    # "word" characters, not just A-Z.
+    exp = re.compile(u"\W", re.UNICODE)
+
+    # strip trailing whitespace
+    value = value.strip()
+
+    # assume string is utf-8 encoded. decode, replace
+    # and re-encode the returned result
+    u_src = value.decode("utf-8")
+    return exp.sub("_", u_src).encode("utf-8")

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/shotgun_entity.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/shotgun_entity.py
@@ -16,7 +16,7 @@ from .base import IODescriptorBase
 from .. import util
 from ..zipfilehelper import unzip_file
 from ..errors import ShotgunDeployError
-from ...shotgun_base import ensure_folder_exists, safe_delete_file
+from ...shotgun_base import ensure_folder_exists, safe_delete_file, create_valid_filename
 
 log = util.get_shotgun_deploy_logger()
 
@@ -110,7 +110,7 @@ class IODescriptorShotgunEntity(IODescriptorBase):
             name = "p%s_%s" % (self._project_id, self._name)
         else:
             name = self._name
-        return util.create_valid_filename(name)
+        return create_valid_filename(name)
 
     def get_version(self):
         """

--- a/python/tank_vendor/shotgun_deploy/manager.py
+++ b/python/tank_vendor/shotgun_deploy/manager.py
@@ -18,7 +18,7 @@ from . import util
 from . import zipfilehelper
 from . import Descriptor, create_descriptor
 from . import constants
-from ..shotgun_base import ensure_folder_exists
+from ..shotgun_base import ensure_folder_exists, initialize_base_file_logger
 from .errors import ShotgunDeployError
 from .configuration import Configuration, create_installed_configuration
 from .resolver import BaseConfigurationResolver
@@ -202,6 +202,10 @@ class ToolkitManager(object):
         :param project_id: Project to bootstrap into, None for site mode
         :returns: sgtk instance
         """
+        # begin writing log to disk. Base the log file name
+        # on the current namespace we are launching into
+        initialize_base_file_logger(self.namespace)
+
         log.debug("Begin bootstrapping sgtk.")
 
         # get an object to represent the business logic for
@@ -531,7 +535,6 @@ class ToolkitManager(object):
     #
     #     return pc_id
     #
-
 
     def _report_progress(self, message, curr_idx=None, max_idx=None):
         """

--- a/python/tank_vendor/shotgun_deploy/paths.py
+++ b/python/tank_vendor/shotgun_deploy/paths.py
@@ -43,7 +43,7 @@ def get_configuration_cache_root(site_url, project_id, pipeline_configuration_id
             pipeline_configuration_id
         ),
         "cfg",
-        util.create_valid_filename(namespace)
+        shotgun_base.create_valid_filename(namespace)
     )
     shotgun_base.ensure_folder_exists(config_cache_root)
     return config_cache_root
@@ -63,7 +63,7 @@ def get_configuration_info_path(site_url, project_id, pipeline_configuration_id,
                       e.g. 'maya', 'rv', 'desktop'.
     :returns: path on disk to file
     """
-    sanitized_namespace = util.create_valid_filename(namespace)
+    sanitized_namespace = shotgun_base.create_valid_filename(namespace)
     cache_filename = "%s_info.yml" % sanitized_namespace
 
     config_info_path = os.path.join(

--- a/python/tank_vendor/shotgun_deploy/util.py
+++ b/python/tank_vendor/shotgun_deploy/util.py
@@ -88,30 +88,6 @@ def execute_git_command(cmd):
             "returned error code %s." % (cmd, status)
         )
 
-def create_valid_filename(value):
-    """
-    Create a sanitized file name given a string.
-    Replaces spaces and other characters with underscores
-
-    'my lovely name ' -> 'my_lovely_name'
-
-    :param value: String value to sanitize
-    :returns: sanitized string
-    """
-    # regex to find non-word characters - in ascii land, that is [^A-Za-z0-9_]
-    # note that we use a unicode expression, meaning that it will include other
-    # "word" characters, not just A-Z.
-    exp = re.compile(u"\W", re.UNICODE)
-
-    # strip trailing whitespace
-    value = value.strip()
-
-    # assume string is utf-8 encoded. decode, replace
-    # and re-encode the returned result
-    u_src = value.decode("utf-8")
-    return exp.sub("_", u_src).encode("utf-8")
-
-
 class SubprocessCalledProcessError(Exception):
     """
     Subprocess exception


### PR DESCRIPTION
I did a super-quick spike to kick off our discussion about logging to disk. I think it's easier to think about it with this first step of code, and it helped me formulate some of the questions i knew I had.

### Generation of log messages

With 0.18, we introduce the notion of a root logger for sgtk. This is defined in `shotgun_base` module (https://github.com/shotgunsoftware/tk-core/blob/develop/0.18/python/tank_vendor/shotgun_base/log.py#L16) and forms the beginnings of a more unified logging system for sgtk. The auth and deploy modules are parented under this logging. By hooking up a handler to this logger, you get all of loolkit logging. The logging is hierarchical.

Then - for our discussion - a natural next step would be to hook up the engine logging methods so that we get for example a `sgtk.platform.tk-maya` namespace where the maya engine and app logging get dispatched. (each app instance could be a child logger of the engine logger too which is kinda neat!

As a third pass, we can look at code where we are specifically passing round log objects (tank commands, path cache syncing, some special places.). I think it would be easy to "anchor" these log objects in the `sgtk` tree - probably a quick change so that when each of these loggers are created, we just put them into the right place in the logging hierarchy.

This addresses the generation of log messages but in 0.18 we haven't yet done any work on the consumer side.

### Consumption of log messages

The new `shotgun_base` module makes it easy for any integrating system (maya, desktop, RV) to hook up the new logging tree with their internal logging facilities. This hooking-up "plumbing" is likely to be specific to the integration target.

In addition to a user facing log stream, it is super useful to have a standard channel to disk. This pull request implements a simple version of this, which automatically sets up a log file on disk whenever someone instantiates a tk instance via the bootstrap. The log file is currently tied to the namespace we are launching into, with namespace loosely capturing the "integration environment" toolkit is in. Here are some questions to kick off further conversation:

- In this PR, the logging begins when the launching of a `tk` instance begins. Do we want to log prior to this? What's the best way to do that? I am thinking about desktop specifically. 

- Heads up that this implementation adds a "logs" folder to the std windows log location for consistency.

- Right now, we write out debug. How do we want to manage that log level? Do we need to?

- How does this work with existing log generation we already have? engine level logging should be fine - I am guessing we would upgrade each engine separately to potentially wire it into this new logging system, and at that point we would also remove any old specific logging logic that is no longer needed. What about more low level things like desktop?

- The file logger is "singleton" in the sense that it only allows for one std file to be written to - no sense having two standard log files writing out the same content. We could for example "swap files" when an engine is created so that messages are then written to a `tk-maya` file for example. With this, we could skip the current name space based file naming and just call the log `sgtk` at first. Alternatively, we could add the ability for the integration code to name it (a property on the Toolkit Manager).

- We won't' run everything through the bootstrap -- something like the launch-app kicking off the maya engine will not use the bootstrap so we would have to add logic somewhere else too to make sure logging was initiated for this case. With the engine centralization and the idea of adding a `sgtk.platform.launch_dcc()` command, this could be a good place to put it.

Hopefully this is enough context and questions to figure out a good direction for this and try to figure out what the right amount of work to do for the time being would be. Over to you guys @thebeeland @robblau @jfboismenu :)
