### PR TITLE
#34715: Adds config syntax to source hooks from the engine the app is running in

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -607,10 +607,10 @@ class TankBundle(object):
                     "engine. Unable to resolve hook path for: '%s'" %
                     (self, settings_name, hook_expression)
                 )
-            else:
-                hooks_folder = os.path.join(engine.disk_location, "hooks")
-                path = hook_expression.replace("{engine}", hooks_folder)
-                path = path.replace("/", os.path.sep)
+
+            hooks_folder = os.path.join(engine.disk_location, "hooks")
+            path = hook_expression.replace("{engine}", hooks_folder)
+            path = path.replace("/", os.path.sep)
         
         elif hook_expression.startswith("{$") and "}" in hook_expression:
             # environment variable: {$HOOK_PATH}/path/to/foo.py

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -439,6 +439,7 @@ class TankBundle(object):
         - hook_expression: {$HOOK_PATH}/path/to/foo.py  -- expression based around an environment variable.
         - hook_expression: {self}/path/to/foo.py -- looks in the hooks folder in the local app, engine of framework.
         - hook_expression: {config}/path/to/foo.py -- Looks in the hooks folder in the project config.
+        - hook_expression: {engine}/path/to/foo.py -- looks in the hooks folder of the current engine.
         - hook_expression: {tk-framework-perforce_v1.x.x}/path/to/foo.py -- looks in the hooks folder of a
           framework instance that exists in the current environment. Basically, each entry inside the 
           frameworks section in the current environment can be specified here - all these entries are 
@@ -595,6 +596,21 @@ class TankBundle(object):
             hooks_folder = self.tank.pipeline_configuration.get_hooks_location()
             path = hook_expression.replace("{config}", hooks_folder)
             path = path.replace("/", os.path.sep)
+
+        elif hook_expression.startswith("{engine}"):
+            # look for the hook in the currently running engine
+            try:
+                engine = self.engine
+            except AttributeError:
+                raise TankError(
+                    "%s config setting %s: Could not determine the current "
+                    "engine. Unable to resolve hook path for: '%s'" %
+                    (self, settings_name, hook_expression)
+                )
+            else:
+                hooks_folder = os.path.join(engine.disk_location, "hooks")
+                path = hook_expression.replace("{engine}", hooks_folder)
+                path = path.replace("/", os.path.sep)
         
         elif hook_expression.startswith("{$") and "}" in hook_expression:
             # environment variable: {$HOOK_PATH}/path/to/foo.py
@@ -662,6 +678,7 @@ class TankBundle(object):
         - hook_setting: {$HOOK_PATH}/path/to/foo.py  -- environment variable.
         - hook_setting: {self}/path/to/foo.py   -- looks in the hooks folder in the local bundle
         - hook_setting: {config}/path/to/foo.py -- looks in the hooks folder in the config
+        - hook_setting: {engine}/path/to/foo.py -- looks in the hooks folder of the current engine.
         - hook_setting: {tk-framework-perforce_v1.x.x}/path/to/foo.py -- looks in the hooks folder of a
           framework instance that exists in the current environment. Basically, each entry inside the 
           frameworks section in the current environment can be specified here - all these entries are 
@@ -926,7 +943,7 @@ def _resolve_default_hook_value(value, engine_name=None):
         #  compatibility, return the value in the new style.
         value = "{self}/%s.py" % (value,)
 
-    # the remaining tokens ({self}, {config}, {tk-framework-...}) will be
-    # resolved at runtime just before the hook is executed.
+    # the remaining tokens ({self}, {config}, {engine}, {tk-framework-...})
+    # will be resolved at runtime just before the hook is executed.
     return value
 

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -608,7 +608,20 @@ class _SettingsValidator:
             # config hook 
             path = hook_name.replace("{config}", hooks_folder)
             hook_path = path.replace("/", os.path.sep)
-        
+
+        elif hook_name.startswith("{engine}"):
+            # engine hook. see if there is a current engine we can use to
+            # validate against. there should be an engine, but in the case
+            # where validation is being run outside of or before engine
+            # startup, continue and assume the hook exists similar to app
+            # hooks.
+            from .engine import current_engine
+            if current_engine():
+                path = os.path.join(current_engine().disk_location, "hooks")
+                hook_path = path.replace("/", os.path.sep)
+            else:
+                return
+
         elif hook_name.startswith("{$") and "}" in hook_name:
             # environment variable: {$HOOK_PATH}/path/to/foo.py
             # lazy (runtime) validation for this - it may be beneficial

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -52,6 +52,8 @@ configuration:
     test_hook_config:
         type: hook
 
+    test_hook_engine:
+        type: hook
 
     test_hook_inheritance_1:
         type: hook
@@ -61,7 +63,10 @@ configuration:
         type: hook
         default_value: "{self}/inheritance2.py"
         
-        
+    test_hook_inheritance_3:
+        type: hook
+        default_value: "{self}/inheritance2.py"
+
     test_hook_inheritance_old_style:
         type: hook
         default_value: "{self}/inheritance_old_style.py"
