### PR TITLE
#36862 #36866 Final round of 0.18 interface changes

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -115,7 +115,8 @@ class ToolkitManager(object):
         review tools for RV, name your entry point "RV Review". If your plugin
         embeds the shotgun panel in a Maya Plugin, name it "Maya Panel".
 
-        The entry point value can be used to customize the behavior of a
+        In the future, it will be possible to use the entry point value
+        to customize the behavior of a
         plugin via Shotgun. At bootstrap, toolkit will look for a pipeline
         configuration with a matching name and entry point. If found, this
         will be used instead of the one defined by the :meth:`base_configuration`

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -95,19 +95,7 @@ class ToolkitManager(object):
         return self._do_shotgun_config_lookup
 
     def _set_do_shotgun_config_lookup(self, status):
-        """
-        Flag to indicate if the bootstrap process should connect to
-        Shotgun and attempt to resolve a config. Defaults to True.
-
-        If True, the bootstrap process will connect to Shotgun as part
-        of the startup, look for a pipeline configuration and attempt
-        to resolve a toolkit environment to bootstrap into via the
-        Pipeline configuration data. Failing this, it will fall back on
-        the :meth:`base_configuration`.
-
-        If False, no Shotgun lookup will happen. Instead, whatever config
-        is defined via :meth:`base_configuration` will always be used.
-        """
+        # setter for do_shotgun_config_lookup
         self._do_shotgun_config_lookup = status
 
     do_shotgun_config_lookup = property(_get_do_shotgun_config_lookup, _set_do_shotgun_config_lookup)
@@ -139,28 +127,7 @@ class ToolkitManager(object):
         return self._entry_point
 
     def _set_entry_point(self, entry_point):
-        """
-        The entry point defines the scope of the bootstrap operation.
-
-        If you are bootstrapping into an entire Toolkit pipeline, e.g
-        a traditional Toolkit setup, this should be left blank.
-
-        If you are writing a plugin that is intended to run side by
-        side with other plugins in your target environment, the entry
-        point will be used to define a scope and sandbox in which your
-        plugin will execute. For example, if your plugin is packaging up
-        review tools for RV, name your entry point "RV Review". If your plugin
-        embeds the shotgun panel in a Maya Plugin, name it "Maya Panel".
-
-        The entry point value can be used to customize the behavior of a
-        plugin via Shotgun. At bootstrap, toolkit will look for a pipeline
-        configuration with a matching name and entry point. If found, this
-        will be used instead of the one defined by the :meth:`base_configuration`
-        property.
-
-            .. note:: If you want to force the :meth:`base_configuration` to always
-                      be used, set :meth:`do_shotgun_config_lookup` to False.
-        """
+        # setter for entry_point
         self._entry_point = entry_point
 
     entry_point = property(_get_entry_point, _set_entry_point)
@@ -175,12 +142,7 @@ class ToolkitManager(object):
         return self._base_config_descriptor
 
     def _set_base_configuration(self, descriptor):
-        """
-        The descriptor (string or dict) for the
-        configuration that should be used as a base fallback
-        to be used whenever runtime and shotgun configuration
-        resolution doesn't resolve an override configuration to use.
-        """
+        # setter for base_configuration
         self._base_config_descriptor = descriptor
 
     base_configuration = property(_get_base_configuration, _set_base_configuration)
@@ -203,19 +165,8 @@ class ToolkitManager(object):
         return self._bundle_cache_fallback_paths
 
     def _set_bundle_cache_fallback_paths(self, paths):
-        """
-        Specifies a list of fallback paths where toolkit will go
-        look for cached bundles in case a bundle isn't found in
-        the primary app cache.
+        # setter for bundle_cache_fallback_paths
 
-        This is useful if you want to distribute a pre-baked
-        package, containing all the app version that a user needs.
-        This avoids downloading anything from the app store or other
-        sources.
-
-        Any missing bundles will be downloaded and cached into
-        the *primary* bundle cache.
-        """
         # @todo - maybe here we can add support for environment variables in the
         #         future so that studios can easily add their own 'primed cache'
         #         locations for performance or to save space.

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -289,9 +289,9 @@ class ToolkitManager(object):
         self._report_progress("Resolving configuration...")
 
         resolver = ConfigurationResolver(
-            project_id,
             self._entry_point,
             engine_name,
+            project_id,
             self._bundle_cache_fallback_paths
         )
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -111,9 +111,7 @@ class ToolkitManager(object):
         If you are writing a plugin that is intended to run side by
         side with other plugins in your target environment, the entry
         point will be used to define a scope and sandbox in which your
-        plugin will execute. For example, if your plugin is packaging up
-        review tools for RV, name your entry point "RV Review". If your plugin
-        embeds the shotgun panel in a Maya Plugin, name it "Maya Panel".
+        plugin will execute.
 
         In the future, it will be possible to use the entry point value
         to customize the behavior of a
@@ -121,6 +119,22 @@ class ToolkitManager(object):
         configuration with a matching name and entry point. If found, this
         will be used instead of the one defined by the :meth:`base_configuration`
         property.
