### PR TITLE
#37214 Fixed issue with limit for log files

### DIFF
--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -582,7 +582,7 @@ class LogManager(object):
         self._std_file_handler = logging.handlers.RotatingFileHandler(
             log_file,
             maxBytes=1024*1024*5,  # 5 MiB
-            backupCount=0
+            backupCount=1          # Need at least one backup in order to rotate
         )
 
         # set the level based on global debug flag


### PR DESCRIPTION
Turns out you need at least one backup file in order for the rotating log file handler
in python to actually be able to rotate the files. We had this set to zero, effectively forcing
the rotation never to happen, causing the file size to grow indefinitely.

This adds a single backup, allowing the files to rotate.