### PR TITLE
#36909 entry point support for local cache manager

### DIFF
--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -26,11 +26,13 @@ class CacheLocation(HookBaseClass):
     For further details, see individual cache methods below.
     """
     
-    def path_cache_v2(self, project_id, entry_point, pipeline_configuration_id):
+    def get_path_cache_path(self, project_id, entry_point, pipeline_configuration_id):
         """
         Establish a location for the path cache database file.
 
-        This hook method was introduced in Toolkit v0.18 and replaces path_cache_v2.
+        This hook method was introduced in Toolkit v0.18 and replaces path_cache.
+        If you already have implemented path_cache, this will be detected and called instead,
+        however we strongly recommend that you tweak your hook.
 
         Overriding this method in a hook allows a user to change the location on disk where
         the path cache file is located. The path cache file holds a temporary cache representation
@@ -111,11 +113,13 @@ class CacheLocation(HookBaseClass):
 
         return target_path
 
-    def bundle_cache_v2(self, project_id, entry_point, pipeline_configuration_id, bundle):
+    def get_bundle_data_cache_path(self, project_id, entry_point, pipeline_configuration_id, bundle):
         """
         Establish a cache folder for an app, engine or framework.
 
         This hook method was introduced in Toolkit v0.18 and replaces bundle_cache.
+        If you already have implemented bundle_cache, this will be detected and called instead,
+        however we strongly recommend that you tweak your hook.
         
         Apps, Engines or Frameworks commonly caches data on disk. This can be 
         small files, shotgun queries, thumbnails etc. This method implements the 
@@ -123,12 +127,6 @@ class CacheLocation(HookBaseClass):
         a way so that all instances of the app can re-use the same data. (Apps 
         which needs to cache things per-instance can implement this using a sub
         folder inside the bundle cache location).
-
-        ..note:: This method may be slightly confusing given the use of the term
-                 "bundle_cache" throughout core which refers to the location on disk
-                 where bundles (apps, engines, frameworks) are installed. A better
-                 name for this method might have been `bundle_data_cache`. The name
-                 remains to avoid breaking client code.
 
         :param project_id: The shotgun id of the project to store caches for
         :param entry_point: Entry point string to identify the scope for a particular plugin

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -45,6 +45,7 @@ class Configuration(object):
             sg,
             descriptor,
             project_id,
+            entry_point,
             pipeline_config_id,
             bundle_cache_fallback_paths
     ):
@@ -57,6 +58,10 @@ class Configuration(object):
         :param project_id: Project id for the shotgun project associated with the
                            configuration. For a site-level configuration, this
                            can be set to None.
+        :param entry_point: Entry point string to identify the scope for a particular plugin
+                            or integration. For more information,
+                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
+                            non-plugin based toolkit projects, this value is None.
         :param pipeline_config_id: Pipeline Configuration id for the shotgun
                                    pipeline config id associated. If a config does
                                    not have an associated entity in Shotgun, this
@@ -67,13 +72,15 @@ class Configuration(object):
         self._sg_connection = sg
         self._descriptor = descriptor
         self._project_id = project_id
+        self._entry_point = entry_point
         self._pipeline_config_id = pipeline_config_id
         self._bundle_cache_fallback_paths = bundle_cache_fallback_paths
 
     def __repr__(self):
-        return "<Config with id %s, project id %s and base %r>" % (
+        return "<Config with id %s, project id %s, ep %s and base %r>" % (
             self._pipeline_config_id,
             self._project_id,
+            self._entry_point,
             self._descriptor
         )
 
@@ -583,6 +590,7 @@ class Configuration(object):
             "pc_name": pipeline_config_name,
             "project_id": self._project_id,
             "project_name": project_name,
+            "entry_point": self._entry_point,
             "published_file_entity_type": "PublishedFile",
             "use_bundle_cache": True,
             "bundle_cache_fallback_roots": self._bundle_cache_fallback_paths,

--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -19,7 +19,7 @@ BUNDLE_METADATA_FILE = "info.yml"
 # if major changes happen to the way cloud based configs are handled
 # by the system, for example requiring any existing deployed cloud
 # configs to be re-deployed, this version number should be incremented.
-BOOTSTRAP_LOGIC_GENERATION = 3
+BOOTSTRAP_LOGIC_GENERATION = 4
 
 # config file with information about which core to use
 CONFIG_CORE_DESCRIPTOR_FILE = "core_api.yml"

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -97,26 +97,16 @@ class ConfigurationResolver(object):
         cache_root = LocalFileStorageManager.get_configuration_root(
             sg_connection.base_url,
             self._project_id,
+            self._entry_point,
             None,  # pipeline config id
             LocalFileStorageManager.CACHE
         )
 
         # resolve the config location both based on entry point and current engine.
         #
-        # Example: ~/Library/Caches/Shotgun/mysitename/site/cfg.tk-rv.review
+        # Example: ~/Library/Caches/Shotgun/mysitename/site.rv_review/cfg
         #
-        config_folder = "cfg.%s" % filesystem.create_valid_filename(self._engine_name)
-
-        if self._entry_point:
-            # append the entry point
-            config_folder = "%s.%s" % (
-                config_folder,
-                filesystem.create_valid_filename(self._entry_point)
-            )
-
-        # now locate configs created by the base config resolver
-        # in cfg/base/engine-name folder
-        config_cache_root = os.path.join(cache_root, config_folder)
+        config_cache_root = os.path.join(cache_root, "cfg")
         filesystem.ensure_folder_exists(config_cache_root)
 
         log.debug("Configuration root resolved to %s." % config_cache_root)
@@ -132,6 +122,7 @@ class ConfigurationResolver(object):
             sg_connection,
             cfg_descriptor,
             self._project_id,
+            self._entry_point,
             None,  # pipeline config id
             self._bundle_cache_fallback_paths
         )

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -165,7 +165,7 @@ class PathCache(object):
             # where the path cache should be located.
             path = self._tk.execute_core_hook_method(
                 constants.CACHE_LOCATION_HOOK_NAME,
-                "path_cache_v2",
+                "get_path_cache_path",
                 project_id=self._tk.pipeline_configuration.get_project_id(),
                 entry_point=self._tk.pipeline_configuration.get_entry_point(),
                 pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id()

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -161,20 +161,15 @@ class PathCache(object):
         """
         if self._tk.pipeline_configuration.get_shotgun_path_cache_enabled():
 
