### PR TITLE
#35773 Added a new exception for missing method in hook

### DIFF
--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -49,6 +49,11 @@ class TankEngineInitError(TankError):
     """
     pass
 
+class TankHookMethodDoesNotExist(TankError):
+    """
+    Exception that indicates that a called method does not exist in the hook.
+    """
+    pass
 
 class TankErrorProjectIsSetup(TankError):
     """

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -49,7 +49,7 @@ class TankEngineInitError(TankError):
     """
     pass
 
-class TankHookMethodDoesNotExist(TankError):
+class TankHookMethodDoesNotExistError(TankError):
     """
     Exception that indicates that a called method does not exist in the hook.
     """

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -16,7 +16,11 @@ import os
 import threading
 from . import loader
 from .platform import constants
-from .errors import TankError, TankFileDoesNotExistError
+from .errors import (
+    TankError,
+    TankFileDoesNotExistError,
+    TankHookMethodDoesNotExist,
+)
 
 class Hook(object):
     """
@@ -276,8 +280,10 @@ def execute_hook_method(hook_paths, parent, method_name, **kwargs):
     try:
         hook_method = getattr(hook, method_name)
     except AttributeError:
-        raise TankError("Cannot execute hook '%s' - the hook class does not "
-                        "have a '%s' method!" % (hook, method_name))
+        raise TankHookMethodDoesNotExist(
+            "Cannot execute hook '%s' - the hook class does not have a '%s' "
+            "method!" % (hook, method_name)
+        )
     
     # execute the method
     ret_val = hook_method(**kwargs)

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -19,7 +19,7 @@ from .platform import constants
 from .errors import (
     TankError,
     TankFileDoesNotExistError,
-    TankHookMethodDoesNotExist,
+    TankHookMethodDoesNotExistError,
 )
 
 class Hook(object):
@@ -280,7 +280,7 @@ def execute_hook_method(hook_paths, parent, method_name, **kwargs):
     try:
         hook_method = getattr(hook, method_name)
     except AttributeError:
-        raise TankHookMethodDoesNotExist(
+        raise TankHookMethodDoesNotExistError(
             "Cannot execute hook '%s' - the hook class does not have a '%s' "
             "method!" % (hook, method_name)
         )

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -15,7 +15,7 @@ import tempfile
 
 from tank_test.tank_test_base import *
 import tank
-from tank.errors import TankError
+from tank.errors import TankError, TankHookMethodDoesNotExistError
 from tank.platform import application
 from tank.platform import constants
 from tank.template import Template
@@ -146,6 +146,17 @@ class TestExecuteHookByName(TestApplication):
         app = self.engine.apps["test_app"]
         self.assertTrue(app.execute_hook_expression("{self}/test_hook.py", "execute", dummy_param=True), 
                         "named_hook_1")
+
+    # calling `execute_hook_method` for a method that does not exist in the hook
+    # should raise the TankHookMethodDoesNotExistError exception
+    def test_no_method(self):
+        app = self.engine.apps["test_app"]
+        self.assertRaises(
+            TankHookMethodDoesNotExistError,
+            app.execute_hook_method,
+            "test_hook_std",
+            "foobar"
+        )
 
 
 class TestExecuteHook(TestApplication):


### PR DESCRIPTION
This is a small change that adds a new exception type to core called `TankHookMethodDoesNotExistError`. This is raised when `execute_hook_method` fails because the specified method does not exist in the hook. 
