### PR TITLE
#37158 Fix for attempting to dump to the source config file.

### DIFF
--- a/python/tank/commands/dump_config.py
+++ b/python/tank/commands/dump_config.py
@@ -285,7 +285,6 @@ class DumpConfigAction(Action):
                 "Could not find an environment named: '%s'. "
                 "Available environments are: %s." % (parameters["env"], ", ".join(valid_env_names)))
 
-
         return parameters
 
     def _usage(self):

--- a/python/tank/commands/dump_config.py
+++ b/python/tank/commands/dump_config.py
@@ -168,11 +168,27 @@ class DumpConfigAction(Action):
         :param params: parameter dict.
         """
 
+        log.info("Dumping config...")
+
         # the env to dump
         env = self.tk.pipeline_configuration.get_environment(
             params["env"],
             writable=True
         )
+
+        # make sure the environment file doesn't match the output file.
+        # at some point we may want to make this possible, but dump_config is
+        # more about debugging, so for now just error out if they're the same file.
+        if params["file"]:
+            out_file = os.path.realpath(params["file"])
+            env_file = os.path.realpath(env.disk_location)
+
+            if out_file == env_file:
+                raise TankError(
+                    "The specified output file matches the environment configuration.\n"
+                    "As a precaution, writing to the source configuration is not allowed.\n"
+                    "Please specify a different output path."
+                )
 
         # get a file to write to
         env_fh = self._get_file_handle(params)
@@ -268,6 +284,7 @@ class DumpConfigAction(Action):
             raise TankError(
                 "Could not find an environment named: '%s'. "
                 "Available environments are: %s." % (parameters["env"], ", ".join(valid_env_names)))
+
 
         return parameters
 


### PR DESCRIPTION
This change adds an additional check to make sure the output file, if specified, is not the path to the source environment config file. Perhaps we want to allow this in the future, but it seems a bit dangerous. This command is more about debugging with the added bonus that it provides a way to transition configs if needed in the short term. For now though I think disallowing this and requiring dumping to a separate file seems the safe approach. 