### PR TITLE
#37386 Improved version of PR #306

### DIFF
--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -109,10 +109,8 @@ def do_localize(log, pc_root_path, suppress_prompts):
     log.info("")
 
     try:
-        # Step 1: First get a list of all bundle descriptors
-        # key by descriptor repr, which ensures uniqueness
-        # at this point we also store the path to each descriptor
-        # before we make any changes to any config files
+        # Step 1: First get a list of all bundle descriptors.
+        # Key by descriptor uri, which ensures no repetition.
         descriptors = {}
         for env_name in pipeline_config.get_environments():
 
@@ -131,16 +129,16 @@ def do_localize(log, pc_root_path, suppress_prompts):
                 descriptors[descriptor.get_uri()] = descriptor
 
 
-        # Step 2: Now re-cache all the relevant apps into the new install location
+        # Step 2: Now re-cache all the relevant apps into the new install location.
         target_bundle_cache_root = os.path.join(pc_root_path, "install")
 
-        for idx, descriptor in enumerate(descriptors.values()):
+        for idx, descriptor in enumerate(descriptors.itervalues()):
             # print one based indices for more human friendly output
-            log.info("%s/%s: Copying %s..." % (idx+1, len(descriptors), descriptor))
+            log.info("%s/%s: Copying %s..." % (idx + 1, len(descriptors), descriptor))
             descriptor.clone_cache(target_bundle_cache_root)
 
 
-        # Step 3: Backup the target core and copy the new core across
+        # Step 3: Backup the target core and copy the new core across.
         source_core = os.path.join(core_api_root, "install", "core")
         target_core = os.path.join(pc_root_path, "install", "core")
         backup_location = os.path.join(pc_root_path, "install", "core.backup")
@@ -158,7 +156,7 @@ def do_localize(log, pc_root_path, suppress_prompts):
         filesystem.copy_folder(source_core, target_core)
 
 
-        # Step 4: Copy some core config files across
+        # Step 4: Copy some core config files across.
         log.info("Copying Core configuration files...")
         for fn in CORE_FILES_FOR_LOCALIZE:
             src = os.path.join(core_api_root, "config", "core", fn)

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -196,7 +196,7 @@ class Descriptor(object):
         administer such a setup, allowing a cached payload to be copied from
         its current location into a new cache structure.
 
-        If the descriptor doesn't exist on disk yet, it will be downloaded.
+        If the descriptor's payload doesn't exist on disk, it will be downloaded.
 
         :param cache_root: Root point of the cache location to copy to.
         """

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -185,6 +185,23 @@ class Descriptor(object):
         """
         self._io_descriptor.copy(target_folder)
 
+    def clone_cache(self, cache_root):
+        """
+        The descriptor system maintains an internal cache where it downloads
+        the payload that is associated with the descriptor. Toolkit supports
+        complex cache setups, where you can specify a series of path where toolkit
+        should go and look for cached items.
+
+        This is an advanced method that helps in cases where a user wishes to
+        administer such a setup, allowing a cached payload to be copied from
+        its current location into a new cache structure.
+
+        If the descriptor doesn't exist on disk yet, it will be downloaded.
+
+        :param cache_root: Root point of the cache location to copy to.
+        """
+        return self._io_descriptor.clone_cache(cache_root)
+
     @property
     def display_name(self):
         """

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -233,6 +233,21 @@ class IODescriptorAppStore(IODescriptorBase):
 
         return metadata
 
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
+
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        return os.path.join(
+            bundle_cache_root,
+            "app_store",
+            self.get_system_name(),
+            self.get_version()
+        )
+
     def _get_cache_paths(self):
         """
         Get a list of resolved paths, starting with the primary and
