### PR TITLE
#37386 Fixed issue preventing project copy in Shotgun desktop

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -38,7 +38,7 @@ sgtk.util.filesystem
 .. autofunction:: with_cleared_umask
 .. autofunction:: touch_file(path, permissions=0666)
 .. autofunction:: ensure_folder_exists(path, permissions=0775, create_placeholder_file=False)
-.. autofunction:: copy_file(src, dst, permissions=0555)
+.. autofunction:: copy_file(src, dst, permissions=0666)
 .. autofunction:: safe_delete_file
 .. autofunction:: copy_folder(src, dst, folder_permissions=0775, skip_list=None)
 .. autofunction:: move_folder(src, dst, folder_permissions=0775)

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -89,13 +89,13 @@ def do_localize(log, pc_root_path, suppress_prompts):
     :param suppress_prompts: Boolean to indicate if no questions should be asked.
     """
 
-    pc = pipelineconfig_factory.from_path(pc_root_path)
+`    pipeline_config = pipelineconfig_factory.from_path(pc_root_path)
 
     log.info("")
-    if pc.is_localized():
+    if pipeline_config.is_localized():
         raise TankError("Looks like your current pipeline configuration already has a local install of the core!")
 
-    core_api_root = pc.get_install_location()
+    core_api_root = pipeline_config.get_install_location()
 
     log.info("This will copy the Core API in %s \ninto the Pipeline configuration %s." % (core_api_root, pc_root_path))
     log.info("")

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # make sure that py25 has access to with statement
@@ -31,8 +31,8 @@ from .. import pipelineconfig_factory
 # when a configuration is upgraded to contain a core API
 CORE_FILES_FOR_LOCALIZE = ["shotgun.yml",
                            "app_store.yml",
-                           "interpreter_Darwin.cfg", 
-                           "interpreter_Linux.cfg", 
+                           "interpreter_Darwin.cfg",
+                           "interpreter_Linux.cfg",
                            "interpreter_Windows.cfg"]
 
 class CoreLocalizeAction(Action):
@@ -40,35 +40,35 @@ class CoreLocalizeAction(Action):
     Action to localize the Core API
     """
     def __init__(self):
-        Action.__init__(self, 
-                        "localize", 
-                        Action.TK_INSTANCE, 
+        Action.__init__(self,
+                        "localize",
+                        Action.TK_INSTANCE,
                         ("Installs the Core API into your current Configuration. This is typically "
                          "done when you want to test a Core API upgrade in an isolated way. If you "
                          "want to safely test an API upgrade, first clone your production configuration, "
-                         "then run the localize command from your clone's tank command."), 
+                         "then run the localize command from your clone's tank command."),
                         "Admin")
-        
+
         # this method can be executed via the API
         self.supports_api = True
-        
+
 
     def run_noninteractive(self, log, parameters):
         """
-        Tank command API accessor. 
+        Tank command API accessor.
         Called when someone runs a tank command through the core API.
-        
+
         :param log: std python logger
         :param parameters: dictionary with tank command parameters
         """
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
         return do_localize(log, pc_root, suppress_prompts=True)
-    
+
     def run_interactive(self, log, args):
         """
         Tank command accessor
-        
+
         :param log: std python logger
         :param args: command line args
         """
@@ -78,26 +78,26 @@ class CoreLocalizeAction(Action):
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
         return do_localize(log, pc_root, suppress_prompts=False)
