### PR TITLE
for #35774: Sets a default timeout for the Toolkit app store connection

### DIFF
--- a/python/tank_vendor/shotgun_deploy/constants.py
+++ b/python/tank_vendor/shotgun_deploy/constants.py
@@ -50,6 +50,9 @@ PIPELINE_CONFIGURATION_ENTITY_TYPE = "PipelineConfiguration"
 # the location of the toolkit app store
 SGTK_APP_STORE = "https://tank.shotgunstudio.com"
 
+# timeout in secs to apply to TK app store connections
+SGTK_APP_STORE_CONN_TIMEOUT = 5
+
 # the manifest file inside a bundle
 BUNDLE_METADATA_FILE = "info.yml"
 

--- a/python/tank_vendor/shotgun_deploy/errors.py
+++ b/python/tank_vendor/shotgun_deploy/errors.py
@@ -25,3 +25,9 @@ class ShotgunAppStoreError(ShotgunDeployError):
     Errors relating to the shotgun app store
     """
     pass
+
+class ShotgunAppStoreConnectionError(ShotgunAppStoreError):
+    """
+    Errors indicating an error connecting to the Toolkit App Store
+    """
+    pass

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
@@ -17,6 +17,7 @@ import cPickle as pickle
 
 from ..zipfilehelper import unzip_file
 from ..descriptor import Descriptor
+from ..errors import ShotgunAppStoreConnectionError
 from ..errors import ShotgunAppStoreError
 from ..errors import ShotgunDeployError
 from ...shotgun_base import (
@@ -603,21 +604,41 @@ class IODescriptorAppStore(IODescriptorBase):
                     raise
 
 
-            # connect to the app store and resolve the script user id we are connecting with
+            # Connect to the app store and resolve the script user id we are connecting with.
+            # Set the timeout explicitly so we ensure the connection won't hang in cases where
+            # a response is not returned in a reasonable amount of time.
             app_store_sg = shotgun_api3.Shotgun(
                 constants.SGTK_APP_STORE,
                 script_name=script_name,
                 api_key=script_key,
-                http_proxy=self._sg_connection.config.raw_http_proxy
+                http_proxy=self._sg_connection.config.raw_http_proxy,
+                connect=False,
+                timeout_secs=5
             )
 
             # determine the script user running currently
             # get the API script user ID from shotgun
-            script_user = app_store_sg .find_one(
-                "ApiUser",
-                [["firstname", "is", script_name]],
-                fields=["type", "id"]
-            )
+            try:
+                script_user = app_store_sg.find_one(
+                    "ApiUser",
+                    filters=[["firstname", "is", script_name]],
+                    fields=["type", "id"]
+                )
+            # Connection errors can occur for a variety of reasons. For example, there is no 
+            # internet access or there is a proxy server blocking access to the Toolkit app store.
+            except (httplib2.HttpLib2Error, httplib2.socks.HTTPError, httplib.HTTPException), e:
+                raise ShotgunAppStoreConnectionError(e)
+            # In cases where there is a firewall/proxy blocking access to the app store, sometimes 
+            # the firewall will drop the connection instead of rejecting it. The API request will 
+            # timeout which unfortunately results in a generic SSLError with only the message text 
+            # to give us a clue why the request failed. 
+            except httplib2.ssl.SSLError, e:
+                if "timed" in e.message:
+                    raise ShotgunAppStoreConnectionError("Connection to %s timed out: %s" % (
+                                                            app_store_sg.config.server, 
+                                                            e))     
+            except Exception:
+                raise ShotgunAppStoreError(e)
 
             if script_user is None:
                 raise ShotgunAppStoreError(

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
@@ -613,7 +613,7 @@ class IODescriptorAppStore(IODescriptorBase):
                 api_key=script_key,
                 http_proxy=self._sg_connection.config.raw_http_proxy,
                 connect=False,
-                timeout_secs=5
+                constants.SGTK_APP_STORE_CONN_TIMEOUT
             )
 
             # determine the script user running currently
@@ -632,6 +632,7 @@ class IODescriptorAppStore(IODescriptorBase):
             # the firewall will drop the connection instead of rejecting it. The API request will 
             # timeout which unfortunately results in a generic SSLError with only the message text 
             # to give us a clue why the request failed. 
+            # The exception raised in this case is "ssl.SSLError: The read operation timed out"
             except httplib2.ssl.SSLError, e:
                 if "timed" in e.message:
                     raise ShotgunAppStoreConnectionError("Connection to %s timed out: %s" % (


### PR DESCRIPTION
When launched, SG Desktop attempts to connect to the Toolkit app store to check for updates to the desktop startup framework. For studios that have blocked internet access, connections to the Toolkit app store are usually rejected, which is handled correctly and the startup process will continue normally and will emit a log message stating the app store was unreachable.

However, if the firewall is configured to drop the connection rather than reject it, the client is left waiting for a response. In this case the "client" is the Shotgun API handle that Toolkit uses, which by default specifies no explicit connection timeout value. This means the timeout used by the API falls back on the default value set by the specific socket implementation for your platform. This could mean the connection waits forever causing SG Desktop to hang upon startup.

This fix ensures a reasonable default (5 seconds) is set on the API connection for the Toolkit App Store. If a connection-related failure occurs, we raise a (new) `ShotgunAppStoreConnectionError`. This allows us to catch exceptions directly related to connecting to the app store.

Note that because the SG API (currently) retries failed connections 3 times by default, this means the full timeout will take 15 seconds. Also (currently) the timeout isn't settable until the SG API instance has been created. Since the SG API also connects to the server by default when instantiated, this would mean the timeout would still be `None` on the initial connection, defeating the purpose. So we also set the `connect` parameter to `False` so that we don't actually connect to the SG server when the SG API instance is created. This allows us to set the timeout before a connection is made.