### PR TITLE
#37459 Adds exception logging to hooks

### DIFF
--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -15,11 +15,14 @@ Defines the base class for all Tank Hooks.
 import os
 import threading
 from .util.loader import load_plugin
+from . import LogManager
 from .errors import (
     TankError,
     TankFileDoesNotExistError,
     TankHookMethodDoesNotExistError,
 )
+
+log = LogManager.get_logger(__name__)
 
 class Hook(object):
     """
@@ -184,10 +187,10 @@ class Hook(object):
 
     # default method to execute on hooks
     DEFAULT_HOOK_METHOD = "execute"
-    
+
     def __init__(self, parent):
         self.__parent = parent
-    
+
     @property
     def parent(self):
         """
@@ -202,7 +205,7 @@ class Hook(object):
                   has a ``shotgun`` property.
         """
         return self.__parent
-    
+
     def get_publish_path(self, sg_publish_data):
         """
         Returns the path on disk for a publish entity in Shotgun.
@@ -212,12 +215,12 @@ class Hook(object):
         the publish path is encoded, a local path is returned.
 
         :param sg_publish_data: Shotgun dictionary containing
-                                information about a publish. Needs to at least 
-                                contain a type, id and a path key. 
+                                information about a publish. Needs to at least
+                                contain a type, id and a path key.
         :returns: String representing a local path on disk.
         """
         return self.get_publish_paths([ sg_publish_data ])[0]
-        
+
     def get_publish_paths(self, sg_publish_data_list):
         """
         Returns several local paths on disk given a
@@ -227,9 +230,9 @@ class Hook(object):
         to get a local path on disk. This method will ensure that however
         the publish path is encoded, a local path is returned.
 
-        :param sg_publish_data_list: List of shotgun data dictionaries 
-                                     containing publish data. Each dictionary 
-                                     needs to at least contain a type, id and 
+        :param sg_publish_data_list: List of shotgun data dictionaries
+                                     containing publish data. Each dictionary
+                                     needs to at least contain a type, id and
                                      a path key.
         :returns: List of strings representing local paths on disk.
         """
@@ -239,15 +242,15 @@ class Hook(object):
             if path_field is None:
                 raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
                                 "not contain a valid path definition" % sg_data)
-            
+
             local_path = path_field.get("local_path")
             if local_path is None:
                 raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
                                 "not contain a valid path definition" % sg_data)
             paths.append(local_path)
-        
+
         return paths
-    
+
     def load_framework(self, framework_instance_name):
         """
         Loads and returns a framework given an environment instance name.
@@ -295,9 +298,9 @@ class Hook(object):
         except:
             raise TankError("Cannot load framework %s for %r - it does not have a "
                             "valid engine property!" % (framework_instance_name, self.__parent))
-            
+
         return framework.load_framework(engine, engine.get_env(), framework_instance_name)
-    
+
     def execute(self):
         """
         Legacy support for old style hooks
@@ -319,7 +322,7 @@ class _HooksCache(object):
 
     def thread_exclusive(func):
         """
-        function decorator to ensure multiple threads can't access the cache 
+        function decorator to ensure multiple threads can't access the cache
         at the same time.
 
         :param func:    The function to wrap
@@ -344,7 +347,7 @@ class _HooksCache(object):
         Clear the hook cache
         """
         self._cache = {}
-    
+
     @thread_exclusive
     def find(self, hook_path, hook_base_class):
         """
@@ -354,27 +357,27 @@ class _HooksCache(object):
         :param hook_base_class: The base class for the hook to find
         :returns:               The Hook class if found, None if not
         """
-        # The unique cache key is a tuple of the path and the base class to allow 
+        # The unique cache key is a tuple of the path and the base class to allow
         # loading of classes with different bases from the same file
         key = (hook_path, hook_base_class)
         return self._cache.get(key, None)
-    
+
     @thread_exclusive
     def add(self, hook_path, hook_base_class, hook_class):
         """
         Add the specified hook to the cache if it isn't already present