-    
-    
+
+
 def do_localize(log, pc_root_path, suppress_prompts):
     """
     Perform the actual localize command.
-    
+
     :param log: logging object
     :param pc_root_path: Path to the config that should be localized.
     :param suppress_prompts: Boolean to indicate if no questions should be asked.
-    """ 
+    """
 
     pc = pipelineconfig_factory.from_path(pc_root_path)
 
     log.info("")
     if pc.is_localized():
         raise TankError("Looks like your current pipeline configuration already has a local install of the core!")
-    
+
     core_api_root = pc.get_install_location()
-    
-    log.info("This will copy the Core API in %s into the Pipeline configuration %s." % (core_api_root, pc_root_path))
+
+    log.info("This will copy the Core API in %s \ninto the Pipeline configuration %s." % (core_api_root, pc_root_path))
     log.info("")
     if not suppress_prompts:
         # check with user if they wanna continue
@@ -105,87 +105,63 @@ def do_localize(log, pc_root_path, suppress_prompts):
             # user says no!
             log.info("Operation cancelled.")
             return
-    
+
     # proceed with setup
     log.info("")
-    
-    # first get a list of all bundle descriptors
-    # key by descriptor repr, which ensures uniqueness   
-    # at this point we also store the path to each descriptor
-    # before we make any changes to any config files 
-    descriptors = {}
-    for env_name in pc.get_environments():
-        
-        env_obj = pc.get_environment(env_name)
-        
-        for engine in env_obj.get_engines():
-            descriptor = env_obj.get_engine_descriptor(engine)
-            descriptors[ repr(descriptor) ] = { "name": str(descriptor), "path": descriptor.get_path() }
-            
-            for app in env_obj.get_apps(engine):
-                descriptor = env_obj.get_app_descriptor(engine, app)
-                descriptors[ repr(descriptor) ] = { "name": str(descriptor), "path": descriptor.get_path() }
-                
-        for framework in env_obj.get_frameworks():
-            descriptor = env_obj.get_framework_descriptor(framework)
-            descriptors[ repr(descriptor) ] = { "name": str(descriptor), "path": descriptor.get_path() }
-    
-    
-    source_core = os.path.join(core_api_root, "install", "core")
-    target_core = os.path.join(pc_root_path, "install", "core")
-    backup_location = os.path.join(pc_root_path, "install", "core.backup")
-        
-    old_umask = os.umask(0)
-    try:        
 
-        # step 1. copy this into backup location
+    try:
+
+        ######################################################################
+        #
+        # step one - copy all the contents of the install location across except
+        # for the contents in the core and core.backup folders - these are handled
+        # explicitly
+
+        source_install_path = os.path.join(core_api_root, "install")
+        target_install_path = os.path.join(pc_root_path, "install")
+
+        names = os.listdir(source_install_path)
+        for name in names:
+
+            if name in ["core", "core.backup"]:
+                # skip now and handle separately
+                continue
+
+            if name.startswith(".") or name.startswith("_"):
+                # skip system directories such as __MACOSX and .DS_store
+                continue
+
+            source = os.path.join(source_install_path, name)
+            target = os.path.join(target_install_path, name)
+            log.info("Localizing the %s folder..." % name)
+            filesystem.copy_folder(source, target)
+
+        ######################################################################
+        #
+        # step two - backup the target core and copy the new core across
+
+        source_core = os.path.join(core_api_root, "install", "core")
+        target_core = os.path.join(pc_root_path, "install", "core")
+        backup_location = os.path.join(pc_root_path, "install", "core.backup")
+
+        log.info("Backing up existing Core API...")
         backup_folder_name = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_path = os.path.join(backup_location, backup_folder_name)
-        log.debug("Backing up Core API: %s -> %s" % (target_core, backup_path))
         src_files = filesystem.copy_folder(target_core, backup_path)
-        
-        # step 2. copy all the bundles that are used by the environment   
-        log.info("Copying %s apps, engines and frameworks..." % len(descriptors))
-        
-        source_base_path = os.path.join(core_api_root, "install")
-        target_base_path = os.path.join(pc_root_path, "install")
 
-        for idx, descriptor in enumerate(descriptors.values()):
-            
-            descriptor_path = descriptor["path"]
-            
-            # print one based indices for more human friendly output
-            log.info("%s/%s: Copying %s..." % (idx+1, len(descriptors), descriptor["name"]))
-            
-            if descriptor_path.startswith(source_base_path):
-                target_path = descriptor_path.replace(source_base_path, target_base_path)
-                if not os.path.exists(target_path):
-                    # create all folders
-                    os.makedirs(target_path, 0777)
-                    # and copy content
-                    filesystem.copy_folder(descriptor_path, target_path)
-                    
-        # step 3. clear out the install location
         log.debug("Clearing out core target location...")
         for f in src_files:
-            try:
-                # on windows, ensure all files are writable
-                if sys.platform == "win32":
-                    attr = os.stat(f)[0]
-                    if (not attr & stat.S_IWRITE):
-                        # file is readonly! - turn off this attribute
-                        os.chmod(f, stat.S_IWRITE)
-                os.remove(f)
-                log.debug("Deleted %s" % f)
-            except Exception, e:
-                log.error("Could not delete file %s: %s" % (f, e))
-        
-        # step 4. copy core distro
-        log.info("Localizing Core: %s -> %s" % (source_core, target_core))
+            filesystem.safe_delete_file(f)
+
+        log.info("Copying Core %s \nto %s" % (source_core, target_core))
         filesystem.copy_folder(source_core, target_core)
-        
-        # copy some core config files across
-        log.info("Copying Core Configuration Files...")
+
+
+        ######################################################################
+        #
+        # step three - copy some core config files across
+
+        log.info("Copying Core configuration files...")
         for fn in CORE_FILES_FOR_LOCALIZE:
             src = os.path.join(core_api_root, "config", "core", fn)
             tgt = os.path.join(pc_root_path, "config", "core", fn)
@@ -197,12 +173,11 @@ def do_localize(log, pc_root_path, suppress_prompts):
             # credentials can be retrieved using a session token and therefore we don't need the
             # AppStore credentials to be saved on disk.
             if fn != "app_store.yml" or os.path.exists(src):
-                shutil.copy(src, tgt)
+                filesystem.copy_file(src, tgt, permissions=0666)
 
     except Exception, e:
+        log.exception("Could not perform localize operation.")
         raise TankError("Could not localize: %s" % e)
-    finally:
-        os.umask(old_umask)
 
     log.info("The Core API was successfully localized.")
 
@@ -212,7 +187,7 @@ def do_localize(log, pc_root_path, suppress_prompts):
              "no other configurations or projects will be affected.")
     log.info("")
     log.info("")
-    
+
 
 
 
@@ -222,23 +197,23 @@ class ShareCoreAction(Action):
     Action to take a localized core and move it out into an external location on disk.
     """
     def __init__(self):
