### PR TITLE
For #35663, race condition in current_bundle

### DIFF
--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -16,29 +16,30 @@ from .engine import start_engine, current_engine, get_engine_path, find_app_sett
 from .application import Application
 from .engine import Engine
 from .framework import Framework
+from .import_stack import ImportStack
 
 from ..errors import TankError, TankContextChangeNotSupportedError
 
 ################################################################################################
 # internal methods
 
+
 def _get_current_bundle():
 
     import sys
-    from .framework import get_current_bundle_doing_import
 
-    # this special variable is set by bundle.import_module() and 
+    # The current import bundle is set by bundle.import_module() and
     # and is a way to defuse the chicken/egg situtation which happens
     # when trying to do an import_framework inside a module that is being
     # loaded by import_module. The crux is that the module._tank_bundle reference
     # that import_module() sets is constructed at the end of the call,
     # meaning that the frameworks import cannot find this during the import
-    # this variable is the fallback in this case and it contains a reference 
+    # this variable is the fallback in this case and it contains a reference
     # to the current bundle.
-    current_bundle = get_current_bundle_doing_import()
+    current_bundle = ImportStack.get_current_bundle()
     if not current_bundle:
-        # try to figure out the associated bundle using module trickery, 
-        # looking for the module which called this command and looking for 
+        # try to figure out the associated bundle using module trickery,
+        # looking for the module which called this command and looking for
         # a ._tank_module property on the module object.
 
         try:
@@ -47,7 +48,7 @@ def _get_current_bundle():
             # get the package name from the caller
             # for example: 0b3d7089471e42a998027fa668adfbe4.tk_multi_about.environment_browser
             calling_name_str = caller.f_globals["__name__"]
-            # now the module imported by Bundle.import_module is 
+            # now the module imported by Bundle.import_module is
             # 0b3d7089471e42a998027fa668adfbe4.tk_multi_about
             # e.g. always the two first items in the name
             chunks = calling_name_str.split(".")
@@ -55,10 +56,10 @@ def _get_current_bundle():
             # get the caller's module from sys.modules
             parent_module = sys.modules[calling_package_str]
         except:
