### PR TITLE
For #34894, core metadata file on upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage.xml
 
 # os files
 .DS_Store
+
+# pyenv
+.python-version

--- a/info.yml
+++ b/info.yml
@@ -12,7 +12,7 @@
 # This is automatically replaced with appropriate values 
 # as the core bundle is uploaded to the app store.
 
-version: "HEAD"
+version: "v0.17.1"
 documentation_url: ""
 
 

--- a/info.yml
+++ b/info.yml
@@ -12,5 +12,5 @@
 # This is automatically replaced with appropriate values
 # as the core bundle is uploaded to the app store.
 
-version: "HEAD"
+version: "v0.17.5"
 documentation_url: ""

--- a/info.yml
+++ b/info.yml
@@ -12,5 +12,5 @@
 # This is automatically replaced with appropriate values
 # as the core bundle is uploaded to the app store.
 
-version: "v0.17.5"
+version: "HEAD"
 documentation_url: ""

--- a/info.yml
+++ b/info.yml
@@ -14,3 +14,4 @@
 
 version: "HEAD"
 documentation_url: ""
+requires_shotgun_version: "v5.0.0"

--- a/info.yml
+++ b/info.yml
@@ -1,18 +1,16 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# Metadata for the Core Tank API.  
-# This is automatically replaced with appropriate values 
+# Metadata for the Core Tank API.
+# This is automatically replaced with appropriate values
 # as the core bundle is uploaded to the app store.
 
-version: "v0.17.1"
+version: "HEAD"
 documentation_url: ""
-
-

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -178,11 +178,10 @@ class CoreUpdateAction(Action):
             msg = (
                 "%s version of core requires a more recent version (%s) of Shotgun!" % (
                     "The newest" if core_constraint_pattern is None else "The requested",
-                    new_version,
                     req_sg
                 )
             )
-            log.warning(msg)
+            log.error(msg)
             return_status = {"status": "update_blocked", "reason": msg}
 
         elif status == TankCoreUpdater.UPDATE_POSSIBLE:

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -309,7 +309,7 @@ class TankCoreUpdater(object):
         :returns: sg version number as a string or None if no version is required. 
         """
         # FIXME: This should look inside Shotgun.
-        return "5.0.0"
+        return self._new_core_descriptor.get_version_constraints()["min_sg"]
 
     def get_release_notes(self):
         """

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Tank command allowing to do core updates.
+"""
+
+from __future__ import with_statement
 
 from ...errors import TankError
 from .action_base import Action
@@ -14,18 +20,14 @@ from .action_base import Action
 import os
 import sys
 import textwrap
-import uuid
-import tempfile
 import optparse
-import copy
 
 from ...util import shotgun
-from ...platform import constants
 from ... import pipelineconfig_utils
-from ..zipfilehelper import unzip_file
+from . import console_utils
 from .. import util
 
-from . import console_utils
+from tank_vendor import yaml
 
 
 # FIXME: This should be refactored into something that can be used by other commands.
@@ -40,9 +42,7 @@ class TkOptParse(optparse.OptionParser):
         Constructor.
         """
         # Don't generate the --help options, since --help is already eaten up by tank_cmd.py
-        kwargs = copy.copy(kwargs)
-        kwargs["add_help_option"] = False
-        optparse.OptionParser.__init__(self, *args, **kwargs)
+        optparse.OptionParser.__init__(self, *args, add_help_option=False, **kwargs)
         # optparse uses argv[0] for the program, but users use the tank command instead, so replace
         # the program.
         self.prog = "tank"
@@ -117,12 +117,11 @@ class CoreUpdateAction(Action):
         :param log: std python logger
         :param args: command line args
         """
-
         core_version = self._parse_arguments(args)
 
         self._run(log, False, core_version)
 
-    def _run(self, log, suppress_prompts, core_version):
+    def _run(self, log, suppress_prompts, core_constraint_pattern):
         """
         Actual execution payload.
 
@@ -133,8 +132,10 @@ class CoreUpdateAction(Action):
         return_status = {"status": "unknown"}
 
         # get the core api root of this installation by looking at the relative location of the running code.
-        code_install_root = pipelineconfig_utils.get_path_to_current_core() 
-        
+        code_install_root = pipelineconfig_utils.get_path_to_current_core()
+
+        installer = TankCoreUpdater(code_install_root, log, core_constraint_pattern)
+
         log.info("")
         log.info("Welcome to the Shotgun Pipeline Toolkit update checker!")
         log.info("This script will check if the Toolkit Core API installed")