-        
+
         :param hook_path:       The path to the hook to add
         :param hook_base_class: The base class for the hook to add
         :param hook_class:      The Hook class to add
         """
-        # The unique cache key is a tuple of the path and the base class to allow 
+        # The unique cache key is a tuple of the path and the base class to allow
         # loading of classes with different bases from the same file
         key = (hook_path, hook_base_class)
-        if key not in self._cache: 
+        if key not in self._cache:
             self._cache[key] = hook_class
 
-    @thread_exclusive        
+    @thread_exclusive
     def __len__(self):
         """
         Return the number of items currently in the hook cache
@@ -392,19 +395,19 @@ def clear_hooks_cache():
 
 def execute_hook(hook_path, parent, **kwargs):
     """
-    Executes a hook, old-school style. 
-    
-    A hook is a python file which 
-    contains exactly one class which derives (at some point 
+    Executes a hook, old-school style.
+
+    A hook is a python file which
+    contains exactly one class which derives (at some point
     in its inheritance tree) from the Hook base class.
-    
+
     Once the file has been loaded (and cached), the execute()
-    method will be called and any optional arguments pass to 
+    method will be called and any optional arguments pass to
     this method will be forwarded on to that execute() method.
-    
+
     :param hook_path: Full path to the hook python file
     :param parent: Parent object. This will be accessible inside
-                   the hook as self.parent, and is typically an 
+                   the hook as self.parent, and is typically an
                    app, engine or core object.
     :returns: Whatever the hook returns.
     """