-        Action.__init__(self, 
-                        "share_core", 
-                        Action.TK_INSTANCE, 
+        Action.__init__(self,
+                        "share_core",
+                        Action.TK_INSTANCE,
                         ("When new projects are created, these are often created in a state where each project "
                          "maintains its own independent copy of the core API. This command allows you to take "
                          "the core for such a project and move it out into a separate location on disk. This "
                          "makes it possible to create a shared core, where several projects share a single copy "
-                         "of the Core API. Note: if you already have a shared Core API that you would like this " 
-                         "configuration to use, instead use the attach_to_core command."), 
+                         "of the Core API. Note: if you already have a shared Core API that you would like this "
+                         "configuration to use, instead use the attach_to_core command."),
                         "Admin")
-        
+
         # this method can be executed via the API
         self.supports_api = True
-        
+
         self.parameters = {}
-        
-        
+
+
         # note how the current platform's default value is None in order to make that required
         self.parameters["core_path_mac"] = { "description": ("The path on disk where the core API should be "
                                                              "installed on Macosx."),
@@ -254,37 +229,37 @@ class ShareCoreAction(Action):
                                                                "installed on Linux."),
                                                "default": ( None if sys.platform == "linux2" else "" ),
                                                "type": "str" }
-        
+
 
     def run_noninteractive(self, log, parameters):
         """
-        Tank command API accessor. 
+        Tank command API accessor.
         Called when someone runs a tank command through the core API.
-        
+
         :param log: std python logger
         :param parameters: dictionary with tank command parameters
         """
-        
+
         # validate params and seed default values
         computed_params = self._validate_parameters(parameters)