@@ -142,47 +143,45 @@ class CoreUpdateAction(Action):
         log.info("is up to date.")
         log.info("")
         log.info("")
-        log.info("Please note that if this is a shared Toolkit Core used by more than one project, "
-                 "this will affect all of the projects that use it. If you want to test a Core API "
-                 "update in isolation, prior to rolling it out to multiple projects, we recommend "
-                 "creating a special *localized* pipeline configuration.")
-        log.info("")
-        log.info("For more information, please see the Toolkit documentation:")
-        log.info("https://support.shotgunsoftware.com/entries/96141707")
-        log.info("https://support.shotgunsoftware.com/entries/96142347")
-        log.info("")
-        log.info("")    
-        
-        installer = TankCoreUpdater(code_install_root, log, core_version)
+
+        if not pipelineconfig_utils.is_localized(self.tk.pipeline_configuration.get_path()):
+            log.info("Please note that when you update the core API, you typically affect "
+                     "more than one project. If you want to test a Core API update in isolation "
+                     "prior to rolling it out to multiple projects, we recommend creating a "
+                     "special *localized* pipeline configuration. For more information about this, please "
+                     "see the Toolkit documentation.")
+            log.info("")
+            log.info("")
+
         cv = installer.get_current_version_number()
-        lv = installer.get_update_version_number()
+        nv = installer.get_update_version_number()
         log.info("You are currently running version %s of the Shotgun Pipeline Toolkit" % cv)
-        
+
         status = installer.get_update_status()
         req_sg = installer.get_required_sg_version_for_update()
-        
+
         if status == TankCoreUpdater.UP_TO_DATE:
             log.info("No need to update the Toolkit Core API at this time!")
             return_status = {"status": "up_to_date"}
-        
+
         elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
             msg = (
                 "%s version (%s) of the core API is available however "
                 "it requires a more recent version (%s) of Shotgun!" % (
-                    "A new" if core_version is None else "The requested",
-                    lv,
+                    "A new" if core_constraint_pattern is None else "The requested",
+                    nv,
                     req_sg
                 )
             )
             log.warning(msg)
             return_status = {"status": "update_blocked", "reason": msg}
-            
+
         elif status == TankCoreUpdater.UPDATE_POSSIBLE:
-            
+
             (summary, url) = installer.get_release_notes()
             log.info(
                 "%s version of the Toolkit API (%s) is available!" % (
-                    "A new" if core_version is None else "The requested", lv
+                    "A new" if core_constraint_pattern is None else "The requested", nv
                 )
             )
             log.info("")
@@ -193,14 +192,15 @@ class CoreUpdateAction(Action):
             log.info("Detailed Release Notes:")
             log.info("%s" % url)
             log.info("")
-            log.info("Please note that if this is a shared core used by more than one project, "
-                     "this will affect the other projects as well.")
+            log.info("Please note that this update will affect all projects")
+            log.info("associated with this Shotgun Pipeline Toolkit installation.")
             log.info("")
-            
+
             if suppress_prompts or console_utils.ask_yn_question("Update to this version of the Core API?"):
                 # install it!
                 log.info("Downloading and installing a new version of the core...")
                 installer.do_install()
+
                 log.info("")
                 log.info("")
                 log.info("----------------------------------------------------------------")
@@ -218,14 +218,14 @@ class CoreUpdateAction(Action):
                 log.info("")
                 log.info("----------------------------------------------------------------")
                 log.info("")
-                return_status = {"status": "updated", "new_version": lv}
-                
+                return_status = {"status": "updated", "new_version": nv}
+
             else:
                 log.info("The Shotgun Pipeline Toolkit will not be updated.")
-            
+
         else:
             raise TankError("Unknown Update state!")
-        
+
         return return_status
 
 
@@ -233,14 +233,15 @@ class TankCoreUpdater(object):
     """
     Class which handles the update of the core API.
     """
-    
-    # possible update status states
-    (UP_TO_DATE,                    # all good, no update necessary  
-     UPDATE_POSSIBLE,              # more recent version exists
-     UPDATE_BLOCKED_BY_SG          # more recent version exists but SG version is too low.
-     ) = range(3)
 