@@ -413,46 +416,46 @@ def execute_hook(hook_path, parent, **kwargs):
 def execute_hook_method(hook_paths, parent, method_name, **kwargs):
     """
     New style hook execution, with method arguments and support for inheritance.
-    
+
     This method takes a list of hook paths and will load each of the classes
-    in, while maintaining the correct state of the class returned via 
-    get_hook_baseclass(). Once all classes have been successfully loaded, 
+    in, while maintaining the correct state of the class returned via
+    get_hook_baseclass(). Once all classes have been successfully loaded,
     the last class in the list is instantiated and the specified method
     is executed.
-    
+
         Example: ["/tmp/a.py", "/tmp/b.py", "/tmp/c.py"]
-        
+
         1. The code in a.py is loaded in. get_hook_baseclass() will return Hook
            at this point. class HookA is returned from our plugin loader.
-        
-        2. /tmp/b.py is loaded in. get_hook_baseclass() now returns HookA, so 
+
+        2. /tmp/b.py is loaded in. get_hook_baseclass() now returns HookA, so
            if the hook code in B utilises get_hook_baseclass, this will will
            set up an inheritance relationship with A
-        
+
         3. /tmp/c.py is finally loaded in, get_hook_baseclass() now returns HookB.
-        
+
         4. HookC class is instantiated and method method_name is executed.
-    
+
     :param hook_paths: List of full paths to hooks, in inheritance order.
     :param parent: Parent object. This will be accessible inside
-                   the hook as self.parent, and is typically an 
+                   the hook as self.parent, and is typically an
                    app, engine or core object.
     :param method_name: method to execute. If None, the default method will be executed.
     :returns: Whatever the hook returns.
-    """    
+    """
     method_name = method_name or Hook.DEFAULT_HOOK_METHOD
 
     # keep track of the current base class - this is used when loading hooks to dynamically
     # inherit from the correct base.
     _current_hook_baseclass.value = Hook
-    
+
     for hook_path in hook_paths:
 
         if not os.path.exists(hook_path):
             raise TankFileDoesNotExistError("Cannot execute hook '%s' - this file does not exist on disk!" % hook_path)
 
         # look to see if we've already loaded this hook into the cache
-        found_hook_class = _hooks_cache.find(hook_path, _current_hook_baseclass.value)         
+        found_hook_class = _hooks_cache.find(hook_path, _current_hook_baseclass.value)
         if not found_hook_class:
             # load the hook class from the hook file and cache it - this explicitly looks for a
             # single class from the hook file that is derived from the current base (or 'Hook' for
@@ -461,34 +464,34 @@ def execute_hook_method(hook_paths, parent, method_name, **kwargs):
             # determine any alternate base classes to look for in addition to the current base:
             alternate_base_classes = []
             if _current_hook_baseclass.value != Hook:
-                # allow deriving from the Hook base class - this is to support the legacy method of 
+                # allow deriving from the Hook base class - this is to support the legacy method of
                 # overriding hooks but without sub-classing them.
                 alternate_base_classes.append(Hook)
-                
+
             # try to load the hook class:
             loaded_hook_class = load_plugin(
                 hook_path,
                 valid_base_class=_current_hook_baseclass.value,
                 alternate_base_classes=alternate_base_classes
             )
-                
+
             # add it to the cache...
             _hooks_cache.add(hook_path, _current_hook_baseclass.value, loaded_hook_class)
-            
-            # ...and find it again - this is to avoid different threads ending up using 
+
+            # ...and find it again - this is to avoid different threads ending up using
             # different instances of the loaded class.
             found_hook_class = _hooks_cache.find(hook_path, _current_hook_baseclass.value)
 
         # keep track of the current base class:
         _current_hook_baseclass.value = found_hook_class
-    
+
     # all class construction done. _current_hook_baseclass contains
-    # the last class we iterated over. This is the one we want to 
+    # the last class we iterated over. This is the one we want to
     # instantiate.
-    
+
     # instantiate the class
     hook = _current_hook_baseclass.value(parent)
-    
+
     # get the method
     try:
         hook_method = getattr(hook, method_name)
@@ -497,10 +500,17 @@ def execute_hook_method(hook_paths, parent, method_name, **kwargs):
             "Cannot execute hook '%s' - the hook class does not have a '%s' "
             "method!" % (hook, method_name)
         )
-    
+
     # execute the method
-    ret_val = hook_method(**kwargs)
-    
+    try:
+        ret_val = hook_method(**kwargs)
+    except:
+        # log the full callstack to make sure that whatever the
+        # calling code is doing, this error is logged to help
+        # with troubleshooting and support
+        log.exception("Exception raised while executing hook '%s'" % hook_paths[-1])
+        raise
+
     return ret_val
 
 def get_hook_baseclass():

--- a/python/tank/util/loader.py
+++ b/python/tank/util/loader.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -19,6 +19,9 @@ import traceback
 import inspect
 
 from ..errors import TankError
+from .. import LogManager
+
+log = LogManager.get_logger(__name__)
 
 class TankLoadPluginError(TankError):
     """
@@ -31,9 +34,9 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
     Load a plugin into memory and extract its single interface class.
 
     :param plugin_file:             The file to use when looking for the plug-in class to load
-    :param valid_base_class:        A type to use when searching for a derived class.  
+    :param valid_base_class:        A type to use when searching for a derived class.
     :param alternate_base_classes:  A list of alternate base classes to be searched for if a class deriving
-                                    from valid_base_class can't be found 
+                                    from valid_base_class can't be found
     :returns:                       A class derived from the base class if found
     :raises:                        Raises a TankError if it fails to load the file or doesn't find exactly
                                     one matching class.
@@ -41,17 +44,22 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
     # build a single list of valid base classes including any alternate base classes
     alternate_base_classes = alternate_base_classes or []
     valid_base_classes = [valid_base_class] + alternate_base_classes
-    
+
     # construct a uuid and use this as the module name to ensure
     # that each import is unique
     import uuid
-    module_uid = uuid.uuid4().hex 
+    module_uid = uuid.uuid4().hex
     module = None
     try:
         imp.acquire_lock()
         module = imp.load_source(module_uid, plugin_file)
     except Exception:
-        # dump out the callstack for this one -- to help people get good messages when there is a plugin error        
+        # log the full callstack to make sure that whatever the
+        # calling code is doing, this error is logged to help
+        # with troubleshooting and support
+        log.exception("Cannot load plugin file '%s'" % plugin_file)
+
+        # dump out the callstack for this one -- to help people get good messages when there is a plugin error
         (exc_type, exc_value, exc_traceback) = sys.exc_info()
         message = ""
         message += "Failed to load plugin %s. The following error was reported:\n" % plugin_file
@@ -61,17 +69,17 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
         raise TankLoadPluginError(message)
     finally:
         imp.release_lock()
-    
+
     # cool, now validate the module
     found_classes = list()
     try:
-        # first, find all classes in the module, being careful to only find classes that 
-        # are actually from this module and not from any other imports! 
+        # first, find all classes in the module, being careful to only find classes that
+        # are actually from this module and not from any other imports!
         search_predicate = lambda member: inspect.isclass(member) and member.__module__ == module.__name__
         all_classes = [cls for _, cls in inspect.getmembers(module, search_predicate)]
 
-        # Now look for classes in the module that are derived from the specified base 
-        # class.  Note that 'inspect.getmembers' returns the contents of the module 
+        # Now look for classes in the module that are derived from the specified base
+        # class.  Note that 'inspect.getmembers' returns the contents of the module
         # in alphabetical order so no assumptions should be made based on the order!
         #
         # Enumerate the valid_base_classes in order so that we find the highest derived
@@ -79,8 +87,8 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
         for base_cls in valid_base_classes:
             found_classes = [cls for cls in all_classes if issubclass(cls, base_cls)]
             if len(found_classes) > 1:
-                # it's possible that this file contains multiple levels of derivation - if this 
-                # is the case then we should try to remove any intermediate classes from the list 
+                # it's possible that this file contains multiple levels of derivation - if this
+                # is the case then we should try to remove any intermediate classes from the list
                 # of found classes so that we are left with only leaf classes:
                 filtered_classes = list(found_classes)
                 for cls in found_classes:
@@ -93,6 +101,12 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
                 # we found at least one class so assume this is a match!
                 break
     except Exception, e:
+
+        # log the full callstack to make sure that whatever the
+        # calling code is doing, this error is logged to help
+        # with troubleshooting and support
+        log.exception("Failed to introspect hook structure for '%s'" % plugin_file)
+
         # re-raise as a TankError
         raise TankError("Introspection error while trying to load and introspect file %s. "
                         "Error Reported: %s" % (plugin_file, e))
@@ -104,8 +118,8 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
                "If your file looks fine, it is possible that the cached .pyc file that python "
                "generates is invalid and this is causing the error. In that case, please delete "
                "the .pyc file and try again." % (plugin_file, valid_base_class.__name__))
-        
+
         raise TankLoadPluginError(msg)
 
-    # return the class that was found.        
+    # return the class that was found.
     return found_classes[0]


### PR DESCRIPTION
The hook interface is a boundary where toolkit executes user code. With 0.18 and its improved logging, we can ensure to consistently trap any errors passing through this boundary.

This change adds a low level exception logging trap for all hooks in toolkit, ensuring that whenever a hook fails to load or execute, this is logged to the logger (and the log file):

```
2016-07-15 09:43:48,642 [90897 ERROR sgtk.core.hook] Exception raised while executing hook '/mnt/wintermute/configs/18_mac/install/core/hooks/tank_init.py'
Traceback (most recent call last):
  File "/mnt/wintermute/configs/18_mac/install/core/python/tank/hook.py", line 506, in execute_hook_method
    ret_val = hook_method(**kwargs)
  File "/mnt/wintermute/configs/18_mac/install/core/hooks/tank_init.py", line 25, in execute
    a = b + c
NameError: global name 'b' is not defined
```

The exception is then bubbled up to the caller. 

Note: Because the caller may implements its own exception trapping and reporting, it is possible, even likely, that the hook exception will be logged twice. But this specific message is useful because (apart from happening every single time) it provides a clear error message that only contains the callstack from the user's code (e.g the hook code).