-        
+
         return _run_unlocalize(self.tk,
-                               log, 
-                               computed_params["core_path_mac"], 
-                               computed_params["core_path_win"], 
+                               log,
+                               computed_params["core_path_mac"],
+                               computed_params["core_path_win"],
                                computed_params["core_path_linux"],
-                               copy_core=True, 
-                               suppress_prompts=True)        
-        
-    
+                               copy_core=True,
+                               suppress_prompts=True)
+
+
     def run_interactive(self, log, args):
         """
         Tank command accessor
-        
+
         :param log: std python logger
         :param args: command line args
         """
-        
+
         if len(args) != 3:
             log.info("Syntax: share_core linux_path windows_path mac_path")
             log.info("")
@@ -302,17 +277,17 @@ class ShareCoreAction(Action):
             log.info('> tank share_core "" "p:\\shotgun\\studio" ""')
             log.info("")
             raise TankError("Please specify three target locations!")
-        
+
         linux_path = args[0]
         windows_path = args[1]
         mac_path = args[2]
 
-        return _run_unlocalize(self.tk, 
-                               log, 
-                               mac_path, 
-                               windows_path, 
-                               linux_path, 
-                               copy_core=True, 
+        return _run_unlocalize(self.tk,
+                               log,
+                               mac_path,
+                               windows_path,
+                               linux_path,
+                               copy_core=True,
                                suppress_prompts=False)
 
 
@@ -321,50 +296,50 @@ class AttachToCoreAction(Action):
     Action to take a localized config, discard the built in core and associate it with an existing core.
     """
     def __init__(self):
-        Action.__init__(self, 
-                        "attach_to_core", 
-                        Action.TK_INSTANCE, 
+        Action.__init__(self,
+                        "attach_to_core",
+                        Action.TK_INSTANCE,
                         ("When new projects are created, these are often created in a state where each project "
                          "maintains its own independent copy of the core API. This command allows you to attach "
                          "the configuration to an existing core API installation rather than having it maintain "
                          "its own embedded version of the Core API. Note: If you don't have a shared core API "
-                         "yet, instead use the share_core command."), 
+                         "yet, instead use the share_core command."),
                         "Admin")
-        
+
         # this method can be executed via the API
         self.supports_api = True
-        
+
         self.parameters = {}
-                
+
         # note how the current platform's default value is None in order to make that required
-        self.parameters["path"] = { "description": "Path to a core you want to attach to.", 
+        self.parameters["path"] = { "description": "Path to a core you want to attach to.",
                                     "default": None,
                                     "type": "str" }
 
 
     def run_noninteractive(self, log, parameters):
         """
-        Tank command API accessor. 
+        Tank command API accessor.
         Called when someone runs a tank command through the core API.
-        
+
         :param log: std python logger
         :param parameters: dictionary with tank command parameters
         """
-        
+
         # validate params and seed default values
         computed_params = self._validate_parameters(parameters)
-        
+
         return self._run_wrapper(log, computed_params["path"], suppress_prompts=True)
-        
-    
+
+
     def run_interactive(self, log, args):
         """
         Tank command accessor
-        
+
         :param log: std python logger
         :param args: command line args
         """
-        
+
         if len(args) != 1:
             log.info("Syntax: attach_to_core path_to_core")
             log.info("")
@@ -379,49 +354,49 @@ class AttachToCoreAction(Action):
             log.info("> tank attach_to_core /mnt/shotgun/studio")
             log.info("")
             raise TankError("Please specify three target locations!")
-        
+
         path_to_core = args[0]
 
         return self._run_wrapper(log, path_to_core, suppress_prompts=False)
- 
- 
+
+
     def _run_wrapper(self, log, path_to_core, suppress_prompts):
         """
         Given the path to the core API, resolves the core path on all three OSes
         and then executes the unlocalize payload.
-        
+
         :param log: Logger
         :param path_to_core: path to core root on current os.
         :param suppress_prompts: Boolean to indicate if no questions should be asked.
         """
-        
+
         # resolve the path to core on all platforms
         log.debug("Running attach to core with specified path to core: '%s' "% path_to_core)
         core_locations = pipelineconfig_utils.resolve_all_os_paths_to_core(path_to_core)
         log.debug("Resolved the following core path locations via install_location: %s" % core_locations)
-        
-        # and run the actual localize        
+
+        # and run the actual localize
         return _run_unlocalize(self.tk,
-                               log, 
-                               core_locations["darwin"], 
-                               core_locations["win32"], 
-                               core_locations["linux2"], 
-                               copy_core=False, 
+                               log,
+                               core_locations["darwin"],
+                               core_locations["win32"],
+                               core_locations["linux2"],
+                               copy_core=False,
                                suppress_prompts=suppress_prompts)
-        
-        
- 
+
+
+
 
 
 def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, suppress_prompts):
     """
-    Actual execution payload for share_core and relocate_core. This method can be used to 
-    
+    Actual execution payload for share_core and relocate_core. This method can be used to
+
     1. Share a core - e.g. copying it into a new location and then point the config
        to that location
     2. Attach to a core - e.g. discarding the current core and then point the config
        to another existing core.
-                           
+
     :param tk: API instance to operate on
     :param log: Logger
     :param mac_path: New core path on mac
@@ -431,7 +406,7 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
                       to copy the core out to an external location. If fase, it will instead
                       try to attach to an existing core.
     :param suppress_prompts: if true, no questions are asked.
-    """ 
+    """
 
     log.debug("Executing the share_core command for %r" % tk)
     log.debug("Mac path: '%s'" % mac_path)
@@ -439,31 +414,31 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
     log.debug("Linux path: '%s'" % linux_path)
     log.debug("Current core version: %s" % tk.version)
     log.info("")
-    
+
     # some basic checks first
     if not tk.pipeline_configuration.is_localized():
         raise TankError("Looks like your current pipeline configuration is not localized and therefore "
                         "does not contain its own copy of the Core API! This configuration is picking "
                         "up its core from the following "
                         "location: '%s'" % tk.pipeline_configuration.get_install_location())
-    
+
     # we need to have at least a path for the current os, otherwise we cannot introspect the API
     lookup = {"win32": windows_path, "linux2": linux_path, "darwin": mac_path}
-    new_core_path_local = lookup[sys.platform] 
-    
+    new_core_path_local = lookup[sys.platform]
+
     if not new_core_path_local:
         raise TankError("You must specify a path to the core API for your current operating system.")
-    
+
     if copy_core:
         # make sure location is empty
         if os.path.exists(new_core_path_local):
             raise TankError("The path '%s' already exists on disk!" % new_core_path_local)
-    
+
     else:
         # make sure location exists and that there is a recent enough API in there
         if not os.path.exists(new_core_path_local):
             raise TankError("The path '%s' does not exist on disk!" % new_core_path_local)
-        
+
         # ensure that the API we are switching to is as recent as the current
         new_core_version = pipelineconfig_utils.get_core_api_version(new_core_path_local)
         if is_version_older(new_core_version, tk.version):
@@ -471,57 +446,57 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
                             "in '%s' is version %s. You cannot switch to a version of the core that is "
                             "older than the current core. Before switching, update the shared core and then "
                             "try again!" % (tk.version, new_core_path_local, new_core_version))
