### PR TITLE
Authentication compatibility fallback

### DIFF
--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -59,28 +59,49 @@ def _get_global_authentication_file_location():
     stores authentication related information for all sites. At this moment,
     the file stores only the current host.
 
+    Looks for the latest file naming convention first, if that doesn't exists
+    tries to fall back to previous path standards.
+
     :returns: Path to the login information.
     """
     # avoid cylic imports
     from ..util import LocalFileStorageManager
 
-    return os.path.join(
+    # try current generation path first
+    path = os.path.join(
         LocalFileStorageManager.get_global_root(LocalFileStorageManager.CACHE),
         _SESSION_CACHE_FILE_NAME
     )
+    if not os.path.exists(path):
+
+        # see if there is a legacy path
+        old_path = os.path.join(
+            LocalFileStorageManager.get_global_root(
+                LocalFileStorageManager.CACHE,
+                generation=LocalFileStorageManager.CORE_V17),
+            _SESSION_CACHE_FILE_NAME
+        )
+
+        if os.path.exists(old_path):
+            logger.debug("Falling back on legacy path for auth: %s" % old_path)
+            path = old_path
+
+    return path
 
 def _get_site_authentication_file_location(base_url):
     """
     Returns the location of the users file on disk for a specific site.
 
-    :param base_url: The site we want the login information for.
+    Looks for the latest file naming convention first, if that doesn't exists
+    tries to fall back to previous path standards.
 
+    :param base_url: The site we want the login information for.
     :returns: Path to the login information.
     """
     # avoid cylic imports
     from ..util import LocalFileStorageManager
 
-    return os.path.join(
+    path = os.path.join(
         LocalFileStorageManager.get_site_root(
             base_url,
             LocalFileStorageManager.CACHE
@@ -88,6 +109,23 @@ def _get_site_authentication_file_location(base_url):
         _SESSION_CACHE_FILE_NAME
     )
 
+    if not os.path.exists(path):
+
+        # see if there is a legacy path
+        old_path = os.path.join(
+            LocalFileStorageManager.get_site_root(
+                base_url,
+                LocalFileStorageManager.CACHE,
+                generation=LocalFileStorageManager.CORE_V17
+            ),
+            _SESSION_CACHE_FILE_NAME
+        )
+
+        if os.path.exists(old_path):
+            logger.debug("Falling back on legacy path for auth: %s" % old_path)
+            path = old_path
+
+    return path
 
 def _ensure_folder_for_file(filepath):
     """


### PR DESCRIPTION
The desktop assumes that if you have authenticated on the site level, you are also authenticated on the project level. In 0.18, a new set of root paths (pending our discussion) are introduced and this means that there was a situation where auth info was stored on disk and readable for a 17 core but not for an 18 core. So if your project was 0.18 and your site config was 0.17, things wouldn't work.

This PR adds a fallback so that if the 0.18 config isn't found, it checks for the 0.17 one as well (similar to how the cache hook works). If none of them is found, the 0.18 path is returned.