### PR TITLE
#38369: Adds get_hyperlink_html utility function to sgtk.platform.

### DIFF
--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -24,7 +24,6 @@ from .util import (
     current_bundle,
     restart,
     get_logger,
-    get_hyperlink_html,
 )
 from . import events
 

--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -17,6 +17,14 @@ from .errors import TankEngineInitError, TankContextChangeNotSupportedError
 from .application import Application
 from .engine import Engine
 from .framework import Framework
-from .util import change_context, get_framework, import_framework, current_bundle, restart, get_logger
+from .util import (
+    change_context,
+    get_framework,
+    import_framework,
+    current_bundle,
+    restart,
+    get_logger,
+    get_hyperlink_html,
+)
 from . import events
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -118,10 +118,6 @@ SG_STYLESHEET_CONSTANTS = { "SG_HIGHLIGHT_COLOR": "#18A7E3",
                             "SG_FOREGROUND_COLOR": "#C8C8C8",
                             "SG_LINK_COLOR": "#C8C8C8"}
 
-# Define a standard template for URL labels. The first string token is for the
-# URL itself, and the second the text/name string to display.
-URL_TEMPLATE = "<a href='%s' style='text-decoration: underline; color: #C8C8C8'>%s</a>"
-
 # the file to look for that defines and bootstraps a framework
 FRAMEWORK_FILE = "framework.py"
 

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -116,7 +116,11 @@ BUNDLE_STYLESHEET_FILE = "style.qss"
 SG_STYLESHEET_CONSTANTS = { "SG_HIGHLIGHT_COLOR": "#18A7E3",
                             "SG_ALERT_COLOR": "#FC6246",
                             "SG_FOREGROUND_COLOR": "#C8C8C8",
-                            "SG_LINK_COLOR": "#CCCED2"}
+                            "SG_LINK_COLOR": "#C8C8C8"}
+
+# Define a standard template for URL labels. The first string token is for the
+# URL itself, and the second the text/name string to display.
+URL_TEMPLATE = "<a href='%s' style='text-decoration: underline; color: #C8C8C8'>%s</a>"
 
 # the file to look for that defines and bootstraps a framework
 FRAMEWORK_FILE = "framework.py"

--- a/python/tank/platform/util.py
+++ b/python/tank/platform/util.py
@@ -260,34 +260,3 @@ def get_logger(module_name):
     full_log_path = "%s.%s" % (curr_bundle.logger.name, module_name)
     return logging.getLogger(full_log_path)
 
-
-def get_hyperlink_html(url, name, color=None, bold=True):
-    """
-    Provides an html string for a hyperlink pointing to the given URL
-    and displaying the provided string name.
-
-    :param str url: The URL that the hyperlink navigates to.
-    :param str name: The string name to display.
-    :param str color: The color of the text. If not given, defaults to
-                      the SG_LINK_COLOR constant.
-    :param bool bold: Whether the displayed text is bold.
-    :return: HTML string.
-    """
-    from sgtk.platform.constants import SG_STYLESHEET_CONSTANTS
-    color = color or SG_STYLESHEET_CONSTANTS["SG_LINK_COLOR"]
-    base = "<a href='{0}' style='text-decoration: none; color: {1}'>".format(
-        url,
-        color,
-    )
-
-    if bold:
-        template = "{0}<b>{1}</b></a>".format(base, name)
-    else:
-        template = "{0}{1}</a>".format(base, name)
-
-    url_template = template.format(
-        url=url,
-        color=color,
-    )
-
-    return url_template

--- a/python/tank/platform/util.py
+++ b/python/tank/platform/util.py
@@ -261,3 +261,33 @@ def get_logger(module_name):
     return logging.getLogger(full_log_path)
 
 
+def get_hyperlink_html(url, name, color=None, bold=True):
+    """
+    Provides an html string for a hyperlink pointing to the given URL
+    and displaying the provided string name.
+
+    :param str url: The URL that the hyperlink navigates to.
+    :param str name: The string name to display.
+    :param str color: The color of the text. If not given, defaults to
+                      the SG_LINK_COLOR constant.
+    :param bool bold: Whether the displayed text is bold.
+    :return: HTML string.
+    """
+    from sgtk.platform.constants import SG_STYLESHEET_CONSTANTS
+    color = color or SG_STYLESHEET_CONSTANTS["SG_LINK_COLOR"]
+    base = "<a href='{0}' style='text-decoration: none; color: {1}'>".format(
+        url,
+        color,
+    )
+
+    if bold:
+        template = "{0}<b>{1}</b></a>".format(base, name)
+    else:
+        template = "{0}{1}</a>".format(base, name)
+
+    url_template = template.format(
+        url=url,
+        color=color,
+    )
+
+    return url_template


### PR DESCRIPTION
This provides a standard html string for use when displaying hyperlinks in QLabels.