-            
-        
-        
-        
+
+
+
+
     pc_root = tk.pipeline_configuration.get_path()
-    
+
     if copy_core:
         log.info("This will move the embedded core API in the configuration '%s'." % pc_root )
         log.info("")
-        
+
     log.info("After this command has completed, the configuration will not contain an "
              "embedded copy of the core but instead it will be picked up from "
              "the following locations:")
     log.info("")
-    log.info(" - Linux: '%s'" % linux_path if linux_path else " - Linux: Not supported") 
+    log.info(" - Linux: '%s'" % linux_path if linux_path else " - Linux: Not supported")
     log.info(" - Windows: '%s'" % windows_path if windows_path else " - Windows: Not supported")
     log.info(" - Mac: '%s'" % mac_path if mac_path else " - Mac: Not supported")
     log.info("")
     log.info("Note for expert users: Prior to executing this command, please ensure that you have "
              "no configurations that are using the core embedded in this configuration.")
     log.info("")
-    
+
     if not suppress_prompts:
         # check with user if they wanna continue
         if not console_utils.ask_yn_question("Do you want to proceed"):
             # user pressed no
             log.info("Operation cancelled.")
             return
-    
-    # proceed with setup    
+
+    # proceed with setup
     log.info("")
-    
+
     old_umask = os.umask(0)
     try:
-        
+
         # these core config files are directly related to the core
         # and not needed by a configuration
-        core_config_file_names = ["shotgun.yml", 
-                                  "interpreter_Darwin.cfg", 
-                                  "interpreter_Linux.cfg", 
+        core_config_file_names = ["shotgun.yml",
+                                  "interpreter_Darwin.cfg",
+                                  "interpreter_Linux.cfg",
                                   "interpreter_Windows.cfg"]
-        
+
         if copy_core:
             # first make the basic structure
             log.info("Setting up base structure...")
             os.mkdir(new_core_path_local, 0775)
-        
+
             # copy across the tank commands
             shutil.copy(os.path.join(pc_root, "tank"), os.path.join(new_core_path_local, "tank"))
             shutil.copy(os.path.join(pc_root, "tank.bat"), os.path.join(new_core_path_local, "tank.bat"))
-            
+
             # make the config folder
             log.info("Copying configuration files...")
             os.mkdir(os.path.join(new_core_path_local, "config"), 0775)
@@ -529,9 +504,9 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
 
             for fn in core_config_file_names:
                 log.debug("Copy %s..." % fn)
-                shutil.copy(os.path.join(pc_root, "config", "core", fn), 
+                shutil.copy(os.path.join(pc_root, "config", "core", fn),
                             os.path.join(new_core_path_local, "config", "core", fn))
-                
+
             # create new install_location.yml file in the target location
             core_path = os.path.join(new_core_path_local, "config", "core", "install_location.yml")
             fh = open(core_path, "wt")
@@ -545,14 +520,14 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
             fh.write("Darwin: '%s'\n" % mac_path if mac_path else "Darwin: undefined_location\n")
             fh.write("Linux: '%s'\n" % linux_path if linux_path else "Linux: undefined_location\n")
             fh.write("# End of file.\n")
-        
+
             # copy the install
             log.info("Copying core installation...")
             filesystem.copy_folder(
                 os.path.join(pc_root, "install"),
                 os.path.join(new_core_path_local, "install")
             )
-        
+
         # back up current core API into the core.backup folder
         log.info("Backing up local core install...")
         current_core = os.path.join(pc_root, "install", "core")
@@ -575,14 +550,14 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
         # create blank core install
         log.info("Creating core proxy...")
         os.mkdir(current_core, 0775)
-        
+
         # copy python API proxy
         tank_proxy = os.path.join(new_core_path_local, "install", "core", "setup", "tank_api_proxy")
         filesystem.copy_folder(
             tank_proxy,
             os.path.join(pc_root, "install", "core", "python")
         )
-        
+
         # create core_XXX redirection files
         core_path = os.path.join(pc_root, "install", "core", "core_Darwin.cfg")
         fh = open(core_path, "wt")
@@ -591,7 +566,7 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
         else:
             fh.write("undefined")
         fh.close()
-        
+
         core_path = os.path.join(pc_root, "install", "core", "core_Linux.cfg")
         fh = open(core_path, "wt")
         if linux_path:
@@ -612,8 +587,8 @@ def _run_unlocalize(tk, log, mac_path, windows_path, linux_path, copy_core, supp
         raise TankError("Could not share the core! Error reported: %s" % e)
     finally:
         os.umask(old_umask)
-        
-    log.info("The Core API was successfully processed.")    
+
+    log.info("The Core API was successfully processed.")
     log.info("")
 
 

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -271,8 +271,9 @@ class IODescriptorAppStore(IODescriptorBase):
                 self.get_system_name(),
                 self.get_version()
             )
-        except RuntimeError:
-            pass
+        except RuntimeError, e:
+            # warn and continue
+            log.warning("Could not add legacy location to bundle search path: %s" % e)
         else:
             paths.append(legacy_folder)
 

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -103,8 +103,9 @@ class IODescriptorGitTag(IODescriptorGit):
                 name,
                 self.get_version()
             )
-        except RuntimeError:
-            pass
+        except RuntimeError, e:
+            # warn and continue
+            log.warning("Could not add legacy location to bundle search path: %s" % e)
         else:
             paths.append(legacy_folder)
 

--- a/python/tank/descriptor/io_descriptor/manual.py
+++ b/python/tank/descriptor/io_descriptor/manual.py
@@ -80,8 +80,9 @@ class IODescriptorManual(IODescriptorBase):
                 self._name,
                 self._version
             )