-            # Site configuration's project id is None. Since we're calling a hook, we'll have to
-            # pass in 0 to avoid client code crashing because it expects an integer and not
-            # the None object. This happens when we are building the cache root, where %d is used to
-            # inject the project id in the file path.
-            if self._tk.pipeline_configuration.is_site_configuration():
-                project_id = 0
-            else:
-                project_id = self._tk.pipeline_configuration.get_project_id()
             # 0.15+ path cache setup - call out to a core hook to determine
             # where the path cache should be located.
-            path = self._tk.execute_core_hook_method(constants.CACHE_LOCATION_HOOK_NAME,
-                                                     "path_cache",
-                                                     project_id=project_id,
-                                                     pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id())
+            path = self._tk.execute_core_hook_method(
+                constants.CACHE_LOCATION_HOOK_NAME,
+                "path_cache_v2",
+                project_id=self._tk.pipeline_configuration.get_project_id(),
+                entry_point=self._tk.pipeline_configuration.get_entry_point(),
+                pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id()
+            )
 
         else:
             # old (v0.14) style path cache

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -90,6 +90,7 @@ class PipelineConfiguration(object):
         self._project_name = pipeline_config_metadata.get("project_name")
         self._project_id = pipeline_config_metadata.get("project_id")
         self._pc_id = pipeline_config_metadata.get("pc_id")
+        self._entry_point = pipeline_config_metadata.get("entry_point")
         self._pc_name = pipeline_config_metadata.get("pc_name")
         self._published_file_entity_type = pipeline_config_metadata.get("published_file_entity_type", "TankPublishedFile")        
         self._use_shotgun_path_cache = pipeline_config_metadata.get("use_shotgun_path_cache", False)
