### PR TITLE
Addendum for #35936, centralized proxy support for core

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -80,9 +80,9 @@ following order:
 
     The Shotgun Desktop user folder is located at:
 
-    - Windows: ``%APPDATA%\Shotgun\desktop\config.ini``
-    - macOS: ``~/Library/Caches/Shotgun/desktop/config.ini``
-    - Linux: ``~/shotgun/desktop/config.ini``
+    - Windows: ``%APPDATA%\Shotgun\desktop\config\config.ini``
+    - macOS: ``~/Library/Caches/Shotgun/desktop/config/config.ini``
+    - Linux: ``~/shotgun/desktop/config/config.ini``
 
 
 Incorrectly configuring this file may raise an exception:

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -21,7 +21,7 @@ Centralizing your settings
 ==========================
 
 Instead of customizing your proxy settings on each of your project, it is possible to configure them once in a file
-called `config.ini` and have your projects inherit these values, unless the project overrides itself the setting
+and have your projects inherit these values, unless the project overrides itself the setting
 inside ``shotgun.yml``.
 
 Here's an example:
@@ -35,7 +35,7 @@ Here's an example:
         # If specified, the username text input on the login screen will be populated
         # with this value when logging into Toolkit for the very first time.
         # Defaults to the user's OS login. Environment variables are actually resolved for
-        # all values in this file, which allows greater flexibility when sharing the config.ini
+        # all values in this file, which allows greater flexibility when sharing this configuration
         # file with multiple users.
         #
         default_login=$USERNAME
@@ -68,17 +68,17 @@ following order:
 
 1. The ``SGTK_PREFERENCES_LOCATION`` environment variable,
 2. The ``SGTK_DESKTOP_CONFIG_LOCATION`` environment variable, for compatibility with the Shotgun Desktop. (deprecated)
-3. Inside the Shotgun preferences folder
-4. Inside the Shotgun Desktop user folder, for compatibility with the Shotgun Desktop. (deprecated)
+3. Inside the Shotgun Toolkit preferences file
+4. Inside the Shotgun Desktop preferences file, for compatibility with the Shotgun Desktop. (deprecated)
 
 .. note::
-    The Shotgun preferences folder is located at:
+    The Shotgun Toolkit preferences file is located at:
 
     - Windows: ``%APPDATA%\Shotgun\Preferences\toolkit.ini``
     - macOS: ``~/Library/Preferences/Shotgun/toolkit.ini``
     - Linux: ``~/.shotgun/preferences/toolkit.ini``
 
-    The Shotgun Desktop user folder is located at:
+    The Shotgun Desktop preferences file is located at:
 
     - Windows: ``%APPDATA%\Shotgun\desktop\config\config.ini``
     - macOS: ``~/Library/Caches/Shotgun/desktop/config/config.ini``

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -66,17 +66,17 @@ Here's an example:
 This file can be configured through multiple means and Toolkit will try to resolve the file in the
 following order:
 
-1. The ``SGTK_CONFIG_LOCATION`` environment variable,
+1. The ``SGTK_PREFERENCES_LOCATION`` environment variable,
 2. The ``SGTK_DESKTOP_CONFIG_LOCATION`` environment variable, for compatibility with the Shotgun Desktop. (deprecated)
-3. Inside the Shotgun user folder
+3. Inside the Shotgun preferences folder
 4. Inside the Shotgun Desktop user folder, for compatibility with the Shotgun Desktop. (deprecated)
 
 .. note::
-    The Shotgun user folder is located at:
+    The Shotgun preferences folder is located at:
 
-    - Windows: ``%APPDATA%\Shotgun\config.ini``
-    - macOS: ``~/Library/Application Support/Shotgun/config.ini``
-    - Linux: ``~/shotgun/config.ini``
+    - Windows: ``%APPDATA%\Shotgun\Preferences\toolkit.ini``
+    - macOS: ``~/Library/Preferences/Shotgun/toolkit.ini``
+    - Linux: ``~/.shotgun/preferences/toolkit.ini``
 
     The Shotgun Desktop user folder is located at:
 

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -33,4 +33,4 @@ from . import filesystem
 
 from .local_file_storage import LocalFileStorageManager
 
-from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
+from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError, EnvironmentVariableFileLookupError

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -44,7 +44,7 @@ class LocalFileStorageManager(object):
     (CORE_V17, CORE_V18) = range(2)
 
     # supported types of paths
-    (LOGGING, CACHE, PERSISTENT) = range(3)
+    (LOGGING, CACHE, PERSISTENT, PREFERENCES) = range(4)
 
     @classmethod
     def get_global_root(cls, path_type, generation=CORE_V18):
@@ -79,18 +79,23 @@ class LocalFileStorageManager(object):
                     return os.path.expanduser("~/Library/Caches/Shotgun")
                 elif path_type == cls.PERSISTENT:
                     return os.path.expanduser("~/Library/Application Support/Shotgun")
+                elif path_type == cls.PREFERENCES:
+                    return os.path.expanduser("~/Library/Preferences/Shotgun")
                 elif path_type == cls.LOGGING:
                     return os.path.expanduser("~/Library/Logs/Shotgun")
                 else:
                     raise ValueError("Unsupported path type!")
 
             elif sys.platform == "win32":
