### PR TITLE
#34448 improved sqlite uniqueness checks

### DIFF
--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -9,10 +9,14 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import time
 import StringIO
+import cPickle as pickle
 import sqlite3
 import shutil
 import logging
+import multiprocessing
+import threading
 
 from tank_test.tank_test_base import *
 
@@ -642,3 +646,183 @@ class TestShotgunSync(TankTestBase):
         # even though there are new entries for other projects.
         log = sync_path_cache(self.tk)
         self.assertTrue("Path cache syncing not necessary" in log)
+
+
+
+class TestConcurrentShotgunSync(TankTestBase):
+    """
+    Tests that the path cache can gracefully handle multiple
+    clients cocurrently synchronizing with it
+    """
+
+    def setUp(self, project_tank_name = "project_code"):
+        """Sets up entities in mocked shotgun database and creates Mock objects
+        to pass in as callbacks to Schema.create_folders. The mock objects are
+        then queried to see what paths the code attempted to create.
+        """
+        super(TestConcurrentShotgunSync, self).setUp(project_tank_name)
+        self.setup_fixtures()
+
+        self.seq = {"type": "Sequence",
+                    "id": 2,
+                    "code": "seq_code",
+                    "project": self.project}
+        self.shot = {"type": "Shot",
+                     "id": 1,
+                     "code": "shot_code",
+                     "sg_sequence": self.seq,
+                     "project": self.project}
+        self.step = {"type": "Step",
+                     "id": 3,
+                     "code": "step_code",
+                     "entity_type": "Shot",
+                     "short_name": "step_short_name"}
+        self.task = {"type": "Task",
+                     "id": 4,
+                     "entity": self.shot,
+                     "step": self.step,
+                     "project": self.project}
+
+        entities = [self.shot, self.seq, self.step, self.project, self.task]
+
+        # Add these to mocked shotgun
+        self.add_to_sg_mock_db(entities)
+
+        self._multiprocess_fail = False
+
+    def concurrent_full_sync(self):
+        """
+        Run full sync 20 times
+        """
+        try:
+            for x in range(20):
+                self.tk.synchronize_filesystem_structure(True)
+        except Exception, e:
+            print "Exception from concurrent full sync process: %s" % e
+            self._multiprocess_fail = True
+
+
+    def test_concurrent_full_sync(self):
+        """
+        test multiple processes doing a full sync of the path cache at the same time
+        """
+        folder.process_filesystem_structure(self.tk,
+                                            self.task["type"],
+                                            self.task["id"],
+                                            preview=False,
+                                            engine=None)
+
+        self.tk.synchronize_filesystem_structure(True)
+        self._multiprocess_fail = False
+
+        processes = []
+
+        for x in range(50):
+            p = multiprocessing.Process(target=self.concurrent_full_sync)
+            p.start()
+            processes.append(p)
+
+        all_processes_finished = False
+        while not all_processes_finished:
+            time.sleep(0.1)
+            all_processes_finished = all([not(p.is_alive()) for p in processes])
+
+        self.assertFalse(self._multiprocess_fail)
+
+    def concurrent_payload(self, mockgun_shared_pipe):
+        """
+        Run incremental sync 20 times
+        """
+        try:
+            for x in range(20):
+                # update the local mockgun db that we have in memory
+                self.tk.shotgun._db = mockgun_shared_pipe.recv()
+                self.tk.synchronize_filesystem_structure()
+        except Exception, e:
+            print "Exception from concurrent sync process: %s" % e
+            self._multiprocess_fail = True
+        finally:
+            mockgun_shared_pipe.close()
+
+    def test_concurrent(self):
+        """
+        Test multi process incremental sync as records are being inserted.
+        """
+        folder.process_filesystem_structure(self.tk,
+                                            self.task["type"],
+                                            self.task["id"],
+                                            preview=False,
+                                            engine=None)
+
+        self.tk.synchronize_filesystem_structure(True)
+
+        processes = []
+        pipes = []
+
+        for x in range(20):
+            pipe, child_pipe = multiprocessing.Pipe()
+            pipes.append(pipe)
+            p = multiprocessing.Process(target=self.concurrent_payload, args=(child_pipe,))
+            p.start()
+            processes.append(p)
+
+        all_processes_finished = False
+
+        shot_id = 5000
+        filesystem_location_id = 6000
+        event_log_id = 7000
+
+        while not all_processes_finished:
+
+            shot_id += 1
+            filesystem_location_id += 1
+            event_log_id += 1
+
+            # create a new shot in shotgun
+            sg_shot = {
+                "type": "Shot",
+                "id": shot_id,
+                "code": "shot_code_%s" % shot_id,
+                "sg_sequence": self.seq,
+                "project": self.project
+            }
+
+            sg_folder = {
+                'id': filesystem_location_id,
+                'type': 'FilesystemLocation',
+                'project': self.project,
+                'code': sg_shot["code"],
+                'linked_entity_type': 'Shot',
+                'linked_entity_id': shot_id,
+                'path': None,
+                'configuration_metadata': '',
+                'is_primary': True,
+                'pipeline_configuration': {'type': 'PipelineConfiguration', 'id': 123},
+                'created_by': None,
+                'entity': sg_shot
+             }
+
+            sg_event_log_entry = {
+                'id': event_log_id,
+                'type': 'EventLogEntry',
+                'project': self.project,
+                'event_type': "Toolkit_Folders_Create",
+                'meta': {
+                    'core_api_version': 'HEAD',
+                    'sg_folder_ids': [filesystem_location_id]
+                }
+             }
+
+            self.add_to_sg_mock_db([sg_shot, sg_folder, sg_event_log_entry])
+
+            # now update the mockgun in all other processes
+            for pipe in pipes:
+                pipe.send(self.tk.shotgun._db)
+
+            time.sleep(0.1)
+            all_processes_finished = all([not(p.is_alive()) for p in processes])
+
+        self.assertFalse(self._multiprocess_fail)
+
+
+

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -578,7 +578,8 @@ class TankTestBase(unittest.TestCase):
 
             # turn any dicts into proper type/id/name refs
             for x in entity:
-                if isinstance(entity[x], dict):
+                # special case: EventLogEntry.meta is not an entity link dict
+                if isinstance(entity[x], dict) and x != "meta":
                     # make a std sg link dict with name, id, type
                     link_dict = {"type": entity[x]["type"], "id": entity[x]["id"] }
 


### PR DESCRIPTION
When the incremental sync runs, toolkit will determine what to update via the data in the database, then pull down the updates from shotgun and lastly update the database.

There is no acidity or transactions around this because of the Shotgun API, so there is a possibility that two syncs run in parallel and both end up deciding that they should insert a row in the db representing a new object that exists in shotgun but not yet in the db.

This used to result in errors due to the unique db constraint:

```
sqlite3.IntegrityError: columns entity_type, entity_id, root, path, primary_entity are not unique
```

This fix fixes that issue by gracefully falling back on the sql level by doing a `INSERT OR IGNORE INTO`, meaning if the record exists, it is skipped.

Also added several concurrency tests as part of trying to create a decent test for the fix above. Unfortunately i wasn't able to add a good test for this particular issue, but added two other concurrently multi process sync tests. 