-    def __init__(self, installation_root, logger, core_version=None):
+    # possible update status states
+    (
+        UP_TO_DATE,                    # all good, no update necessary
+        UPDATE_POSSIBLE,              # more recent version exists
+        UPDATE_BLOCKED_BY_SG          # more recent version exists but SG version is too low.
+    ) = range(3)
+
+    def __init__(self, install_folder_root, logger, core_constraint_pattern=None):
         """
         Constructor
 
@@ -251,20 +252,29 @@ class TankCoreUpdater(object):
                                   e.g. you can run the updater as a totally separate thing.
         :param logger: Logger to send output to.
         :param core_version: Version of the core to update to. If None, the core will be updated to the latest
-                             version.
+                             version. Defaults to None.
         """
         self._log = logger
 
-        (sg_app_store, script_user) = shotgun.create_sg_app_store_connection()
-        self._sg = sg_app_store
-        self._sg_script_user = script_user
+        from tank_vendor.shotgun_deploy import Descriptor, create_descriptor
+
+        self._current_core_descriptor = create_descriptor(
+            shotgun.get_sg_connection(),
+            Descriptor.CORE,
+            {
+                "type": "app_store",
+                "version": pipelineconfig_utils.get_currently_running_api_version(),
+                "name": "core"
+            }
+        )
+
+        self._new_core_descriptor = self._current_core_descriptor.find_latest_version(
+            constraint_pattern=core_constraint_pattern
+        )
+
+        self._install_root = os.path.join(install_folder_root, "install")
 
         self._local_sg = shotgun.get_sg_connection()
-        self._update_version = self.__get_core_version(core_version)
-
-        self._install_root = os.path.join(installation_root, "install")
-
-        self._current_ver = pipelineconfig_utils.get_currently_running_api_version()
 
         # now also extract the version of shotgun currently running
         try:
@@ -272,99 +282,57 @@ class TankCoreUpdater(object):
         except Exception, e:
             raise TankError("Could not extract version number for studio shotgun: %s" % e)
 
-    def __get_core_version(self, version_requested):
-        """
-        Returns info about the new version of the Toolkit API from shotgun.
-
-        :raises TankError: Thrown if no version is found in the app store.
-
-        :returns: The entity dictionary
-        """
-        if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
-            version_filter = [["sg_status_list", "is_not", "bad" ]]
-        else:
-            version_filter = [["sg_status_list", "is_not", "rev" ],
-                              ["sg_status_list", "is_not", "bad" ]]
-
-        if version_requested is not None:
-            version_filter.append(["code", "is", version_requested])
-
-        # connect to the app store
-        version_found = self._sg.find_one(constants.TANK_CORE_VERSION_ENTITY,
-                                         filters=version_filter,
-                                         fields=["sg_min_shotgun_version",
-                                                 "code",
-                                                 "sg_detailed_release_notes",
-                                                 "description",
-                                                 constants.TANK_CODE_PAYLOAD_FIELD],
-                                         order=[{"field_name": "created_at", "direction": "desc"}])
-
-        if version_found is None:
-            if version_requested:
-                raise TankError("Could not find version '%s' of the Core API in the app store!" % version_requested)
-            else:
-                # technical problems?
-                raise TankError("Could not find any version of the Core API in the app store!")
-
-        return version_found
-
     def get_update_version_number(self):
         """
         Returns the new version of the Toolkit API from shotgun
         Returns None if there is no new version
         """
-        return self._update_version["code"]
+        return self._new_core_descriptor.get_version()
 
     def get_current_version_number(self):
         """
         Returns the currently installed version of the Toolkit API
         """
-        return self._current_ver
+        return self._current_core_descriptor.get_version()
 
     def get_required_sg_version_for_update(self):
         """
         Returns the SG version that is required in order to update to the specified
         version of the Tank Core API.
-        
+
         :returns: sg version number as a string or None if no version is required. 
         """
-        return self._update_version["sg_min_shotgun_version"]
+        # FIXME: This should look inside Shotgun.
+        return "5.0.0"
 
     def get_release_notes(self):
         """
         Returns the release notes for the most recent version of the Toolkit API
-        
+
         :returns: tuple with (summary_string, details_url_string)
         """
-        summary = self._update_version.get("description", "")
-        if self._update_version:
-            url = self._update_version["sg_detailed_release_notes"].get("url", "")
-        else:
-            url = ""
-        return (summary, url)
+        return self._new_core_descriptor.get_changelog()
 
     def get_update_status(self):
         """
         Returns true if an update is recommended
         """
-        if self._current_ver == "HEAD":
+        if self._current_core_descriptor.get_version() == "HEAD":
             # head is the verison number which is stored in tank core trunk
             # getting this as a result means that we are not actually running
             # a version of tank that came from the app store, but some sort 
             # of dev version
