### PR TITLE
#37162 [minor] Fixes broken call to tank updates

### DIFF
--- a/python/tank/commands/migrate_entities.py
+++ b/python/tank/commands/migrate_entities.py
@@ -1498,7 +1498,13 @@ class MigratePublishedFileEntitiesAction(Action):
             else:
                 # run the app update:
                 try:
-                    update.check_for_updates(log, self.tk)
+                    update.check_for_updates(
+                        log,
+                        self.tk,
+                        env_name=None,
+                        engine_instance_name=None,
+                        app_instance_name=None
+                    )
                     log.info("App update completed successfully.")
                 except TankError, e:
                     raise TankError("App update failed with the following error: %s" % e)


### PR DESCRIPTION
Tank updates internal interface was updated but the migrate publish command was 
never updated. This happened a *very* long time ago. Now works again.