### PR TITLE
#37486 Setup project from git regression

### DIFF
--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -965,7 +965,7 @@ class TemplateConfiguration(object):
             descriptor = create_descriptor(
                 self._sg,
                 Descriptor.CONFIG,
-                {"type": "git", "path": config_uri},
+                {"type": "git_branch", "path": config_uri, "branch": "master"},
                 resolve_latest=True
             )
             descriptor.ensure_local()


### PR DESCRIPTION
Fixes a regression where projects set up from a git based config was picking up the tag with the highest version number rather than the latest commit from master (as it was previously).