### PR TITLE
#30005 Support for Shotgun specific storage syntax

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -17,6 +17,7 @@ import os
 import sys
 import urllib2
 import urlparse
+import pprint
 
 # use api json to cover py 2.5
 from tank_vendor import shotgun_api3
@@ -766,6 +767,8 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
 
     :returns: The created entity dictionary
     """
+    log.debug("Publish: Begin register publish")
+
     # get the task from the optional args, fall back on context task if not set
     task = kwargs.get("task")
     if task is None:
@@ -791,6 +794,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
 
     published_file_entity_type = get_published_file_entity_type(tk)
 
+    log.debug("Publish: Resolving the published file type")
     sg_published_file_type = None
     # query shotgun for the published_file_type
     if published_file_type:
@@ -813,6 +817,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
                 sg_published_file_type = tk.shotgun.create("TankType", {"code": published_file_type, "project": context.project})
 
     # create the publish
+    log.debug("Publish: Creating publish in Shotgun")
     entity = _create_published_file(tk, 
                                     context, 
                                     path, 
@@ -827,6 +832,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
                                     sg_fields)
 
     # upload thumbnails
+    log.debug("Publish: Uploading thumbnails")
     if thumbnail_path and os.path.exists(thumbnail_path):
 
         # publish
@@ -850,8 +856,10 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
 
 
     # register dependencies
+    log.debug("Publish: Register dependencies")
     _create_dependencies(tk, entity, dependency_paths, dependency_ids)
 
+    log.debug("Publish: Complete")
     return entity
 
 def _translate_abstract_fields(tk, path):
@@ -1002,13 +1010,50 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
         "version_number": version_number,
         })
 
+    # handle the path definition
     if path_is_url:
         data["path"] = { "url":path }
     else:
         # Make path platform agnostic.
-        _, path_cache = _calc_path_cache(tk, path)
-        
-        data["path"] = { "local_path": path }
+        storage_name, path_cache = _calc_path_cache(tk, path)
+
+        # check if the shotgun server supports the storage and relative_path parameters
+        # which allows us to specify exactly which storage to bind a publish to rather
+        # than relying on Shotgun to compute this
+        supports_specific_storage_syntax = (
+            hasattr(tk.shotgun, "server_caps") and
+            tk.shotgun.server_caps.version and
+            tk.shotgun.server_caps.version >= (6, 3, 17)
+        )
+
+        if supports_specific_storage_syntax:
+            # explicitly pass relative path and storage to shotgun
+            storage = tk.shotgun.find_one("LocalStorage", [["code", "is", storage_name]])
+
+            if storage is None:
+                # there is no storage in Shotgun that matches the one toolkit expects.
+                # this *may* be ok because there may be another storage in Shotgun that
+                # magically picks up the publishes and associates with them. In this case,
+                # issue a warning and fall back on the server-side functionality
+                log.warning(
+                    "Could not find the expected storage '%s' in Shotgun to associate "
+                    "publish '%s' with - falling back to Shotgun's built-in storage "
+                    "resolution logic. It is recommended that you add the '%s' storage "
+                    "to Shotgun" % (storage_name, path, storage_name))
+                data["path"] = {"local_path": path}
+
+            else:
+                data["path"] = {"relative_path": path_cache, "local_storage": storage}
+
+        else:
+            # use previous syntax where we pass the whole path to Shotgun
+            # and shotgun will do the storage/relative path split server side.
+            # This operation may do unexpected things if you have multiple
+            # storages that are identical or overlapping
+            data["path"] = {"local_path": path}
+
+        # fill in the path cache field which is used for filtering in Shotgun
+        # (because SG does not support
         data["path_cache"] = path_cache        
 
     if created_by_user:
@@ -1034,6 +1079,7 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     # now call out to hook just before publishing
     data = tk.execute_core_hook(constants.TANK_PUBLISH_HOOK_NAME, shotgun_data=data, context=context)
 
+    log.debug("Registering publish in Shotgun: %s" % pprint.pformat(data))
     return tk.shotgun.create(published_file_entity_type, data)
 
 def _calc_path_cache(tk, path):
@@ -1061,8 +1107,13 @@ def _calc_path_cache(tk, path):
             # Remove parent dir plus "/" - be careful to handle the case where
             # the parent dir ends with a '/', e.g. 'T:/' for a Windows drive
             path_cache = norm_path[len(norm_parent_dir):].lstrip("/")
+            log.debug(
+                "Split up path '%s' into storage %s and relative path '%s'" % (path, root_name, path_cache)
+            )
             return root_name, path_cache
+
     # not found, return None values
+    log.debug("Unable to split path '%s' into a storage and a relative path." % path)
     return None, None
 
 


### PR DESCRIPTION
On Shotgun versions where supported, register publish now explicitly sets the storage it wants to associate with a published file. If not supported or if the storage is not found in Shotgun, it gracefully falls back on the previous implementation, e.g. passing the entire path to Shotgun and relying on Shotgun to compute which storage to associate with. Also added debug logging around the publish process.