### PR TITLE
For #35912, clean up whitespace during auth

### DIFF
--- a/python/tank_vendor/shotgun_authentication/console_authentication.py
+++ b/python/tank_vendor/shotgun_authentication/console_authentication.py
@@ -103,6 +103,16 @@ class ConsoleAuthenticationHandlerBase(object):
             raise AuthenticationCancelled()
         return password
 
+    def _raw_input(self, text):
+        """
+        Wraps the raw_input builtin function so unit tests can mock it.
+
+        :param text: Text to display before prompting the user.
+
+        :returns: The user's text input.
+        """
+        return raw_input(text)
+
     def _get_keyboard_input(self, label, default_value=""):
         """
         Queries for keyboard input.
@@ -116,8 +126,9 @@ class ConsoleAuthenticationHandlerBase(object):
         text += ": "
         user_input = None
         while not user_input:
-            user_input = raw_input(text) or default_value
-        return user_input
+            user_input = self._raw_input(text) or default_value
+        # Strip whitespace before and after user input.
+        return user_input.strip()
 
     def _get_2fa_code(self):
         """
@@ -126,10 +137,10 @@ class ConsoleAuthenticationHandlerBase(object):
         :raises AuthenticationCancelled: If the user enters an empty code, the exception will be
                                          thrown.
         """
-        code = raw_input("Two factor authentication code (empty to abort): ")
+        code = self._raw_input("Two factor authentication code (empty to abort): ")
         if not code:
             raise AuthenticationCancelled()
-        return code
+        return code.strip()
 
 
 class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):
@@ -138,6 +149,7 @@ class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):
     not be instantiated directly and be used through the authenticate and
     renew_session methods.
     """
+
     def _get_user_credentials(self, hostname, login):
         """
         Reads the user password from the keyboard.
@@ -156,6 +168,7 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
     instantiated directly and be used through the authenticate and renew_session
     methods.
     """
+
     def __init__(self, fixed_host):
         """
         Constructor.

--- a/python/tank_vendor/shotgun_authentication/console_authentication.py
+++ b/python/tank_vendor/shotgun_authentication/console_authentication.py
@@ -103,15 +103,16 @@ class ConsoleAuthenticationHandlerBase(object):
             raise AuthenticationCancelled()
         return password
 
-    def _raw_input(self, text):
+    def _read_clean_input(self, text):
         """
-        Wraps the raw_input builtin function so unit tests can mock it.
+        Reads a line a text from the keyboard and strips any trailing or tailing
+        whitespaces.
 
         :param text: Text to display before prompting the user.
 
         :returns: The user's text input.
         """
-        return raw_input(text)
+        return raw_input(text).strip()
 
     def _get_keyboard_input(self, label, default_value=""):
         """
@@ -126,9 +127,9 @@ class ConsoleAuthenticationHandlerBase(object):
         text += ": "
         user_input = None
         while not user_input:
-            user_input = self._raw_input(text) or default_value
+            user_input = self._read_clean_input(text) or default_value
         # Strip whitespace before and after user input.
-        return user_input.strip()
+        return user_input
 
     def _get_2fa_code(self):
         """
@@ -137,10 +138,10 @@ class ConsoleAuthenticationHandlerBase(object):
         :raises AuthenticationCancelled: If the user enters an empty code, the exception will be
                                          thrown.
         """
-        code = self._raw_input("Two factor authentication code (empty to abort): ")
+        code = self._read_clean_input("Two factor authentication code (empty to abort): ")
         if not code:
             raise AuthenticationCancelled()
-        return code.strip()
+        return code
 
 
 class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):

--- a/python/tank_vendor/shotgun_authentication/login_dialog.py
+++ b/python/tank_vendor/shotgun_authentication/login_dialog.py
@@ -112,6 +112,15 @@ class LoginDialog(QtGui.QDialog):
 
         self.ui.forgot_password_link.linkActivated.connect(self._link_activated)
 
+        self.ui.site.editingFinished.connect(self._strip_whitespaces)
+        self.ui.login.editingFinished.connect(self._strip_whitespaces)
+        self.ui._2fa_code.editingFinished.connect(self._strip_whitespaces)
+        self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
+
+    def _strip_whitespaces(self):
+        # Cleans up the field after editing
+        self.sender().setText(self.sender().text().strip())
+
     def _link_activated(self, site):
         """
         Clicked when the user presses on the "Forgot your password?" link.

--- a/python/tank_vendor/shotgun_authentication/login_dialog.py
+++ b/python/tank_vendor/shotgun_authentication/login_dialog.py
@@ -118,7 +118,9 @@ class LoginDialog(QtGui.QDialog):
         self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
 
     def _strip_whitespaces(self):
-        # Cleans up the field after editing
+        """
+        Cleans up a field after editing.
+        """
         self.sender().setText(self.sender().text().strip())
 
     def _link_activated(self, site):
@@ -207,7 +209,7 @@ class LoginDialog(QtGui.QDialog):
 
     def _ok_pressed(self):
         """
-        validate the values, accepting if login is successful and display an error message if not.
+        Validate the values, accepting if login is successful and display an error message if not.
         """
         # pull values from the gui
         site = self.ui.site.text()

--- a/tests/shotgun_authentication_tests/test_interactive_authentication.py
+++ b/tests/shotgun_authentication_tests/test_interactive_authentication.py
@@ -232,7 +232,7 @@ class InteractiveTests(TankTestBase):
             bg.wait()
 
     @patch(
-        "tank_vendor.shotgun_authentication.console_authentication.ConsoleLoginHandler._raw_input",
+        "__builtin__.raw_input",
         side_effect=["  https://test.shotgunstudio.com ", "  username   ", " 2fa code "]
     )
     @patch(

--- a/tests/shotgun_authentication_tests/test_interactive_authentication.py
+++ b/tests/shotgun_authentication_tests/test_interactive_authentication.py
@@ -68,10 +68,12 @@ class InteractiveTests(TankTestBase):
         from tank_vendor.shotgun_authentication import login_dialog
         ld = login_dialog.LoginDialog(is_session_renewal=False)
         self.assertEqual(ld.ui.site.text(), "https://mystudio.shotgunstudio.com")
+        self.assertEqual(ld.ui.site.selectedText(), "mystudio")
         ld.close()
 
         ld = login_dialog.LoginDialog(is_session_renewal=False, login="login")
         self.assertEqual(ld.ui.site.text(), "https://mystudio.shotgunstudio.com")
+        self.assertEqual(ld.ui.site.selectedText(), "mystudio")
         ld.close()
 
         ld = login_dialog.LoginDialog(is_session_renewal=False, hostname="host")


### PR DESCRIPTION
- Removes whitespace before and after user input for the hostname and username to avoid connection error due to user input.
- Removed the interactive unit tests as nobody was aware of their existence and were cumbersome to run in favour of automated UI tests.