### PR TITLE
for #35708 add syntax for optional environment includes

### DIFF
--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -59,9 +59,13 @@ def _resolve_includes(file_name, data, context):
         includes.extend( data[constants.MULTI_INCLUDE_SECTION] )
 
     for include in includes:
+
+        # Check if this include file is optional or not (starts with a ?). If it is optional, 
+        # then we won't raise an exception if it doesn't exist.
         is_optional = False
         if include.startswith("?"):
             is_optional = True
+            # strip out the ? character to get the true path
             include = include[1:]
 
         if "{" in include:

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -59,7 +59,11 @@ def _resolve_includes(file_name, data, context):
         includes.extend( data[constants.MULTI_INCLUDE_SECTION] )
 
     for include in includes:
-        
+        is_optional = False
+        if include.startswith("?"):
+            is_optional = True
+            include = include[1:]
+
         if "{" in include:
             # it's a template path
             if context is None:
@@ -110,6 +114,8 @@ def _resolve_includes(file_name, data, context):
             full_path = os.path.join(os.path.dirname(file_name), adjusted)
             # make sure that the paths all exist
             if not os.path.exists(full_path):
+                if is_optional:
+                    continue
                 raise TankError("Include Resolve error in %s: Included path %s ('%s') "
                                 "does not exist!" % (file_name, full_path, include))
     
@@ -121,6 +127,8 @@ def _resolve_includes(file_name, data, context):
             full_path = os.path.expandvars(include)
             # make sure that the paths all exist
             if not os.path.exists(full_path):
+                if is_optional:
+                    continue
                 raise TankError("Include Resolve error in %s: Included path %s "
                                 "does not exist!" % (file_name, full_path))
             
@@ -132,6 +140,8 @@ def _resolve_includes(file_name, data, context):
             full_path = os.path.expandvars(include)                    
             # make sure that the paths all exist
             if not os.path.exists(full_path):
+                if is_optional:
+                    continue
                 raise TankError("Include Resolve error in %s: Included path %s "
                                 "does not exist!" % (file_name, full_path))
 


### PR DESCRIPTION
Adds support for optional include files. In the includes section of an environment YAML file, any file path that starts with a `?` will be flagged as optional and if the file does not exist on disk, no error will be raised. This enables you to set a base include file and optionally override it with with another file if it exists. 

``` yaml
includes:
# this file is required to exist
- ./shot_step_base.yml 

# this file will be included if it exists, but won't error if it doesn't.
- ?./shot_step_overrides.yml 
```

If you have multiple projects pointing to a central git repo (or symlinking to a central location), this adds a simple way to make changes to a single project by dropping in an overrides file like in the above example.

Previously, any included file that didn't exist on disk would raise an exception.