-            return TankCoreUpdater.UP_TO_DATE
-        
-        elif self.get_update_version_number() == self.get_current_version_number():
-            # running updated version already
-            return TankCoreUpdater.UP_TO_DATE
+            return self.UP_TO_DATE
 
+        elif self._current_core_descriptor.get_version() == self._new_core_descriptor.get_version():
+            # running updated version already
+            return self.UP_TO_DATE
         else:
             # running an older version. Make sure that shotgun has the required version
             req_sg = self.get_required_sg_version_for_update()
             if req_sg is None:
                 # no particular version required! We are good to go!
                 return TankCoreUpdater.UPDATE_POSSIBLE
-            
             else:
                 # there is a sg min version required - make sure we have that!
                 if util.is_version_newer(req_sg, self._sg_studio_version):
@@ -372,63 +340,44 @@ class TankCoreUpdater(object):
                 else:
                     return TankCoreUpdater.UPDATE_POSSIBLE
 
-        
     def do_install(self):
+        """
+        Installs ther requests core and updates core_api.yml.
+        """
+        self._install_core()
+        self._update_core_api_descriptor()
+
+    def _install_core(self):
         """
         Performs the actual installation of the new version of the core API
         """
-        
-        # validation
-        if self.get_update_status() != TankCoreUpdater.UPDATE_POSSIBLE:
-            raise Exception("Update not allowed at this point. Run get_update_status for details.")
-        
-        # download attachment
-        if self._update_version[constants.TANK_CODE_PAYLOAD_FIELD] is None:
-            raise Exception("Cannot find a binary bundle for %s. Please contact support" % self._update_version["code"])
-        
-        self._log.info("Begin downloading Toolkit Core API %s from the App Store..." % self._update_version["code"])
-        
-        zip_tmp = os.path.join(tempfile.gettempdir(), "%s_tank_core.zip" % uuid.uuid4().hex)
-        extract_tmp = os.path.join(tempfile.gettempdir(), "%s_tank_unzip" % uuid.uuid4().hex)
-        
-        # now have to get the attachment id from the data we obtained. This is a bit hacky.
-        # data example for the payload field, as returned by the query above: 
-        # {'url': 'http://tank.shotgunstudio.com/file_serve/attachment/21', 'name': 'tank_core.zip', 
-        #  'content_type': 'application/zip', 'link_type': 'upload'}
-        # 
-        # grab the attachment id off the url field and pass that to the download_attachment()
-        # method below.
-        
+
+        self._log.info("Begin downloading Toolkit Core API %s from the App Store..." % self._new_core_descriptor.get_version())
+        self._new_core_descriptor.ensure_local()
+
+        self._log.info("Download complete - now installing Toolkit Core")
+        sys.path.insert(0, self._new_core_descriptor.get_path())
         try:
-            attachment_id = int(self._update_version[constants.TANK_CODE_PAYLOAD_FIELD]["url"].split("/")[-1])
-        except:
-            raise Exception("Could not extract attachment id from data %s" %  self._update_version)
-        
-        bundle_content = self._sg.download_attachment(attachment_id)
-        fh = open(zip_tmp, "wb")
-        fh.write(bundle_content)
-        fh.close()
-        
-        self._log.info("Download complete - now extracting content...")
-        # unzip core zip file to temp location and run updater
-        unzip_file(zip_tmp, extract_tmp)
-        
-        # and write a custom event to the shotgun event log
-        data = {}
-        data["description"] = "%s: Core API was downloaded" % self._local_sg.base_url
-        data["event_type"] = "TankAppStore_CoreApi_Download"
-        data["entity"] = self._update_version
-        data["user"] = self._sg_script_user
-        data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
-        data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
-        self._sg.create("EventLogEntry", data)
-        
-        
-        self._log.info("Extraction complete - now installing Toolkit Core")
-        sys.path.insert(0, extract_tmp)
-        try:
-            import _core_upgrader            
+            import _core_upgrader
             _core_upgrader.upgrade_tank(self._install_root, self._log)
         except Exception, e:
             self._log.exception(e)
             raise Exception("Could not run update script! Error reported: %s" % e)
