### PR TITLE
#37216 Better retry when attachment downloads fail

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -19,7 +19,7 @@ import httplib
 from tank_vendor.shotgun_api3.lib import httplib2
 import cPickle as pickle
 
-from ...util import shotgun
+from ...util import shotgun, filesystem
 from ...util import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
 from ..descriptor import Descriptor
 from ..errors import TankAppStoreConnectionError
@@ -221,6 +221,7 @@ class IODescriptorAppStore(IODescriptorBase):
             "sg_version_data": sg_version_data
         }
 
+        filesystem.ensure_folder_exists(os.path.dirname(path))
         fp = open(path, "wt")
         try:
             pickle.dump(metadata, fp)

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -112,6 +112,27 @@ class IODescriptorAppStore(IODescriptorBase):
         # cached metadata - loaded on demand
         self.__cached_metadata = None
 
+    def __str__(self):
+        """
+        Human readable representation
+        """
+        display_name_lookup = {
+            Descriptor.APP: "App",
+            Descriptor.FRAMEWORK: "Framework",
+            Descriptor.ENGINE: "Engine",
+            Descriptor.CONFIG: "Config",
+            Descriptor.CORE: "Core",
+        }
+
+        # Toolkit App Store App tk-multi-loader2 v1.2.3
+        # Toolkit App Store Framework tk-framework-shotgunutils v1.2.3
+        # Toolkit App Store Core v1.2.3
+        if self._type == Descriptor.CORE:
+            return "Toolkit App Store Core %s" % self._version
+        else:
+            display_name = display_name_lookup[self._type]
+            return "Toolkit App Store %s %s %s" % (display_name, self._name, self._version)
+
     def _get_app_store_metadata(self):
         """
         Returns a metadata dictionary.
@@ -361,7 +382,7 @@ class IODescriptorAppStore(IODescriptorBase):
             shotgun.download_and_unpack_attachment(sg, attachment_id, target)
         except ShotgunAttachmentDownloadError, e:
             raise TankAppStoreError(
-                "Failed to download %s from the Toolkit App Store (%s). Error: %s" % (self, sg.base_url, e)
+                "Failed to download %s. Error: %s" % (self, e)
             )
 
         # write a stats record to the tank app store

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -13,17 +13,14 @@ Toolkit App Store Descriptor.
 """
 
 import os
-import uuid
-import tempfile
 import urllib
 import urllib2
 import httplib
 from tank_vendor.shotgun_api3.lib import httplib2
 import cPickle as pickle
 
-from ...util.zip import unzip_file
-from ...util import filesystem, shotgun
-from ...util import UnresolvableCoreConfigurationError
+from ...util import shotgun
+from ...util import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
 from ..descriptor import Descriptor
 from ..errors import TankAppStoreConnectionError
 from ..errors import TankAppStoreError
@@ -338,7 +335,6 @@ class IODescriptorAppStore(IODescriptorBase):
 
         # cache into the primary location
         target = self._get_cache_paths()[0]
-        filesystem.ensure_folder_exists(target)
 
         # connect to the app store
         (sg, script_user) = self.__create_sg_app_store_connection()
@@ -359,30 +355,13 @@ class IODescriptorAppStore(IODescriptorBase):
         #  'link_type': 'upload'}
         attachment_id = version[constants.TANK_CODE_PAYLOAD_FIELD]["id"]
 
-        # and now for the download.
-        # @todo: progress feedback here - when the SG api supports it!
-        # sometimes people report that this download fails (because of flaky connections etc)
-        # engines can often be 30-50MiB - as a quick fix, just retry the download once
-        # if it fails.
-        log.debug("Downloading attachment %s..." % self._version)
+        # download and unzip
         try:
-            bundle_content = sg.download_attachment(attachment_id)
-        except Exception, e:
-            # retry once
-            log.debug("Downloading failed, retrying. Error: %s" % e)
-            bundle_content = sg.download_attachment(attachment_id)
-
-        zip_tmp = os.path.join(tempfile.gettempdir(), "%s_tank.zip" % uuid.uuid4().hex)
-        fh = open(zip_tmp, "wb")
-        fh.write(bundle_content)
-        fh.close()
-
-        # unzip core zip file to app target location
-        log.debug("Unpacking %s bytes to %s..." % (os.path.getsize(zip_tmp), target))
-        unzip_file(zip_tmp, target)
-
-        # remove zip file
-        filesystem.safe_delete_file(zip_tmp)
+            shotgun.download_and_unpack_attachment(sg, attachment_id, target)
+        except ShotgunAttachmentDownloadError:
+            raise TankAppStoreError(
+                "Failed to download %s from the Toolkit App Store (%s)" % (self, sg.base_url)
+            )
 
         # write a stats record to the tank app store
         data = {}

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -359,9 +359,9 @@ class IODescriptorAppStore(IODescriptorBase):
         # download and unzip
         try:
             shotgun.download_and_unpack_attachment(sg, attachment_id, target)
-        except ShotgunAttachmentDownloadError:
+        except ShotgunAttachmentDownloadError, e:
             raise TankAppStoreError(
-                "Failed to download %s from the Toolkit App Store (%s)" % (self, sg.base_url)
+                "Failed to download %s from the Toolkit App Store (%s). Error: %s" % (self, sg.base_url, e)
             )
 
         # write a stats record to the tank app store

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -73,6 +73,12 @@ class IODescriptorBase(object):
         self._bundle_cache_root = primary_root
         self._fallback_roots = fallback_roots
 
+    def __str__(self):
+        """
+        Human readable representation
+        """
+        return self.get_uri()
+
     def __repr__(self):
         """
         Low level representation

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -77,6 +77,9 @@ class IODescriptorBase(object):
         """
         Human readable representation
         """
+        # fall back onto uri which is semi-human-readable
+        # it is recommended that each class implements its own
+        # operator in order to better customize the ux.
         return self.get_uri()
 
     def __repr__(self):

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -70,6 +70,13 @@ class IODescriptorGitBranch(IODescriptorGit):
         self._version = descriptor_dict.get("version")
         self._branch = descriptor_dict.get("branch")
 
+    def __str__(self):
+        """
+        Human readable representation
+        """
+        # git@github.com:manneohrstrom/tk-hiero-publish.git, branch master, commit 12313123
+        return "%s, Branch %s, Commit %s" % (self._path, self._branch, self._version)
+
     def _get_cache_paths(self):
         """
         Get a list of resolved paths, starting with the primary and

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -61,6 +61,13 @@ class IODescriptorGitTag(IODescriptorGit):
 
         self._type = bundle_type
 
+    def __str__(self):
+        """
+        Human readable representation
+        """
+        # git@github.com:manneohrstrom/tk-hiero-publish.git, tag v1.2.3
+        return "%s, Tag %s" % (self._path, self._version)
+
     def _get_cache_paths(self):
         """
         Get a list of resolved paths, starting with the primary and

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -130,9 +130,9 @@ class IODescriptorShotgunEntity(IODescriptorBase):
 
         try:
             shotgun.download_and_unpack_attachment(self._sg_connection, self._version, target)
-        except ShotgunAttachmentDownloadError:
+        except ShotgunAttachmentDownloadError, e:
             raise TankDescriptorError(
-                "Failed to download %s from %s!" % (self, self._sg_connection.base_url)
+                "Failed to download %s from %s. Error: %s" % (self, self._sg_connection.base_url, e)
             )
 
 

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -33,4 +33,4 @@ from . import filesystem
 
 from .local_file_storage import LocalFileStorageManager
 
-from .errors import UnresolvableCoreConfigurationError
+from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError

--- a/python/tank/util/errors.py
+++ b/python/tank/util/errors.py
@@ -10,6 +10,11 @@
 
 from ..errors import TankError
 
+class ShotgunAttachmentDownloadError(TankError):
+    """
+    Raised when a Shotgun attachment could not be downloaded
+    """
+
 class UnresolvableCoreConfigurationError(TankError):
     """
     Raises when Toolkit is not able to resolve the path

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -294,7 +294,6 @@ def download_and_unpack_attachment(sg, attachment_id, target, retries=5):
     # sometimes people report that this download fails (because of flaky connections etc)
     # engines can often be 30-50MiB - as a quick fix, just retry the download once
     # if it fails.
