### PR TITLE
#37434 Plugin build script

### DIFF
--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+# Toolkit core API version
+__version__ = "HEAD"
 
 ########################################################################
 # Establish pipeline configuration context if needed

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -185,10 +185,6 @@ class ToolkitManager(object):
 
     def _set_bundle_cache_fallback_paths(self, paths):
         # setter for bundle_cache_fallback_paths
-
-        # @todo - maybe here we can add support for environment variables in the
-        #         future so that studios can easily add their own 'primed cache'
-        #         locations for performance or to save space.
         self._bundle_cache_fallback_paths = paths
 
     bundle_cache_fallback_paths = property(

--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -161,13 +161,13 @@ class CoreUpdateAction(Action):
         log.info("You are currently running version %s of the Shotgun Pipeline Toolkit" % current_version)
 
         status = installer.get_update_status()
-        req_sg = installer.get_required_sg_version_for_update()
 
         if status == TankCoreUpdater.UP_TO_DATE:
             log.info("No need to update the Toolkit Core API at this time!")
             return_status = {"status": "up_to_date"}
 
         elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
+            req_sg = installer.get_required_sg_version_for_update()
             msg = (
                 "%s version of core requires a more recent version (%s) of Shotgun!" % (
                     "The newest" if core_version is None else "The requested",

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -61,8 +61,14 @@ def create_descriptor(
     if bundle_cache_root_override is None:
         bundle_cache_root_override = _get_default_bundle_cache_root()
         filesystem.ensure_folder_exists(bundle_cache_root_override)
+    else:
+        # expand environment variables
+        bundle_cache_root_override = os.path.expandvars(os.path.expanduser(bundle_cache_root_override))
 
     fallback_roots = fallback_roots or []
+
+    # expand environment variables
+    fallback_roots = [os.path.expandvars(os.path.expanduser(x)) for x in fallback_roots]
 
     # first construct a low level IO descriptor
     io_descriptor = create_io_descriptor(

--- a/python/tank/descriptor/io_descriptor/manual.py
+++ b/python/tank/descriptor/io_descriptor/manual.py
@@ -110,7 +110,7 @@ class IODescriptorManual(IODescriptorBase):
         """
         # ensure that this exists on disk
         if not self.exists_local():
-            raise TankDescriptorError("%s does not exist on disk!")
+            raise TankDescriptorError("%s does not exist on disk!" % self)
 
     def get_latest_version(self, constraint_pattern=None):
         """

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -21,7 +21,7 @@ from tank_vendor import yaml
 from .errors import TankError, TankUnreadableFileError
 from .util.version import is_version_older
 from . import constants
-from .platform.environment import Environment, WritableEnvironment
+from .platform.environment import InstalledEnvironment, WritableEnvironment
 from .util import shotgun, yaml_cache
 from .util import ShotgunPath
 from . import hook
@@ -793,7 +793,7 @@ class PipelineConfiguration(object):
         :returns:           An environment object
         """        
         env_file = self.get_environment_path(env_name)
-        EnvClass = WritableEnvironment if writable else Environment
+        EnvClass = WritableEnvironment if writable else InstalledEnvironment
         env_obj = EnvClass(env_file, self, context)
         return env_obj
 

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -503,7 +503,11 @@ class InstalledEnvironment(Environment):
     """
     def __init__(self, env_path, pipeline_config, context=None):
         """
-        Constructor
+        :param env_path: Path to the environment file
+        :param pipeline_config: Pipeline configuration assocaited with the installed environment
+        :param context: Optional context object. If this is omitted,
+                        context-based include file resolve will be
+                        skipped.
         """
         super(InstalledEnvironment, self).__init__(env_path, context)
         self.__pipeline_config = pipeline_config
@@ -573,7 +577,11 @@ class WritableEnvironment(InstalledEnvironment):
 
     def __init__(self, env_path, pipeline_config, context=None):
         """
-        Constructor
+        :param env_path: Path to the environment file
+        :param pipeline_config: Pipeline configuration assocaited with the installed environment
+        :param context: Optional context object. If this is omitted,
+                        context-based include file resolve will be
+                        skipped.
         """
         self.set_yaml_preserve_mode(True)
         super(WritableEnvironment, self).__init__(env_path, pipeline_config, context)

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -493,7 +493,7 @@ class Environment(object):
 
 
 
-class InstalledEnvironment(object):
+class InstalledEnvironment(Environment):
     """
     Represents an :class:`Environment` that has been installed
     and has an associated pipeline configuration.

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -33,17 +33,17 @@ class Environment(object):
     about the different parts of the configuration (by pulling the info.yml
     files from the various apps and engines referenced in the environment file)
 
-    Don't construct this class by hand! Instead, use the
-    pipelineConfiguration.get_environment() method.
-
     This class contains immutable methods only, e.g. you can only read from
     the yaml file. If you want to modify the yaml content, create a 
     WritableEnvironment instance instead.
     """
 
-    def __init__(self, env_path, pipeline_config, context=None):
+    def __init__(self, env_path, context=None):
         """
-        Constructor
+        :param env_path: Path to the environment file
+        :param context: Optional context object. If this is omitted,
+                        context-based include file resolve will be
+                        skipped.
         """
         self._env_path = env_path
         self._env_data = None
@@ -52,7 +52,6 @@ class Environment(object):
         self.__app_locations = {}
         self.__framework_locations = {}
         self.__context = context
-        self.__pipeline_config = pipeline_config
 
         # validate and populate config
         self._refresh()
@@ -194,7 +193,11 @@ class Environment(object):
             # remove location from dict
             self.__engine_locations[(eng,app)] = self.__app_settings[(eng,app)].pop(constants.ENVIRONMENT_LOCATION_KEY)
 
-
+    def __load_data(self, path):
+        """
+        loads the main data from disk, raw form
+        """
+        return g_yaml_cache.get(path)
 
     ##########################################################################################
     # Properties
@@ -281,51 +284,51 @@ class Environment(object):
             raise TankError("App '%s.%s' is not part of environment %s" % (engine, app, self._env_path))
         return d
 
-    def get_framework_descriptor(self, framework_name):
+    ##########################################################################################
+    # Public methods - data update
+
+    def get_framework_descriptor_dict(self, framework_name):
         """
-        Returns the descriptor object for a framework.
+        Returns the descriptor dictionary for a framework.
+
+        :param framework_name: Name of framework instance
+        :returns: descriptor dictionary or uri
         """
         descriptor_dict = self.__framework_locations.get(framework_name)
         if descriptor_dict is None:
-            raise TankError("The framework %s does not have a valid location "
-                            "key for engine %s" % (self._env_path, framework_name))
+            raise TankError(
+                "The framework %s does not have a valid location "
+                "key for engine %s" % (self._env_path, framework_name))
+        return descriptor_dict
 
-        # get the descriptor object for the location
-        return self.__pipeline_config.get_framework_descriptor(descriptor_dict)
-
-    def get_engine_descriptor(self, engine_name):
+    def get_engine_descriptor_dict(self, engine_name):
         """
-        Returns the descriptor object for an engine.
+        Returns the descriptor dictionary for an engine.
+
+        :param engine_name: Name of engine instance
+        :returns: descriptor dictionary or uri
         """
         descriptor_dict = self.__engine_locations.get(engine_name)
         if descriptor_dict is None:
-            raise TankError("The environment %s does not have a valid location "
-                            "key for engine %s" % (self._env_path, engine_name))
+            raise TankError(
+                "The environment %s does not have a valid location "
+                "key for engine %s" % (self._env_path, engine_name)
+            )
+        return descriptor_dict
 
-        # get the descriptor object for the location
-        return self.__pipeline_config.get_engine_descriptor(descriptor_dict)
-
-    def get_app_descriptor(self, engine_name, app_name):
+    def get_app_descriptor_dict(self, engine_name, app_name):
         """
-        Returns the descriptor object for an app.
-        """
+        Returns the descriptor dictionary for an app.
 
+        :param engine_name: Name of engine instance
+        :param app_name: Name of app instance
+        :returns: descriptor dictionary or uri
+        """
         descriptor_dict = self.__engine_locations.get((engine_name, app_name))
         if descriptor_dict is None:
             raise TankError("The environment %s does not have a valid location "
                             "key for app %s.%s" % (self._env_path, engine_name, app_name))
-
-        # get the version object for the location
-        return self.__pipeline_config.get_app_descriptor(descriptor_dict)
-
-    ##########################################################################################
-    # Public methods - data update
-
-    def __load_data(self, path):
-        """
-        loads the main data from disk, raw form
-        """
-        return g_yaml_cache.get(path)
+        return descriptor_dict
 
     def find_location_for_engine(self, engine_name):
         """
@@ -344,7 +347,7 @@ class Environment(object):
         if not path:
             raise TankError("Failed to find the location of the '%s' engine in the '%s' environment!"
                             % (engine_name, self._env_path))
-            
+
         return tokens, path
 
     def find_framework_instances_from(self, yml_file):
@@ -490,7 +493,67 @@ class Environment(object):
 
 
 
-class WritableEnvironment(Environment):
+class InstalledEnvironment(object):
+    """
+    Represents an :class:`Environment` that has been installed
+    and has an associated pipeline configuration.
+
+    Don't construct this class by hand! Instead, use the
+    pipelineConfiguration.get_environment() method.
+    """
+    def __init__(self, env_path, pipeline_config, context=None):
+        """
+        Constructor
+        """
+        super(InstalledEnvironment, self).__init__(env_path, context)
+        self.__pipeline_config = pipeline_config
+
+    def get_framework_descriptor(self, framework_name):
+        """
+        Returns the descriptor object for a framework.
+
+        :param framework_name: Name of framework
+        :returns: :class:`~sgtk.descriptor.BundleDescriptor` that represents
+                  this object. The descriptor has been configured to use
+                  whatever caching settings the associated pipeline
+                  configuration is using.
+        """
+        return self.__pipeline_config.get_framework_descriptor(
+            self.get_framework_descriptor_dict(framework_name)
+        )
+
+    def get_engine_descriptor(self, engine_name):
+        """
+        Returns the descriptor object for an engine.
+
+        :param engine_name: Name of engine
+        :returns: :class:`~sgtk.descriptor.BundleDescriptor` that represents
+                  this object. The descriptor has been configured to use
+                  whatever caching settings the associated pipeline
+                  configuration is using.
+        """
+        return self.__pipeline_config.get_engine_descriptor(
+            self.get_engine_descriptor_dict(engine_name)
+        )
+
+    def get_app_descriptor(self, engine_name, app_name):
+        """
+        Returns the descriptor object for an app.
+
+        :param engine_name: Name of engine
+        :param app_name: Name of app
+        :returns: :class:`~sgtk.descriptor.BundleDescriptor` that represents
+                  this object. The descriptor has been configured to use
+                  whatever caching settings the associated pipeline
+                  configuration is using.
+        """
+        return self.__pipeline_config.get_app_descriptor(
+            self.get_app_descriptor_dict(engine_name, app_name)
+        )
+
+
+
+class WritableEnvironment(InstalledEnvironment):
     """
     Represents a mutable environment.
 
@@ -513,7 +576,7 @@ class WritableEnvironment(Environment):
         Constructor
         """
         self.set_yaml_preserve_mode(True)
-        Environment.__init__(self, env_path, pipeline_config, context)
+        super(WritableEnvironment, self).__init__(env_path, pipeline_config, context)
 
     def __load_writable_yaml(self, path):
         """

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -36,10 +36,13 @@ import copy
 from ..errors import TankError
 from ..template import TemplatePath
 from ..templatekey import StringKey
+from ..log import LogManager
 
 from . import constants
 
 from ..util.yaml_cache import g_yaml_cache
+
+log = LogManager.get_logger(__name__)
 
 def _resolve_includes(file_name, data, context):
     """
@@ -62,6 +65,10 @@ def _resolve_includes(file_name, data, context):
             # it's a template path
             if context is None:
                 # skip - these paths are optional always
+                log.debug(
+                    "%s: Skipping template based include '%s' "
+                    "because there is no active context." % (file_name, include)
+                )
                 continue
             
             # extract all {tokens}

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -18,6 +18,7 @@ import sys
 import errno
 import stat
 import shutil
+import datetime
 import functools
 from .. import LogManager
 
@@ -261,6 +262,22 @@ def move_folder(src, dst, folder_permissions=0775):
                 os.remove(f)
             except Exception, e:
                 log.error("Could not delete file %s: %s" % (f, e))
+
+@with_cleared_umask
+def backup_folder(src, dst=None):
+    """
+    Moves the given directory into
+    :param src:
+    :param dst:
+    :return:
+    """
+    if os.path.exists(src):
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        if dst is None:
+            backup_path = "%s.%s" % (src, timestamp)
+        else:
+            backup_path = os.path.join(dst, "%s.%s" % (os.path.basename(src), timestamp))
+        move_folder(src, backup_path)
 
 def create_valid_filename(value):
     """

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -20,6 +20,7 @@ import uuid
 import urllib2
 import urlparse
 import pprint
+import time
 import threading
 import tempfile
 
@@ -269,10 +270,13 @@ def download_and_unpack_attachment(sg, attachment_id, target, retries=5):
     attempt = 0
     done = False
 
+
+
     while not done and attempt < retries:
 
         zip_tmp = os.path.join(tempfile.gettempdir(), "%s_tank.zip" % uuid.uuid4().hex)
         try:
+            time_before = time.time()
             log.debug("Downloading attachment id %s..." % attachment_id)
             bundle_content = sg.download_attachment(attachment_id)
 
@@ -280,7 +284,15 @@ def download_and_unpack_attachment(sg, attachment_id, target, retries=5):
             with open(zip_tmp, "wb") as fh:
                 fh.write(bundle_content)
 
-            log.debug("Unpacking %s bytes to %s..." % (os.path.getsize(zip_tmp), target))
+            file_size = os.path.getsize(zip_tmp)
+
+            # log connection speed
+            time_to_download = time.time() - time_before
+            broadband_speed_bps = file_size * 8.0 / time_to_download
+            broadband_speed_mibps = broadband_speed_bps / (1024 * 1024)
+            log.debug("Download speed: %4f Mbit/s" % broadband_speed_mibps)
+
+            log.debug("Unpacking %s bytes to %s..." % (file_size, target))
             filesystem.ensure_folder_exists(target)
             unzip_file(zip_tmp, target)
 

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -36,6 +36,7 @@ from . import login
 from . import yaml_cache
 from .zip import unzip_file
 from . import filesystem
+from .metrics import log_user_attribute_metric
 
 log = LogManager.get_logger(__name__)
 
@@ -291,6 +292,8 @@ def download_and_unpack_attachment(sg, attachment_id, target, retries=5):
             broadband_speed_bps = file_size * 8.0 / time_to_download
             broadband_speed_mibps = broadband_speed_bps / (1024 * 1024)
             log.debug("Download speed: %4f Mbit/s" % broadband_speed_mibps)
+            log_user_attribute_metric("Tk attachment download speed", "%4f Mbit/s" % broadband_speed_mibps)
+
 
             log.debug("Unpacking %s bytes to %s..." % (file_size, target))
             filesystem.ensure_folder_exists(target)

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -467,8 +467,6 @@ if __name__ == "__main__":
     try:
         main()
         exit_code = 0
-    except TankError, e:
-        logger.error(str(e))
     except Exception, e:
         logger.exception("An exception was raised: %s" % e)
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -132,7 +132,7 @@ def _process_configuration(sg_connection, manifest_data):
                     "will be performed at startup.")
         using_latest_config = False
     else:
-        logger.debug("Your configuration definition does not contain a version number. "
+        logger.info("Your configuration definition does not contain a version number. "
                      "This means that the plugin will attempt to auto update at startup.")
         using_latest_config = True
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
+import os
+import sys
+import optparse
+
+# add sgtk API
+this_folder = os.path.abspath(os.path.dirname(__file__))
+python_folder = os.path.abspath(os.path.join(this_folder, "..", "python"))
+sys.path.append(python_folder)
+
+from tank import LogManager
+from tank.util import filesystem
+from tank.errors import TankError
+from tank.platform import environment
+from tank.descriptor import Descriptor, descriptor_uri_to_dict, create_descriptor
+from tank.authentication import ShotgunAuthenticator
+
+from tank_vendor import yaml
+
+# set up logging
+logger = LogManager.get_logger("build_plugin")
+
+# required keys in the info.yml plugin manifest file
+REQUIRED_MANIFEST_PARAMETERS = [
+    "base_configuration",
+    "entry_point",
+    "display_name",
+    "description",
+    "configuration"
+]
+
+# the folder where all items will be cached
+BUNDLE_CACHE_ROOT_FOLDER_NAME = "bundle_cache"
+
+
+
+class OptionParserLineBreakingEpilog(optparse.OptionParser):
+    """
+    Subclassed version of the option parser that doesn't
+    swallow white space in the epilog
+    """
+    def format_epilog(self, formatter):
+        return self.epilog
+
+def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
+    """
+    Iterates over all environments within the given configuration descriptor
+    and caches all items into the bundle cache root.
+
+    :param sg_connection: Shotgun connection
+    :param cfg_descriptor: Config descriptor
+    :param bundle_cache_root: Root where to cache payload
+    """
+    # introspect the config and cache everything
+    logger.info("Introspecting environments...")
+    env_path = os.path.join(cfg_descriptor.get_path(), "env")
+
+    # find all environment files
+    env_filenames = []
+    for filename in os.listdir(env_path):
+        if filename.endswith(".yml"):
+            # matching the env filter (or no filter set)
+            logger.info("> found %s" % filename)
+            env_filenames.append(os.path.join(env_path, filename))
+
+    # traverse and cache
+    for env_path in env_filenames:
+        logger.info("Processing %s..." % env_path)
+        env = environment.Environment(env_path)
+
+        for eng in env.get_engines():
+            # resolve descriptor and clone cache into bundle cache
+            desc = create_descriptor(
+                sg_connection,
+                Descriptor.ENGINE,
+                env.get_engine_descriptor_dict(eng),
+            )
+            logger.info("Caching %s..." % desc)
+            desc.clone_cache(bundle_cache_root)
+
+            for app in env.get_apps(eng):
+                # resolve descriptor and clone cache into bundle cache
+                desc = create_descriptor(
+                    sg_connection,
+                    Descriptor.APP,
+                    env.get_app_descriptor_dict(eng, app),
+                )
+                logger.info("Caching %s..." % desc)
+                desc.clone_cache(bundle_cache_root)
+
+        for framework in env.get_frameworks():
+            desc = create_descriptor(
+                sg_connection,
+                Descriptor.FRAMEWORK,
+                env.get_framework_descriptor_dict(framework),
+            )
+            logger.info("Caching %s..." % desc)
+            desc.clone_cache(bundle_cache_root)
+
+def _process_configuration(sg_connection, manifest_data):
+    """
+    Given data in the plugin manifest, download resolve and
+    cache the configuration.
+
+    :param sg_connection: Shotgun connection
+    :param manifest_data: Manifest data as a dictionary
+    :return: Resolved config descriptor object
+    """
+    logger.info("Analyzing configuration")
+
+    base_config_def = manifest_data["base_configuration"]
+
+    if isinstance(base_config_def, str):
+        # convert to dict so we can introspect
+        base_config_def = descriptor_uri_to_dict(base_config_def)
+
+    # if the descriptor in the config contains a version number
+    # we will go into a fixed update mode.
+    if "version" in base_config_def:
+        logger.info("Your configuration definition contains a version number. "
+                    "This means that the plugin will be frozen and no automatic updates "
+                    "will be performed at startup.")
+        using_latest_config = False
+    else:
+        logger.debug("Your configuration definition does not contain a version number. "
+                     "This means that the plugin will attempt to auto update at startup.")
+        using_latest_config = True
+
+    cfg_descriptor = create_descriptor(
+        sg_connection,
+        Descriptor.CONFIG,
+        base_config_def,
+        resolve_latest=using_latest_config
+    )
+
+    logger.info("Resolved config %r" % cfg_descriptor)
+
+    return cfg_descriptor
+
+def _validate_manifest(source_path):
+    """
+    Validate that the manifest file is present and valid.
+
+    :param source_path: Source path to plugin
+    :return: parsed yaml content of manifest file
+    """
+    # check for source manifest file
+    manifest_path = os.path.join(source_path, "info.yml")
+    if not os.path.exists(manifest_path):
+        raise TankError("Cannot find plugin manifest '%s'" % manifest_path)
+
+    logger.debug("Reading %s" % manifest_path)
+    with open(manifest_path, "rt") as fh:
+        manifest_data = yaml.load(fh)
+
+    logger.debug("Validating manifest...")
+    for parameter in REQUIRED_MANIFEST_PARAMETERS:
+        if parameter not in manifest_data:
+            raise TankError(
+                "Required plugin manifest parameter '%s' missing in '%s'" % (parameter, manifest_path)
+            )
+
+    return manifest_data
+
+def build_plugin(sg_connection, source_path, target_path):
+    """
+    Perform a build of a plugin.
+
+    This will introspect the info.yml in the source path,
+    copy over everything in the source path into target path
+    and then establish a bundle cache containing a reflection
+    of all items required by the config.
+
+    :param sg_connection: Shotgun connection
+    :param source_path: Path to plugin.
+    :param target_path: Path to build
+    """
+    logger.info("Your toolkit plugin in '%s' will be processed." % source_path)
+    logger.info("The build will generated into '%s'" % target_path)
+
+    # check for existence
+    if not os.path.exists(source_path):
+        raise TankError("Source path '%s' cannot be found on disk!" % source_path)
+
+    # check that target path doesn't exist
+    if os.path.exists(target_path):
+        raise TankError("Target path '%s' already exists!" % target_path)
+
+    # try to create target path
+    filesystem.ensure_folder_exists(target_path)
+
+    # check manifest
+    manifest_data = _validate_manifest(source_path)
+
+    # copy all plugin data across
+    logger.info("Copying plugin data across...")
+    filesystem.copy_folder(source_path, target_path)
+
+    # create bundle cache
+    logger.info("Creating bundle cache folder...")
+    bundle_cache_root = os.path.join(target_path, BUNDLE_CACHE_ROOT_FOLDER_NAME)
+    filesystem.ensure_folder_exists(bundle_cache_root)
+
+    # resolve config descriptor
+    cfg_descriptor = _process_configuration(sg_connection, manifest_data)
+
+    # cache config in bundle cache
+    logger.info("Downloading and caching config...")
+    cfg_descriptor.clone_cache(bundle_cache_root)
+
+    # cache all apps, engines and frameworks
+    _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root)
+
+    # get latest core
+    latest_core_desc = create_descriptor(
+        sg_connection,
+        Descriptor.CORE,
+        {"type": "app_store", "name": "tk-core"},
+        resolve_latest=True
+    )
+
+    logger.info("Downloading latest official core %s" % latest_core_desc)
+    latest_core_desc.ensure_local()
+
+    # copy into bundle_cache/tk-core
+    logger.info("Copying into fixed bootstrap location bundle_cache/tk-core...")
+    fixed_core_path = os.path.join(target_path, "bundle_cache", "tk-core")
+    latest_core_desc.copy(fixed_core_path)
+
+    # now analyze what core the config needs
+    if cfg_descriptor.associated_core_descriptor:
+        logger.info("Config is using a custom core...")
+        associated_core_desc = create_descriptor(
+            sg_connection,
+            Descriptor.CORE,
+            cfg_descriptor.associated_core_descriptor
+        )
+        logger.info("Caching %s" % associated_core_desc)
+        associated_core_desc.clone_cache(bundle_cache_root)
+
+    else:
+        # config requires latest core
+        logger.info("Caching latest core %s" % latest_core_desc)
+        latest_core_desc.clone_cache(bundle_cache_root)
+
+    logger.info("")
+    logger.info("Build complete!")
+    logger.info("")
+    logger.info("- Your plugin is ready in '%s'" % target_path)
+    logger.info("- Plugin uses config %s" % cfg_descriptor)
+    logger.info("- A bootstrap core has been installed into bundle_cache/tk-core")
+    logger.info("- Bootstrap core is %s" % latest_core_desc)
+    logger.info("- All dependencies have been written out to bundle_cache")
+    logger.info("")
+    logger.info("")
+    logger.info("")
+
+
+
+
+
+def main():
+    """
+    Main entry point for script.
+
+    Handles argument parsing and validation and then calls the script payload.
+    """
+
+    usage = "%prog source_path target_path (run with --help for more information)"
+
+    desc = "One line description"
+
+    epilog = """
+Examples:
+
+Building docs for a tag named 'v1.2.3':
+
+Shotgun API:       python api_docs_to_github.py -r python-api -l v1.2.3 --preview
+Toolkit Core API:  python api_docs_to_github.py -r tk-core -l v1.2.3 --preview
+Toolkit Framework: python api_docs_to_github.py -c /path/to/tk-core -r tk-framework-xyz -l v1.2.3 --preview
+
+Building docs for a branch named 'branch_abc':
+
+Shotgun API:       python api_docs_to_github.py -r python-api -l branch_abc --preview
+Toolkit Core API:  python api_docs_to_github.py -r tk-core -l branch_abc --preview
+Toolkit Framework: python api_docs_to_github.py -c /path/to/tk-core -r tk-framework-xyz -l branch_abc --preview
+
+(Just omit the --preview flag to release)
+
+"""
+
+    parser = OptionParserLineBreakingEpilog(usage=usage, description=desc, epilog=epilog)
+
+    parser.add_option("-d", "--debug",
+                      default=False,
+                      action="store_true",
+                      help="Enable debug logging"
+                      )
+
+    # parse cmd line
+    (options, remaining_args) = parser.parse_args()
+
+    logger.info("Welcome to the Toolkit plugin builder.")
+    logger.info("")
+
+    if options.debug:
+        LogManager().global_debug = True
+
+    if len(remaining_args) != 2:
+        parser.print_help()
+        return
+
+    # get paths
+    source_path = remaining_args[0]
+    target_path = remaining_args[1]
+
+    # convert any env vars and tildes
+    source_path = os.path.expanduser(os.path.expandvars(source_path))
+    target_path = os.path.expanduser(os.path.expandvars(target_path))
+
+    # now authenticate to shotgun
+    sg_auth = ShotgunAuthenticator()
+    sg_user = sg_auth.get_user()
+    sg_connection = sg_user.create_sg_connection()
+
+    # we are all set.
+    build_plugin(sg_connection, source_path, target_path)
+
+
+if __name__ == "__main__":
+
+    # set up std toolkit logging to file
+    LogManager().initialize_base_file_handler("build_plugin")
+
+    # set up output of all sgtk log messages to stdout
+    LogManager().initialize_custom_handler()
+
+    exit_code = 1
+    try:
+        main()
+        exit_code = 0
+    except TankError, e:
+        logger.error(str(e))
+    except Exception, e:
+        logger.exception("An exception was raised: %s" % e)
+
+    sys.exit(exit_code)

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -362,7 +362,7 @@ def build_plugin(sg_connection, source_path, target_path):
     # copy all plugin data across
     # skip info.yml, this is baked into the manifest python code
     logger.info("Copying plugin data across...")
-    filesystem.copy_folder(source_path, target_path, skip_list=["info.yml"])
+    filesystem.copy_folder(source_path, target_path, skip_list=["info.yml", ".git"])
 
     # create bundle cache
     logger.info("Creating bundle cache folder...")

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -94,6 +94,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                 sg_connection,
                 Descriptor.ENGINE,
                 env.get_engine_descriptor_dict(eng),
+                fallback_roots=[bundle_cache_root]
             )
             logger.info("Caching %s..." % desc)
             desc.clone_cache(bundle_cache_root)
@@ -104,6 +105,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                     sg_connection,
                     Descriptor.APP,
                     env.get_app_descriptor_dict(eng, app),
+                    fallback_roots=[bundle_cache_root]
                 )
                 logger.info("Caching %s..." % desc)
                 desc.clone_cache(bundle_cache_root)
@@ -113,6 +115,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                 sg_connection,
                 Descriptor.FRAMEWORK,
                 env.get_framework_descriptor_dict(framework),
+                fallback_roots=[bundle_cache_root]
             )
             logger.info("Caching %s..." % desc)
             desc.clone_cache(bundle_cache_root)
@@ -201,6 +204,7 @@ def _process_configuration(sg_connection, source_path, target_path, bundle_cache
             sg_connection,
             Descriptor.CONFIG,
             base_config_def,
+            fallback_roots=[bundle_cache_root],
             resolve_latest=using_latest_config
         )
 
@@ -370,7 +374,8 @@ def build_plugin(sg_connection, source_path, target_path):
         associated_core_desc = create_descriptor(
             sg_connection,
             Descriptor.CORE,
-            cfg_descriptor.associated_core_descriptor
+            cfg_descriptor.associated_core_descriptor,
+            fallback_roots=[bundle_cache_root]
         )
         logger.info("Caching %s" % associated_core_desc)
         associated_core_desc.clone_cache(bundle_cache_root)

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -51,7 +51,7 @@ BUNDLE_CACHE_ROOT_FOLDER_NAME = "bundle_cache"
 
 # when we are baking a config, use these settings
 BAKED_BUNDLE_NAME = "tk-config-plugin"
-BAKED_BUNDLE_VERSION = "v1.0.0"
+BAKED_BUNDLE_VERSION = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
 
 class OptionParserLineBreakingEpilog(optparse.OptionParser):

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -243,6 +243,8 @@ def _bake_manifest(manifest_data, cfg_descriptor, sgtk_plugin_path):
     # write init.py
     with open(os.path.join(sgtk_plugin_path, "__init__.py"), "wt") as fh:
         fh.write("# this file was auto generated.\n")
+        fh.write("from . import manifest\n")
+        fh.write("# end of file.\n")
 
     # now bake out the manifest into code
     params_path = os.path.join(sgtk_plugin_path, "manifest.py")
@@ -272,11 +274,14 @@ def _bake_manifest(manifest_data, cfg_descriptor, sgtk_plugin_path):
                 )
 
         fh.write("\n\n# system generated parameters\n")
-        fh.write("BUILD_DATE=\"%s\"\n" % datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
-        fh.write("BUILD_FQDN=\"%s\"\n" % socket.getfqdn())
-        fh.write("BUILD_USER=\"%s\"\n" % getpass.getuser())
-
-        fh.write("# end of file.\n")
+        fh.write(
+            "BUILD_INFO=\"%s %s@%s\"\n" % (
+                datetime.datetime.now().strftime("%Y%m%d_%H%M%S"),
+                socket.getfqdn(),
+                getpass.getuser()
+            )
+        )
+        fh.write("\n# end of file.\n")
 
 def build_plugin(sg_connection, source_path, target_path):
     """

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -257,7 +257,7 @@ def _bake_manifest(manifest_data, cfg_descriptor, core_descriptor, plugin_root):
     :param plugin_root: Root path for plugin
     """
     # add entry point to our module to ensure multiple plugins can live side by side
-    module_name = "sgtk_plugin_%s" % manifest_data["entry_point"]
+    module_name = "tk_plugin_%s" % manifest_data["entry_point"]
     full_module_path = os.path.join(plugin_root, "python", module_name)
     filesystem.ensure_folder_exists(full_module_path)
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -127,13 +127,17 @@ def _process_configuration(sg_connection, manifest_data):
     # if the descriptor in the config contains a version number
     # we will go into a fixed update mode.
     if "version" in base_config_def:
-        logger.info("Your configuration definition contains a version number. "
-                    "This means that the plugin will be frozen and no automatic updates "
-                    "will be performed at startup.")
+        logger.info(
+            "Your configuration definition contains a version number. "
+            "This means that the plugin will be frozen and no automatic updates "
+            "will be performed at startup."
+        )
         using_latest_config = False
     else:
-        logger.info("Your configuration definition does not contain a version number. "
-                     "This means that the plugin will attempt to auto update at startup.")
+        logger.info(
+            "Your configuration definition does not contain a version number. "
+            "This means that the plugin will attempt to auto update at startup."
+        )
         using_latest_config = True
 
     cfg_descriptor = create_descriptor(
@@ -144,7 +148,6 @@ def _process_configuration(sg_connection, manifest_data):
     )
 
     logger.info("Resolved config %r" % cfg_descriptor)
-
     return cfg_descriptor
 
 def _validate_manifest(source_path):
@@ -260,7 +263,7 @@ def build_plugin(sg_connection, source_path, target_path):
     logger.info("- Plugin uses config %s" % cfg_descriptor)
     logger.info("- A bootstrap core has been installed into bundle_cache/tk-core")
     logger.info("- Bootstrap core is %s" % latest_core_desc)
-    logger.info("- All dependencies have been written out to bundle_cache")
+    logger.info("- All dependencies have been written out to the bundle_cache folder")
     logger.info("")
     logger.info("")
     logger.info("")
@@ -278,27 +281,14 @@ def main():
 
     usage = "%prog source_path target_path (run with --help for more information)"
 
-    desc = "One line description"
+    desc = "Builds a standard toolkit plugin structure ready for testing and deploy"
 
     epilog = """
 Examples:
 
-Building docs for a tag named 'v1.2.3':
-
-Shotgun API:       python api_docs_to_github.py -r python-api -l v1.2.3 --preview
-Toolkit Core API:  python api_docs_to_github.py -r tk-core -l v1.2.3 --preview
-Toolkit Framework: python api_docs_to_github.py -c /path/to/tk-core -r tk-framework-xyz -l v1.2.3 --preview
-
-Building docs for a branch named 'branch_abc':
-
-Shotgun API:       python api_docs_to_github.py -r python-api -l branch_abc --preview
-Toolkit Core API:  python api_docs_to_github.py -r tk-core -l branch_abc --preview
-Toolkit Framework: python api_docs_to_github.py -c /path/to/tk-core -r tk-framework-xyz -l branch_abc --preview
-
-(Just omit the --preview flag to release)
+> python build_plugin.py ~/dev/tk-maya/plugins/basic /tmp/maya-plugin
 
 """
-
     parser = OptionParserLineBreakingEpilog(usage=usage, description=desc, epilog=epilog)
 
     parser.add_option("-d", "--debug",

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -300,7 +300,10 @@ def _bake_manifest(manifest_data, cfg_descriptor, core_descriptor, plugin_root):
 
         fh.write("def add_sgtk_to_pythonpath(plugin_root):\n")
         fh.write("    import sys\n")
-        fh.write("    sys.path.append(plugin_root, '%s')\n" % core_python_path_relative)
+        fh.write("    import os\n")
+        fh.write("    core_path = os.path.join(plugin_root, '%s')\n" % core_python_path_relative)
+        fh.write("    sys.path.append(core_path)\n")
+        fh.write("    return core_path\n")
         fh.write("\n\n")
 
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -49,10 +49,6 @@ REQUIRED_MANIFEST_PARAMETERS = ["base_configuration", "entry_point"]
 # the folder where all items will be cached
 BUNDLE_CACHE_ROOT_FOLDER_NAME = "bundle_cache"
 
-# when we are baking a config, use these settings
-BAKED_BUNDLE_NAME = "tk-config-plugin"
-BAKED_BUNDLE_VERSION = "v1.0.0"
-
 
 class OptionParserLineBreakingEpilog(optparse.OptionParser):
     """
@@ -94,6 +90,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                 sg_connection,
                 Descriptor.ENGINE,
                 env.get_engine_descriptor_dict(eng),
+                fallback_roots=[bundle_cache_root]
             )
             logger.info("Caching %s..." % desc)
             desc.clone_cache(bundle_cache_root)
@@ -104,6 +101,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                     sg_connection,
                     Descriptor.APP,
                     env.get_app_descriptor_dict(eng, app),
+                    fallback_roots=[bundle_cache_root]
                 )
                 logger.info("Caching %s..." % desc)
                 desc.clone_cache(bundle_cache_root)
@@ -113,6 +111,7 @@ def _cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
                 sg_connection,
                 Descriptor.FRAMEWORK,
                 env.get_framework_descriptor_dict(framework),
+                fallback_roots=[bundle_cache_root]
             )
             logger.info("Caching %s..." % desc)
             desc.clone_cache(bundle_cache_root)
@@ -137,72 +136,34 @@ def _process_configuration(sg_connection, source_path, target_path, bundle_cache
         # convert to dict so we can introspect
         base_config_def = descriptor_uri_to_dict(base_config_def)
 
-    # special case - check for the 'baked' descriptor type
-    # and process it
-    if base_config_def["type"] == "baked":
-        logger.info("Baked descriptor detected.")
-
-        baked_path = os.path.expanduser(os.path.expandvars(base_config_def["path"]))
-
-        # if it's a relative path, expand it
-        if not os.path.isabs(baked_path):
-            full_baked_path = os.path.abspath(os.path.join(source_path, baked_path))
-
-            # if it's a relative path, we have already copied it to the build
-            # target location. In this case, attempt to locate it and remove it.
-            baked_target_path = os.path.abspath(os.path.join(target_path, baked_path))
-            if baked_target_path.startswith(baked_target_path):
-                logger.debug("Removing '%s' from build" % baked_target_path)
-                shutil.rmtree(baked_target_path)
-        else:
-            # path is absolute
-            full_baked_path = os.path.abspath(baked_path)
-
-        logger.info("Will bake config from '%s'" % full_baked_path)
-
-        manual_location = os.path.join(bundle_cache_root, "manual", BAKED_BUNDLE_NAME, BAKED_BUNDLE_VERSION)
-        logger.info("Copying %s -> %s" % (full_baked_path, manual_location))
-        filesystem.ensure_folder_exists(manual_location)
-        filesystem.copy_folder(full_baked_path, manual_location)
-
-        # now make a manual descriptor
-        descriptor = {
-            "type": "manual",
-            "version": BAKED_BUNDLE_VERSION,
-            "name": BAKED_BUNDLE_NAME
-        }
-
-        cfg_descriptor = create_descriptor(
-            sg_connection,
-            Descriptor.CONFIG,
-            descriptor,
-            fallback_roots=[bundle_cache_root]
+    # if the descriptor in the config contains a version number
+    # we will go into a fixed update mode.
+    if "version" in base_config_def:
+        logger.info(
+            "Your configuration definition contains a version number. "
+            "This means that the plugin will be frozen and no automatic updates "
+            "will be performed at startup."
         )
-
+        using_latest_config = False
     else:
-
-        # if the descriptor in the config contains a version number
-        # we will go into a fixed update mode.
-        if "version" in base_config_def:
-            logger.info(
-                "Your configuration definition contains a version number. "
-                "This means that the plugin will be frozen and no automatic updates "
-                "will be performed at startup."
-            )
-            using_latest_config = False
-        else:
-            logger.info(
-                "Your configuration definition does not contain a version number. "
-                "This means that the plugin will attempt to auto update at startup."
-            )
-            using_latest_config = True
-
-        cfg_descriptor = create_descriptor(
-            sg_connection,
-            Descriptor.CONFIG,
-            base_config_def,
-            resolve_latest=using_latest_config
+        logger.info(
+            "Your configuration definition does not contain a version number. "
+            "This means that the plugin will attempt to auto update at startup."
         )
+        using_latest_config = True
+
+    # resolve cfg descriptor
+    # note how we set the fallback roots to the bundle cache root
+    # this is in case there are any manual descriptors that are
+    # part of the config payload, to ensure that these are located correctly.
+    cfg_descriptor = create_descriptor(
+        sg_connection,
+        Descriptor.CONFIG,
+        base_config_def,
+        fallback_roots=[bundle_cache_root],
+        resolve_latest=using_latest_config
+
+    )
 
     logger.info("Resolved config %r" % cfg_descriptor)
     return cfg_descriptor
@@ -370,7 +331,8 @@ def build_plugin(sg_connection, source_path, target_path):
         associated_core_desc = create_descriptor(
             sg_connection,
             Descriptor.CORE,
-            cfg_descriptor.associated_core_descriptor
+            cfg_descriptor.associated_core_descriptor,
+            fallback_roots=[bundle_cache_root]
         )
         logger.info("Caching %s" % associated_core_desc)
         associated_core_desc.clone_cache(bundle_cache_root)

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -12,6 +12,7 @@ from __future__ import with_statement
 import os
 import sys
 import optparse
+import datetime
 
 # add sgtk API
 this_folder = os.path.abspath(os.path.dirname(__file__))
@@ -34,7 +35,12 @@ logger = LogManager.get_logger("build_plugin")
 REQUIRED_MANIFEST_PARAMETERS = [
     "base_configuration",
     "entry_point",
-    "display_name",
+    "name",
+    "author",
+    "organization",
+    "contact",
+    "url",
+    "version",
     "description",
     "configuration"
 ]
@@ -197,7 +203,11 @@ def build_plugin(sg_connection, source_path, target_path):
 
     # check that target path doesn't exist
     if os.path.exists(target_path):
-        raise TankError("Target path '%s' already exists!" % target_path)
+        logger.info("The folder '%s' already exists on disk." % target_path)
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_path = "%s.%s" % (target_path, timestamp)
+        filesystem.move_folder(target_path, backup_path)
+        logger.info("...moved it to '%s'" % backup_path)
 
     # try to create target path
     filesystem.ensure_folder_exists(target_path)
@@ -255,6 +265,7 @@ def build_plugin(sg_connection, source_path, target_path):
         # config requires latest core
         logger.info("Caching latest core %s" % latest_core_desc)
         latest_core_desc.clone_cache(bundle_cache_root)
+
 
     logger.info("")
     logger.info("Build complete!")

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -257,7 +257,7 @@ def _bake_manifest(manifest_data, cfg_descriptor, core_descriptor, plugin_root):
     :param plugin_root: Root path for plugin
     """
     # add entry point to our module to ensure multiple plugins can live side by side
-    module_name = "tk_plugin_%s" % manifest_data["entry_point"]
+    module_name = "sgtk_plugin_%s" % manifest_data["entry_point"]
     full_module_path = os.path.join(plugin_root, "python", module_name)
     filesystem.ensure_folder_exists(full_module_path)
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -234,13 +234,13 @@ def _validate_manifest(source_path):
 
 def _bake_manifest(manifest_data, cfg_descriptor, python_bundle_cache):
     """
-    Bake manifest into python files
+    Bake the info.yml manifest into a python file.
 
-    :param manifest_data:
-    :param cfg_descriptor:
-    :param sgtk_plugin_path:
+    :param manifest_data: info.yml manifest data
+    :param cfg_descriptor: descriptor object pointing at the config to use
+    :param sgtk_plugin_path: path to std bundle_cache/python location
     """
-    # the name of the module will encode the entry point
+    # add entry point to our module to ensure multiple plugins can live side by side
     module_name = "sgtk_plugin_%s" % manifest_data["entry_point"]
     full_module_path = os.path.join(python_bundle_cache, module_name)
     filesystem.ensure_folder_exists(full_module_path)
@@ -262,17 +262,15 @@ def _bake_manifest(manifest_data, cfg_descriptor, python_bundle_cache):
         for (parameter, value) in manifest_data.iteritems():
 
             if parameter == "base_configuration":
+                # configuration is processed separately
                 continue
 
             if isinstance(value, str):
                fh.write("%s=\"%s\"\n" % (parameter, value.replace("\"", "'")))
-
             elif isinstance(value, int):
                 fh.write("%s=%d\n" % (parameter, value))
-
             elif isinstance(value, bool):
                 fh.write("%s=%s\n" % (parameter, value))
-
             else:
                 raise ValueError(
                     "Invalid manifest value %s: %s - data type not supported!" % (parameter, value)
@@ -390,12 +388,10 @@ def build_plugin(sg_connection, source_path, target_path):
     logger.info("- Plugin uses config %s" % cfg_descriptor)
     logger.info("- A bootstrap core has been installed into bundle_cache/tk-core")
     logger.info("- Bootstrap core is %s" % latest_core_desc)
-    logger.info("- All dependencies have been written out to the bundle_cache folder")
+    logger.info("- All dependencies have been baked out into the bundle_cache folder")
     logger.info("")
     logger.info("")
     logger.info("")
-
-
 
 
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -350,11 +350,8 @@ def build_plugin(sg_connection, source_path, target_path):
 
     # check that target path doesn't exist
     if os.path.exists(target_path):
-        logger.info("The folder '%s' already exists on disk." % target_path)
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        backup_path = "%s.%s" % (target_path, timestamp)
-        filesystem.move_folder(target_path, backup_path)
-        logger.info("...moved it to '%s'" % backup_path)
+        logger.info("The folder '%s' already exists on disk. Moving it to backup location" % target_path)
+        filesystem.backup_folder(target_path)
 
     # try to create target path
     filesystem.ensure_folder_exists(target_path)

--- a/tests/commands_tests/test_updates.py
+++ b/tests/commands_tests/test_updates.py
@@ -30,7 +30,7 @@ from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.descriptor.descriptor import create_descriptor
 
 from tank import TankError
-from tank.platform.environment import Environment
+from tank.platform.environment import InstalledEnvironment
 from distutils.version import LooseVersion
 
 
@@ -524,7 +524,7 @@ class TestSimpleUpdates(TankTestBase):
         """
         Make sure we can instantiate an environment and get information about the installed apps and their descriptors.
         """
-        env = Environment(os.path.join(self.project_config, "env", "simple.yml"), self.pipeline_configuration)
+        env = InstalledEnvironment(os.path.join(self.project_config, "env", "simple.yml"), self.pipeline_configuration)
 
         self.assertListEqual(env.get_engines(), ["tk-test"])
         self.assertListEqual(env.get_apps("tk-test"), ["tk-multi-nodep"])
@@ -555,7 +555,7 @@ class TestSimpleUpdates(TankTestBase):
         command.execute({"environment_filter": "simple"})
 
         # Make sure we are v2.
-        env = Environment(os.path.join(self.project_config, "env", "simple.yml"), self.pipeline_configuration)
+        env = InstalledEnvironment(os.path.join(self.project_config, "env", "simple.yml"), self.pipeline_configuration)
 
         desc = env.get_app_descriptor("tk-test", "tk-multi-nodep")
         self.assertEqual(desc.version, "v2.0.0")
@@ -597,7 +597,7 @@ class TestIncludeUpdates(TankTestBase):
         """
         Retrieves the environment file specified.
         """
-        return Environment(
+        return InstalledEnvironment(
             os.path.join(self.project_config, "env", "%s.yml" % env_name), self.pipeline_configuration
         )
 

--- a/tests/platform_tests/test_validation.py
+++ b/tests/platform_tests/test_validation.py
@@ -1,10 +1,6 @@
-import tank
-import tank.platform.constants
-from tank.errors import TankError
 from tank.templatekey import StringKey
 from tank_test.tank_test_base import *
 from tank.platform.validation import *
-from tank.platform.environment import Environment
 
 class TestValidateSchema(TankTestBase):
     def setUp(self):


### PR DESCRIPTION
This adds a new script to toolkit, located here: `scripts/build_plugin.py`. This script introduces guidelines and process around plugin development (Docs TBD) 

```
> python build_plugin.py -h
Usage: build_plugin.py source_path target_path (run with --help for more information)

Builds a standard toolkit plugin structure ready for testing and deploy

Options:
  -h, --help   show this help message and exit
  -d, --debug  Enable debug logging

Examples:

> python build_plugin.py ~/dev/tk-maya/plugins/basic /tmp/maya-plugin
```

See screencast video for an introduction.

Other changes:

- Adds a `__version__` to core. 😋 
- Descriptor primary and fallback paths now support environment variables and tildes
- The bootstrap logic has been changes so that if a `base_configuration` descriptor is passed in without a version number, it is assumed to be auto updated. If however, the version number is provided, it will not auto update at bootstrap time.
- (minor) Optimized the core upgrade to download less from the app store
- (minor) Shotgun attachment download now logs download speed to debug.
- Split up `Environment` class into a `Environment` and `InstalledEnvironment`, allowing for access of the environment even when a core has not been installed and associated with a project.