+
+    def _update_core_api_descriptor(self):
+        """
+        Updates the core_api.yml descriptor file.
+        """
+
+        core_api_yaml_path = os.path.join(
+            os.path.dirname(self._install_root), "config", "core", "core_api.yml"
+        )
+
+        message = "# Shotgun Pipeline Toolkit configuration file. This file was automatically\n"\
+                  "# created during the latest core update.\n"
+        with open(core_api_yaml_path, "w") as f:
+            f.writelines(message)
+            yaml.safe_dump(
+                {"location": self._new_core_descriptor.get_dict()}, f,
+                default_flow_style=False
+            )

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -156,6 +156,8 @@ class CoreUpdateAction(Action):
         log.info("For more information, please see the Toolkit documentation:")
         log.info("https://support.shotgunsoftware.com/entries/96141707")
         log.info("https://support.shotgunsoftware.com/entries/96142347")
+        log.info("")
+        log.info("")
 
         cv = installer.get_current_version_number()
         nv = installer.get_update_version_number()

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -21,6 +21,7 @@ import os
 import sys
 import textwrap
 import optparse
+import copy
 
 from ...util import shotgun
 from ... import pipelineconfig_utils
@@ -42,7 +43,10 @@ class TkOptParse(optparse.OptionParser):
         Constructor.
         """
         # Don't generate the --help options, since --help is already eaten up by tank_cmd.py
-        optparse.OptionParser.__init__(self, *args, add_help_option=False, **kwargs)
+        kwargs = copy.copy(kwargs)
+        kwargs["add_help_option"] = False
+        optparse.OptionParser.__init__(self, *args, **kwargs)
+        optparse.OptionParser.__init__(self, *args, **kwargs)
         # optparse uses argv[0] for the program, but users use the tank command instead, so replace
         # the program.
         self.prog = "tank"
@@ -144,14 +148,14 @@ class CoreUpdateAction(Action):
         log.info("")
         log.info("")
 
-        if not pipelineconfig_utils.is_localized(self.tk.pipeline_configuration.get_path()):
-            log.info("Please note that when you update the core API, you typically affect "
-                     "more than one project. If you want to test a Core API update in isolation "
-                     "prior to rolling it out to multiple projects, we recommend creating a "
-                     "special *localized* pipeline configuration. For more information about this, please "
-                     "see the Toolkit documentation.")
-            log.info("")
-            log.info("")
+        log.info("Please note that if this is a shared Toolkit Core used by more than one project, "
+                 "this will affect all of the projects that use it. If you want to test a Core API "
+                 "update in isolation, prior to rolling it out to multiple projects, we recommend "
+                 "creating a special *localized* pipeline configuration.")
+        log.info("")
+        log.info("For more information, please see the Toolkit documentation:")
+        log.info("https://support.shotgunsoftware.com/entries/96141707")
+        log.info("https://support.shotgunsoftware.com/entries/96142347")
 
         cv = installer.get_current_version_number()
         nv = installer.get_update_version_number()
@@ -192,8 +196,8 @@ class CoreUpdateAction(Action):
             log.info("Detailed Release Notes:")
             log.info("%s" % url)
             log.info("")
-            log.info("Please note that this update will affect all projects")
-            log.info("associated with this Shotgun Pipeline Toolkit installation.")
+            log.info("Please note that if this is a shared core used by more than one project, "
+                     "this will affect the other projects as well.")
             log.info("")
 
             if suppress_prompts or console_utils.ask_yn_question("Update to this version of the Core API?"):
@@ -351,7 +355,6 @@ class TankCoreUpdater(object):
         """
         Performs the actual installation of the new version of the core API
         """
-
         self._log.info("Begin downloading Toolkit Core API %s from the App Store..." % self._new_core_descriptor.get_version())
         self._new_core_descriptor.ensure_local()
 
@@ -368,7 +371,6 @@ class TankCoreUpdater(object):
         """
         Updates the core_api.yml descriptor file.
         """
-
         core_api_yaml_path = os.path.join(
             os.path.dirname(self._install_root), "config", "core", "core_api.yml"
         )

--- a/python/tank/deploy/tank_commands/core_upgrade.py
+++ b/python/tank/deploy/tank_commands/core_upgrade.py
@@ -46,7 +46,6 @@ class TkOptParse(optparse.OptionParser):
         kwargs = copy.copy(kwargs)
         kwargs["add_help_option"] = False
         optparse.OptionParser.__init__(self, *args, **kwargs)
-        optparse.OptionParser.__init__(self, *args, **kwargs)
         # optparse uses argv[0] for the program, but users use the tank command instead, so replace
         # the program.
         self.prog = "tank"
@@ -138,8 +137,6 @@ class CoreUpdateAction(Action):
         # get the core api root of this installation by looking at the relative location of the running code.
         code_install_root = pipelineconfig_utils.get_path_to_current_core()
 
-        installer = TankCoreUpdater(code_install_root, log, core_constraint_pattern)
-
         log.info("")
         log.info("Welcome to the Shotgun Pipeline Toolkit update checker!")
         log.info("This script will check if the Toolkit Core API installed")
@@ -159,6 +156,7 @@ class CoreUpdateAction(Action):
         log.info("")
         log.info("")
 
+        installer = TankCoreUpdater(code_install_root, log, core_constraint_pattern)
         cv = installer.get_current_version_number()
         nv = installer.get_update_version_number()
         log.info("You are currently running version %s of the Shotgun Pipeline Toolkit" % cv)
@@ -242,7 +240,7 @@ class TankCoreUpdater(object):
 
     # possible update status states
     (
-        UP_TO_DATE,                    # all good, no update necessary
+        UP_TO_DATE,                   # all good, no update necessary
         UPDATE_POSSIBLE,              # more recent version exists
         UPDATE_BLOCKED_BY_SG          # more recent version exists but SG version is too low.
     ) = range(3)
@@ -348,7 +346,7 @@ class TankCoreUpdater(object):
 
     def do_install(self):
         """