-            raise Exception("import_framework could not determine the calling module layout! " 
+            raise Exception("import_framework could not determine the calling module layout! "
                             "You can only use this method on items imported using the import_module() "
                             "method!")
-        
+
         # ok we got our module
         try:
             current_bundle = parent_module._tank_bundle
@@ -66,7 +67,7 @@ def _get_current_bundle():
             raise Exception("import_framework could not access current app/engine on calling module %s. "
                             "You can only use this method on items imported using the import_module() "
                             "method!" % parent_module)
- 
+
     return current_bundle
 
 

--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -25,26 +25,22 @@ from ..errors import TankError, TankContextChangeNotSupportedError
 def _get_current_bundle():
 
     import sys
-    from .framework import CURRENT_BUNDLE_DOING_IMPORT
-    
-    if len(CURRENT_BUNDLE_DOING_IMPORT) > 0:
-        # this special variable is set by bundle.import_module() and 
-        # and is a way to defuse the chicken/egg situtation which happens
-        # when trying to do an import_framework inside a module that is being
-        # loaded by import_module. The crux is that the module._tank_bundle reference
-        # that import_module() sets is constructed at the end of the call,
-        # meaning that the frameworks import cannot find this during the import
-        # this variable is the fallback in this case and it contains a reference 
-        # to the current bundle.
-        
-        # this variable is a stack, so grab the last element
-        current_bundle = CURRENT_BUNDLE_DOING_IMPORT[-1]
-        
-    else:
+    from .framework import get_current_bundle_doing_import
+
+    # this special variable is set by bundle.import_module() and 
+    # and is a way to defuse the chicken/egg situtation which happens
+    # when trying to do an import_framework inside a module that is being
+    # loaded by import_module. The crux is that the module._tank_bundle reference
+    # that import_module() sets is constructed at the end of the call,
+    # meaning that the frameworks import cannot find this during the import
+    # this variable is the fallback in this case and it contains a reference 
+    # to the current bundle.
+    current_bundle = get_current_bundle_doing_import()
+    if not current_bundle:
         # try to figure out the associated bundle using module trickery, 
         # looking for the module which called this command and looking for 
         # a ._tank_module property on the module object.
-    
+
         try:
             # get the caller's stack frame
             caller = sys._getframe(2)

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -21,6 +21,7 @@ import uuid
 from .. import hook
 from ..errors import TankError, TankContextChangeNotSupportedError
 from . import constants
+from .import_stack import ImportStack
 
 class TankBundle(object):
     """
@@ -318,10 +319,9 @@ class TankBundle(object):
         For more information, see the API documentation.
         """
         # local import to avoid cycles
-        from . import framework
-        
+
         # first, set the module we are currently processing
-        framework.set_current_bundle_doing_import(self)
+        ImportStack.push_current_bundle(self)
         
         try:
         
@@ -348,7 +348,7 @@ class TankBundle(object):
         
         finally:
             # no longer processing this one
-            framework.reset_current_bundle_doing_import()
+            ImportStack.pop_current_bundle()
         
         return sys.modules[mod_name]
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -321,7 +321,7 @@ class TankBundle(object):
         from . import framework
         
         # first, set the module we are currently processing
-        framework.CURRENT_BUNDLE_DOING_IMPORT.append(self)
+        framework.set_current_bundle_doing_import(self)
         
         try:
         
@@ -348,7 +348,7 @@ class TankBundle(object):
         
         finally:
             # no longer processing this one
-            framework.CURRENT_BUNDLE_DOING_IMPORT.pop()
+            framework.reset_current_bundle_doing_import()
         
         return sys.modules[mod_name]
 

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -25,54 +25,6 @@ from .bundle import TankBundle
 from . import validation
 from ..util import log_user_activity_metric
 
-# global variable that holds a stack of references to
-# a current bundle object, per thread - this variable is populated
-# whenever the bundle.import_module method is executed
-# and is a way for import_framework() to be able to resolve
-# the current bundle even when being recursively called 
-# inside an import_module call.
-__threadlocal_storage = threading.local()
-
-
-def _get_thread_import_stack():
-    """
-    Gets the import stack for the current thread.
-
-    :returns: A list of TankBundles.
-    """
-    global __threadlocal_storage
-    if not hasattr(__threadlocal_storage, "import_stack"):
-        __threadlocal_storage.import_stack = []
-    return __threadlocal_storage.import_stack
-
-
-def set_current_bundle_doing_import(bundle):
-    """
-    Sets which bundle we are currently importing from.
-
-    :param bundle: Bundle we are importing from.
-    """
-    _get_thread_import_stack().append(bundle)
-
-
-def reset_current_bundle_doing_import():
-    """
-    Resets the current bundle to the previous value.
-    """
-    _get_thread_import_stack().pop()
-
-
-def get_current_bundle_doing_import():
-    """
-    Retrieves the bundle doing an import in the current thread.
-
-    :returns: A TankBundle derived object.
-    """
-    import_stack = _get_thread_import_stack()
-    if len(import_stack) > 0:
-        return import_stack[-1]
-    return None
-
 
 class Framework(TankBundle):
     """

--- a/python/tank/platform/import_stack.py
+++ b/python/tank/platform/import_stack.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Manages a thread-safe stack of Toolkit imports.
+"""
+
+import threading
+
+
+class ImportStack(object):
+    """
+    Manages a thread-safe stack of Toolkit imports.
+    """
+
+    # global variable that holds a stack of references to
+    # a current bundle object, per thread - this variable is populated
+    # whenever the bundle.import_module method is executed
+    # and is a way for import_framework() to be able to resolve
+    # the current bundle even when being recursively called
+    # inside an import_module call.
+    __threadlocal_storage = threading.local()
+
+    @classmethod
+    def get_current_bundle(cls):
+        """
+        Retrieves the bundle currently importing from.
+
+        :returns: The TankBundle currently importing from.
+        """
+        import_stack = cls._get_thread_import_stack()
+        if len(import_stack) > 0:
+            return import_stack[-1]
+        return None
+
+    @classmethod
+    def push_current_bundle(cls, bundle):
+        """
+        Sets which bundle we are currently importing from.
+
+        :param bundle: Bundle we are importing from.
+        """
+        cls._get_thread_import_stack().append(bundle)
+
+    @classmethod
+    def pop_current_bundle(cls):
+        """
+        Pops the current bundle we're importing from from the stack.
+        """
+        cls._get_thread_import_stack().pop()
+
+    @classmethod
+    def _get_thread_import_stack():
+        """
+        Gets the import stack for the current thread.
+
+        :returns: A list of TankBundles.
+        """
+        global __threadlocal_storage
+        if not hasattr(__threadlocal_storage, "import_stack"):
+            __threadlocal_storage.import_stack = []
+        return __threadlocal_storage.import_stack

--- a/python/tank/platform/import_stack.py
+++ b/python/tank/platform/import_stack.py
@@ -57,13 +57,12 @@ class ImportStack(object):
         cls._get_thread_import_stack().pop()
 
     @classmethod
-    def _get_thread_import_stack():
+    def _get_thread_import_stack(cls):
         """
         Gets the import stack for the current thread.
 
         :returns: A list of TankBundles.
         """
-        global __threadlocal_storage
-        if not hasattr(__threadlocal_storage, "import_stack"):
-            __threadlocal_storage.import_stack = []
-        return __threadlocal_storage.import_stack
+        if not hasattr(cls.__threadlocal_storage, "import_stack"):
+            cls.__threadlocal_storage.import_stack = []
+        return cls.__threadlocal_storage.import_stack


### PR DESCRIPTION
We were tracking the module being imported from in a thread-unsafe manner. Not only multiple threads importing at the same time corrupted the import stack, but threads that were not importing were going to report the wrong current bundle if another thread was importing at the same time.

To fix this, I've introduced a per-thread import stack through the use of thread local storage.