+
+        It is possible for multiple plugins running in different DCCs
+        to share the same entry point - in this case, they would all
+        get their settings and setup from a shared configuration. If you
+        were to override the base configuration in Shotgun, your override
+        would affect the entire suite of plugins. This kind of setup allows
+        for the development of several plugins in different DCCs that together
+        form a curated workflow.
+
+        Consider the following when deciding how to name your entry point:
+
+        - The entry point needs to be unique
+        - It should be clear and concise
+        - We recommend that you use the following naming convention:
+          ``provider_service``, for example ``rv_review`` for an entry point
+          maintained by the rv group which hosts review functionality.
 
             .. note:: If you want to force the :meth:`base_configuration` to always
                       be used, set :meth:`do_shotgun_config_lookup` to False.

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -46,7 +46,6 @@ class ToolkitManager(object):
         self._bundle_cache_fallback_paths = []
         self._pipeline_configuration_name = constants.PRIMARY_PIPELINE_CONFIG_NAME
         self._base_config_descriptor = None
-        self._resolve_latest_base_descriptor = False
         self._progress_cb = None
         self._do_shotgun_config_lookup = True
         self._entry_point = None
@@ -356,7 +355,6 @@ class ToolkitManager(object):
             self._pipeline_configuration_name,
             engine_name,
             self._base_config_descriptor,
-            self._resolve_latest_base_descriptor
         )
 
         # see what we have locally

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -48,6 +48,7 @@ class ToolkitManager(object):
         self._base_config_descriptor = None
         self._resolve_latest_base_descriptor = False
         self._progress_cb = None
+        self._shotgun_config_lookup = True
 
         log.debug("%s instantiated" % self)
 
@@ -75,6 +76,31 @@ class ToolkitManager(object):
         return self._pipeline_configuration_name
 
     pipeline_configuration = property(_get_pipeline_configuration, _set_pipeline_configuration)
+
+    def _set_shotgun_config_lookup(self, status):
+        """
+        Flag to indicate if the bootstrap process should connect to
+        Shotgun and attempt to resolve a config. Defaults to True.
+        """
+        self._shotgun_config_lookup = status
+
+    def _get_shotgun_config_lookup(self):
+        """
+        Flag to indicate if the bootstrap process should connect to
+        Shotgun and attempt to resolve a config. Defaults to True.
+
+        If True, the bootstrap process will connect to Shotgun as part
+        of the startup, look for a pipeline configuration and attempt
+        to resolve a toolkit environment to bootstrap into via the
+        Pipeline configuration data. Failing this, it will fall back on
+        the :meth:`base_configuration`.
+
+        If False, no Shotgun lookup will happen. Instead, whatever config
+        is defined via :meth:`base_configuration` will always be used.
+        """
+        return self._shotgun_config_lookup
+
+    shotgun_config_lookup = property(_get_shotgun_config_lookup, _set_shotgun_config_lookup)
 
     def _get_base_configuration(self):
         """

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -92,8 +92,7 @@ class BaseConfigurationResolver(ConfigurationResolver):
         project_id,
         pipeline_config_name,
         engine_name,
-        base_config_descriptor,
-        get_latest_config
+        base_config_descriptor
     ):
         """
         Given a Shotgun project (or None for site mode), return a configuration
@@ -110,8 +109,6 @@ class BaseConfigurationResolver(ConfigurationResolver):
         :param pipeline_config_name: Name of configuration branch (e.g Primary)
         :param engine_name: Engine name for which we are resolving the configuration.
         :param base_config_descriptor: descriptor dict or string for fallback config.
-        :param get_latest_config: Flag to indicate that latest version of the fallback config
-                                  should be resolved and used.
         :return: Configuration instance
         """
         log.debug(
@@ -131,12 +128,21 @@ class BaseConfigurationResolver(ConfigurationResolver):
                 "configuration exists in Shotgun for the given project. "
                 "Cannot create a configuration object.")
 
+        # note how we currently always prefer latest as part of the resolve.
+        # later on, it will be possible to specify an update policy as part of
+        # the descriptor system, allowing a user to specify what latest means -
+        # does it actually mean that the version is frozen to a particular version,
+        # the latest release on a conservative release track, the latest alpha etc.
+        #
+        # for installations bundled with manual descriptors, latest currently
+        # means the same version that the descriptor is pointing at, so for
+        # these installations, version numbers are effectively fixed.
         cfg_descriptor = create_descriptor(
             self._sg_connection,
             Descriptor.CONFIG,
             base_config_descriptor,
             fallback_roots=self._bundle_cache_fallback_paths,
-            resolve_latest=get_latest_config
+            resolve_latest=True
         )
 
         log.debug("Configuration resolved to %r." % cfg_descriptor)

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -37,7 +37,7 @@ class ConfigurationResolver(object):
             project_id,
             entry_point,
             engine_name,
-            bundle_cache_fallback_paths
+            bundle_cache_fallback_paths=None
     ):
         """
         Constructor
