### PR TITLE
#36869 Shotgun Pipeline Configuration Lookup

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -63,10 +63,21 @@ class ToolkitManager(object):
 
     def _get_pipeline_configuration(self):
         """
-        The pipeline configuration that is being operated on.
-        By default, the manager will attempt to automatically determine
-        which pipeline configuration to use based on the data in Shotgun,
-        taking into account the assigned users field.
+        The pipeline configuration that is should be operated on.
+
+        By default, this value is set to ``None``, indicating to the Manager
+        that it should attempt to find the most suitable Shotgun pipeline configuration
+        given the project and entry point. In this case, it will look for all pipeline
+        configurations associated with the project who are associated with the current
+        user. If no user-tagged pipeline configuration exists, it will look for
+        the primary configuration, and in case this is not found, it will fall back on the
+        :meth:`base_configuration`. If you don't want this check to be carried out in
+        Shotgun, please set :meth:`do_shotgun_config_lookup` to False.
+
+        Alternatively, you can set this to a specific pipeline configuration. In that
+        case, the Manager will look for a pipeline configuration that matches that name
+        and the associated project and entry point. If such a config cannot be found in
+        Shotgun, it falls back on the :meth:`base_configuration`.
         """
         return self._pipeline_configuration_name
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -318,11 +318,13 @@ class ToolkitManager(object):
 
         if self._do_shotgun_config_lookup:
             # do the full resolve where we connect to shotgun etc.
+            log.debug("Checking for pipeline configuration overrides in Shotgun.")
+            log.debug("In order to turn this off, set do_shotgun_config_lookup to False")
             config = resolver.resolve_shotgun_configuration(
                 self._pipeline_configuration_name,
                 self._base_config_descriptor,
                 self._sg_connection,
-                self._sg_user.get_login()
+                self._sg_user.login
             )
 
         else:

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -44,7 +44,7 @@ class ToolkitManager(object):
 
         # defaults
         self._bundle_cache_fallback_paths = []
-        self._pipeline_configuration_name = constants.PRIMARY_PIPELINE_CONFIG_NAME
+        self._pipeline_configuration_name = None
         self._base_config_descriptor = None
         self._progress_cb = None
         self._do_shotgun_config_lookup = True
@@ -64,15 +64,13 @@ class ToolkitManager(object):
     def _get_pipeline_configuration(self):
         """
         The pipeline configuration that is being operated on.
-        By default, the primary pipeline config will be used.
+        By default, the manager will attempt to automatically determine
+        which pipeline configuration to use based on the data in Shotgun,
+        taking into account the assigned users field.
         """
         return self._pipeline_configuration_name
 
     def _set_pipeline_configuration(self, name):
-        """
-        The pipeline configuration that is being operated on.
-        By default, the primary pipeline config will be used.
-        """
         self._pipeline_configuration_name = name
 
     pipeline_configuration = property(_get_pipeline_configuration, _set_pipeline_configuration)
@@ -323,7 +321,8 @@ class ToolkitManager(object):
             config = resolver.resolve_shotgun_configuration(
                 self._pipeline_configuration_name,
                 self._base_config_descriptor,
-                self._sg_connection
+                self._sg_connection,
+                self._sg_user.get_login()
             )
 
         else:

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -220,10 +220,7 @@ class ConfigurationResolver(object):
                     user_config = pc
 
             # user pc takes precedence if available.
-            if user_config:
-                pipeline_config = user_config
-            else:
-                pipeline_config = primary_config
+            pipeline_config = user_config if user_config else primary_config
 
         else:
             # there is a fixed pipeline configuration name specified.

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -14,6 +14,7 @@ on disk.
 """
 
 import os
+import pprint
 
 from ..descriptor import Descriptor, create_descriptor
 from .errors import TankBootstrapError
@@ -22,6 +23,7 @@ from ..util import filesystem
 from ..util import ShotgunPath
 from ..util import LocalFileStorageManager
 from .. import LogManager
+from . import constants
 
 log = LogManager.get_logger(__name__)
 
@@ -131,36 +133,175 @@ class ConfigurationResolver(object):
         self,
         pipeline_config_name,
         fallback_config_descriptor,
-        sg_connection
+        sg_connection,
+        current_login
     ):
         """
         Return a configuration object by requesting a pipeline configuration
         in Shotgun. If no suitable configuration is found, return a configuration
         for the given fallback config.
 
-            .. note:: The current implementation for this is a pass-through
-                      to the base configuration resolver. In the future, business
-                      logic will be added to handle this.
-
-        :param pipeline_config_name: Name of configuration branch (e.g Primary)
+        :param pipeline_config_name: Name of configuration branch (e.g Primary).
+                                     if None, the method will automatically attempt
+                                     to resolve the right configuration based on the
+                                     current user and the users field on the pipeline
+                                     configuration.
         :param fallback_config_descriptor: descriptor dict or string for fallback config.
         :param sg_connection: Shotgun API instance