-        Installs ther requests core and updates core_api.yml.
+        Installs the requested core and updates core_api.yml.
         """
         self._install_core()
         self._update_core_api_descriptor()
@@ -357,10 +355,13 @@ class TankCoreUpdater(object):
         """
         Performs the actual installation of the new version of the core API
         """
-        self._log.info("Begin downloading Toolkit Core API %s from the App Store..." % self._new_core_descriptor.get_version())
-        self._new_core_descriptor.ensure_local()
+        if not self._new_core_descriptor.exists_local():
+            self._log.info("Begin downloading Toolkit Core API %s from the App Store..." % self._new_core_descriptor.get_version())
+            self._new_core_descriptor.ensure_local()
+            self._log.info("Download complete.")
 
-        self._log.info("Download complete - now installing Toolkit Core")
+        self._log.info("Now installing Toolkit Core.")
+
         sys.path.insert(0, self._new_core_descriptor.get_path())
         try:
             import _core_upgrader

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -143,6 +143,18 @@ def subprocess_check_output(*popenargs, **kwargs):
 
 ################################################################################################
 
+
+def is_version_head(version):
+    """
+    Returns if the specified version is HEAD or MASTER. The comparison is case insensitive.
+
+    :param version: Version to test.
+
+    :returns: True if version is HEAD or MASTER, false otherwise.
+    """
+    return version.lower() in ["head", "master"]
+
+
 def is_version_newer(a, b):
     """
     Is the version number string a newer than b?
@@ -153,11 +165,11 @@ def is_version_newer(a, b):
     a=master b=0.13.4 -- Returns False
 
     """
-    if a.lower() in ["head", "master"]:
+    if is_version_head(a):
         # our version is latest
         return True
     
-    if b.lower() in ["head", "master"]:
+    if is_version_head(b):
         # comparing against HEAD - our version is always old
         return False
 
@@ -179,11 +191,11 @@ def is_version_older(a, b):
     a=master b=0.13.4 -- Returns False
 
     """
-    if a.lower() in ["head", "master"]:
+    if is_version_head(a):
         # other version is latest
         return False
     
-    if b.lower() in ["head", "master"]:
+    if is_version_head(b):
         # comparing against HEAD - our version is always old
         return True
 

--- a/python/tank_vendor/shotgun_deploy/constants.py
+++ b/python/tank_vendor/shotgun_deploy/constants.py
@@ -108,3 +108,9 @@ LATEST_CORE_DESCRIPTOR = {"type": "app_store", "name": "tk-core"}
 DESKTOP_PYTHON_MAC = "/Applications/Shotgun.app/Contents/Resources/Python/bin/python"
 DESKTOP_PYTHON_WIN = "C:\\Program Files\\Shotgun\\Python\\python.exe"
 DESKTOP_PYTHON_LINUX = "/opt/Shotgun/Python/bin/python"
+
+# This is the earliest version of Shotgun that Toolkit has historically been compatible
+# with. Code that use this constant do so because the manifest from a core doesn't
+# have a requires_shotgun_version. 5.0.0 is the minimum Shotgun version that every
+# version fo Toolkit have been published with ever since it came out.
+LOWEST_SHOTGUN_VERSION = "5.0.0"

--- a/python/tank_vendor/shotgun_deploy/descriptor_bundle.py
+++ b/python/tank_vendor/shotgun_deploy/descriptor_bundle.py
@@ -11,6 +11,7 @@
 from .descriptor import Descriptor
 from .errors import ShotgunDeployError
 from . import util