@@ -45,12 +45,12 @@ class ConfigurationResolver(object):
         :param project_id: Project id to create a config object for, None for the site config.
         :param entry_point: The entry point name of the system that is being bootstrapped.
         :param engine_name: Name of the engine that is about to be launched.
-        :param bundle_cache_fallback_paths: List of additional paths where apps are cached.
+        :param bundle_cache_fallback_paths: Optional list of additional paths where apps are cached.
         """
         self._project_id = project_id
         self._entry_point = entry_point
         self._engine_name = engine_name
-        self._bundle_cache_fallback_paths = bundle_cache_fallback_paths
+        self._bundle_cache_fallback_paths = bundle_cache_fallback_paths or []
 
     def __repr__(self):
         return "<Resolver: proj id %s, engine %s, entry point %s>" % (

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -34,17 +34,17 @@ class ConfigurationResolver(object):
 
     def __init__(
             self,
-            project_id,
             entry_point,
             engine_name,
+            project_id=None,
             bundle_cache_fallback_paths=None
     ):
         """
         Constructor
 
-        :param project_id: Project id to create a config object for, None for the site config.
         :param entry_point: The entry point name of the system that is being bootstrapped.
         :param engine_name: Name of the engine that is about to be launched.
+        :param project_id: Project id to create a config object for, None for the site config.
         :param bundle_cache_fallback_paths: Optional list of additional paths where apps are cached.
         """
         self._project_id = project_id

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -101,6 +101,10 @@ class ConfigurationResolver(object):
             LocalFileStorageManager.CACHE
         )
 
+        # resolve the config location both based on entry point and current engine.
+        #
+        # Example: ~/Library/Caches/Shotgun/mysitename/site/cfg.tk-rv.review
+        #
         config_folder = "cfg.%s" % filesystem.create_valid_filename(self._engine_name)
 
         if self._entry_point:

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -147,6 +147,10 @@ class ConfigurationResolver(object):
         in Shotgun. If no suitable configuration is found, return a configuration
         for the given fallback config.
 
+            .. note:: The current implementation for this is a pass-through
+                      to the base configuration resolver. In the future, business
+                      logic will be added to handle this.
+
         :param pipeline_config_name: Name of configuration branch (e.g Primary)
         :param fallback_config_descriptor: descriptor dict or string for fallback config.
         :param sg_connection: Shotgun API instance

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -89,13 +89,18 @@ def create_io_descriptor(
     # at this point we didn't have a cache hit,
     # so construct the object manually
 
-    # check latest versions
-    descriptors_using_version = ["app_store", "shotgun", "manual", "git", "git_branch"]
-    if resolve_latest and descriptor_dict.get("type") in descriptors_using_version:
-        # for the case of latest version, make sure we attach a version
-        # key as part of the descriptor dictionary so that the descriptor
-        # is valid
-        descriptor_dict["version"] = "latest"
+    if resolve_latest:
+        # if someone is requesting a latest descriptor and not providing a version token
+        # make sure to add an artificial one so that we can resolve it.
+        #
+        # We only do this for descriptor types that supports a version number concept
+        descriptors_using_version = ["app_store", "shotgun", "manual", "git", "git_branch"]
+
+        if "version" not in descriptor_dict and descriptor_dict.get("type") in descriptors_using_version:
+            # for the case of latest version, make sure we attach a version
+            # key as part of the descriptor dictionary so that the descriptor
+            # is valid
+            descriptor_dict["version"] = "latest"
 
     # factory logic
     if descriptor_dict.get("type") == "app_store":

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -189,7 +189,7 @@ class LocalFileStorageManager(object):
 
         :param hostname: Shotgun hostname as string, e.g. 'https://foo.shotgunstudio.com'
         :param project_id: Shotgun project id as integer. For the site config, this should be None.
-        :param pipeline_config_id: Shotgun pipeline config id.
+        :param pipeline_config_id: Shotgun pipeline config id. None for bootstraped configs.
         :param path_type: Type of path to return. One of ``LocalFileStorageManager.LOGGING``,
                           ``LocalFileStorageManager.CACHE``, ``LocalFileStorageManager.PERSISTENT``, where
                           logging is a path where log- and debug related data should be stored,


### PR DESCRIPTION
This implements the final round of 0.18 interface changes.

- Added `do_shotgun_config_lookup` property (defaults to `True`) which makes i possible for "static" plugins such as RV to implement a fixed policy where shotgun is not interrogated for config overrides.

- Removed `resolve_latest_base_configuration` property - this is in anticipation of a future introduction of a descriptor update policy which will allow us to control updates in a generic and much more flexible manner. The initial version of 0.18 bootstrap will always resolve the latest of whatever descriptor is provided. For static distributions, manual descriptors are normally used and these do not implement a concept of latest version, making this change of policy safe for such implementations.

- Added `entry_point` property - this makes it possible to maintain more than one plugin for a DCC environment. It also allows for a future setup where each plugin can be individually customized by adding a pipeline configuration entry to Shotgun (assuming the plugin has `do_shotgun_config_lookup` set to True).

- The configuration resolver has been updated to better manage the above options and a stub has been introduced to prepare for the addition of a shotgun config lookup setup.