+        :param current_login: The login of the currently logged in user.
+
         :return: :class:`Configuration` instance
         """
         log.debug(
             "%s resolving configuration from Shotgun Pipeline Configuration %s" % (self, pipeline_config_name)
         )
 
-        log.warning(
-            "Shotgun pipeline configuration resolve has not been implemented yet. "
-            "Falling back on the base configuration resolver."
-        )
+        fields = [
+            "code",
+            "users",
+            "windows_path",
+            "linux_path",
+            "mac_path",
+            "sg_descriptor",
+            "descriptor"
+        ]
 
-        # TODO: add shotgun resolve logic
-        # - find pipeline config record that matches both
-        #   name and entry point
-        # - if found, bootstrap into it
-        # - if not found, try the fallback
+        pipeline_config = None
 
-        return self.resolve_configuration(fallback_config_descriptor, sg_connection)
+        if pipeline_config_name is None:
+            log.debug("Will auto-detect which pipeline configuration to use.")
+
+            # get the pipeline configs for the current project which are
+            # either the primary or is associated with the currently logged in user.
+            pipeline_configs = sg_connection.find(
+                "PipelineConfiguration",
+                [{
+                    "filter_operator": "all",
+                    "filters": [
+                        ["project", "is", self._project_id],
+
+                        {
+                            "filter_operator": "any",
+                            "filters": [
+                                ["entry_point", "is", self._entry_point],
+                                ["sg_entry_point", "is", self._entry_point],
+                            ]
+                        },
+
+
+                        {
+                            "filter_operator": "any",
+                            "filters": [
+                                ["code", "is", constants.PRIMARY_PIPELINE_CONFIG_NAME],
+                                ["users.HumanUser.login", "contains", current_login]
+                            ]
+                        }
+                    ]
+                }],
+                fields,
+                order=[{"field_name": "updated_at", "direction": "asc"}]
+            )
+
+            log.debug(
+                "The following pipeline configurations were found: %s" % pprint.pformat(pipeline_configs)
+            )
+
+            # resolve primary and user config
+            primary_config = None
+            user_config = None
+            for pc in pipeline_configs:
+                if pc["code"] == constants.PRIMARY_PIPELINE_CONFIG_NAME:
+                    primary_config = pc
+                else:
+                    # user config
+                    if user_config:
+                        log.warning(
+                            "More than one user config detected. Will use the most "
+                            "recently updated one."
+                        )
+                    user_config = pc
+
+            # user pc takes precedence if available.
+            if user_config:
+                pipeline_config = user_config
+            else:
+                pipeline_config = primary_config
+
+        else:
+            # there is a fixed pipeline configuration name specified.
+            log.debug("Will use pipeline configuration '%s'" % pipeline_config_name)
+
+            pipeline_configs = sg_connection.find(
+                "PipelineConfiguration",
+
+                [{
+                    "filter_operator": "all",
+                    "filters": [
+                        ["project", "is", self._project_id],
+                        ["code", "is", pipeline_config_name],
+                        {
+                            "filter_operator": "any",
+                            "filters": [
+                                ["entry_point", "is", self._entry_point],
+                                ["sg_entry_point", "is", self._entry_point],
+                            ]
+                        }
+                    ]
+                }],
+
+                fields,
+                order=[{"field_name": "updated_at", "direction": "desc"}]
+            )
+
+            log.debug(
+                "The following pipeline configurations were found: %s" % pprint.pformat(pipeline_configs)
+            )
+
+            if len(pipeline_configs) > 1:
+                log.warning(
+                    "More than one shotgun pipeline configuration found in Shotgun "
+                    "for project id %s, name '%s'. Will pick the first item out of "
+                    "the result." % (self._project_id, pipeline_config_name)
+                )
+                pipeline_config = pipeline_configs[0]
+
+            elif len(pipeline_configs) == 1:
+                pipeline_config = pipeline_configs[0]
+
+
+        # now resolve the descriptor to use based on the pipeline config record
+
+        # default to the fallback descriptor
+        descriptor = fallback_config_descriptor
+
+        if pipeline_config is None:
+            log.debug("No pipeline configuration found. Using fallback descriptor")
+
+        else:
+            log.debug(
+                "The following pipeline configuration will be used: %s" % pprint.pformat(pipeline_config)
+            )
+
+            # now create a descriptor based on the data in the fields.
+            # the following priority order exists:
+            #
+            # 1 windows/linux/mac path
+            # 2 descriptor
+            # 3 sg_descriptor
+
+            path = ShotgunPath.from_shotgun_dict(pipeline_config)
+
+            if path.current_os:
+                log.debug("Descriptor will be based off the path in the pipeline configuration")
+                descriptor = {"type": "path", "path": path.current_os}
+            elif pipeline_config.get("descriptor"):
+                log.debug("Descriptor will be based off the descriptor field in the pipeline configuration")
+                descriptor = pipeline_config.get("descriptor")
+            elif pipeline_config.get("sg_descriptor"):
+                log.debug("Descriptor will be based off the sg_descriptor field in the pipeline configuration")
+                descriptor = pipeline_config.get("sg_descriptor")
+
+        log.debug("The descriptor representing the config is %s" % descriptor)
+
+        return self.resolve_configuration(descriptor, sg_connection)
 


### PR DESCRIPTION
This adds Shotgun runtime configuration lookup to the Toolkit boostrap manager.
This means that it's possible to implement dynamic overrides via the existing Pipeline Configuration concept in Shotgun, allowing for shotgun users to take control over the behaviour, configuration and deployment of plugin based payloads. Notable points:

- The system will look for the fields `entry_point` or `sg_entry_point` to determine the entry point. The latter field is to ensure backwards compatibility with older shotgun versions, where you can create this field by hand.
- The lookup will first check the traditional path fields, then look for the fields `descriptor` and `sg_descriptor` where it expects to find a descriptor uri string to resolve the config from
- The ToolkitManager.pipeline_configuration property has shifted its default value to be None rather than primary. If None, it will automatically determine the pipeline configuration to be used by looking at the users field in Shotgun. This makes it easy to support dev sandboxes for taap.

