### PR TITLE
For #38087, updating metadata fails

### DIFF
--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -201,9 +201,9 @@ class PipelineConfiguration(object):
             fh.close()
             os.umask(old_umask)            
 
-        self._project_id = curr_settings.get("project").get("id")
-        self._pc_id = curr_settings.get("id")
-        self._pc_name = curr_settings.get("code")
+        self._project_id = curr_settings.get("project_id")
+        self._pc_id = curr_settings.get("pc_id")
+        self._pc_name = curr_settings.get("pc_name")
 
     def _populate_yaml_cache(self):
         """

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+import copy
+
+from tank_test.tank_test_base import *
+
+from tank.util import LocalFileStorageManager
+
+class TestPipelineConfig(TankTestBase):
+
+    def test_update_metadata(self):
+        self.assertFalse(self.tk.pipeline_configuration.is_site_configuration())
+        self.tk.pipeline_configuration.convert_to_site_config()
+        self.assertTrue(self.tk.pipeline_configuration.is_site_configuration())

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -8,13 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import sys
-import copy
 
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase, setUpModule
 
-from tank.util import LocalFileStorageManager
 import tank
 
 class TestPipelineConfig(TankTestBase):

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -15,10 +15,27 @@ import copy
 from tank_test.tank_test_base import *
 
 from tank.util import LocalFileStorageManager
+import tank
 
 class TestPipelineConfig(TankTestBase):
+    """
+    Tests for the pipeline configuration.
+    """
 
     def test_update_metadata(self):
+        """
+        Tests if updating the pipeline to site config actually updates it.
+        """
         self.assertFalse(self.tk.pipeline_configuration.is_site_configuration())
+
+        # Make sure the project has been concerted to a site config.
         self.tk.pipeline_configuration.convert_to_site_config()
         self.assertTrue(self.tk.pipeline_configuration.is_site_configuration())
+
+        # Make sure that the setting was correctly written to disk by recreating
+        # another instance of the pipeline configuration object so that it reloads
+        # it from disk.
+        tk2 = tank.sgtk_from_path(self.tk.pipeline_configuration.get_path())
+        self.assertTrue(tk2.pipeline_configuration.is_site_configuration())
+
+

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -33,5 +33,3 @@ class TestPipelineConfig(TankTestBase):
         # it from disk.
         tk2 = tank.sgtk_from_path(self.tk.pipeline_configuration.get_path())
         self.assertTrue(tk2.pipeline_configuration.is_site_configuration())
-
-


### PR DESCRIPTION
Fixes a regression introduced in 0.18. The dictionary we pull values from at the end of _update_metadata used to come from Shotgun, but it is now coming from the cache, which uses different keys.