### PR TITLE
#38064 .git not copied across at project setup (and in other places)

### DIFF
--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -197,3 +197,25 @@ class IODescriptorGit(IODescriptorBase):
             log.debug("...could not establish connection: %s" % e)
             can_connect = False
         return can_connect
+
+    def copy(self, target_path):
+        """
+        Copy the contents of the descriptor to an external location
+
+        Subclassed git implementation which includes .git folders
+        in the copy.
+
+        :param target_path: target path to copy the descriptor to.
+        """
+        log.debug("Copying %r -> %s" % (self, target_path))
+        # make sure config exists
+        self.ensure_local()
+        # copy descriptor into target.
+        # reset the skip list which by default includes .git folders
+        # in the case of the git descriptor, we want to transfer this folder
+        # as well.
+        filesystem.copy_folder(
+            self.get_path(),
+            target_path,
+            skip_list=[]
+        )

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -208,12 +208,12 @@ class IODescriptorGit(IODescriptorBase):
         :param target_path: target path to copy the descriptor to.
         """
         log.debug("Copying %r -> %s" % (self, target_path))
-        # make sure config exists
+        # make sure item exists locally
         self.ensure_local()
         # copy descriptor into target.
-        # reset the skip list which by default includes .git folders
-        # in the case of the git descriptor, we want to transfer this folder
-        # as well.
+        # the skip list contains .git folders by default, so pass in []
+        # to turn that restriction off. In the case of the git descriptor,
+        # we want to transfer this folder as well.
         filesystem.copy_folder(
             self.get_path(),
             target_path,

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -193,7 +193,14 @@ def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
     SKIP_LIST_DEFAULT = [".svn", ".git", ".gitignore", ".hg", ".hgignore"]
 
     # compute full skip list
-    actual_skip_list = skip_list or SKIP_LIST_DEFAULT
+    # note: we don't do
+    # actual_skip_list = skip_list or SKIP_LIST_DEFAULT
+    # because we want users to be able to pass in
+    # skip_list=[] in order to clear the default skip list.
+    if skip_list is None:
+        actual_skip_list = SKIP_LIST_DEFAULT
+    else:
+        actual_skip_list = skip_list
     actual_skip_list.extend(SKIP_LIST_ALWAYS)
 
     files = []

--- a/tests/descriptor_tests/test_git.py
+++ b/tests/descriptor_tests/test_git.py
@@ -107,6 +107,11 @@ class TestGitIODescriptor(TankTestBase):
             os.path.join(self.bundle_cache, "git", "tk-config-default.git", "v0.15.11")
         )
 
+        # test that the copy method copies the .git folder
+        copy_target = os.path.join(self.project_root, "test_copy_target")
+        latest_desc.copy(copy_target)
+        self.assertTrue(os.path.exists(os.path.join(copy_target, ".git")))
+
 
     @skip_if_git_missing
     def test_branch_shorthash(self):
@@ -192,3 +197,9 @@ class TestGitIODescriptor(TankTestBase):
             latest_desc.get_path(),
             os.path.join(self.bundle_cache, "gitbranch", "tk-config-default.git", "7fa75a7")
         )
+
+        # test that the copy method copies the .git folder
+        copy_target = os.path.join(self.project_root, "test_copy_target")
+        latest_desc.copy(copy_target)
+        self.assertTrue(os.path.exists(os.path.join(copy_target, ".git")))
+


### PR DESCRIPTION
Fixes a regression where projects set up with a git based config didn't end up with a `.git` folder. 

This was an oversight when trying to improve the behaviour of the `copy_folder` generic I/O command. The `descriptor.copy()` command has been updated to always include `.git` folders when a git descriptor (tag or branch) is copied across. Also fixes an issue with how the skip list is handled within the `copy_folder()` method.