### PR TITLE
For #38747, global logging turned off by engine start

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -127,9 +127,8 @@ class Engine(TankBundle):
         # (and the rest of the sgtk logging ) to the user
         self.__log_handler = self.__initialize_logging()
 
-        # check general debug log setting and update the global debug flag accordingly. Do not set this
-        # flag only when the debug_logging is "true" because the global_debug flag is... global... and it
-        # needs to be reset during engine instantiation if the debug_logging setting suddenly turns false.
+        # check general debug log setting and if this flag is turned on,
+        # adjust the global setting
         if self.get_setting("debug_logging", False):
             LogManager().global_debug = True
             self.log_debug(

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -130,8 +130,8 @@ class Engine(TankBundle):
         # check general debug log setting and update the global debug flag accordingly. Do not set this
         # flag only when the debug_logging is "true" because the global_debug flag is... global... and it
         # needs to be reset during engine instantiation if the debug_logging setting suddenly turns false.
-        LogManager().global_debug = self.get_setting("debug_logging", False)
-        if LogManager().global_debug:
+        if self.get_setting("debug_logging", False):
+            LogManager().global_debug = True
             self.log_debug(
                 "Detected setting 'config/env/%s.yml:%s.debug_logging: true' "
                 "in your environment configuration. Turning on debug output." % (env.name, engine_instance_name)


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/shotgunsoftware/tk-core/commit/0efd9a5f58365a261b2c5b5bfa1eb98f2551fe41