@@ -195,6 +200,10 @@ configuration:
     test_hook_std_sparse:
         type: hook
         default_value: "{config}/config_test_hook.py"
+
+    test_hook_engine_sparse:
+        type: hook
+        default_value: "{engine}/engine_test_hook.py"
 
     test_hook_default_sparse:
         type: hook

--- a/tests/fixtures/config/bundles/test_engine/hooks/engine_test_hook.py
+++ b/tests/fixtures/config/bundles/test_engine/hooks/engine_test_hook.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class TestHook(Hook):
+    
+    def execute(self, dummy_param):
+        return True
+        
+    def second_method(self, another_dummy_param):
+        return True

--- a/tests/fixtures/config/bundles/test_engine/hooks/foo/bar.py
+++ b/tests/fixtures/config/bundles/test_engine/hooks/foo/bar.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class TestHook(Hook):
+    
+    def execute(self, dummy_param):
+        return True
+        

--- a/tests/fixtures/config/bundles/test_engine/hooks/inherit.py
+++ b/tests/fixtures/config/bundles/test_engine/hooks/inherit.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class TestHook(HookBaseClass):
+    
+    def foo2(self, bar):
+        
+        val = HookBaseClass.foo2(self, bar)
+        
+        return "custom class %s" % val
+        

--- a/tests/fixtures/config/bundles/test_engine/hooks/named_hook.py
+++ b/tests/fixtures/config/bundles/test_engine/hooks/named_hook.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+from tank import Hook
+
+class TestHook(Hook):
+    
+    def execute(self, dummy_param):
+        return "named_hook_1"
+        
+    def second_method(self, another_dummy_param):
+        return "named_hook_2"

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -22,9 +22,11 @@ engines:
                 test_hook_env_var: "{$TEST_ENV_VAR}/test_env_var_hook.py"
                 test_hook_self: "{self}/test_hook.py"
                 test_hook_config: "{config}/foo/bar.py"
+                test_hook_engine: "{engine}/foo/bar.py"
                 
                 test_hook_inheritance_1: "{self}/inheritance1.py"
                 test_hook_inheritance_2: "{config}/inherit.py"
+                test_hook_inheritance_3: "{engine}/inherit.py"
                 
                 test_hook_inheritance_old_style: "{self}/inheritance_old_style.py"
                 test_hook_inheritance_old_style_fails: "{self}/inheritance_old_style_fails.py"

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -140,6 +140,11 @@ class TestGetSetting(TestApplication):
         )
 
         self.assertEqual(
+            "{engine}/engine_test_hook.py",
+            self.app.get_setting("test_hook_engine_sparse")
+        )
+
+        self.assertEqual(
             "{self}/test_hook.py",
             self.app.get_setting("test_hook_default_sparse")
         )
@@ -185,6 +190,11 @@ class TestExecuteHookByName(TestApplication):
         self.assertEqual(app.execute_hook_expression("{config}/named_hook.py", "execute", dummy_param=True), 
                          "named_hook_1")
 
+    def test_engine(self):
+        app = self.engine.apps["test_app"]
+        self.assertEqual(app.execute_hook_expression("{engine}/named_hook.py", "execute", dummy_param=True),
+                         "named_hook_1")
+
     def test_self(self):
         app = self.engine.apps["test_app"]
         self.assertTrue(app.execute_hook_expression("{self}/test_hook.py", "execute", dummy_param=True), 
@@ -210,6 +220,10 @@ class TestExecuteHook(TestApplication):
         app = self.engine.apps["test_app"]
         self.assertTrue(app.execute_hook("test_hook_config", dummy_param=True))
 
+    def test_engine_format(self):
+        app = self.engine.apps["test_app"]
+        self.assertTrue(app.execute_hook("test_hook_engine", dummy_param=True))
+
     def test_default_format(self):
         app = self.engine.apps["test_app"]
         self.assertTrue(app.execute_hook("test_hook_default", dummy_param=True))
@@ -229,6 +243,10 @@ class TestExecuteHook(TestApplication):
     def test_inheritance_2(self):
         app = self.engine.apps["test_app"]
         self.assertEqual(app.execute_hook_method("test_hook_inheritance_2", "foo2", bar=True), "custom class base class")
+
+    def test_inheritance_3(self):
+        app = self.engine.apps["test_app"]
+        self.assertEqual(app.execute_hook_method("test_hook_inheritance_3", "foo2", bar=True), "custom class base class")
 
     def test_inheritance_old_style(self):
         """


### PR DESCRIPTION
This change adds a new config syntax for hooks to allow them to be sourced from within the current engine. The new syntax looks like this:

`hook_setting: {engine}/my_hook.py`

At runtime, the `{engine}` token will be evaluated to the `hooks` directory within the currently running engine. This change makes it possible to package DCC-specific behavior with the engine rather than in each of the individual multi-apps. 

NOTE: This is branched from `34913_sparse_configs` branch as it modifies the same files. This should be merged after that work is complete. 