@@ -324,6 +325,12 @@ class PipelineConfiguration(object):
         Returns the shotgun id for this PC.
         """
         return self._pc_id
+
+    def get_entry_point(self):
+        """
+        Returns the entry point for this PC.
+        """
+        return self._entry_point
 
     def get_project_id(self):
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -232,7 +232,7 @@ class TankBundle(object):
 
             self.__cache_location = self.__tk.execute_core_hook_method(
                 constants.CACHE_LOCATION_HOOK_NAME,
-                "bundle_cache_v2",
+                "get_bundle_data_cache_path",
                 project_id=self.__tk.pipeline_configuration.get_project_id(),
                 entry_point=self.__tk.pipeline_configuration.get_entry_point(),
                 pipeline_configuration_id=self.__tk.pipeline_configuration.get_shotgun_id(),

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -229,22 +229,13 @@ class TankBundle(object):
         """
         # this method is memoized for performance since it is being called a lot!
         if self.__cache_location is None:
-            # Site configuration's project id is None. Since we're calling a hook, we'll have to
-            # pass in 0 to avoid client code crashing because it expects an integer and not
-            # the None object. This happens when we are building the cache root, where %d is used to
-            # inject the project id in the file path.        
-            if self.__tk.pipeline_configuration.is_site_configuration():
-                project_id = 0
-            else:
-                project_id = self.__tk.pipeline_configuration.get_project_id()
-            
-            pc_id = self.__tk.pipeline_configuration.get_shotgun_id()
-            
+
             self.__cache_location = self.__tk.execute_core_hook_method(
                 constants.CACHE_LOCATION_HOOK_NAME,
-                "bundle_cache",
-                project_id=project_id,
-                pipeline_configuration_id=pc_id,
+                "bundle_cache_v2",
+                project_id=self.__tk.pipeline_configuration.get_project_id(),
+                entry_point=self.__tk.pipeline_configuration.get_entry_point(),
+                pipeline_configuration_id=self.__tk.pipeline_configuration.get_shotgun_id(),
                 bundle=self
             )
         

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -194,7 +194,24 @@ class LocalFileStorageManager(object):
         """
         Returns the storage root for any data that is project and config specific.
 
+        - A well defined project id should always be passed. Passing None as the project
+          id indicates that the *site* configuration, a special toolkit configuration
+          that represents the non-project state in Shotgun.
+
+        - Configurations that have a pipeline configuration in Shotgun should pass in
+          a pipeline configuration id. When a pipeline configuration is not registered
+          in Shotgun, this value should be None.
+
+        - If the configuration has been bootstrapped or has a known entry point, this
+          should be specified via the entry point parameter.
+
         For more details, see :meth:`LocalFileStorageManager.get_global_root`.
+
+        Examples of paths that will be generated:
+
+        - Site config: ``ROOT/shotgunsite/p0``
+        - Project 123, config 33: ``ROOT/shotgunsite/p123c33``
+        - project 123, no config, entry point rv_review: ``ROOT/shotgunsite/p123.rv_review``
 
         .. note:: This method does not ensure that the folder exists.
 


### PR DESCRIPTION
This is a subtle yet important change to allow for a fully sandboxed and consistent setup when running TaaP entry point name spaces.

Previously, we only distinguished between toolkit configs that either had a pipeline config id or not. Most TaaP setups will not have a pc id in shotgun and this change ensures that a TaaP setup cache structure works the same way as cache structures for toolkit configs that have a pipeline config id. 

This is an example of the cache structure with this change:

![screen shot 2016-06-17 at 14 07 25](https://cloud.githubusercontent.com/assets/337710/16151522/5f73e4fa-3495-11e6-9c2b-140bc4522941.png)

Note the `site.rv_review` entry that is a config that is bootstrapped out of TaaP and doesn't have a pipeline config id in shotgun - this is now positioned alongside traditional configs that have ids. We don't have an id, so instead the entry point is used to create a cache "sandbox".

Further changes:

- This change changes the interface of the cache hook. Created new interfaces with graceful fallbacks for any user that has overridden it. I am pleased with how this turned out :) Any existing implementation should work perfectly as long as they don't try to run TaaP with it. A long warning is issued.
- Pipeline configuration class now tracks entry point alongside project id and pc id.
- Untangled a long standing issue where the core code tried to be backwards compatible by explicitly changing the site config (project id None) into project 0. This was causing the cache structure to be a bit messy. Now it is clean and backwards compatible and supports old hooks.