+from . import constants
 
 log = util.get_shotgun_deploy_logger()
 
@@ -41,7 +42,7 @@ class BundleDescriptor(Descriptor):
 
         manifest = self._io_descriptor.get_manifest()
 
-        constraints["min_sg"] = manifest.get("requires_shotgun_version", "5.0.0")
+        constraints["min_sg"] = manifest.get("requires_shotgun_version", constants.LOWEST_SHOTGUN_VERSION)
 
         if manifest.get("requires_core_version") is not None:
             constraints["min_core"] = manifest.get("requires_core_version")

--- a/python/tank_vendor/shotgun_deploy/descriptor_bundle.py
+++ b/python/tank_vendor/shotgun_deploy/descriptor_bundle.py
@@ -41,8 +41,7 @@ class BundleDescriptor(Descriptor):
 
         manifest = self._io_descriptor.get_manifest()
 
-        if manifest.get("requires_shotgun_version") is not None:
-            constraints["min_sg"] = manifest.get("requires_shotgun_version")
+        constraints["min_sg"] = manifest.get("requires_shotgun_version", "5.0.0")
 
         if manifest.get("requires_core_version") is not None:
             constraints["min_core"] = manifest.get("requires_core_version")

--- a/python/tank_vendor/shotgun_deploy/descriptor_core.py
+++ b/python/tank_vendor/shotgun_deploy/descriptor_core.py
@@ -36,7 +36,6 @@ class CoreDescriptor(Descriptor):
 
         manifest = self._io_descriptor.get_manifest()
 
-        if manifest.get("requires_shotgun_version") is not None:
-            constraints["min_sg"] = manifest.get("requires_shotgun_version")
+        constraints["min_sg"] = manifest.get("requires_shotgun_version", "5.0.0")
 
         return constraints

--- a/python/tank_vendor/shotgun_deploy/descriptor_core.py
+++ b/python/tank_vendor/shotgun_deploy/descriptor_core.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .descriptor import Descriptor
+from . import constants
 
 class CoreDescriptor(Descriptor):
     """
@@ -36,6 +37,6 @@ class CoreDescriptor(Descriptor):
 
         manifest = self._io_descriptor.get_manifest()
 
-        constraints["min_sg"] = manifest.get("requires_shotgun_version", "5.0.0")
+        constraints["min_sg"] = manifest.get("requires_shotgun_version", constants.LOWEST_SHOTGUN_VERSION)
 
         return constraints

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
@@ -291,7 +291,7 @@ class IODescriptorAppStore(IODescriptorBase):
             msg = sg_bundle_data.get("sg_deprecation_message", "No reason given.")
             return (True, msg)
         else:
-            return (False, "")        
+            return (False, "")
 
     def get_version(self):
         """

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
@@ -455,10 +455,6 @@ class IODescriptorAppStore(IODescriptorBase):
                 [[link_field, "is", sg_bundle_data]] + latest_filter,
                 ["code"]
             )
-
-            if len(sg_data) == 0:
-                raise ShotgunDeployError("Cannot find any versions for %s in the App store!" % self._name)
-
         else:
             # now get all versions
             sg_data = sg.find(
@@ -466,6 +462,9 @@ class IODescriptorAppStore(IODescriptorBase):
                 filters=latest_filter,
                 fields=["code"]
             )
+
+        if len(sg_data) == 0:
+            raise ShotgunDeployError("Cannot find any versions for %s in the App store!" % self._name)
 
         version_numbers = [x.get("code") for x in sg_data]
         version_to_use = self._find_latest_tag_by_pattern(version_numbers, version_pattern)

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/appstore.py
@@ -15,6 +15,7 @@ import urllib
 import urllib2
 import cPickle as pickle
 
+from ..errors import ShotgunDeployError
 from ..zipfilehelper import unzip_file
 from ..descriptor import Descriptor
 from ..errors import ShotgunAppStoreError
