### PR TITLE
Ensures that the host and http_proxy strings are utf-8.

### DIFF
--- a/python/tank_vendor/shotgun_authentication/user_impl.py
+++ b/python/tank_vendor/shotgun_authentication/user_impl.py
@@ -48,7 +48,14 @@ class ShotgunUserImpl(object):
         if not host:
             raise IncompleteCredentials("missing host")
 
-        self._host = host
+        # We need to ensure that we are always storing utf-8 so that
+        # we don't end up infecting API instances with unicode strings
+        # that would then cause some string data to be unicoded during
+        # concatenation operations.
+        if http_proxy is not None:
+            http_proxy = http_proxy.encode("utf-8")
+
+        self._host = host.encode("utf-8")
         self._http_proxy = http_proxy
 
     def get_host(self):

--- a/python/tank_vendor/shotgun_authentication/user_impl.py
+++ b/python/tank_vendor/shotgun_authentication/user_impl.py
@@ -52,10 +52,13 @@ class ShotgunUserImpl(object):
         # we don't end up infecting API instances with unicode strings
         # that would then cause some string data to be unicoded during
         # concatenation operations.
-        if http_proxy is not None:
+        if isinstance(http_proxy, unicode):
             http_proxy = http_proxy.encode("utf-8")
 
-        self._host = host.encode("utf-8")
+        if isinstance(host, unicode):
+            host = host.encode("utf-8")
+
+        self._host = host
         self._http_proxy = http_proxy
 
     def get_host(self):


### PR DESCRIPTION
In RV (and possibly elsewhere in the future) we need to be careful about not propagating unicode strings into the Python API when establishing the connection to Shotgun. The host and http_proxy strings are concatenated with data on upload, which can cause Python to try to convert the contents of a file to unicode which then throws a UnicodeDecodeError.