### PR TITLE
For #36538, bring back app store proxy

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -22,7 +22,7 @@ from tank_vendor.shotgun_api3.lib import httplib2
 import cPickle as pickle
 
 from ...util.zip import unzip_file
-from ...util import filesystem
+from ...util import filesystem, shotgun
 from ..descriptor import Descriptor
 from ..errors import TankAppStoreConnectionError
 from ..errors import TankAppStoreError
@@ -96,7 +96,7 @@ class IODescriptorAppStore(IODescriptorBase):
 
         :param descriptor_dict: descriptor dictionary describing the bundle
         :param sg_connection: Shotgun connection to associated site
-        :param bundle_type: Either Descriptor.APP, CORE, ENGINE or FRAMEWORK
+        :param bundle_type: Either Descriptor.APP, CORE, ENGINE or FRAMEWORK or CONFIG
         :return: Descriptor instance
         """
         super(IODescriptorAppStore, self).__init__(descriptor_dict)
@@ -622,7 +622,7 @@ class IODescriptorAppStore(IODescriptorBase):
                 constants.SGTK_APP_STORE,
                 script_name=script_name,
                 api_key=script_key,
-                http_proxy=self._sg_connection.config.raw_http_proxy,
+                http_proxy=self.__get_app_store_proxy_setting(),
                 connect=False
             )
             # set the default timeout for app store connections
@@ -661,6 +661,24 @@ class IODescriptorAppStore(IODescriptorBase):
             self._app_store_connections[sg_url] = (app_store_sg, script_user)
 
         return self._app_store_connections[sg_url]
+
+    def __get_app_store_proxy_setting(self):
+        """
+        Retrieve the app store proxy settings. If the key app_store_http_proxy is not found in the
+        ``shotgun.yml`` file, the proxy settings from the client site connection will be used. If the key
+        is found, than its value will be used. Note that if the ``app_store_http_proxy`` setting is set
+        to ``null`` in the configuration file, it means that the app store proxy is being forced to ``None``
+        and therefore won't be inherited from the http proxy setting.
+
+        :returns: The http proxy connection string.
+        """
+        config_data = shotgun.get_associated_sg_config_data()
+        if config_data and constants.APP_STORE_HTTP_PROXY in config_data:
+            return config_data[constants.APP_STORE_HTTP_PROXY]
+        else:
+            # Use the http proxy from the connection so we don't have to run
+            # the connection hook again.
+            return self._sg_connection.config.raw_http_proxy
 
     def __get_app_store_key_from_shotgun(self):
         """

--- a/tests/run_auth_tests.sh
+++ b/tests/run_auth_tests.sh
@@ -9,10 +9,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-./run_tests.sh shotgun_authentication_tests.test_shotgun_wrapper &&
-    ./run_tests.sh shotgun_authentication_tests.test_shotgun_authenticator &&
-    ./run_tests.sh shotgun_authentication_tests.test_user &&
-    ./run_tests.sh shotgun_authentication_tests.test_session_cache &&
+./run_tests.sh authentication_tests.test_shotgun_wrapper &&
+    ./run_tests.sh authentication_tests.test_shotgun_authenticator &&
+    ./run_tests.sh authentication_tests.test_user &&
+    ./run_tests.sh authentication_tests.test_session_cache &&
     ./run_tests.sh util_tests.test_login &&
     ./run_tests.sh util_tests.test_shotgun &&
-    ./run_tests.sh shotgun_authentication_tests.test_interactive_authentication $*
+    ./run_tests.sh authentication_tests.test_interactive_authentication $*

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -22,6 +22,8 @@ from tank.template import TemplatePath
 from tank.templatekey import SequenceKey
 from tank.authentication.user import ShotgunUser
 from tank.authentication.user_impl import SessionUser
+from tank.descriptor import Descriptor
+from tank.descriptor.io_descriptor.appstore import IODescriptorAppStore
 
 
 class TestShotgunFindPublish(TankTestBase):
@@ -554,8 +556,12 @@ class ConnectionSettingsTestCases:
             self.assertEqual(sg.base_url, self._SITE)
             self.assertEqual(sg.config.raw_http_proxy, source_proxy)
 
-            # NEED TO FIX FOR APP STORE CHANGES
-            self.assertEqual(sg.config["http_proxy"], expected_store_proxy)
+            descriptor = IODescriptorAppStore(
+                {"name": "tk-multi-app", "version": "v0.0.1", "type": "app_store"},
+                sg, Descriptor.CORE
+            )
+            http_proxy = descriptor._IODescriptorAppStore__get_app_store_proxy_setting()
+            self.assertEqual(http_proxy, expected_store_proxy)
 
 
 class LegacyAuthConnectionSettings(ConnectionSettingsTestCases.Impl):


### PR DESCRIPTION
Brings back the app_store_proxy_server setting in shotgun.yml and updates the unit test.

I recommend skipping the first commit since it's a bunch of PEP8 changes on comment lines and empty lines with whitespaces, so start from here: https://github.com/shotgunsoftware/tk-core/pull/282/commits/fd517f1de05a2f40bd6e2f472fdb3afa45f5cd49