### PR TITLE
#36806 descriptors for unauthenticated pathways

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -599,7 +599,17 @@ class PipelineConfiguration(object):
                                     - v1.x.x - get the highest v1 version
         :returns: Descriptor object
         """
-        sg_connection = shotgun.get_sg_connection()
+
+        # note: certain legacy methods, for example how shotgun menu actions are cached
+        # from the tank command, are not authenticated pathways. This is something we
+        # ultimately need to more away from, ensuring that the system is fully authenticated
+        # across the board. However, in the meantime, ensure that *basic* descriptor operations can
+        # be accessed without having a valid shotgun connection by using a deferred shotgun API wrapper
+        # rather than a wrapper that is initialized straight away. This ensures that a valid authentication
+        # state in toolkit is not required until the connection is actually needed. In the case of descriptors,
+        # a connection is typically only needed at download and when checking for latest. Path resolution
+        # methods do not require a connection.
+        sg_connection = shotgun.get_deferred_sg_connection()
 
         if isinstance(dict_or_uri, basestring):
             descriptor_dict = descriptor_uri_to_dict(dict_or_uri)

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -301,6 +301,30 @@ def get_associated_sg_config_data():
     cfg = __get_sg_config()
     return __get_sg_config_data(cfg)
 
+def get_deferred_sg_connection():
+    """
+    Returns a shotgun API instance that is lazily initialized.
+    This is a method intended only to support certain legacy cases
+    where some operations in Toolkit are not fully authenticated.
+    When descriptor objects are constructed, they are associated with a
+    SG API handle. This handle is not necessary for basic operations such
+    as path resolution. By passing a deferred connection object to
+    descriptors, authentication is essentially deferred until the need
+    for more complex operations arises, allowing for simple, *legacy*
+    non-authenticated pathways.
+
+    :return: Proxied SG API handle
+    """
+    class DeferredInitShotgunProxy(object):
+        def __init__(self):
+            self._sg = None
+        def __getattr__(self, key):
+            if self._sg is None:
+                self._sg = get_sg_connection()
+            return getattr(self._sg, key)
+
+    return DeferredInitShotgunProxy()
+
 
 g_sg_cached_connection = None
 def get_sg_connection():


### PR DESCRIPTION
In 0.17, the shotgun connection was happening on demand inside the descriptor code. In 0.18, a descriptor object is initialized with a shotgun connection. This is in order to provide better encapsulation, be able to better control where a shotgun connection stems from and ultimately run the descriptor API in an environment that doesn't necessarily require a full toolkit setup.

Unfortunately, We have a very special case where this is causing issues - when menu items are cached by the tank command and shotgun engine, this is taking place in an unauthenticated fashion - this is to prevent authentication prompts to pop up as part of a page load in Shotgun. This is very much a legacy case and something we will ultimately move away from when we release the next iteration on websockets based communication with desktop.

For the time being, I have done a simple patch to work around this issue - a proxied shotgun connection is passed in to the descriptors in order to allow for basic operations such as local cache access to take place without actually establishing an sg connection up front (for which an well authenticated state is required). This is meant as a semi-temporary approach to handle an fairly special edge case that we are expecting to go away in the medium to long term.