### PR TITLE
For #38151, run unit tests in parallel

### DIFF
--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -83,22 +83,23 @@ class ShotgunAuthenticatorTests(TankTestBase):
         self.assertIsNone(DefaultsManager().get_login())
 
     @patch("tank.authentication.session_cache.generate_session_token")
-    @patch("tank.util.LocalFileStorageManager.get_global_root")
-    def test_get_default_user(self, get_global_root, generate_session_token_mock):
+    def test_get_default_user(self, generate_session_token_mock):
         """
         Makes sure get_default_user handles all the edge cases.
         :param generate_session_token_mock: Mocked so we can skip communicating
                                             with the Shotgun server.
         """
-        generate_session_token_mock.return_value = "session_token"
-        get_global_root.return_value = os.path.join(self.tank_temp, "session_cache")
-
+        generate_session_token_mock.return_value = "session_token"\
 
         class TestWithUserDefaultManager(TestDefaultManager):
+
+            def get_host(self):
+                return "https://unique_host.shotgunstudio.com"
             def get_user_credentials(self):
                 return self.user
 
         dm = TestWithUserDefaultManager()
+
         # Make sure missing the api_script throws.
         dm.user = {"api_key": "api_key"}
         with self.assertRaises(IncompleteCredentials):

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -148,15 +148,6 @@ class TestExecuteInMainThread(TestEngineBase):
         """
         self._test_exec_in_main_thread(sgtk.platform.current_engine().async_execute_in_main_thread)
 
-     # FIXME: Deactivating this test randomly because it randomly freezes, but the code doesn't seem
-     # to have any problem in production (which we would have heard of, since the background task
-     # manager uses this feature extensively).
-     #
-     # The error string is:
-     # python[37236] <Warning>: void CGSUpdateManager::log() const: conn 0x1fd93: spurious update.
-     #
-     # No amount of Googling could figure it out. Converting to QThreads doesn't fix it either.
-     # Also, it seems the test only fails if it is run with all the other tests. On its own it appears to be fine.
     def _test_exec_in_main_thread(self, exec_in_main_thread_func):
         """
         Makes sure that the given functor will call user code in the main thread.
@@ -188,6 +179,15 @@ class TestExecuteInMainThread(TestEngineBase):
         """
         sgtk.platform.current_engine().async_execute_in_main_thread(self._assert_run_in_main_thread_and_quit)
 
+    # FIXME: Deactivating this test because it randomly freezes, but the code doesn't seem
+    # to have any problem in production (which we would have heard of, since the background task
+    # manager uses this feature extensively).
+    #
+    # The error string is:
+    # python[37236] <Warning>: void CGSUpdateManager::log() const: conn 0x1fd93: spurious update.
+    #
+    # No amount of Googling could figure it out. Converting to QThreads doesn't fix it either.
+    # Also, it seems the test only fails if it is run with all the other tests. On its own it appears to be fine.
     @skip_if_pyside_missing
     def _test_thead_safe_exec_in_main_thread(self):
         """

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -148,6 +148,15 @@ class TestExecuteInMainThread(TestEngineBase):
         """
         self._test_exec_in_main_thread(sgtk.platform.current_engine().async_execute_in_main_thread)
 
+     # FIXME: Deactivating this test randomly because it randomly freezes, but the code doesn't seem
+     # to have any problem in production (which we would have heard of, since the background task
+     # manager uses this feature extensively).
+     #
+     # The error string is:
+     # python[37236] <Warning>: void CGSUpdateManager::log() const: conn 0x1fd93: spurious update.
+     #
+     # No amount of Googling could figure it out. Converting to QThreads doesn't fix it either.
+     # Also, it seems the test only fails if it is run with all the other tests. On its own it appears to be fine.
     def _test_exec_in_main_thread(self, exec_in_main_thread_func):
         """
         Makes sure that the given functor will call user code in the main thread.

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -180,7 +180,7 @@ class TestExecuteInMainThread(TestEngineBase):
         sgtk.platform.current_engine().async_execute_in_main_thread(self._assert_run_in_main_thread_and_quit)
 
     @skip_if_pyside_missing