@@ -242,17 +257,8 @@ class IODescriptorAppStore(IODescriptorBase):
 
         :return: List of path strings
         """
-        paths = []
-
-        for root in [self._bundle_cache_root] + self._fallback_roots:
-            paths.append(
-                os.path.join(
-                    root,
-                    "app_store",
-                    self.get_system_name(),
-                    self.get_version()
-                )
-            )
+        # get default cache paths from base class
+        paths = super(IODescriptorAppStore, self)._get_cache_paths()
 
         # for compatibility with older versions of core, prior to v0.18.x,
         # add the old-style bundle cache path as a fallback. As of v0.18.x,

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -550,7 +550,7 @@ class IODescriptorBase(object):
         administer such a setup, allowing a cached payload to be copied from
         its current location into a new cache structure.
 
-        If the descriptor doesn't exist on disk yet, it will be downloaded.
+        If the descriptor's payload doesn't exist on disk, it will be downloaded.
 
         :param cache_root: Root point of the cache location to copy to.
         """

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -556,13 +556,19 @@ class IODescriptorBase(object):
         """
         # compute new location
         new_cache_path = self._get_bundle_cache_path(cache_root)
-        log.debug("Clone cache for %r: Copying to '%s'" % new_cache_path)
+        log.debug("Clone cache for %r: Copying to '%s'" % (self, new_cache_path))
 
         # make sure we have something to copy
         self.ensure_local()
 
+        # check that we aren't trying to copy onto ourself
+        if new_cache_path == self.get_path():
+            log.debug("Clone cache for %r: No need to copy, source and target are same." % self)
+            return
+
         # and to the actual I/O
         # pass an empty skip list to ensure we copy things like the .git folder
+        filesystem.ensure_folder_exists(new_cache_path, permissions=0777)
         filesystem.copy_folder(self.get_path(), new_cache_path, skip_list=[])
 
     ###############################################################################################

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -70,17 +70,14 @@ class IODescriptorGitBranch(IODescriptorGit):
         self._version = descriptor_dict.get("version")
         self._branch = descriptor_dict.get("branch")
 
-    def _get_cache_paths(self):
+    def _get_bundle_cache_path(self, bundle_cache_root):
         """
-        Get a list of resolved paths, starting with the primary and
-        continuing with alternative locations where it may reside.
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
 
-        Note: This method only computes paths and does not perform any I/O ops.
-
-        :return: List of path strings
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
         """
-        paths = []
-
         # to be MAXPATH-friendly, we only use the first seven chars
         short_hash = self._version[:7]
 
@@ -88,16 +85,12 @@ class IODescriptorGitBranch(IODescriptorGit):
         # /full/path/to/local/repo.git -> repo.git
         name = os.path.basename(self._path)
 
-        for root in [self._bundle_cache_root] + self._fallback_roots:
-            paths.append(
-                os.path.join(
-                    root,
-                    "git",
-                    name,
-                    short_hash
-                )
-            )
-        return paths
+        return os.path.join(
+            bundle_cache_root,
+            "git",
+            name,
+            short_hash
+        )
 
     def _clone_into(self, target_path):
         """

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -61,6 +61,25 @@ class IODescriptorGitTag(IODescriptorGit):
 
         self._type = bundle_type
 
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
+
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        # git@github.com:manneohrstrom/tk-hiero-publish.git -> tk-hiero-publish.git
+        # /full/path/to/local/repo.git -> repo.git
+        name = os.path.basename(self._path)
+
+        return os.path.join(
+            bundle_cache_root,
+            "git",
+            name,
+            self.get_version()
+        )
+
     def _get_cache_paths(self):
         """
         Get a list of resolved paths, starting with the primary and
@@ -70,21 +89,8 @@ class IODescriptorGitTag(IODescriptorGit):
 
         :return: List of path strings
         """
-        paths = []
-
-        # git@github.com:manneohrstrom/tk-hiero-publish.git -> tk-hiero-publish.git
-        # /full/path/to/local/repo.git -> repo.git
-        name = os.path.basename(self._path)
-
-        for root in [self._bundle_cache_root] + self._fallback_roots:
-            paths.append(
-                os.path.join(
-                    root,
-                    "git",
-                    name,
-                    self.get_version()
-                )
-            )
+        # get default cache paths from base class
+        paths = super(IODescriptorGitTag, self)._get_cache_paths()
 
         # for compatibility with older versions of core, prior to v0.18.x,
         # add the old-style bundle cache path as a fallback. As of v0.18.x,