@@ -419,47 +420,52 @@ class IODescriptorAppStore(IODescriptorBase):
 
         :returns: IODescriptorAppStore instance
         """
-
         # connect to the app store
         (sg, _) = self.__create_sg_app_store_connection()
 
-        # set up some lookup tables so we look in the right table in sg
-
-        # find the main entry
-        sg_bundle_data = sg.find_one(
-            self._APP_STORE_OBJECT[self._type],
-            [["sg_system_name", "is", self._name]],
-            ["id", "sg_status_list"]
-        )
-
-        if sg_bundle_data is None:
-            raise ShotgunDeployError("App store does not contain an item named '%s'!" % self._name)
-
-        # check if this has been deprecated in the app store
-        # in that case we should ensure that the metadata is refreshed later
-        is_deprecated = False
-        if sg_bundle_data["sg_status_list"] == "dep":
-            is_deprecated = True
-
-        # now get all versions
-        
         # get latest get the filter logic for what to exclude
         if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
             latest_filter = [["sg_status_list", "is_not", "bad" ]]
         else:
             latest_filter = [["sg_status_list", "is_not", "rev" ],
-                             ["sg_status_list", "is_not", "bad" ]]        
-        
-        link_field = self._APP_STORE_LINK[self._type]
-        entity_type = self._APP_STORE_VERSION[self._type]
-        sg_data = sg.find(
-            entity_type,
-            [[link_field, "is", sg_bundle_data]] + latest_filter,
-            ["code"]
-        )
+                             ["sg_status_list", "is_not", "bad" ]]
 
-        if len(sg_data) == 0:
-            raise ShotgunDeployError("Cannot find any versions for %s in the App store!" % self._name)
+        is_deprecated = False
+        if self._type != self.CORE:
+            # find the main entry
+            sg_bundle_data = sg.find_one(
+                self._APP_STORE_OBJECT[self._type],
+                [["sg_system_name", "is", self._name]],
+                ["id", "sg_status_list"]
+            )
+
+            if sg_bundle_data is None:
+                raise ShotgunDeployError("App store does not contain an item named '%s'!" % self._name)
+
+            # check if this has been deprecated in the app store
+            # in that case we should ensure that the metadata is refreshed later
+            if sg_bundle_data["sg_status_list"] == "dep":
+                is_deprecated = True
+
+            # now get all versions
+            link_field = self._APP_STORE_LINK[self._type]
+            entity_type = self._APP_STORE_VERSION[self._type]
+            sg_data = sg.find(
+                entity_type,
+                [[link_field, "is", sg_bundle_data]] + latest_filter,
+                ["code"]
+            )
+
+            if len(sg_data) == 0:
+                raise ShotgunDeployError("Cannot find any versions for %s in the App store!" % self._name)
+
+        else:
+            # now get all versions
+            sg_data = sg.find(
+                constants.TANK_CORE_VERSION_ENTITY_TYPE,
+                filters=latest_filter,
+                fields=["code"]
+            )
 
         version_numbers = [x.get("code") for x in sg_data]
         version_to_use = self._find_latest_tag_by_pattern(version_numbers, version_pattern)

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
@@ -193,8 +193,8 @@ class IODescriptorBase(object):
             version_digit = int(version_digit)
             if version_digit not in current:
                 raise ShotgunDeployError(
-                    "%s does not have a version matching the pattern '%s'. "
-                    "Available versions are: %s" % (self._path, pattern, ", ".join(version_numbers))
+                    "'%s' does not have a version matching the pattern '%s'. "
+                    "Available versions are: %s" % (self.get_system_name(), pattern, ", ".join(version_numbers))
                 )
             current = current[version_digit]
             if version_to_use is None:

--- a/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
+++ b/python/tank_vendor/shotgun_deploy/io_descriptor/base.py
@@ -476,5 +476,3 @@ class IODescriptorBase(object):
         :returns: descriptor object
         """
         raise NotImplementedError
-
-

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -650,12 +650,12 @@ def _shotgun_run_action(log, install_root, pipeline_config_root, is_localized, a
         log.info("")
 
         status = installer.get_update_status()
-        req_sg = installer.get_required_sg_version_for_update()
 
         if status == TankCoreUpdater.UP_TO_DATE:
             log.info("<b>You are up to date! There is no need to update the Toolkit Core API at this time!</b>")
 
         elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
+            req_sg = installer.get_required_sg_version_for_update()
             log.warning("<b>A new version (%s) of the core API is available however "
                         "it requires a more recent version (%s) of Shotgun!</b>" % (lv, req_sg))
 


### PR DESCRIPTION
- Writes core_api.yml on upgrade of core.
- Also revamped the core command to use the new descriptor framework
- Updated the app store descriptor to be able to enumerate core versions as well as bundle versions
- The minimal version of Shotgun required is now retrieved from the info.yml, not from Shotgun. This means that the core will always be downloaded now when trying to upgrade to it in order to know the minimal shotgun version. Ideally in the future info.yml would be cached in Shotgun so this download wouldn't be necessary.