### PR TITLE
For #36067, command line auth fix

### DIFF
--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -207,7 +207,7 @@ Log out of the current user (no context required):
         log.info(x)
 
 
-def ensure_authenticated(script_name=None, script_key=None):
+def ensure_authenticated(script_name, script_key):
     """
     Make sure that there is a current toolkit user set.
     May prompt for a login/password if needed. Note that if command line
@@ -1601,7 +1601,10 @@ if __name__ == "__main__":
                     ctx_list = [ os.getcwd() ] # path
 
             # first make sure there is a current user
-            ensure_authenticated(credentials)
+            ensure_authenticated(
+                credentials.get("script-name"),
+                credentials.get("script-key")
+            )
 
             # now run the command
             exit_code = run_engine_cmd(logger, pipeline_config_root, ctx_list, cmd_name, using_cwd, cmd_args)

--- a/tests/fixtures/integration_tests/authentication/bad_credentials
+++ b/tests/fixtures/integration_tests/authentication/bad_credentials
@@ -1,0 +1,2 @@
+script-name: test
+script-key: 1234

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -41,14 +41,14 @@ def _test_return_value(expected_result, args):
     args = [tank_path] + args.split(" ")
     print "Running %s" % " ".join(args)
     try:
-        result = subprocess.check_output(args)
-        output = ""
+        output = subprocess.check_output(args, stdin=None)
+        result = 0
     except subprocess.CalledProcessError, e:
         result = e.returncode
         output = e.output
 
     if result != expected_result:
-        print "Expecting %d, got %d" % (expected_result, result)
+        print "Expecting %s, got %s" % (expected_result, result)
         print output
         assert(result == expected_result)
 

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -25,10 +25,9 @@ def get_test_resource_path(rel_path):
     return os.path.join(os.path.split(__file__)[0], "fixtures", "integration_tests", rel_path)
 
 
-def test_return_value(expected_result, args):
+def _test_return_value(expected_result, args):
     """
-    Invokes the tank command with the arguments provided and compares the
-    result with the expected value.
+    Invokes the tank command compares the result with the expected value.
 
     e.g.
 
@@ -39,7 +38,6 @@ def test_return_value(expected_result, args):
 
     :raises AssertError: If the error codes differ, this exception is raised.
     """
-    global tank_path
     args = [tank_path] + args.split(" ")
     print "Running %s" % " ".join(args)
     try:
@@ -55,6 +53,26 @@ def test_return_value(expected_result, args):
         assert(result == expected_result)
 
 
+def test_return_value(expected_result, args):
+    """
+    Invokes the tank command with the arguments provided with and without a core
+    command and compares the result with the expected value.
+
+    e.g.
+
+    test_return_value(9, "--login=login --password=password")
+
+    :param expected_result: The expected integer return code for the tank process.
+    :param args: String containing all the parameters for the command line.
+
+    :raises AssertError: If the error codes differ, this exception is raised.
+    """
+    global tank_path
+
+    _test_return_value(expected_result, args)
+    _test_return_value(expected_result, args + " shell")
+
+
 def command_line_authentication_tests():
     """
     Runs command line authentication tests.
@@ -63,7 +81,7 @@ def command_line_authentication_tests():
     # missing param
     test_return_value(9, "--script-name=test")
     test_return_value(9, "--script-key=1234")
-    test_return_value(9, "--credentials-file==%s" % get_test_resource_path("authentication/missing_file"))
+    test_return_value(9, "--credentials-file=%s" % get_test_resource_path("authentication/missing_file"))
 
     test_return_value(9, "--script-name=test --script-name=test --script-key=1234")
     test_return_value(9, "--script-name=test --script-key=1234 --script-key=1234")
@@ -71,6 +89,10 @@ def command_line_authentication_tests():
     # mixing params
     test_return_value(9, "--script-name=test --credentials-file=/var/tmp/script_credentials.yml")
     test_return_value(9, "--script-key=test --credentials-file=/var/tmp/script_credentials.yml")
+
+    # Bad credentials
+    test_return_value(7, "--script-name=test --script-key=1234")
+    test_return_value(7, "--credentials-file=%s" % get_test_resource_path("authentication/bad_credentials"))
 
 
 def main():

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -8,6 +8,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+"""
+Integration tests for core.
+"""
+
 import sys
 import os
 import subprocess
@@ -58,10 +62,6 @@ def test_return_value(expected_result, args):
     Invokes the tank command with the arguments provided with and without a core
     command and compares the result with the expected value.
 
-    e.g.
-
-    test_return_value(9, "--login=login --password=password")
-
     :param expected_result: The expected integer return code for the tank process.
     :param args: String containing all the parameters for the command line.
 
@@ -77,7 +77,6 @@ def command_line_authentication_tests():
     """
     Runs command line authentication tests.
     """
-
     # missing param
     test_return_value(9, "--script-name=test")
     test_return_value(9, "--script-key=1234")


### PR DESCRIPTION
- Fixes script based authentication on the command line when user types in a command.
- Updated integration tests to validate the bug.