@@ -95,6 +101,11 @@ class IODescriptorGitTag(IODescriptorGit):
         # cache root didn't change (when use_bundle_cache is set to False).
         # If the bundle cache root changes across core versions, then this will
         # need to be refactored.
+
+        # git@github.com:manneohrstrom/tk-hiero-publish.git -> tk-hiero-publish.git
+        # /full/path/to/local/repo.git -> repo.git
+        name = os.path.basename(self._path)
+
         try:
             legacy_folder = self._get_legacy_bundle_install_folder(
                 "git",

--- a/python/tank/descriptor/io_descriptor/manual.py
+++ b/python/tank/descriptor/io_descriptor/manual.py
@@ -10,6 +10,7 @@
 import os
 from .base import IODescriptorBase
 from ... import LogManager
+from ...util import filesystem
 from ..errors import TankDescriptorError
 
 log = LogManager.get_logger(__name__)
@@ -42,6 +43,21 @@ class IODescriptorManual(IODescriptorBase):
         self._name = descriptor_dict.get("name")
         self._version = descriptor_dict.get("version")
 
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
+
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        return os.path.join(
+            bundle_cache_root,
+            "manual",
+            self._name,
+            self._version
+        )
+
     def _get_cache_paths(self):
         """
         Get a list of resolved paths, starting with the primary and
@@ -51,17 +67,8 @@ class IODescriptorManual(IODescriptorBase):
 
         :return: List of path strings
         """
-        paths = []
-
-        for root in [self._bundle_cache_root] + self._fallback_roots:
-            paths.append(
-                os.path.join(
-                    root,
-                    "manual",
-                    self._name,
-                    self._version
-                )
-            )
+        # get default cache paths from base class
+        paths = super(IODescriptorManual, self)._get_cache_paths()
 
         # for compatibility with older versions of core, prior to v0.18.x,
         # add the old-style bundle cache path as a fallback. As of v0.18.x,

--- a/python/tank/descriptor/io_descriptor/path.py
+++ b/python/tank/descriptor/io_descriptor/path.py
@@ -90,7 +90,15 @@ class IODescriptorPath(IODescriptorBase):
             bn = os.path.basename(self._path)
             self._name, _ = os.path.splitext(bn)
 
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
 
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        return self._path
 
     def _get_cache_paths(self):
         """
@@ -148,4 +156,20 @@ class IODescriptorPath(IODescriptorBase):
         # we are always the latest version :)
         return self
 
+    def clone_cache(self, cache_root):
+        """
+        The descriptor system maintains an internal cache where it downloads
+        the payload that is associated with the descriptor. Toolkit supports
+        complex cache setups, where you can specify a series of path where toolkit
+        should go and look for cached items.
 
+        This is an advanced method that helps in cases where a user wishes to
+        administer such a setup, allowing a cached payload to be copied from
+        its current location into a new cache structure.
+
+        If the descriptor doesn't exist on disk yet, it will be downloaded.
+
+        :param cache_root: Root point of the cache location to copy to.
+        """
+        # no payload is cached at all, so nothing to do
+        log.debug("Clone cache for %r: Not copying anything for this descriptor type")

--- a/python/tank/descriptor/io_descriptor/path.py
+++ b/python/tank/descriptor/io_descriptor/path.py
@@ -167,7 +167,7 @@ class IODescriptorPath(IODescriptorBase):
         administer such a setup, allowing a cached payload to be copied from
         its current location into a new cache structure.
 
-        If the descriptor doesn't exist on disk yet, it will be downloaded.
+        If the descriptor's payload doesn't exist on disk, it will be downloaded.
 
         :param cache_root: Root point of the cache location to copy to.
         """

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -79,26 +79,19 @@ class IODescriptorShotgunEntity(IODescriptorBase):
 
         self._project_id = descriptor_dict.get("project_id")
 
-    def _get_cache_paths(self):
+    def _get_bundle_cache_path(self, bundle_cache_root):
         """
-        Get a list of resolved paths, starting with the primary and
-        continuing with alternative locations where it may reside.
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
 
-        Note: This method only computes paths and does not perform any I/O ops.
-
-        :return: List of path strings
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
         """
-        paths = []
-
-        for root in [self._bundle_cache_root] + self._fallback_roots:
-            paths.append(
-                os.path.join(
-                    root,
-                    "sg_upload",
-                    self.get_version()
-                )
-            )
-        return paths
+        return os.path.join(
+            bundle_cache_root,
+            "sg_upload",
+            self.get_version()
+        )
 
     def get_system_name(self):
         """
@@ -227,3 +220,4 @@ class IODescriptorShotgunEntity(IODescriptorBase):
 
         log.debug("Latest version resolved to %s" % desc)
         return desc
+

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -169,8 +169,9 @@ def safe_delete_file(path):
 def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
     """
     Alternative implementation to ``shutil.copytree``
+
     Copies recursively and creates folders if they don't already exist.
-    Skips a fixed list of system files such as .svn, .git, etc.
+    Always skips system files such as ``"__MACOSX"``, ``".DS_Store"``, etc.
     Files will the extension ``.sh``, ``.bat`` or ``.exe`` will be given
     executable permissions.
 
@@ -179,10 +180,20 @@ def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
     :param src: Source path to copy from
     :param dst: Destination to copy to
     :param folder_permissions: permissions to use for new folders
-    :param skip_list: List of file names to skip
+    :param skip_list: List of file names to skip. If this parameter is
+                      omitted or set to None, common files such as ``.git``,
+                      ``.gitignore`` etc will be ignored.
     :returns: List of files copied
     """
-    SKIP_LIST = [".svn", ".git", ".gitignore", "__MACOSX", ".DS_Store"]
+    # files or directories to always skip
+    SKIP_LIST_ALWAYS = ["__MACOSX", ".DS_Store"]
+
+    # files or directories to skip if no skip_list is specified
+    SKIP_LIST_DEFAULT = [".svn", ".git", ".gitignore"]
+
+    # compute full skip list
+    actual_skip_list = skip_list or SKIP_LIST_DEFAULT
+    actual_skip_list.extend(SKIP_LIST_ALWAYS)
 
     files = []
 
@@ -193,12 +204,8 @@ def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
     names = os.listdir(src)
     for name in names:
 
-        if skip_list and name in skip_list:
-            # skip!
-            continue
-
         # get rid of system files
-        if name in SKIP_LIST:
+        if name in actual_skip_list:
             continue
 
         srcname = os.path.join(src, name)

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -189,7 +189,7 @@ def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
     SKIP_LIST_ALWAYS = ["__MACOSX", ".DS_Store"]
 
     # files or directories to skip if no skip_list is specified
-    SKIP_LIST_DEFAULT = [".svn", ".git", ".gitignore"]
+    SKIP_LIST_DEFAULT = [".svn", ".git", ".gitignore", ".hg", ".hgignore"]
 
     # compute full skip list
     actual_skip_list = skip_list or SKIP_LIST_DEFAULT


### PR DESCRIPTION
See #306 for initial attempt to fix this issue. This is a more elegant, less brute force approach to fixing localize bug happening when you try to set up a new project based on an existing project.

This implementation is smarter and has the same performance characteristics as the 0.17 version.

Introduces `descriptor.clone_cache(target_bundle_cache_root)` method which is generally useful for any time of bundle cache management (likely to be useful soon in TaaP).

- As a consequence, reshuffled descriptor code which removes some duplication
- As a side effect, this will fix a long standing issue with manual and git descriptors not being copied across from existing projects (YAY!)

