### PR TITLE
#38304 #37933 entry point > plugin id, site level overrides

### DIFF
--- a/developer/build_plugin.py
+++ b/developer/build_plugin.py
@@ -272,6 +272,13 @@ def _validate_manifest(source_path):
         raise TankError("Cannot parse info.yml manifest: %s" % e)
 
     logger.debug("Validating manifest...")
+
+    # legacy check - if we find entry_point, convert it across
+    # to be plugin_id
+    if "entry_point" in manifest_data:
+        logger.warning("Found legacy entry_point syntax. Please upgrade to use plugin_id instead.")
+        manifest_data["plugin_id"] = manifest_data["entry_point"]
+
     for parameter in REQUIRED_MANIFEST_PARAMETERS:
         if parameter not in manifest_data:
             raise TankError(

--- a/developer/build_plugin.py
+++ b/developer/build_plugin.py
@@ -46,7 +46,7 @@ from tank_vendor import yaml
 logger = LogManager.get_logger("build_plugin")
 
 # required keys in the info.yml plugin manifest file
-REQUIRED_MANIFEST_PARAMETERS = ["base_configuration", "entry_point"]
+REQUIRED_MANIFEST_PARAMETERS = ["base_configuration", "plugin_id"]
 
 # the folder where all items will be cached
 BUNDLE_CACHE_ROOT_FOLDER_NAME = "bundle_cache"
@@ -210,7 +210,7 @@ def _process_configuration(sg_connection, source_path, target_path, bundle_cache
         BakedConfiguration.bake_config_scaffold(
             install_path,
             sg_connection,
-            manifest_data["entry_point"],
+            manifest_data["plugin_id"],
             cfg_descriptor
         )
 
@@ -290,7 +290,7 @@ def _bake_manifest(manifest_data, config_uri, core_descriptor, plugin_root):
     :param plugin_root: Root path for plugin
     """
     # add entry point to our module to ensure multiple plugins can live side by side
-    module_name = "sgtk_plugin_%s" % manifest_data["entry_point"]
+    module_name = "sgtk_plugin_%s" % manifest_data["plugin_id"]
     full_module_path = os.path.join(plugin_root, "python", module_name)
     filesystem.ensure_folder_exists(full_module_path)
 
@@ -403,7 +403,7 @@ def _bake_manifest(manifest_data, config_uri, core_descriptor, plugin_root):
             fh.write("    manager.base_configuration = '%s'\n" % config_uri)
 
             # set entry point
-            fh.write("    manager.entry_point = '%s'\n" % manifest_data["entry_point"])
+            fh.write("    manager.plugin_id = '%s'\n" % manifest_data["plugin_id"])
 
             # set shotgun config lookup flag if defined
             if "do_shotgun_config_lookup" in manifest_data:

--- a/docs/bootstrap.rst
+++ b/docs/bootstrap.rst
@@ -72,6 +72,7 @@ ToolkitManager
 .. autoclass:: ToolkitManager
     :members:
     :inherited-members:
+    :exclude-members: entry_point, set_progress_callback
 
 Exception Classes
 ========================================

--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -26,7 +26,7 @@ class CacheLocation(HookBaseClass):
     For further details, see individual cache methods below.
     """
     
-    def get_path_cache_path(self, project_id, entry_point, pipeline_configuration_id):
+    def get_path_cache_path(self, project_id, plugin_id, pipeline_configuration_id):
         """
         Establish a location for the path cache database file.
 
@@ -44,10 +44,10 @@ class CacheLocation(HookBaseClass):
         id will be set to None.
 
         :param project_id: The shotgun id of the project to store caches for
-        :param entry_point: Entry point string to identify the scope for a particular plugin
-                            or integration. For more information,
-                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
-                            non-plugin based toolkit projects, this value is None.
+        :param plugin_id: Unique string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param pipeline_configuration_id: The shotgun pipeline config id to store caches for
         :returns: The path to a path cache file. This file should exist when this method returns.
         """
@@ -76,7 +76,7 @@ class CacheLocation(HookBaseClass):
         cache_root = LocalFileStorageManager.get_configuration_root(
             tk.shotgun_url,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_configuration_id,
             LocalFileStorageManager.CACHE
         )
@@ -95,7 +95,7 @@ class CacheLocation(HookBaseClass):
         legacy_cache_root = LocalFileStorageManager.get_configuration_root(
             tk.shotgun_url,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_configuration_id,
             LocalFileStorageManager.CACHE,
             generation=LocalFileStorageManager.CORE_V17
@@ -113,7 +113,7 @@ class CacheLocation(HookBaseClass):
 
         return target_path
 
-    def get_bundle_data_cache_path(self, project_id, entry_point, pipeline_configuration_id, bundle):
+    def get_bundle_data_cache_path(self, project_id, plugin_id, pipeline_configuration_id, bundle):
         """
         Establish a cache folder for an app, engine or framework.
 
@@ -129,10 +129,10 @@ class CacheLocation(HookBaseClass):
         folder inside the bundle cache location).
 
         :param project_id: The shotgun id of the project to store caches for
-        :param entry_point: Entry point string to identify the scope for a particular plugin
-                            or integration. For more information,
-                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
-                            non-plugin based toolkit projects, this value is None.
+        :param plugin_id: Unique string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param pipeline_configuration_id: The shotgun pipeline config id to store caches for
         :param bundle: The app, engine or framework object which is requesting the cache folder.
         :returns: The path to a folder which should exist on disk.
@@ -159,7 +159,7 @@ class CacheLocation(HookBaseClass):
         cache_root = LocalFileStorageManager.get_configuration_root(
             tk.shotgun_url,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_configuration_id,
             LocalFileStorageManager.CACHE
         )
@@ -189,7 +189,7 @@ class CacheLocation(HookBaseClass):
         legacy_cache_root = LocalFileStorageManager.get_configuration_root(
             tk.shotgun_url,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_configuration_id,
             LocalFileStorageManager.CACHE,
             generation=LocalFileStorageManager.CORE_V17

--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -124,7 +124,10 @@ class BakedConfiguration(Configuration):
 
         :param path: Path to generate scaffold in.
         :param sg_connection: Shotgun API instance
-        :param plugin_id: Config plugin id
+        :param plugin_id: Plugin id string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param config_descriptor: Descriptor object describing the configuration.
         """
         config_writer = ConfigurationWriter(ShotgunPath.from_current_os_path(path), sg_connection)

--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -33,7 +33,7 @@ class BakedConfiguration(Configuration):
             path,
             sg,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_config_id,
             bundle_cache_fallback_paths
     ):
@@ -45,10 +45,10 @@ class BakedConfiguration(Configuration):
         :param project_id: Project id for the shotgun project associated with the
                            configuration. For a site-level configuration, this
                            can be set to None.
-        :param entry_point: Entry point string to identify the scope for a particular plugin
-                            or integration. For more information,
-                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
-                            non-plugin based toolkit projects, this value is None.
+        :param plugin_id: Plugin id string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param pipeline_config_id: Pipeline Configuration id for the shotgun
                                    pipeline config id associated. If a config does
                                    not have an associated entity in Shotgun, this
@@ -59,7 +59,7 @@ class BakedConfiguration(Configuration):
         self._path = path
         self._sg_connection = sg
         self._project_id = project_id
-        self._entry_point = entry_point
+        self._plugin_id = plugin_id
         self._pipeline_config_id = pipeline_config_id
         self._bundle_cache_fallback_paths = bundle_cache_fallback_paths
 
@@ -118,13 +118,13 @@ class BakedConfiguration(Configuration):
         return super(BakedConfiguration, self).get_tk_instance(sg_user)
 
     @classmethod
-    def bake_config_scaffold(cls, path, sg_connection, entry_point, config_descriptor):
+    def bake_config_scaffold(cls, path, sg_connection, plugin_id, config_descriptor):
         """
         Helper method that can be used to generate a baked scaffold in a given path.
 
         :param path: Path to generate scaffold in.
         :param sg_connection: Shotgun API instance
-        :param entry_point: Config entry point
+        :param plugin_id: Config plugin id
         :param config_descriptor: Descriptor object describing the configuration.
         """
         config_writer = ConfigurationWriter(ShotgunPath.from_current_os_path(path), sg_connection)
@@ -138,7 +138,7 @@ class BakedConfiguration(Configuration):
         config_writer.write_pipeline_config_file(
             pipeline_config_id=None,
             project_id=None,
-            entry_point=entry_point,
+            plugin_id=plugin_id,
             bundle_cache_fallback_paths=[]
         )
 

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -38,7 +38,7 @@ class CachedConfiguration(Configuration):
             sg,
             descriptor,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_config_id,
             bundle_cache_fallback_paths
     ):
@@ -49,10 +49,10 @@ class CachedConfiguration(Configuration):
         :param project_id: Project id for the shotgun project associated with the
                            configuration. For a site-level configuration, this
                            can be set to None.
-        :param entry_point: Entry point string to identify the scope for a particular plugin
-                            or integration. For more information,
-                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
-                            non-plugin based toolkit projects, this value is None.
+        :param plugin_id: Plugin id string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param pipeline_config_id: Pipeline Configuration id for the shotgun
                                    pipeline config id associated. If a config does
                                    not have an associated entity in Shotgun, this
@@ -64,7 +64,7 @@ class CachedConfiguration(Configuration):
         self._sg_connection = sg
         self._descriptor = descriptor
         self._project_id = project_id
-        self._entry_point = entry_point
+        self._plugin_id = plugin_id
         self._pipeline_config_id = pipeline_config_id
         self._bundle_cache_fallback_paths = bundle_cache_fallback_paths
 
@@ -80,10 +80,10 @@ class CachedConfiguration(Configuration):
         """
         Low level representation of the config.
         """
-        return "<Config with id %s, project id %s, ep %s and base %r>" % (
+        return "<Config with id %s, project id %s, id %s and base %r>" % (
             self._pipeline_config_id,
             self._project_id,
-            self._entry_point,
+            self._plugin_id,
             self._descriptor
         )
 
@@ -183,7 +183,7 @@ class CachedConfiguration(Configuration):
             self._config_writer.write_pipeline_config_file(
                 self._pipeline_config_id,
                 self._project_id,
-                self._entry_point,
+                self._plugin_id,
                 self._bundle_cache_fallback_paths
             )
 

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -316,7 +316,7 @@ class ConfigurationWriter(object):
 
         log.debug("Wrote %s" % sg_file)
 
-    def write_pipeline_config_file(self, pipeline_config_id, project_id, entry_point, bundle_cache_fallback_paths):
+    def write_pipeline_config_file(self, pipeline_config_id, project_id, plugin_id, bundle_cache_fallback_paths):
         """
         Writes out the the pipeline configuration file config/core/pipeline_config.yml
 
@@ -325,7 +325,7 @@ class ConfigurationWriter(object):
 
         :param pipeline_config_id: Pipeline config id or None for an unmanaged config.
         :param project_id: Project id or None for the site config or for a baked config.
-        :param entry_point: Entry point for the boostrap.
+        :param plugin_id: Plugin id for the bootstrap.
         :param bundle_cache_fallback_paths: List of bundle cache fallback paths.
         """
         # the pipeline config metadata
@@ -368,7 +368,7 @@ class ConfigurationWriter(object):
             "pc_name": pipeline_config_name,
             "project_id": project_id,
             "project_name": project_name,
-            "entry_point": entry_point,
+            "plugin_id": plugin_id,
             "published_file_entity_type": "PublishedFile",
             "use_bundle_cache": True,
             "bundle_cache_fallback_roots": bundle_cache_fallback_paths,

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -325,7 +325,10 @@ class ConfigurationWriter(object):
 
         :param pipeline_config_id: Pipeline config id or None for an unmanaged config.
         :param project_id: Project id or None for the site config or for a baked config.
-        :param plugin_id: Plugin id for the bootstrap.
+        :param plugin_id: Plugin id string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param bundle_cache_fallback_paths: List of bundle cache fallback paths.
         """
         # the pipeline config metadata

--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -19,7 +19,7 @@ BUNDLE_METADATA_FILE = "info.yml"
 # if major changes happen to the way cloud based configs are handled
 # by the system, for example requiring any existing deployed cloud
 # configs to be re-deployed, this version number should be incremented.
-BOOTSTRAP_LOGIC_GENERATION = 4
+BOOTSTRAP_LOGIC_GENERATION = 5
 
 # config file with information about which core to use
 CONFIG_CORE_DESCRIPTOR_FILE = "core_api.yml"

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -118,7 +118,7 @@ class ToolkitManager(object):
 
     def _get_plugin_id(self):
         """
-        The entry_point defines the scope of the bootstrap operation.
+        The Plugin Id is a string that defines the scope of the bootstrap operation.
 
         If you are bootstrapping into an entire Toolkit pipeline, e.g
         a traditional Toolkit setup, this should be left blank.
@@ -128,35 +128,20 @@ class ToolkitManager(object):
         point will be used to define a scope and sandbox in which your
         plugin will execute.
 
-        In the future, it will be possible to use the entry point value
-        to customize the behavior of a
-        plugin via Shotgun. At bootstrap, toolkit will look for a pipeline
-        configuration with a matching name and entry point. If found, this
-        will be used instead of the one defined by the :meth:`base_configuration`
-        property.
+        When constructing a plugin id for an integration the following
+        should be considered:
 
-        It is possible for multiple plugins running in different DCCs
-        to share the same entry point - in this case, they would all
-        get their settings and setup from a shared configuration. If you
-        were to override the base configuration in Shotgun, your override
-        would affect the entire suite of plugins. This kind of setup allows
-        for the development of several plugins in different DCCs that together
-        form a curated workflow.
+        - Plugin Ids should uniquely identify the plugin.
+        - The name should be short and descriptive.
 
-        We recommend an entry point naming convention of ``provider_service``,
+        We recommend a Plugin Id naming convention of ``service.dcc``,
         for example:
 
-        - A plugin maintained by the RV group which handles review inside RV would
-          be named ``rv_review``.
-        - A plugin for a toolkit load/publish workflow that runs inside of Maya and
-          Nuke, maintained by the Toolkit team, could be named ``sgtk_publish``.
-        - A plugin containg a studio VR workflow across multiple DCCs could be
-          named ``studioname_vrtools``.
+        - A review plugin running inside RV: ``review.rv``.
+        - A basic set of pipeline tools running inside of Nuke: ``basic.nuke``
+        - A plugin containg a suite of motion capture tools for maya: ``mocap.maya``
 
-        Please make sure that your entry point is **unique, explicit and short**.
-
-            .. note:: If you want to force the :meth:`base_configuration` to always
-                      be used, set :meth:`do_shotgun_config_lookup` to False.
+        Please make sure that your Plugin Id is **unique, explicit and short**.
         """
         return self._plugin_id
 
@@ -209,7 +194,6 @@ class ToolkitManager(object):
         _set_bundle_cache_fallback_paths
     )
 
-
     def _get_progress_callback(self):
         """
         Callback function property to call whenever progress of the bootstrap should be reported back.
@@ -231,7 +215,6 @@ class ToolkitManager(object):
 
     progress_callback = property(_get_progress_callback, _set_progress_callback)
 
-
     def set_progress_callback(self, progress_callback):
         """
         Sets the function to call whenever progress of the bootstrap should be reported back.
@@ -242,7 +225,6 @@ class ToolkitManager(object):
         """
 
         self.progress_callback = progress_callback
-
 
     def bootstrap_engine(self, engine_name, entity=None):
         """

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -55,7 +55,7 @@ class ToolkitManager(object):
         self._base_config_descriptor = None
         self._progress_cb = None
         self._do_shotgun_config_lookup = True
-        self._entry_point = None
+        self._plugin_id = None
 
         log.debug("%s instantiated" % self)
 
@@ -116,9 +116,9 @@ class ToolkitManager(object):
 
     do_shotgun_config_lookup = property(_get_do_shotgun_config_lookup, _set_do_shotgun_config_lookup)
 
-    def _get_entry_point(self):
+    def _get_plugin_id(self):
         """
-        The entry point defines the scope of the bootstrap operation.
+        The entry_point defines the scope of the bootstrap operation.
 
         If you are bootstrapping into an entire Toolkit pipeline, e.g
         a traditional Toolkit setup, this should be left blank.
@@ -158,13 +158,16 @@ class ToolkitManager(object):
             .. note:: If you want to force the :meth:`base_configuration` to always
                       be used, set :meth:`do_shotgun_config_lookup` to False.
         """
-        return self._entry_point
+        return self._plugin_id
 
-    def _set_entry_point(self, entry_point):
-        # setter for entry_point
-        self._entry_point = entry_point
+    def _set_plugin_id(self, plugin_id):
+        # setter for plugin_id
+        self._plugin_id = plugin_id
 
-    entry_point = property(_get_entry_point, _set_entry_point)
+    plugin_id = property(_plugin_id, _plugin_id)
+
+    # backwards compatibility
+    entry_point = plugin_id
 
     def _get_base_configuration(self):
         """
@@ -437,7 +440,7 @@ class ToolkitManager(object):
         self._report_progress(progress_callback, 0.1, "Resolving configuration...")
 
         resolver = ConfigurationResolver(
-            self._entry_point,
+            self._plugin_id,
             engine_name,
             project_id,
             self._bundle_cache_fallback_paths

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -121,7 +121,7 @@ class ToolkitManager(object):
         The Plugin Id is a string that defines the scope of the bootstrap operation.
 
         If you are bootstrapping into an entire Toolkit pipeline, e.g
-        a traditional Toolkit setup, this should be left blank.
+        a traditional Toolkit setup, this should be left at its default ``None`` value.
 
         If you are writing a plugin that is intended to run side by
         side with other plugins in your target environment, the entry
@@ -202,10 +202,10 @@ class ToolkitManager(object):
 
             progress_callback(progress_value, message)
 
-        where:
-        - ``progress_value`` is the current progress value, a float number ranging from 0.0 to 1.0
-                             representing the percentage of work completed.
-        - ``message`` is the progress message string to report.
+            # progress_value is the current progress value, a float number
+            # ranging from 0.0 to 1.0 and representing the percentage of work completed.
+            #
+            # message is the progress message string to report.
         """
         return self._progress_cb or self._default_progress_callback
 
@@ -286,24 +286,27 @@ class ToolkitManager(object):
 
             completed_callback(engine)
 
-        where:
-        - ``engine``is the launched :class:`~sgtk.platform.Engine` instance.
+            # the engine parameter passes the launched engine instance
 
         A callback function that handles cleanup after failed completion of the bootstrap
         with the following signature::
 
             failed_callback(phase, exception)
 
-        where:
-        - ``phase`` is the bootstrap phase that raised the exception,
-                    ``ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE`` or ``ToolkitManager.ENGINE_STARTUP_PHASE``.
-                    Using this phase, the callback can decide if the toolkit core needs
-                    to be re-imported to ensure usage of a swapped in version.
-        - ``exception`` is the python exception raised while bootstrapping.
+            # The phase parameter indicates in which phase of the bootstrap the exception
+            # was raised:
+            #
+            # ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE if the failure happened while the system
+            # was still bootstrapping or ToolkitManager.ENGINE_STARTUP_PHASE if the system had
+            # switched over into the toolkit startup phase. At this point, the running core API
+            # instance may habe been swapped over to another version than the one that was
+            # originally loaded.
+            #
+            # Using this parameter, a callback implementation can decide if the toolkit core needs
+            # to be re-imported to ensure usage of a swapped in version.
+            #
+            # The exception parameter contains the python exception raised.
 
-        Please note that the API version of the tk instance that hosts
-        the engine may not be the same as the API version that was
-        executed during the bootstrap.
 
         :param engine_name: Name of engine to launch (e.g. ``tk-nuke``).
         :param entity: Shotgun entity to launch engine for.

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -164,7 +164,7 @@ class ToolkitManager(object):
         # setter for plugin_id
         self._plugin_id = plugin_id
 
-    plugin_id = property(_plugin_id, _plugin_id)
+    plugin_id = property(_get_plugin_id, _set_plugin_id)
 
     # backwards compatibility
     entry_point = plugin_id

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -201,12 +201,15 @@ class ToolkitManager(object):
 
         This function should have the following signature::
 
-            progress_callback(progress_value, message)
+            def progress_callback(progress_value, message):
+                '''
+                Called whenever toolkit reports progress.
 
-            # progress_value is the current progress value, a float number
-            # ranging from 0.0 to 1.0 and representing the percentage of work completed.
-            #
-            # message is the progress message string to report.
+                :param progress_value: The current progress value as float number.
+                                       values will be reported in incremental order
+                                       and always in the range 0.0 to 1.0
+                :param message:        Progress message string
+                '''
         """
         return self._progress_cb or self._default_progress_callback
 
@@ -284,29 +287,34 @@ class ToolkitManager(object):
         A callback function that handles cleanup after successful completion of the bootstrap
         with the following signature::
 
-            completed_callback(engine)
+            def completed_callback(engine):
+                '''
+                Called by the asynchronous bootstrap upon completion.
 
-            # the engine parameter passes the launched engine instance
+                :param engine: Engine instance representing the engine
+                               that was launched.
+                '''
 
         A callback function that handles cleanup after failed completion of the bootstrap
         with the following signature::
 
-            failed_callback(phase, exception)
+            def failed_callback(phase, exception):
+                '''
+                Called by the asynchronous bootstrap if an exception is raised.
 
-            # The phase parameter indicates in which phase of the bootstrap the exception
-            # was raised:
-            #
-            # ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE if the failure happened while the system
-            # was still bootstrapping or ToolkitManager.ENGINE_STARTUP_PHASE if the system had
-            # switched over into the toolkit startup phase. At this point, the running core API
-            # instance may habe been swapped over to another version than the one that was
-            # originally loaded.
-            #
-            # Using this parameter, a callback implementation can decide if the toolkit core needs
-            # to be re-imported to ensure usage of a swapped in version.
-            #
-            # The exception parameter contains the python exception raised.
+                :param phase: Indicates in which phase of the bootstrap the exception
+                              was raised. An integer constant which is either
+                              ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE or
+                              ToolkitManager.ENGINE_STARTUP_PHASE. The former if the
+                              failure happened while the system was still bootstrapping
+                              and the latter if the system had switched over into the
+                              Toolkit startup phase. At this point, the running core API
+                              instance may have been swapped over to another version than
+                              the one that was originally loaded and may need to be reset
+                              in an implementation of this callback.
 
+                :param exception: The python exception that was raised.
+                '''
 
         :param engine_name: Name of engine to launch (e.g. ``tk-nuke``).
         :param entity: Shotgun entity to launch engine for.

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -306,25 +306,27 @@ class ConfigurationResolver(object):
 
             # Now select in order of priority:
 
-            # we may not have any pipeline configuration matches at all:
-            pipeline_config = None
+            if user_config:
+                # A per-user pipeline config for the current project has top priority
+                pipeline_config = user_config
 
-            if primary_config_fallback:
-                # Lowest priority - A Primary pipeline configuration with project field None
-                pipeline_config = primary_config_fallback
-
-            if primary_config:
-                # if there is a primary config for our current project, this takes precedence
-                pipeline_config = primary_config
-
-            if user_config_fallback:
+            elif user_config_fallback:
                 # if there is a pipeline config for our current user with project field None
                 # that takes precedence
                 pipeline_config = user_config_fallback
 
-            if user_config:
-                # and a per-user pipeline config for the current project has top priority
-                pipeline_config = user_config
+            elif primary_config:
+                # if there is a primary config for our current project, this takes precedence
+                pipeline_config = primary_config
+
+            elif primary_config_fallback:
+                # Lowest priority - A Primary pipeline configuration with project field None
+                pipeline_config = primary_config_fallback
+
+            else:
+                # we may not have any pipeline configuration matches at all:
+                pipeline_config = None
+
 
         else:
             # there is a fixed pipeline configuration name specified.

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -271,7 +271,7 @@ class ConfigurationResolver(object):
 
                 # make sure configuration matches our entry point
 
-                if self.__match_plugin_id(pc.get("plugin_ids")) or self.__match_plugin_id(pc.get("sg_plugin_ids")):
+                if self._match_plugin_id(pc.get("plugin_ids")) or self._match_plugin_id(pc.get("sg_plugin_ids")):
                     # we have a matching pipeline configuration!
 
                     if pc["project"] == self._proj_entity_dict:
@@ -329,7 +329,7 @@ class ConfigurationResolver(object):
 
             for pc in pipeline_configs:
 
-                if self.__match_plugin_id(pc.get("plugin_ids")) or self.__match_plugin_id(pc.get("sg_plugin_ids")):
+                if self._match_plugin_id(pc.get("plugin_ids")) or self._match_plugin_id(pc.get("sg_plugin_ids")):
                     # we have a matching pipeline configuration!
 
                     if pipeline_config:
@@ -375,7 +375,7 @@ class ConfigurationResolver(object):
 
         return self.resolve_configuration(descriptor, sg_connection)
 
-    def __match_plugin_id(self, value):
+    def _match_plugin_id(self, value):
         """
         Given a plugin id pattern, determine if the current
         plugin id (entry point) matches.

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -38,7 +38,7 @@ class ConfigurationResolver(object):
 
     def __init__(
             self,
-            entry_point,
+            plugin_id,
             engine_name,
             project_id=None,
             bundle_cache_fallback_paths=None
@@ -46,14 +46,14 @@ class ConfigurationResolver(object):
         """
         Constructor
 
-        :param entry_point: The entry point name of the system that is being bootstrapped.
+        :param plugin_id: The plugin id of the system that is being bootstrapped.
         :param engine_name: Name of the engine that is about to be launched.
         :param project_id: Project id to create a config object for, None for the site config.
         :param bundle_cache_fallback_paths: Optional list of additional paths where apps are cached.
         """
         self._project_id = project_id
         self._proj_entity_dict = {"type": "Project", "id": self._project_id} if self._project_id else None
-        self._entry_point = entry_point
+        self._plugin_id = plugin_id
         self._engine_name = engine_name
         self._bundle_cache_fallback_paths = bundle_cache_fallback_paths or []
 
@@ -61,7 +61,7 @@ class ConfigurationResolver(object):
         return "<Resolver: proj id %s, engine %s, entry point %s>" % (
             self._project_id,
             self._engine_name,
-            self._entry_point,
+            self._plugin_id,
         )
 
     def resolve_configuration(self, config_descriptor, sg_connection):
@@ -113,7 +113,7 @@ class ConfigurationResolver(object):
                 baked_config_root,
                 sg_connection,
                 self._project_id,
-                self._entry_point,
+                self._plugin_id,
                 None,  # pipeline config id
                 self._bundle_cache_fallback_paths
             )
@@ -150,7 +150,7 @@ class ConfigurationResolver(object):
             cache_root = LocalFileStorageManager.get_configuration_root(
                 sg_connection.base_url,
                 self._project_id,
-                self._entry_point,
+                self._plugin_id,
                 None,  # pipeline config id
                 LocalFileStorageManager.CACHE
             )
@@ -175,7 +175,7 @@ class ConfigurationResolver(object):
                 sg_connection,
                 cfg_descriptor,
                 self._project_id,
-                self._entry_point,
+                self._plugin_id,
                 None,  # pipeline config id
                 self._bundle_cache_fallback_paths
             )
@@ -371,8 +371,8 @@ class ConfigurationResolver(object):
 
         # glob match each item
         for pattern in patterns:
-            if fnmatch.fnmatch(self._entry_point, pattern):
-                log.debug("Our entry point '%s' matches pattern '%s'" % (self._entry_point, value))
+            if fnmatch.fnmatch(self._plugin_id, pattern):
+                log.debug("Our plugin id '%s' matches pattern '%s'" % (self._plugin_id, value))
                 return True
 
         return False

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -620,7 +620,7 @@ class LogManager(object):
         self._root_logger.addHandler(self._std_file_handler)
 
         # log the fact that we set up the log file :)
-        log.debug("Writing to log standard log file %s" % log_file)
+        log.debug("Writing to standard log file %s" % log_file)
 
         # return previous log name
         return previous_log_file

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -167,7 +167,7 @@ class PathCache(object):
                 constants.CACHE_LOCATION_HOOK_NAME,
                 "get_path_cache_path",
                 project_id=self._tk.pipeline_configuration.get_project_id(),
-                entry_point=self._tk.pipeline_configuration.get_entry_point(),
+                plugin_id=self._tk.pipeline_configuration.get_plugin_id(),
                 pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id()
             )
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -89,7 +89,7 @@ class PipelineConfiguration(object):
         self._project_name = pipeline_config_metadata.get("project_name")
         self._project_id = pipeline_config_metadata.get("project_id")
         self._pc_id = pipeline_config_metadata.get("pc_id")
-        self._entry_point = pipeline_config_metadata.get("entry_point")
+        self._plugin_id = pipeline_config_metadata.get("plugin_id")
         self._pc_name = pipeline_config_metadata.get("pc_name")
         self._published_file_entity_type = pipeline_config_metadata.get(
             "published_file_entity_type",
@@ -369,11 +369,12 @@ class PipelineConfiguration(object):
         """
         return self._pc_id
 
-    def get_entry_point(self):
+    def get_plugin_id(self):
         """
-        Returns the entry point for this PC.
+        Returns the plugin id for this PC.
+        For more information, see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`.
         """
-        return self._entry_point
+        return self._plugin_id
 
     def get_project_id(self):
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -421,7 +421,7 @@ class TankBundle(object):
                 constants.CACHE_LOCATION_HOOK_NAME,
                 "get_bundle_data_cache_path",
                 project_id=project_id,
-                entry_point=self.__tk.pipeline_configuration.get_entry_point(),
+                plugin_id=self.__tk.pipeline_configuration.get_plugin_id(),
                 pipeline_configuration_id=self.__tk.pipeline_configuration.get_shotgun_id(),
                 bundle=self
             )

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -200,7 +200,7 @@ class LocalFileStorageManager(object):
             cls,
             hostname,
             project_id,
-            entry_point,
+            plugin_id,
             pipeline_config_id,
             path_type,
             generation=CORE_V18):
@@ -230,10 +230,10 @@ class LocalFileStorageManager(object):
 
         :param hostname: Shotgun hostname as string, e.g. 'https://foo.shotgunstudio.com'
         :param project_id: Shotgun project id as integer. For the site config, this should be None.
-        :param entry_point: Entry point string to identify the scope for a particular plugin
-                            or integration. For more information,
-                            see :meth:`~sgtk.bootstrap.ToolkitManager.entry_point`. For
-                            non-plugin based toolkit projects, this value is None.
+        :param plugin_id: Plugin id string to identify the scope for a particular plugin
+                          or integration. For more information,
+                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                          non-plugin based toolkit projects, this value is None.
         :param pipeline_config_id: Shotgun pipeline config id. None for bootstraped configs.
         :param path_type: Type of path to return. One of ``LocalFileStorageManager.LOGGING``,
                           ``LocalFileStorageManager.CACHE``, ``LocalFileStorageManager.PERSISTENT``, where
@@ -269,9 +269,9 @@ class LocalFileStorageManager(object):
             if pipeline_config_id:
                 # a config that has a shotgun counterpart
                 pc_suffix = "c%d" % pipeline_config_id
-            elif entry_point:
+            elif plugin_id:
                 # no pc id but instead an entry point string
-                pc_suffix = ".%s" % filesystem.create_valid_filename(entry_point)
+                pc_suffix = ".%s" % filesystem.create_valid_filename(plugin_id)
             else:
                 # this is a possible, however not recommended state
                 pc_suffix = ""

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1451,13 +1451,10 @@ if __name__ == "__main__":
 
     # check if there is a --debug flag anywhere in the args list.
     # in that case turn on debug logging and remove the flag
-    debug_mode = False
     if "--debug" in cmd_line:
-        debug_mode = True
-        log_handler.setLevel(logging.DEBUG)
+        LogManager().global_debug = True
         logger.debug("")
         logger.debug("A log file can be found in %s" % LogManager().log_folder)
-        logger.debug("To permanently set debug, define a TK_DEBUG environment variable.")
         logger.debug("")
     cmd_line = [arg for arg in cmd_line if arg != "--debug"]
 
@@ -1629,7 +1626,7 @@ if __name__ == "__main__":
 
     except AuthenticationCancelled:
         logger.info("")
-        if debug_mode:
+        if LogManager().global_debug:
             # full stack trace
             logger.exception("An AuthenticationCancelled error was raised: %s" % "Authentication was cancelled.")
         else:
@@ -1641,7 +1638,7 @@ if __name__ == "__main__":
 
     except IncompleteCredentials, e:
         logger.info("")
-        if debug_mode:
+        if LogManager().global_debug:
             # full stack trace
             logger.exception("An IncompleteCredentials exception was raised: %s" % e)
         else:
@@ -1651,7 +1648,7 @@ if __name__ == "__main__":
 
     except ShotgunAuthenticationError, e:
         logger.info("")
-        if debug_mode:
+        if LogManager().global_debug:
             # full stack trace
             logger.exception("A ShotgunAuthenticationError was raised: %s" % str(e))
         else:
@@ -1662,7 +1659,7 @@ if __name__ == "__main__":
 
     except TankError, e:
         logger.info("")
-        if debug_mode:
+        if LogManager().global_debug:
             # full stack trace
             logger.exception("A TankError was raised: %s" % e)
         else:

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -57,6 +57,66 @@ class TestResolver(TankTestBase):
         fh.write("foo")
         fh.close()
 
+    def test_plugin_resolve(self):
+        """
+        Tests the plugin id resolve syntax
+        """
+        resolver = sgtk.bootstrap.resolver.ConfigurationResolver(
+            plugin_id="foo.maya",
+            engine_name="tk-test",
+            project_id=123,
+            bundle_cache_fallback_paths=[self.install_root]
+        )
+
+        # test full match
+        resolver._plugin_id="foo.maya"
+        self.assertTrue(resolver._match_plugin_id("*"))
+
+        # test no match
+        resolver._plugin_id="foo.maya"
+        self.assertFalse(resolver._match_plugin_id(""))
+        self.assertFalse(resolver._match_plugin_id("None"))
+        self.assertFalse(resolver._match_plugin_id(" "))
+        self.assertFalse(resolver._match_plugin_id(",,,,"))
+        self.assertFalse(resolver._match_plugin_id("."))
+
+        # test comma separation
+        resolver._plugin_id="foo.maya"
+        self.assertFalse(resolver._match_plugin_id("foo.hou, foo.may, foo.nuk"))
+        self.assertTrue(resolver._match_plugin_id("foo.hou, foo.maya, foo.nuk"))
+
+        # test comma separation
+        resolver._plugin_id="foo"
+        self.assertFalse(resolver._match_plugin_id("foo.*"))
+        self.assertTrue(resolver._match_plugin_id("foo*"))
+
+        resolver._plugin_id="foo.maya"
+        self.assertTrue(resolver._match_plugin_id("foo.*"))
+        self.assertTrue(resolver._match_plugin_id("foo*"))
+
+        resolver._plugin_id="foo.maya"
+        self.assertTrue(resolver._match_plugin_id("foo.maya"))
+        self.assertFalse(resolver._match_plugin_id("foo.nuke"))
+
+
+    def _match_plugin_id(self, value):
+        """
+        Given a plugin id pattern, determine if the current
+        plugin id (entry point) matches.
+
+        Patterns can be comma separated and glob style patterns.
+        Examples:
+
+            - basic.nuke, basic.maya
+            - basic.*, rv_review
+
+        :param value: pattern string to check or None
+        :return: True if matching false if not
+        """
+
+
+
+
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_resolve_base_config(self, find_mock):
         """

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -42,7 +42,7 @@ class TestResolver(TankTestBase):
 
         # set up a resolver
         self.resolver = sgtk.bootstrap.resolver.ConfigurationResolver(
-            entry_point="foo.maya",
+            plugin_id="foo.maya",
             engine_name="tk-test",
             project_id=123,
             bundle_cache_fallback_paths=[self.install_root]
@@ -382,7 +382,7 @@ class TestResolverSiteConfig(TestResolver):
 
         # set up a resolver
         self.resolver = sgtk.bootstrap.resolver.ConfigurationResolver(
-            entry_point="foo.maya",
+            plugin_id="foo.maya",
             engine_name="tk-test",
             project_id=None,
             bundle_cache_fallback_paths=[self.install_root]

--- a/tests/util_tests/test_local_path.py
+++ b/tests/util_tests/test_local_path.py
@@ -180,7 +180,7 @@ class TestLocalFileStorage(TankTestBase):
                 )
             )
 
-    def _compute_config_root(self, project_id, entry_point, pc_id, expected_suffix):
+    def _compute_config_root(self, project_id, plugin_id, pc_id, expected_suffix):
 
         hostname = "http://test.shotgunstudio.com"
 
@@ -195,7 +195,7 @@ class TestLocalFileStorage(TankTestBase):
             root = LocalFileStorageManager.get_configuration_root(
                 hostname,
                 project_id,
-                entry_point,
+                plugin_id,
                 pc_id,
                 path_type
             )
@@ -212,41 +212,41 @@ class TestLocalFileStorage(TankTestBase):
 
         self._compute_config_root(
             project_id=123,
-            entry_point=None,
+            plugin_id=None,
             pc_id=1234,
             expected_suffix="p123c1234"
         )
 
         self._compute_config_root(
             project_id=None,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=None,
             expected_suffix="site.foo"
         )
 
         self._compute_config_root(
             project_id=None,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=1234,
             expected_suffix="sitec1234"
         )
 
         self._compute_config_root(
             project_id=123,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=1234,
             expected_suffix="p123c1234"
         )
 
         self._compute_config_root(
             project_id=123,
-            entry_point="flame",
+            plugin_id="flame",
             pc_id=None,
             expected_suffix="p123.flame"
         )
 
 
-    def _compute_legacy_config_root(self, project_id, entry_point, pc_id, expected_suffix):
+    def _compute_legacy_config_root(self, project_id, plugin_id, pc_id, expected_suffix):
 
         hostname = "http://test.shotgunstudio.com"
 
@@ -260,7 +260,7 @@ class TestLocalFileStorage(TankTestBase):
             root = LocalFileStorageManager.get_configuration_root(
                 hostname,
                 project_id,
-                entry_point,
+                plugin_id,
                 pc_id,
                 path_type,
                 LocalFileStorageManager.CORE_V17
@@ -278,35 +278,35 @@ class TestLocalFileStorage(TankTestBase):
 
         self._compute_legacy_config_root(
             project_id=123,
-            entry_point=None,
+            plugin_id=None,
             pc_id=1234,
             expected_suffix=os.path.join("project_123", "config_1234")
         )
 
         self._compute_legacy_config_root(
             project_id=None,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=None,
             expected_suffix=os.path.join("project_0", "config_None")
         )
 
         self._compute_legacy_config_root(
             project_id=None,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=1234,
             expected_suffix=os.path.join("project_0", "config_1234")
         )
 
         self._compute_legacy_config_root(
             project_id=123,
-            entry_point="foo",
+            plugin_id="foo",
             pc_id=1234,
             expected_suffix=os.path.join("project_123", "config_1234")
         )
 
         self._compute_legacy_config_root(
             project_id=123,
-            entry_point="flame",
+            plugin_id="flame",
             pc_id=None,
             expected_suffix=os.path.join("project_123", "config_None")
         )


### PR DESCRIPTION
This renames `entry_point` to `plugin_id` across the code. Existing plugins are likely (but not guaranteed) to be backwards compatible.

Also implements site level overrides for pipeline configurations. Practically, this means that if you are user john smith and you start up the following:

```
mgr = sgtk.bootstrap.ToolkitManager()
mgr.base_configuration = "sgtk:descriptor:app_store?name=tk-config-default"
mgr.plugin_id = "test.maya"
mgr.bootstrap_engine("tk-maya", entity={"type": "Project", "id": 123})
```

The following resolution order will be attempted:

1. First toolkit will check for a project level, user associated pipeline configuration with
   - `PipelineConfig.users` field containing john smith
   - `PipelineConfig.project` field set to project 123
   - `PipelineConfig.plugin_id` matching `test.maya`

2. Next it will check for any user associated pipeline config with matching plugin id:
   - `PipelineConfig.users` field containing john smith
   - `PipelineConfig.plugin_id` matching `test.maya`

3. Next it will check for a project level primary config:
   - `PipelineConfig.code` field set to `Primary`
   - `PipelineConfig.project` field set to project 123
   - `PipelineConfig.plugin_id` matching `test.maya`

4. Next it checks for a primary config matching plugin id:
   - `PipelineConfig.code` field set to `Primary`
   - `PipelineConfig.plugin_id` matching `test.maya`

5. if none of the above returns a valid config, it falls back on the base config.

This means that you can set up both dev sandboxes and configs that will be used across *all projects* on your site. These can in turn be overridden per project if needed.