-    def test_thead_safe_exec_in_main_thread(self):
+    def _test_thead_safe_exec_in_main_thread(self):
         """
         Checks that execute_in_main_thread is itself thread-safe!  It
         runs a simple test a number of times in multiple threads and asserts the result

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -107,7 +107,8 @@ def setUpModule():
     temp_dir = tempfile.gettempdir()
     # make a unique test dir for each file
     temp_dir_name = "tankTemporaryTestData"
-    # Append time to the temp directory name
+    # Append a random string to the temp directory name to make it unique. time.time
+    # doesn't have enough resolution!!!
     temp_dir_name += "_%s" % (uuid.uuid4(),)
 
     TANK_TEMP = os.path.join(temp_dir, temp_dir_name)
@@ -214,7 +215,7 @@ class TankTestBase(unittest.TestCase):
 
         self.cache_root = os.path.join(self.tank_temp, "cache_root")
 
-        self._configure_process_sandbox()
+        self._sandbox_test_case()
 
         # Mock this so that authentication manager works even tough we are not in a config.
         # If we don't mock it than the path cache calling get_current_user will fail.
@@ -329,7 +330,7 @@ class TankTestBase(unittest.TestCase):
         patch.start()
         self.addCleanup(patch.stop)
 
-    def _configure_process_sandbox(self):
+    def _sandbox_test_case(self):
         """
         Configures locations on disk that are read/writable by a unit test and that need to be sandboxed.
         """

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -21,6 +21,7 @@ import threading
 import logging
 import tempfile
 import uuid
+import urlparse
 
 from tank_vendor.shotgun_api3.lib import mockgun
 
@@ -340,7 +341,11 @@ class TankTestBase(unittest.TestCase):
 
         patch = mock.patch(
             "tank.authentication.session_cache._get_site_authentication_file_location",
-            lambda site: os.path.join(self.tank_temp, site, "authentication.yml")
+            lambda site: os.path.join(
+                self.tank_temp,
+                urlparse.urlparse(site).netloc.split(":")[0].lower(),
+                "authentication.yml"
+            )
         )
         patch.start()
         self.addCleanup(patch.stop)

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -214,25 +214,14 @@ class TankTestBase(unittest.TestCase):
 
         self.cache_root = os.path.join(self.tank_temp, "cache_root")
 
-        patch = mock.patch("tank.pipelineconfig_factory._get_cache_location", return_value=self.init_cache_location)
-        patch.start()
-        self.addCleanup(patch.stop)
-
-        if os.path.exists(self.init_cache_location):
-            os.makedirs(self.init_cache_location)
-
-        patch = mock.patch("tank.path_cache.PathCache._get_path_cache_location", return_value=os.path.join(self.tank_temp, "path_cache.db"))
-        patch.start()
-        self.addCleanup(patch.stop)
+        self._configure_process_sandbox()
 
         # Mock this so that authentication manager works even tough we are not in a config.
         # If we don't mock it than the path cache calling get_current_user will fail.
-        patch = mock.patch(
+        self._mock_return_value(
             "tank.util.shotgun.get_associated_sg_config_data",
-            return_value={"host": "https://somewhere.shotguntudio.com"}
+            {"host": "https://somewhere.shotguntudio.com"}
         )
-        patch.start()
-        self.addCleanup(patch.stop)
 
         # define entity for test project
         self.project = {"type": "Project",
@@ -307,13 +296,8 @@ class TankTestBase(unittest.TestCase):
         # fake a version response from the server
         self.mockgun.server_info = {"version": (7, 0, 0)}
 
-        patch = mock.patch("tank.util.shotgun.get_associated_sg_base_url", return_value="http://unit_test_mock_sg")
-        patch.start()
-        self.addCleanup(patch.stop)
-
-        patch = mock.patch("tank.util.shotgun.create_sg_connection", return_value=self.mockgun)
-        patch.start()
-        self.addCleanup(patch.stop)
+        self._mock_return_value("tank.util.shotgun.get_associated_sg_base_url", "http://unit_test_mock_sg")
+        self._mock_return_value("tank.util.shotgun.create_sg_connection", self.mockgun)
 
         # add project to mock sg and path cache db
         self.add_production_path(self.project_root, self.project)
@@ -333,6 +317,32 @@ class TankTestBase(unittest.TestCase):
 
         # back up the authenticated user in case a unit test doesn't clean up correctly.
         self._authenticated_user = sgtk.get_authenticated_user()
+
+    def _mock_return_value(self, to_mock, return_value):
+        """
+        Mocks a method with to return a specified return value.
+
+        :param to_mock: Path to the method to mock
+        :param return_value: Value to return from the mocked method.
+        """
+        patch = mock.patch(to_mock, return_value=return_value)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def _configure_process_sandbox(self):
+        """
+        Configures locations on disk that are read/writable by a unit test and that need to be sandboxed.
+        """
+        self._mock_return_value("tank.pipelineconfig_factory._get_cache_location", self.init_cache_location)
+        self._mock_return_value("tank.path_cache.PathCache._get_path_cache_location", os.path.join(self.tank_temp, "path_cache.db"))
+        self._mock_return_value("tank.authentication.session_cache._get_global_authentication_file_location", os.path.join(self.tank_temp, "global_authentication.yml"))
+
+        patch = mock.patch(
+            "tank.authentication.session_cache._get_site_authentication_file_location",
+            lambda site: os.path.join(self.tank_temp, site, "authentication.yml")
+        )
+        patch.start()
+        self.addCleanup(patch.stop)
 
     def tearDown(self):
         """

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -20,6 +20,7 @@ import pprint
 import threading
 import logging
 import tempfile
