### PR TITLE
#37555 fixes issues with the tank command and python 2.5

### DIFF
--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -149,7 +149,14 @@ class AltCustomFormatter(logging.Formatter):
                 # do not wrap exceptions and debug
                 # wrap other log levels on an 80 char wide boundary
                 lines = []
-                for x in textwrap.wrap(record.msg, width=78, break_long_words=False, break_on_hyphens=False):
+
+                if sys.version_info < (2,6):
+                    # python 2.5 doesn't support all params
+                    wrapped_lines = textwrap.wrap(record.msg, width=78)
+                else:
+                    wrapped_lines = textwrap.wrap(record.msg, width=78, break_long_words=False, break_on_hyphens=False)
+
+                for x in wrapped_lines:
                     lines.append(x)
                 record.msg = "\n".join(lines)
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -152,7 +152,7 @@ class AltCustomFormatter(logging.Formatter):
 
                 if sys.version_info < (2,6):
                     # python 2.5 doesn't support all params
-                    wrapped_lines = textwrap.wrap(record.msg, width=78)
+                    wrapped_lines = textwrap.wrap(record.msg, width=78, break_long_words=False)
                 else:
                     wrapped_lines = textwrap.wrap(record.msg, width=78, break_long_words=False, break_on_hyphens=False)
 


### PR DESCRIPTION
Fixes a long standing issue where the `tank` command wasn't working in Python 2.5