### PR TITLE
Removes app store timeout logic

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -219,17 +219,10 @@ def __create_sg_connection(config_data=None, user=None):
         # mechanism for script user.
         sg = shotgun_api3.Shotgun(
             config_data["host"],
-            script_name=config_data["api_script"], api_key=config_data["api_key"],
-            http_proxy=config_data.get("http_proxy"), connect=config_data.get("connect", True))
-
-        if "timeout_secs" in config_data:
-            sg.config.timeout_secs = config_data.get("timeout_secs")
-            # The timeout can't be set until after the sg instance is created (when it has already
-            # stored the timeout setting in the connection). We have to force it to re-spawn
-            # the connection with the new timeout settings. It will create a new conneciton 
-            # automatically the next time it's called. There shouldn't be a connection yet, but
-            # if there is, let's close it just in case.
-            sg.close()
+            script_name=config_data["api_script"],
+            api_key=config_data["api_key"],
+            http_proxy=config_data.get("http_proxy")
+        )
     elif user:
         sg = user.create_sg_connection()
     else:


### PR DESCRIPTION
Because the way the app store logic has been refactored in 0.18, changes needed to be manually merged from 0.17. This backs out of some logic which was specifically added solely for the purpose to be able to set the app store connection timeout. For the merge from 0.17 to 0.18, we did some adjustments in 5554d12 to make the app store timeout changes became 0.18 compatible, but we never removed the code which was added in 0.17, which is no longer used anywhere.

This logic was added so that technically a timeout parameter could be added to the normal shotgun connection as well as the app store connection, however this would only work if the shotgun connection 
was using script based credentials. I don't believe this is currently documented and adds complexity in what is essentially a legacy part of the system, so I am keen on backing out of this change for 0.18.

We need to improve the ability to control timeouts and proxies, but that information will ultimately not be stored in the `shotgun.yml` file.

for context, here's the original 0.17 change - https://github.com/shotgunsoftware/tk-core/pull/251