### PR TITLE
#35511 Adds a new command to dump configs to stdout/file as full/sparse

### DIFF
--- a/python/tank/deploy/tank_command.py
+++ b/python/tank/deploy/tank_command.py
@@ -26,6 +26,7 @@ from .tank_commands import update
 from .tank_commands import push_pc
 from .tank_commands import setup_project
 from .tank_commands import setup_project_wizard
+from .tank_commands import dump_config
 from .tank_commands import validate_config
 from .tank_commands import cache_apps
 from .tank_commands import switch
@@ -53,6 +54,7 @@ BUILT_IN_ACTIONS = [setup_project.SetupProjectAction,
                     core_localize.CoreLocalizeAction,
                     core_localize.ShareCoreAction,
                     core_localize.AttachToCoreAction,
+                    dump_config.DumpConfigAction,
                     validate_config.ValidateConfigAction,
                     cache_apps.CacheAppsAction,
                     misc.ClearCacheAction,

--- a/python/tank/deploy/tank_commands/dump_config.py
+++ b/python/tank/deploy/tank_commands/dump_config.py
@@ -36,6 +36,8 @@ class DumpConfigAction(Action):
         # this method can be executed via the API
         self.supports_api = True
 
+        self._is_interactive = False
+
         self.parameters = {}
 
         self.parameters["env"] = {
@@ -102,12 +104,15 @@ class DumpConfigAction(Action):
         :param args: command line args
         """
 
+        self._is_interactive = True
+
         parameters = {}
 
         # look for a --file argument
         parameters["file"] = ""
         for arg in args:
             if arg == "--file":
+                print "\nUsage: %s\n" % (self._usage(),)
                 raise TankError(
                     "Must specify a path: --file=/path/to/write/to.yml"
                 )
@@ -117,6 +122,7 @@ class DumpConfigAction(Action):
                 # from '--file=/path/to/my config' get '/path/to/my config'
                 parameters["file"] = arg[len("--file="):]
                 if parameters["file"] == "":
+                    print "\nUsage: %s\n" % (self._usage(),)
                     raise TankError(
                         "Must specify a path: --file=/path/to/write/to.yml"
                     )
@@ -145,6 +151,7 @@ class DumpConfigAction(Action):
         # if there are any options left, bail
         for arg in args:
             if arg.startswith("-"):
+                print "\nUsage: %s\n" % (self._usage(),)
                 raise TankError("Unknown argument: %s" % (arg,))
 
         # everything left should be the env argument
@@ -240,6 +247,8 @@ class DumpConfigAction(Action):
 
         # make sure we don't have too many dump types
         if parameters["full"] and parameters["sparse"]:
+            if self._is_interactive:
+                print "\nUsage: %s\n" % (self._usage(),)
             raise TankError(
                 "The 'full' and 'sparse' options are mutually exclusive.")
 
@@ -253,3 +262,8 @@ class DumpConfigAction(Action):
             )
 
         return parameters
+
+    def _usage(self):
+        """Return a string displaying the usage of this command."""
+        return "./tank dump_config env_name [--sparse | --full] [--debug-comments] [--file=/path/to/output/file.yml]"
+

--- a/python/tank/deploy/tank_commands/dump_config.py
+++ b/python/tank/deploy/tank_commands/dump_config.py
@@ -170,23 +170,28 @@ class DumpConfigAction(Action):
         # get a file to write to
         env_fh= self._get_file_handle(params)
 
-        # dump the environment to the in-memory file
-        if params["sparse"]:
-            # write a sparse representation of the config to the file
-            env.dump_sparse(env_fh, params["debug_comments"])
-        elif params["full"]:
-            # write a full representation of the config to the file
-            env.dump_full(env_fh, params["debug_comments"])
-        else:
-            # write the config as-is
-            env.dump(env_fh)
+        try:
+            # dump the environment to the in-memory file
+            if params["sparse"]:
+                # write a sparse representation of the config to the file
+                env.dump_sparse(env_fh, params["debug_comments"])
+            elif params["full"]:
+                # write a full representation of the config to the file
+                env.dump_full(env_fh, params["debug_comments"])
+            else:
+                # write the config as-is
+                env.dump(env_fh)
 
-        if not params["file"]:
-            # no file specified, write the in-memory file contents to <stdout>
-            print env_fh.getvalue()
-
-        # all done, close the file handle
-        env_fh.close()
+            if not params["file"]:
+                # no file, write the in-memory file contents to <stdout>
+                print env_fh.getvalue()
+        except Exception, e:
+            raise TankError(
+                "There was a problem dumping the config: '%s'" % (e,)
+            )
+        finally:
+            # all done, close the file handle
+            env_fh.close()
 
     def _get_file_handle(self, params):
         """

--- a/python/tank/deploy/tank_commands/dump_config.py
+++ b/python/tank/deploy/tank_commands/dump_config.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import StringIO
+
+from tank import TankError
+from .action_base import Action
+from tank_vendor.shotgun_base import ensure_folder_exists
+
+class DumpConfigAction(Action):
+    """
+    Action that dumps configs as full or sparse representations.
+    """
+    def __init__(self):
+        Action.__init__(
+            self,
+            "dump_config",
+            Action.TK_INSTANCE,
+            ("Dump the specified config to a file or <stdout>."
+             "If the `--file` option is not specified, the config will be "
+             "written to stdout. The tank command itself also writes to "
+             "<stdout> so be careful of redirecting to a file and expecting "
+             "to use the config immediately. "
+            ),
+            "Configuration"
+        )
+
+        # this method can be executed via the API
+        self.supports_api = True
+
+        self.parameters = {}
+
+        self.parameters["env"] = {
+            "description": "The name of environment to dump. (Required)",
+            "type": "str",
+            "default": [],
+        }
+
+        self.parameters["file"] = {
+            "description": (
+                "The path to a file to dump to. If not supplied, the command "
+                "will write ot <stdout>."
+            ),
+            "type": "str",
+            "default": "",
+        }
+
+        self.parameters["full"] = {
+            "description": (
+                "Dump the environment fully evaluated. All settings from the "
+                "manifest will be included with a value."
+            ),
+            "type": "bool",
+            "default": False,
+        }
+
+        self.parameters["sparse"] = {
+            "description": (
+                "Dump the environment sparsely. Settings from the manifest "
+                "with default values will not be included."
+            ),
+            "type": "bool",
+            "default": False,
+        }
+
+        self.parameters["debug_comments"] = {
+            "description": (
+                "Add debug comments to the dumped environment. Note this only "
+                "works when using the new style yaml parser introduced in "
+                "toolkit core v0.16.30. When using an older version of core, "
+                "this parameter is a no-op."
+            ),
+            "type": "bool",
+            "default": False,
+        }
+
+    def run_noninteractive(self, log, parameters):
+        """
+        Tank command API accessor.
+        Called when someone runs a tank command through the core API.
+
+        :param log: std python logger
+        :param parameters: dictionary with tank command parameters
+        """
+
+        # validate params and seed default values
+        return self._run(log, self._validate_parameters(parameters))
+
+    def run_interactive(self, log, args):
+        """
+        Tank command accessor
+
+        :param log: std python logger
+        :param args: command line args
+        """
+
+        parameters = {}
+
+        # look for a --file argument
+        parameters["file"] = ""
+        for arg in args:
+            if arg == "--file":
+                raise TankError(
+                    "Must specify a path: --file=/path/to/write/to.yml"
+                )
+            elif arg.startswith("--file="):
+                # remove it from args list
+                args.remove(arg)
+                # from '--file=/path/to/my config' get '/path/to/my config'
+                parameters["file"] = arg[len("--file="):]
+                if parameters["file"] == "":
+                    raise TankError(
+                        "Must specify a path: --file=/path/to/write/to.yml"
+                    )
+
+        # look for the full flag
+        if "--full" in args:
+            parameters["full"] = True
+            args.remove("--full")
+        else:
+            parameters["full"] = False
+
+        # look for the sparse flag
+        if "--sparse" in args:
+            parameters["sparse"] = True
+            args.remove("--sparse")
+        else:
+            parameters["sparse"] = False
+
+        # debug
+        if "--debug-comments" in args:
+            parameters["debug_comments"] = True
+            args.remove("--debug-comments")
+        else:
+            parameters["debug_comments"] = False
+
+        # if there are any options left, bail
+        for arg in args:
+            if arg.startswith("-"):
+                raise TankError("Unknown argument: %s" % (arg,))
+
+        # everything left should be the env argument
+        parameters["env"] = " ".join(args)
+
+        # do work after validating
+        return self._run(log, self._validate_parameters(parameters))
+
+    def _run(self, log, params):
+        """
+        Dump the supplied environment with the specified parameters
+
+        :param log: A logger instance.
+        :param params: parameter dict.
+        """
+
+        # the env to dump
+        env = self.tk.pipeline_configuration.get_environment(
+            params["env"],
+            writable=True
+        )
+
+        # get a file to write to
+        env_fh= self._get_file_handle(params)
+
+        # dump the environment to the in-memory file
+        if params["sparse"]:
+            # write a sparse representation of the config to the file
+            env.dump_sparse(env_fh, params["debug_comments"])
+        elif params["full"]:
+            # write a full representation of the config to the file
+            env.dump_full(env_fh, params["debug_comments"])
+        else:
+            # write the config as-is
+            env.dump(env_fh)
+
+        if not params["file"]:
+            # no file specified, write the in-memory file contents to <stdout>
+            print env_fh.getvalue()
+
+        # all done, close the file handle
+        env_fh.close()
+
+    def _get_file_handle(self, params):
+        """
+        Returns a file handle to use for dumping.
+
+        :param params: The command parameters dict.
+        :return: An open file handle object.
+        """
+
+        if params["file"]:
+            # open a real file handle to write to
+            path = params["file"]
+            dir = os.path.dirname(path)
+            if not os.path.isdir(dir):
+                try:
+                    ensure_folder_exists(dir)
+                except OSError, e:
+                    raise TankError(
+                        "Unable to create directory: %s\n"
+                        "  Error reported: %s" % (dir, e)
+                    )
+            try:
+                fh = open(path, "w")
+            except Exception, e:
+                raise TankError(
+                    "Unable to open file: %s\n"
+                    "  Error reported: %s" % (path, e)
+                )
+        else:
+            # get an in-memory file handle
+            fh = StringIO.StringIO()
+
+        return fh
+
+    def _validate_parameters(self, parameters):
+        """
+        Do validation of the parameters that arse specific to this action.
+
+        :param parameters: The dict of parameters
+        :returns: The validated and fully populated dict of parameters.
+        """
+
+        # do the base class default validation
+        parameters = super(DumpConfigAction, self)._validate_parameters(
+            parameters)
+
+        # make sure we don't have too many dump types
+        if parameters["full"] and parameters["sparse"]:
+            raise TankError(
+                "The 'full' and 'sparse' options are mutually exclusive.")
+
+        # get a list of valid env names
+        valid_env_names = self.tk.pipeline_configuration.get_environments()
+
+        if parameters["env"] not in valid_env_names:
+           raise TankError(
+                "Could not find a valid config named: '%s'" %
+                (parameters["env"],)
+            )
+
+        return parameters

--- a/python/tank/deploy/tank_commands/validate_config.py
+++ b/python/tank/deploy/tank_commands/validate_config.py
@@ -37,7 +37,9 @@ class ValidateConfigAction(Action):
         
         # this method can be executed via the API
         self.supports_api = True
-        
+
+        self._is_interactive = False
+
     def run_noninteractive(self, log, parameters):
         """
         Tank command API accessor. 
@@ -57,6 +59,8 @@ class ValidateConfigAction(Action):
         :param log: std python logger
         :param args: command line args
         """
+
+        self._is_interactive = True
 
         # currently, environment names are passed in as arguments for
         # validation. Just translate the args to the env list and validate them
@@ -130,7 +134,7 @@ class ValidateConfigAction(Action):
         """
 
         # do the base class default validation
-        params = super(ValidateConfigAction, self)._validate_parameters(
+        parameters = super(ValidateConfigAction, self)._validate_parameters(
             parameters)
 
         # get a list of valid env names
@@ -154,6 +158,8 @@ class ValidateConfigAction(Action):
 
         # bail if any bad env names
         if bad_env_names:
+            if self._is_interactive:
+                print "\nUsage: %s\n" % (self._usage(),)
             raise TankError(
                 "Error retrieving environments mathing supplied arguments: %s"
                 % (", ".join(bad_env_names),)
@@ -161,8 +167,12 @@ class ValidateConfigAction(Action):
 
         parameters["envs"] = sorted(env_names_to_process)
 
-        return params
-        
+        return parameters
+
+    def _usage(self):
+        """Return a string displaying the usage of this command."""
+        return "./tank validate [env_name, env_name, ...] "
+
 g_templates = set()
 g_hooks = set()
 

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -18,6 +18,7 @@ import sys
 import copy
 
 from tank_vendor import yaml
+from .bundle import resolve_default_value
 from . import constants
 from . import environment_includes
 from ..errors import TankError, TankUnreadableFileError
@@ -109,6 +110,7 @@ class Environment(object):
         handles the checks to see if an item is disabled
         """
         descriptor_dict = settings.get(constants.ENVIRONMENT_LOCATION_KEY)
+
         # Check for disabled and deny_platforms
         is_disabled = descriptor_dict.get("disabled", False)
         if is_disabled:
@@ -462,30 +464,34 @@ class Environment(object):
 
 
 
-
-
-
 class WritableEnvironment(Environment):
     """
     Represents a mutable environment.
-    
+
     If you need to make change to the environment, this class should be used
     rather than the Environment class. Additional methods are added
     to support modification and updates and handling of writing yaml
     content back to disk.
     """
 
+    (FULL, SPARSE) = range(2)
+    """Format enumeration to use when updating all settings in an environment.
+
+    FULL: Include all settings, using default values when necessary.
+    SPARSE: Exclude settings using default values.
+    """
+
     def __init__(self, env_path, pipeline_config, context=None):
         """
         Constructor
         """
-        self.set_yaml_preserve_mode(False)        
+        self.set_yaml_preserve_mode(False)
         Environment.__init__(self, env_path, pipeline_config, context)
 
     def __load_writable_yaml(self, path):
         """
         Loads yaml data from disk.
-        
+
         :param path: Path to yaml file
         :returns: yaml object representing the data structure
         """
@@ -531,57 +537,68 @@ class WritableEnvironment(Environment):
         except Exception, e:
             raise TankError("Could not open file '%s' for writing. "
                             "Error reported: '%s'" % (path, e))
-        
+
         try:
-            # the ruamel parser doesn't have 2.5 support so 
-            # only use it on 2.6+
-            if self._use_ruamel_yaml_parser and not(sys.version_info < (2,6)):
-                # note that we are using the RoundTripDumper in order to 
-                # preserve the structure when writing the file to disk.
-                #
-                # the default_flow_style=False tells the parse to write
-                # any modified values on multi-line form, e.g.
-                # 
-                # foo:
-                #   bar: 3
-                #   baz: 4
-                #
-                # rather than
-                #
-                # foo: { bar: 3, baz: 4 }
-                #
-                # note that safe_dump is not needed when using the 
-                # roundtrip dumper, it will adopt a 'safe' behaviour
-                # by default.
-                from tank_vendor import ruamel_yaml
-                ruamel_yaml.dump(data, 
-                                 fh, 
-                                 default_flow_style=False, 
-                                 Dumper=ruamel_yaml.RoundTripDumper)
-            else:
-                # use pyyaml parser
-                #
-                # using safe_dump instead of dump ensures that we
-                # don't serialize any non-std yaml content. In particular,
-                # this causes issues if a unicode object containing a 7-bit
-                # ascii string is passed as part of the data. in this case, 
-                # dump will write out a special format which is later on 
-                # *loaded in* as a unicode object, even if the content doesn't  
-                # need unicode handling. And this causes issues down the line
-                # in toolkit code, assuming strings:
-                #
-                # >>> yaml.dump({"foo": u"bar"})
-                # "{foo: !!python/unicode 'bar'}\n"
-                # >>> yaml.safe_dump({"foo": u"bar"})
-                # '{foo: bar}\n'
-                #                
-                yaml.safe_dump(data, fh)
-                
+            self.__write_data_file(fh, data)
         except Exception, e:
             raise TankError("Could not write to environment file '%s'. "
                             "Error reported: %s" % (path, e))
         finally:
             fh.close()
+
+
+    def __write_data_file(self, fh, data):
+        """
+        Writes the yaml data to a supplied file handle
+
+        :param fh: An open file handle to write to.
+        :param data: yaml data structure to write
+        """
+
+        # the ruamel parser doesn't have 2.5 support so
+        # only use it on 2.6+
+        if self._use_ruamel_yaml_parser and not(sys.version_info < (2,6)):
+            # note that we are using the RoundTripDumper in order to
+            # preserve the structure when writing the file to disk.
+            #
+            # the default_flow_style=False tells the parse to write
+            # any modified values on multi-line form, e.g.
+            #
+            # foo:
+            #   bar: 3
+            #   baz: 4
+            #
+            # rather than
+            #
+            # foo: { bar: 3, baz: 4 }
+            #
+            # note that safe_dump is not needed when using the
+            # roundtrip dumper, it will adopt a 'safe' behaviour
+            # by default.
+            from tank_vendor import ruamel_yaml
+            ruamel_yaml.dump(data,
+                             fh,
+                             default_flow_style=False,
+                             Dumper=ruamel_yaml.RoundTripDumper)
+        else:
+            # use pyyaml parser
+            #
+            # using safe_dump instead of dump ensures that we
+            # don't serialize any non-std yaml content. In particular,
+            # this causes issues if a unicode object containing a 7-bit
+            # ascii string is passed as part of the data. in this case,
+            # dump will write out a special format which is later on
+            # *loaded in* as a unicode object, even if the content doesn't
+            # need unicode handling. And this causes issues down the line
+            # in toolkit code, assuming strings:
+            #
+            # >>> yaml.dump({"foo": u"bar"})
+            # "{foo: !!python/unicode 'bar'}\n"
+            # >>> yaml.safe_dump({"foo": u"bar"})
+            # '{foo: bar}\n'
+            #
+            yaml.safe_dump(data, fh)
+                
 
     def set_yaml_preserve_mode(self, val):
         """
@@ -602,6 +619,7 @@ class WritableEnvironment(Environment):
         """
         Updates the engine configuration
         """
+
         if engine_name not in self._env_data["engines"]:
             raise TankError("Engine %s does not exist in environment %s" % (engine_name, self._env_path) )
 
@@ -630,6 +648,7 @@ class WritableEnvironment(Environment):
         """
         Updates the app configuration.
         """
+
         if engine_name not in self._env_data["engines"]:
             raise TankError("Engine %s does not exist in environment %s" % (engine_name, self._env_path) )
         if app_name not in self._env_data["engines"][engine_name]["apps"]:
@@ -648,6 +667,7 @@ class WritableEnvironment(Environment):
 
         # finally update the file
         app_data[constants.ENVIRONMENT_LOCATION_KEY] = new_location
+
         self._update_settings_recursive(app_data, new_data)
         self.__write_data(yml_file, yml_data)
 
@@ -658,6 +678,7 @@ class WritableEnvironment(Environment):
         """
         Updates the framework configuration
         """
+
         if framework_name not in self._env_data["frameworks"]:
             raise TankError("Framework %s does not exist in environment %s" % (framework_name, self._env_path) )
 
@@ -680,7 +701,6 @@ class WritableEnvironment(Environment):
 
         # sync internal data with disk
         self._refresh()
-
 
     def _update_settings_recursive(self, settings, new_data):
         """
@@ -878,3 +898,271 @@ class WritableEnvironment(Environment):
         self.__write_data(self._env_path, data)
         # sync internal data with disk
         self._refresh()
+
+
+    ############################################################################
+    # Methods specific to dumping environment settings
+
+    def dump(self, file):
+        """
+        Dump a copy of this environment's settings to a file.
+
+        NOTE: The calling code is responsible for closing the file handle.
+
+        :param file: An open file object to write to.
+        """
+
+        # load the output path's yaml
+        yml_data = self.__load_writable_yaml(self._env_path)
+        self.__write_data_file(file, yml_data)
+
+    def dump_sparse(self, file, debug=False):
+        """
+        Dump a sparse copy of this environment's settings to a file.
+
+        Any setting defined in the environment that matches the default value
+        specified will not be included.
+
+        NOTE: The calling code is responsible for closing the file handle.
+
+        :param file: An open file object to write to.
+        :param debug: If True, include debug comments on lines using a
+            non-default value.
+        """
+
+        self._dump_settings(self.SPARSE, file, debug)
+
+    def dump_full(self, file, debug=False):
+        """
+        Dump a full copy of this environment's settings to a file.
+
+        Any setting not specified in the environment will be dumped with the
+        default value.
+
+        NOTE: The calling code is responsible for closing the file handle.
+
+        :param file: An open file object to write to.
+        :param debug: If True, include debug comments on lines using a default
+            value.
+        """
+
+        self._dump_settings(self.FULL, file, debug)
+
+    def _update_settings_sparse(self, schema, settings, engine_name=None,
+        manifest_file=None, debug=False):
+        """
+        Given a schema and settings, make sure that the settings are sparse.
+
+        Iterate over the schema key's default values and remove any settings
+        that use the default.
+
+        :param schema: A schema defining types and defaults for settings.
+        :param settings: A dict of settings to sparsify.
+        :param engine_name: The name of the current engine
+        :param manifest_file: The path to the manifest file if known.
+        :param debug: If True, include debug comments on lines using a
+            non-default value.
+
+        :returns: bool - True if the settings were modified, False otherwise.
+        """
+
+        modified = False
+
+        # check each key defined in the schema
+        for setting_name in schema.keys():
+
+            # identify the portion of the manifest that defines the setting
+            setting_schema = schema[setting_name]
+
+            # if defined, check the settings against the default value
+            if setting_name in settings:
+                setting_value = settings[setting_name]
+                schema_default = resolve_default_value(
+                    setting_schema, engine_name=engine_name)
+
+                if setting_value == schema_default:
+                    # the setting value matches the schema default. remove the
+                    # setting.
+                    del settings[setting_name]
+                    modified = True
+
+                elif debug:
+                    # Add a comment to identify default values in the dumped
+                    # file to help with debugging. The comment shows the
+                    # default value and the path to the manifest where the
+                    # default value is defined.
+                    if hasattr(settings, 'yaml_add_eol_comment'):
+                        settings.yaml_add_eol_comment(
+                            "Differs from %s default value (%s) in manifest %s"
+                                % (engine_name or "",
+                                   schema_default or '""',
+                                   manifest_file or ""
+                                ),
+                            setting_name,
+                            column=80
+                        )
+
+                # identify the type to address any special cases
+                setting_type = setting_schema["type"]
+
+                # remove any legacy "default" hook references
+                if setting_type == "hook" and setting_value == "default":
+                    del settings[setting_name]
+                    modified = True
+
+        return modified
+
+    def _update_settings_full(self, schema, settings, engine_name=None,
+        manifest_file=None, debug=False):
+        """
+        Given a schema and settings, make sure that the settings are fully
+        defined.
+
+        Iterate over the schema key's default values and add any settings
+        that aren't defined by using the default value.
+
+        :param schema: A schema defining types and defaults for settings.
+        :param settings: A dict of settings to sparsify.
+        :param engine_name: The name of the engine currently running if there
+            is one.
+        :param manifest_file: The path to the manifest file if known.
+        :param debug: If True, include debug comments on lines using a default
+            value.
+
+        :returns: bool - True if the settings were modified, False otherwise.
+        """
+
+        modified = False
+
+        # check each key defined in the schema
+        for setting_name in schema.keys():
+
+            # get the default value for the setting
+            setting_schema = schema[setting_name]
+            schema_default = resolve_default_value(
+                setting_schema, engine_name=engine_name)
+
+            if setting_name not in settings:
+                # No value specified in the settings. Just set the default.
+                settings[setting_name] = schema_default
+                modified = True
+
+            if schema_default == settings[setting_name] and debug:
+                # The value of the setting matches the default value in the
+                # manifest. Add a comment to identify default values in the
+                # dumped file to help with debugging. The comment will display
+                # the path to the manifest.
+                if hasattr(settings, 'yaml_add_eol_comment'):
+                    settings.yaml_add_eol_comment(
+                        "Matches %s default value in manifest %s" % (
+                            engine_name or "",
+                            manifest_file or ""),
+                        setting_name,
+                        column=80
+                    )
+
+        return modified
+
+    def _dump_settings(self, dump_format, file, debug=False):
+        """
+        Dump a copy of this environment's settings to the supplied file.
+
+        :param dump_format: WritableEnvironment.[FULL|SPARSE]
+        :param file: A file like object to dump to
+        :param debug: Include debug comments in the dumped settings.
+        """
+
+        # we're either adding or remove settings depending on the update format.
+        # either way we access the data the same, and the arguments are the
+        # same so just call a different method based on what needs to be
+        # done.
+        if dump_format == self.SPARSE:
+            update_settings = self._update_settings_sparse
+        else:
+            update_settings = self._update_settings_full
+
+        # load the output path's yaml
+        yml_data = self.__load_writable_yaml(self._env_path)
+
+        # process each of the engines for the environment
+        for engine_name in self.get_engines():
+
+            # only process settings in this file
+            (tokens, engine_file) = self.find_location_for_engine(engine_name)
+            if not engine_file == self._env_path:
+                continue
+
+            # drill down into the yml data to find the chunk where the
+            # engine settings live
+            engine_settings = yml_data
+            for token in tokens:
+                engine_settings = engine_settings.get(token)
+
+            # get information about the engine in order to process the
+            # settings.
+            engine_descriptor = self.get_engine_descriptor(engine_name)
+            engine_schema = engine_descriptor.get_configuration_schema()
+            engine_manifest_file = os.path.join(
+                engine_descriptor.get_path(),
+                constants.BUNDLE_METADATA_FILE
+            )
+
+            # update the settings by adding or removing keys based on the
+            # type of dumping being performed.
+            update_settings(engine_schema, engine_settings, engine_name,
+                engine_manifest_file, debug)
+
+            # processing all the installed apps
+            for app_name in self.get_apps(engine_name):
+
+                # only process settings in this file
+                (tokens, app_file) = self.find_location_for_app(engine_name,
+                    app_name)
+                if not app_file == self._env_path:
+                    continue
+
+                # drill down into the yml data to find the chunk where the
+                # app settings live
+                app_settings = yml_data
+                for token in tokens:
+                    app_settings = app_settings.get(token)
+
+                # get information about the app in order to process the
+                # settings.
+                app_descriptor = self.get_app_descriptor(engine_name, app_name)
+                app_schema = app_descriptor.get_configuration_schema()
+                app_manifest_file = os.path.join(app_descriptor.get_path(),
+                    constants.BUNDLE_METADATA_FILE)
+
+                # update the settings by adding or removing keys based on the
+                # type of dumping being performed.
+                update_settings(app_schema, app_settings, engine_name,
+                    app_manifest_file, debug)
+
+        # processing all the frameworks
+        for fw_name in self.get_frameworks():
+
+            # only process settings in this file
+            (tokens, fw_file) = self.find_location_for_framework(fw_name)
+            if not fw_file == self._env_path:
+                continue
+
+            # drill down into the yml data to find the chunk where the
+            # framework settings live
+            fw_settings = yml_data
+            for token in tokens:
+                fw_settings = fw_settings.get(token)
+
+            # get information about the framework in order to process the
+            # settings.
+            fw_descriptor = self.get_framework_descriptor(fw_name)
+            fw_schema = fw_descriptor.get_configuration_schema()
+            fw_manifest_file = os.path.join(fw_descriptor.get_path(),
+                constants.BUNDLE_METADATA_FILE)
+
+            # update the settings by adding or removing keys based on the
+            # type of dumping being performed.
+            update_settings(fw_schema, fw_settings, fw_manifest_file, debug)
+
+        self.__write_data_file(file, yml_data)
+

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -914,7 +914,14 @@ class WritableEnvironment(Environment):
 
         # load the output path's yaml
         yml_data = self.__load_writable_yaml(self._env_path)
-        self.__write_data_file(file, yml_data)
+
+        try:
+            self.__write_data_file(file, yml_data)
+        except Exception, e:
+            raise TankError(
+                "Could not write to environment file handle. "
+                "Error reported: %s" % (e,)
+            )
 
     def dump_sparse(self, file, debug=False):
         """
@@ -1164,5 +1171,11 @@ class WritableEnvironment(Environment):
             # type of dumping being performed.
             update_settings(fw_schema, fw_settings, fw_manifest_file, debug)
 
-        self.__write_data_file(file, yml_data)
+        try:
+            self.__write_data_file(file, yml_data)
+        except Exception, e:
+            raise TankError(
+                "Could not write to environment file handle. "
+                "Error reported: %s" % (e,)
+            )
 

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -1010,10 +1010,8 @@ class WritableEnvironment(Environment):
     def _update_settings(self, transform, schema, settings, engine_name=None,
         manifest_file=None, include_debug_comments=False):
         """
-        Given a schema and settings, make sure that the settings are sparse.
-
-        Iterate over the schema key's default values and remove any settings
-        that use the default.
+        Given a schema and settings, update them based on the specified
+        transform mode.
 
         :param transform: one of WritableEnvironment.[NONE | INCLUDE_DEFAULTS |
             STRIP_DEFAULTS]

--- a/tests/fixtures/config/env/test_dump.yml
+++ b/tests/fixtures/config/env/test_dump.yml
@@ -1,0 +1,95 @@
+include: ./empty_config.yml
+
+engines:
+    test_engine:
+        location: {'type': 'dev', 'path': '{PIPELINE_CONFIG}/config/bundles/test_engine'}
+        debug_logging: false
+
+        apps:
+            test_app:
+                location: {'type': 'dev', 'path': '{PIPELINE_CONFIG}/config/bundles/test_app'}
+                test_str: a
+                test_int: 1 
+                test_float: 1.1
+                test_bool: true 
+                test_template: maya_publish_name
+                test_icon: "foo/bar.png"
+                
+                #
+
+                test_hook_std: config_test_hook
+                test_hook_default: default
+                test_hook_env_var: "{$TEST_ENV_VAR}/test_env_var_hook.py"
+                test_hook_self: "{self}/test_hook.py"
+                test_hook_config: "{config}/foo/bar.py"
+                test_hook_engine: "{engine}/foo/bar.py"
+                
+                test_hook_inheritance_1: "{self}/inheritance1.py"
+                test_hook_inheritance_2: "{config}/inherit.py"
+                test_hook_inheritance_3: "{engine}/inherit.py"
+                
+                test_hook_inheritance_old_style: "{self}/inheritance_old_style.py"
+                test_hook_inheritance_old_style_fails: "{self}/inheritance_old_style_fails.py"
+                
+                test_hook_new_style_config_old_style_hook: "{config}/config_test_hook.py"
+                test_hook_new_style_config_old_style_engine_specific_hook: "{config}/config_test_hook-{engine_name}.py"
+                test_default_syntax_with_new_style_hook: default
+                test_default_syntax_with_new_style_engine_specific_hook: "{self}/test_hook-{engine_name}.py"
+                test_default_syntax_missing_implementation: "{config}/no_app_implementation.py"
+
+                test_no_schema: 1234.5678
+
+                test_simple_dictionary:
+                    test_str: a
+                    test_int: 1
+                    
+                test_complex_dictionary:
+                    test_str: a
+                    test_list:
+                        -   test_str: a
+                            test_int: 1
+                        -   test_str: b
+                            test_int: 2
+
+                test_simple_list: ['a','b','c','d']
+
+                test_complex_list:
+                
+                    -   test_str: a
+                        test_int: 1
+                        test_float: 1.1
+                        test_bool: true
+                        test_template: maya_shot_work
+                        test_hook: config_test_hook
+                        test_extra: extra
+                        
+                    -   test_str: b
+                        test_int: 2
+                        test_float: 2.2
+                        test_bool: false
+                        test_template: maya_shot_publish
+                        test_hook: config_test_hook
+                        test_extra: extra
+                        
+                test_very_complex_list:
+                
+                    -   test_str: a
+                        test_list:
+                            -   test_str: aa
+                            -   test_str: ab
+                            
+                    -   test_str: b
+                        test_list:
+                            -   test_str: ba
+                            -   test_str: bb
+
+            disabled_app:
+                location: {'type': 'dev', 'path': 'DISABLED_APP_LOCATION', 'disabled': True}
+    disabled_engine:
+        location: {'type': 'dev', 'path': 'DISABLED_ENGINE_LOCATION', 'disabled': True}
+        apps:
+            test_app:
+                location: {'type': 'dev', 'path': 'TEST_APP_LOCATION'}
+
+
+

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -1,11 +1,8 @@
 import os
 
-import tank
-import tank.platform.constants
 from tank.errors import TankError
 from tank_test.tank_test_base import *
 from tank.platform.validation import *
-from tank.platform.environment import Environment, WritableEnvironment
 from tank_vendor import yaml
 
 import copy


### PR DESCRIPTION
These changes adds a new `dump_config` action to the `./tank` command. The action allows the user to write out the contents of an existing environment to `<stdout>` or a file. It supports both full and sparse config dumping.

The changes correspond to recent modifications to the `develop/0.18` branch of core to allow for the use of sparse configurations (not requiring configuration settings when the default value is used). 

The usage for the `dump_config` option looks like this:

```
./tank dump_config env_name [--sparse | --full] [--debug-comments] [--file=/path/to/output/file.yml]
```

The `--sparse` and `--full` options are mutually exclusive. If neither are included, then the config will be dumped as it exists on disk.

By default, the action writes to `<stdout>`. If the `--file` option is supplied then it will write to the specified path.

The `--debug-comments` option will include additonal comments in the dumped config. If dumping as sparse, the comments will include the default value and where it comes from. If dumping as full, the comments will note which values are default values.

The dumping is made possible via changes to the `WritableEnvironment` object in `tank.platform.environment`. Three new public methods have been added: `dump`, `dump_sparse`, and `dump_full`. Each of these methods accepts an open file handle to write to. The `WritableEnvironment` itself is heavily tied to its location on disk, and these methods allow dumping that source file to the handle provided. 

The other change of note in the `WritableEnvironment` object is the new private method called `__write_data_file()`. This logic is pulled directly from `__write_data()` (which now calls `__write_data_file()`) and allows you to write the supplied yaml data to a file handle. This is what facilitates the new dumping methods. None of the logic has changed, only exposed internally as a separate private method.

The `validate` action was also updated to include the ability to process a subset of configs. You can now filter the environment names to process. Before this change, the `validate` command would validate each environment file it found. Now you can specify a list of environment names to process:

```yaml
./tank validate asset_step shot_step
```

The above command would validate/dump each of the `asset_step` and `shot_step` environments.