+                app_data = os.environ.get("APPDATA", "APPDATA_NOT_SET")
                 if path_type == cls.CACHE:
-                    return os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun")
+                    return os.path.join(app_data, "Shotgun")
                 elif path_type == cls.PERSISTENT:
-                    return os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun", "Data")
+                    return os.path.join(app_data, "Shotgun", "Data")
+                elif path_type == cls.PREFERENCES:
+                    return os.path.join(app_data, "Shotgun", "Preferences")
                 elif path_type == cls.LOGGING:
-                    return os.path.join(os.environ.get("APPDATA", "APPDATA_NOT_SET"), "Shotgun", "Logs")
+                    return os.path.join(app_data, "Shotgun", "Logs")
                 else:
                     raise ValueError("Unsupported path type!")
 
@@ -99,6 +104,8 @@ class LocalFileStorageManager(object):
                     return os.path.expanduser("~/.shotgun")
                 elif path_type == cls.PERSISTENT:
                     return os.path.expanduser("~/.shotgun/data")
+                elif path_type == cls.PREFERENCES:
+                    return os.path.expanduser("~/.shotgun/preferences")
                 elif path_type == cls.LOGGING:
                     return os.path.expanduser("~/.shotgun/logs")
                 else:

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -155,13 +155,13 @@ class UserSettings(Singleton):
 
         # This is the default location.
         default_location = os.path.join(
-            LocalFileStorageManager.get_global_root(LocalFileStorageManager.PERSISTENT),
-            "config.ini"
+            LocalFileStorageManager.get_global_root(LocalFileStorageManager.PREFERENCES),
+            "toolkit.ini"
         )
 
         # This is the complete list of paths we need to test.
         file_locations = [
-            self._evaluate_env_var("SGTK_CONFIG_LOCATION"),
+            self._evaluate_env_var("SGTK_PREFERENCES_LOCATION"),
             self._evaluate_env_var("SGTK_DESKTOP_CONFIG_LOCATION"),
             # Default location first
             default_location,

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -133,6 +133,8 @@ class UserSettings(Singleton):
 
         # If the path doesn't exist, raise an error.
         path = os.environ[var_name]
+        path = os.path.expanduser(path)
+        path = os.path.expandvars(path)
         if not os.path.exists(path):
             raise EnvironmentVariableFileLookupError(var_name, path)
 

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -132,11 +132,11 @@ class UserSettings(Singleton):
             return None
 
         # If the path doesn't exist, raise an error.
-        path = os.environ[var_name]
-        path = os.path.expanduser(path)
+        raw_path = os.environ[var_name]
+        path = os.path.expanduser(raw_path)
         path = os.path.expandvars(path)
         if not os.path.exists(path):
-            raise EnvironmentVariableFileLookupError(var_name, path)
+            raise EnvironmentVariableFileLookupError(var_name, raw_path)
 
         # Path is set and exist, we've found it!
         return path

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -70,7 +70,7 @@ class UserSettingsTests(unittest.TestCase):
         UserSettings.clear_singleton()
         self.addCleanup(UserSettings.clear_singleton)
 
-    @patch("tank.settings.user.UserSettings._load_config", return_value=MockConfigParser({}))
+    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({}))
     def test_empty_file(self, mock):
         """
         Tests a complete yaml file.
@@ -81,7 +81,7 @@ class UserSettingsTests(unittest.TestCase):
         self.assertIsNone(settings.shotgun_proxy)
         self.assertFalse(settings.is_app_store_proxy_set())
 
-    @patch("tank.settings.user.UserSettings._load_config", return_value=MockConfigParser({
+    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
         "default_site": "site",
         "default_login": "login",
         "http_proxy": "http_proxy",
@@ -98,7 +98,7 @@ class UserSettingsTests(unittest.TestCase):
         self.assertTrue(settings.is_app_store_proxy_set())
         self.assertEqual(settings.app_store_proxy, "app_store_http_proxy")
 
-    @patch("tank.settings.user.UserSettings._load_config", return_value=MockConfigParser({
+    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
         # Config parser represent empty settings as empty strings
         "app_store_http_proxy": ""
     }))
@@ -110,7 +110,7 @@ class UserSettingsTests(unittest.TestCase):
         self.assertTrue(settings.is_app_store_proxy_set())
         self.assertEqual(settings.app_store_proxy, None)
 
-    @patch("tank.settings.user.UserSettings._load_config", return_value=MockConfigParser({
+    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
         # Config parser represent empty settings as empty strings
         "default_site": "https://${SGTK_TEST_SHOTGUN_SITE}.shotgunstudio.com"
     }))
@@ -126,7 +126,7 @@ class UserSettingsTests(unittest.TestCase):
         """
         Test environment variables being set to files that don't exist.
         """
-        with patch.dict(os.environ, {"SGTK_CONFIG_LOCATION": "/a/b/c"}):
+        with patch.dict(os.environ, {"SGTK_PREFERENCES_LOCATION": "/a/b/c"}):
             with self.assertRaisesRegexp(EnvironmentVariableFileLookupError, "/a/b/c"):
                 UserSettings()
 


### PR DESCRIPTION
- Fixed documentation
- Evaluating `~` and environment variables when looking at SGTK_*CONFIG_LOCATION