### PR TITLE
[minor] for #35492 log message improvement and deprecation of context_additional_entities

### DIFF
--- a/hooks/context_additional_entities.py
+++ b/hooks/context_additional_entities.py
@@ -9,6 +9,18 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
+*******************************************************************************
+* DEPRECATION WARNING!                                                        *
+*******************************************************************************
+This hook should not be used if you haven't already implemented it in your 
+pipeline configuration. Support for it is minimal and it will likely be removed 
+in a future release.
+
+If you are currently using this hook in your studio, please contact 
+support@shotgunsoftware.com so we can discuss how to migrate your workflow to 
+one that doesn't use this hook.
+*******************************************************************************
+
 Hook which provides advanced customization of context creation.
 Returns a dict with two keys:
 

--- a/hooks/context_additional_entities.py
+++ b/hooks/context_additional_entities.py
@@ -12,13 +12,12 @@
 *******************************************************************************
 * DEPRECATION WARNING!                                                        *
 *******************************************************************************
-This hook should not be used if you haven't already implemented it in your 
-pipeline configuration. Support for it is minimal and it will likely be removed 
-in a future release.
+This hook should not be used if you aren't already using it.  It probably 
+doesn't do what you think it does and it will likely be removed in a future 
+release.
 
-If you are currently using this hook in your studio, please contact 
-support@shotgunsoftware.com so we can discuss how to migrate your workflow to 
-one that doesn't use this hook.
+Email support@shotgunsoftware.com if you have any questions about how to 
+migrate away from this hook.
 *******************************************************************************
 
 Hook which provides advanced customization of context creation.

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -92,11 +92,14 @@ class CoreUpgradeAction(Action):
         log.info("is up to date.")
         log.info("")
         log.info("")
-        log.info("Please note that when you upgrade the core API, you typically affect "
-                 "more than one project. If you want to test a Core API upgrade in isolation "
-                 "prior to rolling it out to multiple projects, we recommend creating a "
-                 "special *localized* pipeline configuration. For more information about this, please "
-                 "see the Toolkit documentation.")
+        log.info("Please note that if this is a shared Toolkit Core used by more than one project, "
+                 "this will affect all of the projects that use it. If you want to test a Core API "
+                 "upgrade in isolation, prior to rolling it out to multiple projects, we recommend "
+                 "creating a special *localized* pipeline configuration.")
+        log.info("")
+        log.info("For more information, please see the Toolkit documentation:")
+        log.info("https://support.shotgunsoftware.com/entries/96141707")
+        log.info("https://support.shotgunsoftware.com/entries/96142347")
         log.info("")
         log.info("")    
         
@@ -131,8 +134,8 @@ class CoreUpgradeAction(Action):
             log.info("Detailed Release Notes:")
             log.info("%s" % url)
             log.info("")
-            log.info("Please note that this upgrade will affect all projects")
-            log.info("Associated with this Shotgun Pipeline Toolkit installation.")
+            log.info("Please note that if this is a shared core used by more than one project, "
+                     "this will affect the other projects as well.")
             log.info("")
             
             if suppress_prompts or console_utils.ask_yn_question("Update to the latest version of the Core API?"):


### PR DESCRIPTION
* **Updated note about core upgrade potentially affecting multiple projects.**
  The note emitted when upgrading core was originally written when Toolkit used a shared studio core by default. Since this is currently no longer the case and SG Desktop localizes your core by default when setting up a project, we've re-worded the note to make it clearer and a little less scary. This was previously causing some confusion for clients who didn't even necessarily know what a shared core was, which means this shouldn't affect them anyway. Added links to documentation as well.

* **Added a deprecation warning to the `context_additional_entities` hook.**
  This is an old hook that never matured to a point for wide use and generates more questions than answers. Support for it is limited and there are now better ways to solve the challenges it was attempting to solve. Because there may be studios that still use it, we won't remove it until we can confirm all clients have removed it from their configs (somehow).