-        except RuntimeError:
-            pass
+        except RuntimeError, e:
+            # warn and continue
+            log.warning("Could not add legacy location to bundle search path: %s" % e)
         else:
             paths.append(legacy_folder)
 

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -62,14 +62,12 @@ def with_cleared_umask(func):
     def wrapper(*args, **kwargs):
         # set umask to zero, store old umask
         old_umask = os.umask(0)
-        #log.debug("Umask cleared")
         try:
             # execute method payload
             return func(*args, **kwargs)
         finally:
             # set mask back to previous value
             os.umask(old_umask)
-            #log.debug("Umask reset back to %o" % old_umask)
     return wrapper
 
 @with_cleared_umask
@@ -78,7 +76,8 @@ def touch_file(path, permissions=0666):
     Touch a file and optionally set its permissions.
 
     :param path: path to touch
-    :param permissions: Optional permissions to set on the file.
+    :param permissions: Optional permissions to set on the file. Default value is 0666,
+                        creating a file that is readable and writable for all users.
 
     :raises: OSError - if there was a problem reading/writing the file
     """
@@ -130,13 +129,14 @@ def ensure_folder_exists(path, permissions=0775, create_placeholder_file=False):
                 raise
 
 @with_cleared_umask
-def copy_file(src, dst, permissions=0555):
+def copy_file(src, dst, permissions=0666):
     """
-    Copy file with permissions
+    Copy file and sets its permissions.
 
     :param src: Source file
     :param dst: Target destination
-    :param permissions: Permissions to use for target file
+    :param permissions: Permissions to use for target file. Default permissions will
+                        be readable and writable for all users.
     """
     shutil.copy(src, dst)
     os.chmod(dst, permissions)


### PR DESCRIPTION
Fixed a bug which was causing certain items to be missing from a new project's app cache when it the project was created from another project's config. This issue was caused by the fact that toolkit maintains a global in-memory cache of descriptors. The assumption is that if a descriptor points at Core 1.2.3, this descriptor can be used by any process that wants to pick up v1.2.3 (see [here](https://github.com/shotgunsoftware/tk-core/blob/3813ea760484c4b418d468120032ab9a1f919b81/python/tank/descriptor/io_descriptor/factory.py#L79)).

Special logic was used inside the localize method to determine if an item should be copied or not - making assumptions about how descriptors were implemented under the hood. These assumptions not only conflict with this global cache, but generally going forward with the whole concept of the global bundle cache (so good we found this issue).

The most reliable fix I can think of here is to essentially copy the install folder across at localization time - we cannot make any clever assumptions anymore around descriptors and install locations since descriptors now can be stored in many different places etc. This means that the implementation is going back to something that is similar to its original design.

Notable points:

- Everything in `install` is now copied across, including versions that are not used by the config. This is not necessarily a bad thing, but in some cases can increase the I/O burden.
- Modified the default permissions for the copy file I/O method. This was introduced in 0.18 and they were wrong.
- This change may affect larger setups which rely on complex localization workflows. Such clients are unlikely to be affected negatively by this change but should check carefully.
- improved use of internal I/O methods
- added logging around descriptors.