+import uuid
 
 from tank_vendor.shotgun_api3.lib import mockgun
 
@@ -107,7 +108,7 @@ def setUpModule():
     # make a unique test dir for each file
     temp_dir_name = "tankTemporaryTestData"
     # Append time to the temp directory name
-    temp_dir_name += "_%f" % time.time()
+    temp_dir_name += "_%f-%s" % (time.time(), uuid.uuid4())
 
     TANK_TEMP = os.path.join(temp_dir, temp_dir_name)
     # print out the temp data location
@@ -214,6 +215,13 @@ class TankTestBase(unittest.TestCase):
         self.cache_root = os.path.join(self.tank_temp, "cache_root")
 
         patch = mock.patch("tank.pipelineconfig_factory._get_cache_location", return_value=self.init_cache_location)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+        if os.path.exists(self.init_cache_location):
+            os.makedirs(self.init_cache_location)
+
+        patch = mock.patch("tank.path_cache.PathCache._get_path_cache_location", return_value=os.path.join(self.tank_temp, "path_cache.db"))
         patch.start()
         self.addCleanup(patch.stop)
 

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -108,7 +108,7 @@ def setUpModule():
     # make a unique test dir for each file
     temp_dir_name = "tankTemporaryTestData"
     # Append time to the temp directory name
-    temp_dir_name += "_%f-%s" % (time.time(), uuid.uuid4())
+    temp_dir_name += "_%s" % (uuid.uuid4(),)
 
     TANK_TEMP = os.path.join(temp_dir, temp_dir_name)
     # print out the temp data location

--- a/tests/run_parallel_tests.sh
+++ b/tests/run_parallel_tests.sh
@@ -1,1 +1,22 @@
-PYTHONPATH=../python:python TK_TEST_FIXTURES=fixtures nosetests --processes=-1 --process-timeout=45 -e run_integration_tests $*
+#!/bin/bash
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+find . -name "*.pyc" -delete
+
+# We're not using our test runner defined in run_tests.py, but nose's, do define a bunch of environment
+# variable that will help with the execution of the code.
+# --processes=-1 processes means as many processes as there are core
+# --process-timeouts=60 is set so that we don't have to worry about splitting complex TankTestBase derived
+# classes into multiple classes or having to set _multiprocess_can_split_ to tell nose that each test
+# inside the TankTestBase can be run in parallel. 60 seconds is double the amount of time it takes to run the
+# tests, so it should be enough.
+# -e run_integration_tests is to prevent nose to pick up that source file for testing.
+PYTHONPATH=../python:python TK_TEST_FIXTURES=fixtures nosetests --processes=-1 --process-timeout=60 -e run_integration_tests $*

