### PR TITLE
For #37605, authentication crashes if not current host is set.

### DIFF
--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -96,7 +96,10 @@ class DefaultsManager(object):
         :returns: Default implementation returns the login for the
                   currently stored user.
         """
-        return session_cache.get_current_user(self.get_host())
+        if self.get_host():
+            return session_cache.get_current_user(self.get_host())
+        else:
+            return None
 
     def get_user_credentials(self):
         """

--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -75,6 +75,13 @@ class ShotgunAuthenticatorTests(TankTestBase):
         self.assertEqual(connection.config.script_name, "api_script")
         self.assertEqual(connection.config.api_key, "api_key")
 
+    @patch("tank.authentication.session_cache.get_current_host", return_value=None)
+    def test_no_current_host(self, _):
+        """
+        Makes sure the login is None when there is no host.
+        """
+        self.assertIsNone(DefaultsManager().get_login())
+
     @patch("tank.authentication.session_cache.generate_session_token")
     @patch("tank.util.LocalFileStorageManager.get_global_root")
     def test_get_default_user(self, get_global_root, generate_session_token_mock):


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/shotgunsoftware/tk-core/commit/4bf50557222574a633b53c1855e71666bde51dce?w=1.