### PR TITLE
For #36848, add core 0.18 support to tk-desktop

### DIFF
--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -54,7 +54,7 @@ class CoreImportHandler(object):
         # and associated with the singleton as these will be lost
         # use local imports to ensure a fresh cut of the code
         from ..log import LogManager
-        prev_log_name = LogManager().uninitialize_base_file_handler()
+        prev_log_file = LogManager().uninitialize_base_file_handler()
         # logging to file is now disabled and will be renamed after the
         # main tank import of the new code.
 
@@ -104,13 +104,13 @@ class CoreImportHandler(object):
         # and re-init our disk logging based on the new code
         # access it from the new tank instance to ensure we get the new code
         try:
-            if prev_log_name:
-                tank.LogManager().initialize_base_file_handler(prev_log_name)
+            if prev_log_file:
+                tank.LogManager().initialize_base_file_handler_from_path(prev_log_file)
         except AttributeError, e:
             # older versions of the API may not have this defined.
             log.warning(
                 "Switching to a version of the core API that doesn't "
-                "have a LogManager.initialize_base_file_handler method defined."
+                "have a LogManager.initialize_base_file_handler_from_path method defined."
             )
 
 

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -251,7 +251,7 @@ class LogManager(object):
             # a global and standard rotating log file handler
             # for writing generic toolkit logs to disk
             instance._std_file_handler = None
-            instance._std_file_handler_log_name = None
+            instance._std_file_handler_log_file = None
 
             # collection of weak references to handlers
             # that were created via the log manager.
@@ -513,25 +513,24 @@ class LogManager(object):
         """
         Uninitialize base file handler created with :meth:`initialize_base_file_handler`.
 
-        :returns: The name of the previous log_name that is being switched away from,
+        :returns: The path to the previous log file that is being switched away from,
                   None if no base logger was previously active.
         """
         if self._std_file_handler is None:
-            base_log_name = None
+            return None
 
-        else:
-            base_log_name = self._std_file_handler_log_name
+        base_log_file = self._std_file_handler_log_file
 
-            # there is a log handler, so terminate it
-            log.debug(
-                "Tearing down existing log handler '%s' (%s)" % (base_log_name, self._std_file_handler)
-            )
-            self._root_logger.removeHandler(self._std_file_handler)
-            self._std_file_handler = None
-            self._std_file_handler_log_name = None
+        # there is a log handler, so terminate it
+        log.debug(
+            "Tearing down existing log handler '%s' (%s)" % (base_log_file, self._std_file_handler)
+        )
+        self._root_logger.removeHandler(self._std_file_handler)
+        self._std_file_handler = None
+        self._std_file_handler_log_file = None
 
-        # return the previous base log name
-        return base_log_name
+        # return the previous base log file path.
+        return base_log_file
 
     def initialize_base_file_handler(self, log_name):
         """
@@ -554,7 +553,8 @@ class LogManager(object):
 
         :param log_name: Name of logger to create. This will form the
                          filename of the log file.
-        :returns: The name of the previous log_name that is being switched away from,
+
+        :returns: The path to the previous log file that is being switched away from,
                   None if no base logger was previously active.
         """
         # avoid cyclic references
@@ -576,19 +576,19 @@ class LogManager(object):
 
         :param log_file: Path of the file to write the logs to.
 
-        :returns: The name of the previous log_name that is being switched away from,
+        :returns: The path to the previous log file that is being switched away from,
                   None if no base logger was previously active.
         """
         # shut down any previous logger
-        previous_log_name = self.uninitialize_base_file_handler()
+        previous_log_file = self.uninitialize_base_file_handler()
 
         log_folder, log_file_name = os.path.split(log_file)
         log_name, _ = os.path.splitext(log_file_name)
 
-        log.debug("Switching file based std logger from %s to %s" % (previous_log_name, log_name))
+        log.debug("Switching file based std logger from '%s' to '%s'.", previous_log_file, log_file)
 
         # store new log name
-        self._std_file_handler_log_name = log_name
+        self._std_file_handler_log_file = log_file
 
         # avoid cyclic references
         from .util import filesystem
@@ -623,7 +623,7 @@ class LogManager(object):
         log.debug("Writing to log standard log file %s" % log_file)
 
         # return previous log name
-        return previous_log_name
+        return previous_log_file
 
 # the logger for logging messages from this file :)
 log = LogManager.get_logger(__name__)

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -116,12 +116,13 @@ class Engine(TankBundle):
         # (and the rest of the sgtk logging ) to the user
         self.__log_handler = self.__initialize_logging()
 
-        # check general debug log setting and if this flag is turned on,
-        # adjust the global setting
-
-        if self.get_setting("debug_logging", False):
-            LogManager().global_debug = True
+        # check general debug log setting and update the global debug flag accordingly. Do not set this
+        # flag only when the debug_logging is "true" because the global_debug flag is... global... and it
+        # needs to be reset during engine instantiation if the debug_logging setting suddenly turns false.
+        global_debug = self.get_setting("debug_logging", False)
+        if global_debug:
             self.log_debug("Engine config flag 'debug_logging' detected, turning on debug output.")
+        LogManager().global_debug = global_debug
 
         # check that the context contains all the info that the app needs
         validation.validate_context(descriptor, context)


### PR DESCRIPTION
The current version of the Shotgun Desktop requires that the log file be stored in `%AppData%\Shotgun\tx-desktop.log` and not `%AppData%\Shotgun\Logs\tx-desktop` like core does by default. We've therefore added a method that allows to tell the core where exactly to write the log file. This fix won't be required once we switch to the Toolkit as a Plugin APIs.

This branch also fixes a bug where it was impossible to turn off global debug by setting `debug_logging` to false in the .yml files and then reloading the engine.