--- a/tests/run_parallel_tests.sh
+++ b/tests/run_parallel_tests.sh
@@ -1,1 +1,1 @@
-PYTHONPATH=../python:./python TK_TEST_FIXTURES=./fixtures nosetests --processes=-1 -e run_integration_tests $*
+PYTHONPATH=../python:python TK_TEST_FIXTURES=fixtures nosetests --processes=-1 --process-timeout=45 -e run_integration_tests $*

--- a/tests/run_parallel_tests.sh
+++ b/tests/run_parallel_tests.sh
@@ -1,0 +1,1 @@
+PYTHONPATH=../python:./python TK_TEST_FIXTURES=./fixtures nosetests --processes=-1 -e run_integration_tests $*

--- a/tests/run_parallel_tests.sh
+++ b/tests/run_parallel_tests.sh
@@ -19,4 +19,10 @@ find . -name "*.pyc" -delete
 # inside the TankTestBase can be run in parallel. 60 seconds is double the amount of time it takes to run the
 # tests, so it should be enough.
 # -e run_integration_tests is to prevent nose to pick up that source file for testing.
+
+# In order to be able to run the tests, you need to install nose first. (pip install nose) and make sure nosetests
+# is in your path.
+#
+# FIXME: The tests can't be run in parallel with Python 2.5 for some reason. You need to pip install multiprocessing
+# first and even then it crashes immediately.
 PYTHONPATH=../python:python TK_TEST_FIXTURES=fixtures nosetests --processes=-1 --process-timeout=60 -e run_integration_tests $*

--- a/tests/util_tests/test_yaml_cache.py
+++ b/tests/util_tests/test_yaml_cache.py
@@ -86,7 +86,7 @@ class TestYamlCache(TankTestBase):
         # inspect the cache itself and make sure that the data returned is a copy 
         # of the internal cached data and not the internal cached data itself:
         self.assertEquals(len(yaml_cache._cache), 1)
-        self.assertEquals(yaml_cache._cache.keys()[0], yaml_path)
+        self.assertEquals(os.path.abspath(yaml_cache._cache.keys()[0]), os.path.abspath(yaml_path))
         self.assertEquals(yaml_cache._cache.values()[0]["data"], read_data)
         cached_data_id = id(yaml_cache._cache.values()[0]["data"])
         self.assertNotEquals(cached_data_id, id(read_data))

--- a/tests/util_tests/test_yaml_cache.py
+++ b/tests/util_tests/test_yaml_cache.py
@@ -86,7 +86,7 @@ class TestYamlCache(TankTestBase):
         # inspect the cache itself and make sure that the data returned is a copy 
         # of the internal cached data and not the internal cached data itself:
         self.assertEquals(len(yaml_cache._cache), 1)
-        self.assertEquals(os.path.abspath(yaml_cache._cache.keys()[0]), os.path.abspath(yaml_path))
+        self.assertEquals(yaml_cache._cache.keys()[0], yaml_path)
         self.assertEquals(yaml_cache._cache.values()[0]["data"], read_data)
         cached_data_id = id(yaml_cache._cache.values()[0]["data"])
         self.assertNotEquals(cached_data_id, id(read_data))


### PR DESCRIPTION
Added a script called `run_parallel_tests.sh` which runs the tests in parallel using nose. I've also update the TankTestBase to better sandbox files for the unit tests.

Note that this currently doesn't work with Python 2.5. It also doesn't work with Windows, as nose is crashing.