-    log.debug("Downloading attachment id %s..." % attachment_id)
     attempt = 1
     done = False
 

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -15,19 +15,23 @@ Shotgun utilities
 
 import os
 import sys
+import uuid
 import urllib2
 import urlparse
+import tempfile
 
 # use api json to cover py 2.5
 from tank_vendor import shotgun_api3
 
-from .errors import UnresolvableCoreConfigurationError
+from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
 from ..errors import TankError
 from ..log import LogManager
 from .. import hook
 from . import constants
 from . import login
 from . import yaml_cache
+from .zip import unzip_file
+from . import filesystem
 
 log = LogManager.get_logger(__name__)
 
@@ -272,7 +276,64 @@ def download_url(sg, url, location):
             f.close()
     except Exception, e:
         raise TankError("Could not download contents of url '%s'. Error reported: %s" % (url, e))
-    
+
+@LogManager.log_timing
+def download_and_unpack_attachment(sg, attachment_id, target, retries=5):
+    """
+    Downloads the given attachment from Shotgun, assumes it is a zip file
+    and attempts to unpack it into the given location.
+
+    :param sg: Shotgun API instance
+    :param attachment_id: Attachment to download
+    :param target: Folder to unpack zip to. if not created, the method will
+                   try to create it.
+    :param retries: Number of times to retry before giving up
+    :raises: ShotgunAttachmentDownloadError on failure
+    """
+    # @todo: progress feedback here - when the SG api supports it!
+    # sometimes people report that this download fails (because of flaky connections etc)
+    # engines can often be 30-50MiB - as a quick fix, just retry the download once
+    # if it fails.
+    log.debug("Downloading attachment id %s..." % attachment_id)
+    attempt = 1
+    done = False
+
+    while not done and attempt < retries:
+
+        zip_tmp = os.path.join(tempfile.gettempdir(), "%s_tank.zip" % uuid.uuid4().hex)
+        try:
+            log.debug("Downloading attachment id %s..." % attachment_id)
+            bundle_content = sg.download_attachment(attachment_id)
+
+            log.debug("Download complete. Saving into %s" % zip_tmp)
+            fh = open(zip_tmp, "wb")
+            fh.write(bundle_content)
+            fh.close()
+
+            log.debug("Unpacking %s bytes to %s..." % (os.path.getsize(zip_tmp), target))
+            filesystem.ensure_folder_exists(target)
+            unzip_file(zip_tmp, target)
+
+        except Exception, e:
+            # retry once
+            log.debug("Attempt %s: Attachment download failed: %s" % (attempt, e))
+            attempt += 1
+        else:
+            done = True
+        finally:
+            # remove zip file
+            filesystem.safe_delete_file(zip_tmp)
+
+    if not done:
+        # we were not successful
+        raise ShotgunAttachmentDownloadError(
+            "Could not download attachment id %s from %s" % (attachment_id, sg.base_url)
+        )
+
+    else:
+        log.debug("Attachment download and unpack complete.")
+
+
     
 def get_associated_sg_base_url():
     """


### PR DESCRIPTION
Adds smarter retries when a bad attachment is downloaded. This helps with the particularly annoying issue where desktop says "file is not a zip file". Instead, toolkit will now retry 4 times (which likely will resolve the issue) and if that still fails, it will emit the following error message:

```
Failed to download sgtk:descriptor:app_store?version=v0.7.37&name=tk-multi-workfiles2 
from the Toolkit App Store (https://tank.shotgunstudio.com)
```