### PR TITLE
For #38532, include env vars broken on windows

### DIFF
--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -28,61 +28,39 @@ c:\foo\bar\hello.yml - absolute path, windows
 
 """
 
-
-
 import os
-import sys
 
 from .errors import TankError
 from . import constants
 from .util import yaml_cache
+from .util.includes import resolve_include
 
 
 def _get_includes(file_name, data):
     """
-    Parses the includes section and returns a list of valid paths
+    Parse the includes section and return a list of valid paths
+
+    :param str file_name: Name of the file to parse.
+    :param aray or str data: Include path or array of include paths to evaluate.
     """
     includes = []
-    resolved_includes = []
-    
+
+    resolved_includes = set()
+
     if constants.SINGLE_INCLUDE_SECTION in data:
         # single include section
         includes.append( data[constants.SINGLE_INCLUDE_SECTION] )
-            
+
     if constants.MULTI_INCLUDE_SECTION in data:
         # multi include section
         includes.extend( data[constants.MULTI_INCLUDE_SECTION] )
 
     for include in includes:
-        
-        if "/" in include and not include.startswith("/") and not include.startswith("$"):
-            # relative path: foo/bar.yml or ./foo.bar.yml
-            # note the $ check to avoid paths beginning with env vars to fall into this branch
-            adjusted = include.replace("/", os.path.sep)
-            full_path = os.path.join(os.path.dirname(file_name), adjusted)
-    
-        elif "\\" in include:
-            # windows absolute path
-            if sys.platform != "win32":
-                # ignore this on other platforms
-                continue
-            full_path = os.path.expandvars(include)
-            
-        else:
-            # linux absolute path
-            if sys.platform == "win32":
-                # ignore this on other platforms
-                continue
-            full_path = os.path.expandvars(include)
-                    
-        # make sure that the paths all exist
-        if not os.path.exists(full_path):
-            raise TankError("Include Resolve error in %s: Included path %s "
-                            "does not exist!" % (file_name, full_path))
+        resolved = resolve_include(file_name, include)
+        if resolved:
+            resolved_includes.add(resolved)
 
-        resolved_includes.append(full_path)
-
-    return resolved_includes
+    return list(resolved_includes)
 
 
 def _process_template_includes_r(file_name, data):

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -53,10 +53,10 @@ def resolve_include(file_name, include):
     If the path is relative, it will be considered relative to the file that
     included it and it will be considered for any OS.
 
-    If the path is absolute, the file will be resolved only if it uses the current
-    platform's path separator.
+    If the path is absolute, it will only be considered to be a valid include if
+    it is an absolute path for the current platform.
 
-    Finally, the path will be sanitized to remove any extraenous slashes or slashes
+    Finally, the path will be sanitized to remove any extraneous slashes or slashes
     in the wrong direction.
 
     :param str file_name: Name of the file containing the include.

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import posixpath
+import ntpath
+from .shotgun_path import ShotgunPath
+from ..errors import TankError
+
+
+def _is_abs(path):
+    """
+    Check if path is absolute on any platform.
+
+    :param str path: Path to validate.
+
+    :returns bool: True is absolute on any platform, False otherwise.
+    """
+    return posixpath.isabs(path) or ntpath.isabs(path)
+
+
+def resolve_include(file_name, include):
+    """
+    Resolve an include.
+
+    If the path has a ~ or an environment variable, it will be resolved first.
+
+    If the path is relative, it will be considered relative to the file that
+    included it.
+
+    If the path is absolute, the file will be resolved only if it uses the current
+    platform's path separator.
+
+    Finally, the path will be sanitized to remove any extraenous slashes or slashes
+    in the wrong direction.
+
+    :param str file_name: Name of the file containing the include.
+    :param str include: Include to resolve.
+
+    :returns str: An absolute path to the resolved include or None if the file wasn't
+        specified for the current platform.
+
+    :raises TankError: Raised when the path doesn't exist.
+    """
+    # First resolve all environment variables and ~
+    path = os.path.expanduser(os.path.expandvars(include))
+
+    # Then, if the path is not absolute
+    if not _is_abs(path):
+        # Append it to the current file's directory.
+        path = os.path.join(os.path.dirname(file_name), path)
+    # Then if this path doesn't use the path separator for the current platform.
+    elif os.path.sep not in path:
+        return
+
+    # ShotgunPath cleans up paths so that slashes are all in the same direction
+    # and no doubles exists.
+    path = ShotgunPath.from_current_os_path(path).current_os
+
+    # make sure that the paths all exist
+    if not os.path.exists(path):
+        raise TankError("Include Resolve error in %s: Included path %s "
+                        "does not exist!" % (file_name, path))
+
+    return path

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -143,12 +143,16 @@ class TestIncludes(object):
 
         def test_missing_file(self):
             """
-            Makes sure an exception is raised when the include doesn't exist.
+            Make sure an exception is raised when the include doesn't exist.
             """
             with self.assertRaisesRegexp(tank.TankError, "Include Resolve error"):
                 self._resolve_includes("dead/path/to/a/file")
 
 
+# TODO: These tests should be move within the respective test package, but because they share
+# the same suite of tests there's no easy way to share the suite. However, once we finish the
+# refactoring of the include system, I suspect most of these tests will move to the refactored
+# framework location and this messiness will go away.
 
 class TestTemplateIncludes(TestIncludes.Imp):
     """

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -1,126 +1,178 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
 import os
 import sys
 
+import tank
 from tank_test.tank_test_base import TankTestBase, setUpModule, temp_env_var
-from tank.template_includes import _get_includes
+from tank.template_includes import _get_includes as get_template_includes
+from tank.platform.environment_includes import _resolve_includes as get_environment_includes
 from mock import patch
 
 
-class TestIncludes(TankTestBase):
+class TestIncludes(object):
     """
-    Tests template includes.
-
-    Note that these tests will only test the code for the current platform. They
-    need to be run on other platforms to get complete coverage.
+    Allows to nest the Imp class so that the unit test runner doesn't try to run it.
     """
 
-    _file_name = os.path.join(os.getcwd(), "test.yml")
-    _file_dir = os.path.dirname(_file_name)
+    class Imp(TankTestBase):
+        """
+        Tests includes. _resolve_includes needs to be reimplemented by the derived class
 
-    @patch("os.path.exists", return_value=True)
-    def test_env_var_only(self, _):
+        Note that these tests will only test the code for the current platform. They
+        need to be run on other platforms to get complete coverage.
         """
-        Validate that a lone environment variable will resolve on all platforms.
-        """
-        resolved_include = os.path.join(os.getcwd(), "test.yml")
-        with temp_env_var(INCLUDE_ENV_VAR=resolved_include):
-            os.environ["INCLUDE_ENV_VAR"]
+
+        _file_name = os.path.join(os.getcwd(), "test.yml")
+        _file_dir = os.path.dirname(_file_name)
+
+        @patch("os.path.exists", return_value=True)
+        def test_env_var_only(self, _):
+            """
+            Validate that a lone environment variable will resolve on all platforms.
+            """
+            resolved_include = os.path.join(os.getcwd(), "test.yml")
+            with temp_env_var(INCLUDE_ENV_VAR=resolved_include):
+                os.environ["INCLUDE_ENV_VAR"]
+                self.assertEqual(
+                    self._resolve_includes("$INCLUDE_ENV_VAR"),
+                    [resolved_include]
+                )
+
+        @patch("os.path.exists", return_value=True)
+        def test_tilde(self, _):
+            """
+            Validate that a tilde will resolve on all platforms.
+            """
+            include = os.path.join("~", "test.yml")
+            resolved_include = os.path.expanduser(include)
             self.assertEqual(
-                self._resolve_includes("$INCLUDE_ENV_VAR"),
+                self._resolve_includes(include),
                 [resolved_include]
             )
 
-    @patch("os.path.exists", return_value=True)
-    def test_tilde(self, _):
-        """
-        Validate that a tilde will resolve on all platforms.
-        """
-        include = os.path.join("~", "test.yml")
-        resolved_include = os.path.expanduser(include)
-        self.assertEqual(
-            self._resolve_includes(include),
-            [resolved_include]
-        )
-
-    @patch("os.path.exists", return_value=True)
-    def test_relative_path(self, _):
-        """
-        Validate that relative path are processed correctly
-        """
-        relative_include = "sub_folder/include.yml"
-        self.assertEqual(
-            self._resolve_includes(relative_include),
-            [os.path.join(self._file_dir, "sub_folder", "include.yml")]
-        )
-
-    @patch("os.path.exists", return_value=True)
-    def test_relative_path_with_env_var(self, _):
-        """
-        Validate that relative path with env vars are processed correctly
-        """
-        relative_include = "$INCLUDE_ENV_VAR/include.yml"
-        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+        @patch("os.path.exists", return_value=True)
+        def test_relative_path(self, _):
+            """
+            Validate that relative path are processed correctly
+            """
+            relative_include = "sub_folder/include.yml"
             self.assertEqual(
                 self._resolve_includes(relative_include),
-                [os.path.join(os.getcwd(), "include.yml")]
+                [os.path.join(self._file_dir, "sub_folder", "include.yml")]
             )
 
-    @patch("os.path.exists", return_value=True)
-    def test_path_with_env_var_in_front(self, _):
-        """
-        Validate that relative path are processed correctly on all platforms.
-        """
-        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
-        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+        @patch("os.path.exists", return_value=True)
+        def test_relative_path_with_env_var(self, _):
+            """
+            Validate that relative path with env vars are processed correctly
+            """
+            relative_include = "$INCLUDE_ENV_VAR/include.yml"
+            with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+                self.assertEqual(
+                    self._resolve_includes(relative_include),
+                    [os.path.join(os.getcwd(), "include.yml")]
+                )
+
+        @patch("os.path.exists", return_value=True)
+        def test_path_with_env_var_in_front(self, _):
+            """
+            Validate that relative path are processed correctly on all platforms.
+            """
+            include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+            with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+                self.assertEqual(
+                    self._resolve_includes(include),
+                    [os.path.join(os.getcwd(), "include.yml")]
+                )
+
+        @patch("os.path.exists", return_value=True)
+        def test_path_with_env_var_in_middle(self, _):
+            """
+            Validate that relative path are processed correctly on all platforms.
+            """
+            include = os.path.join(os.getcwd(), "$INCLUDE_ENV_VAR", "include.yml")
+            with temp_env_var(INCLUDE_ENV_VAR="includes"):
+                self.assertEqual(
+                    self._resolve_includes(include),
+                    [os.path.expandvars(include)]
+                )
+
+        @patch("os.path.exists", return_value=True)
+        def test_path_with_multi_os_path(self, _):
+            """
+            Validate that relative path are processed correctly on all platforms.
+            """
+            paths = {
+                "win32": "C:\\$test.yml",
+                "darwin": "/test.yml",
+                "linux2": "/test.yml"
+            }
+            # Make sure that we are returning the include for the current platform.
             self.assertEqual(
-                self._resolve_includes(include),
-                [os.path.join(os.getcwd(), "include.yml")]
+                self._resolve_includes(set(paths.values())), # get unique values.
+                [paths[sys.platform]] # get the value for the current platform
             )
 
-    @patch("os.path.exists", return_value=True)
-    def test_path_with_env_var_in_middle(self, _):
-        """
-        Validate that relative path are processed correctly on all platforms.
-        """
-        include = os.path.join(os.getcwd(), "$INCLUDE_ENV_VAR", "include.yml")
-        with temp_env_var(INCLUDE_ENV_VAR="includes"):
-            self.assertEqual(
-                self._resolve_includes(include),
-                [os.path.expandvars(include)]
-            )
+        @patch("os.path.exists", return_value=True)
+        def test_path_with_relative_env_var(self, _):
+            """
+            Validate that relative path are processed correctly on all platforms.
+            """
+            include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+            with temp_env_var(INCLUDE_ENV_VAR="sub_folder"):
+                self.assertEqual(
+                    self._resolve_includes(include),
+                    [os.path.join(os.getcwd(), "sub_folder", "include.yml")]
+                )
 
-    @patch("os.path.exists", return_value=True)
-    def test_path_with_multi_os_path(self, _):
-        """
-        Validate that relative path are processed correctly on all platforms.
-        """
-        paths = {
-            "win32": "C:\\$test.yml",
-            "darwin": "/test.yml",
-            "linux2": "/test.yml"
-        }
-        # Make sure that we are returning the include for the current platform.
-        self.assertEqual(
-            self._resolve_includes(set(paths.values())), # get unique values.
-            [paths[sys.platform]] # get the value for the current platform
-        )
+        def _resolve_includes(self, includes):
+            """
+            Take the tedium out of calling _get_include
+            """
+            raise NotImplementedError("TestIncludes._resolve_includes is not implemented.")
 
-    @patch("os.path.exists", return_value=True)
-    def test_path_with_relative_env_var(self, _):
-        """
-        Validate that relative path are processed correctly on all platforms.
-        """
-        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
-        with temp_env_var(INCLUDE_ENV_VAR="sub_folder"):
-            self.assertEqual(
-                self._resolve_includes(include),
-                [os.path.join(os.getcwd(), "sub_folder", "include.yml")]
-            )
+        def test_missing_file(self):
+            """
+            Makes sure an exception is raised when the include doesn't exist.
+            """
+            with self.assertRaisesRegexp(tank.TankError, "Include Resolve error"):
+                self._resolve_includes("dead/path/to/a/file")
+
+
+
+class TestTemplateIncludes(TestIncludes.Imp):
+    """
+    Tests template includes.
+    """
 
     def _resolve_includes(self, includes):
         """
-        Take the tedium out of calling _get_include
+        Resolve template includes.
         """
         if isinstance(includes, str):
             includes = [includes]
-        return _get_includes(self._file_name, {"includes": includes})
+        return get_template_includes(self._file_name, {"includes": includes})
+
+
+class TestEnvironmentIncludes(TestIncludes.Imp):
+    """
+    Tests environment includes.
+    """
+
+    def _resolve_includes(self, includes):
+        """
+        Resolve environment includes.
+        """
+        if isinstance(includes, str):
+            includes = [includes]
+        return get_environment_includes(self._file_name, {"includes": includes}, None)

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -1,0 +1,114 @@
+import os
+import sys
+
+from tank_test.tank_test_base import TankTestBase, setUpModule, temp_env_var
+from tank.template_includes import _get_includes
+from mock import patch
+
+
+class TestIncludes(TankTestBase):
+    """
+    Tests template includes.
+
+    Note that these tests will only test the code for the current platform. They
+    need to be run on other platforms to get complete coverage.
+    """
+
+    _file_name = os.path.join(os.getcwd(), "test.yml")
+    _file_dir = os.path.dirname(_file_name)
+
+    @patch("os.path.exists", return_value=True)
+    def test_env_var_only(self, _):
+        """
+        Validate that a lone environment variable will resolve on all platforms.
+        """
+        resolved_include = os.path.join(os.getcwd(), "test.yml")
+        with temp_env_var(INCLUDE_ENV_VAR=resolved_include):
+            os.environ["INCLUDE_ENV_VAR"]
+            self.assertEqual(
+                self._resolve_includes("$INCLUDE_ENV_VAR"),
+                [resolved_include]
+            )
+
+    @patch("os.path.exists", return_value=True)
+    def test_tilde(self, _):
+        """
+        Validate that a tilde will resolve on all platforms.
+        """
+        include = os.path.join("~", "test.yml")
+        resolved_include = os.path.expanduser(include)
+        self.assertEqual(
+            self._resolve_includes(include),
+            [resolved_include]
+        )
+
+    @patch("os.path.exists", return_value=True)
+    def test_relative_path(self, _):
+        """
+        Validate that relative path are processed correctly
+        """
+        relative_include = "sub_folder/include.yml"
+        self.assertEqual(
+            self._resolve_includes(relative_include),
+            [os.path.join(self._file_dir, "sub_folder", "include.yml")]
+        )
+
+    @patch("os.path.exists", return_value=True)
+    def test_relative_path_with_env_var(self, _):
+        """
+        Validate that relative path with env vars are processed correctly
+        """
+        relative_include = "$INCLUDE_ENV_VAR/include.yml"
+        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+            self.assertEqual(
+                self._resolve_includes(relative_include),
+                [os.path.join(os.getcwd(), "include.yml")]
+            )
+
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_env_var_in_front(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
+            self.assertEqual(
+                self._resolve_includes(include),
+                [os.path.join(os.getcwd(), "include.yml")]
+            )
+
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_env_var_in_middle(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join(os.getcwd(), "$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR="includes"):
+            self.assertEqual(
+                self._resolve_includes(include),
+                [os.path.expandvars(include)]
+            )
+
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_multi_os_path(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        paths = {
+            "win32": "C:\\$test.yml",
+            "darwin": "/test.yml",
+            "linux2": "/test.yml"
+        }
+        # Make sure that we are returning the include for the current platform.
+        self.assertEqual(
+            self._resolve_includes(set(paths.values())), # get unique values.
+            [paths[sys.platform]] # get the value for the current platform
+        )
+
+    def _resolve_includes(self, includes):
+        """
+        Take the tedium out of calling _get_include
+        """
+        if isinstance(includes, str):
+            includes = [includes]
+        return _get_includes(self._file_name, {"includes": includes})

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -113,7 +113,7 @@ class TestIncludes(object):
             Validate that relative path are processed correctly on all platforms.
             """
             paths = {
-                "win32": "C:\\$test.yml",
+                "win32": "C:\\test.yml",
                 "darwin": "/test.yml",
                 "linux2": "/test.yml"
             }

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -105,6 +105,18 @@ class TestIncludes(TankTestBase):
             [paths[sys.platform]] # get the value for the current platform
         )
 
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_relative_env_var(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR="sub_folder"):
+            self.assertEqual(
+                self._resolve_includes(include),
+                [os.path.join(os.getcwd(), "sub_folder", "include.yml")]
+            )
+
     def _resolve_includes(self, includes):
         """
         Take the tedium out of calling _get_include

--- a/tests/tank_test_tests/test_decorators.py
+++ b/tests/tank_test_tests/test_decorators.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import uuid
+import os
+
+from tank_test.tank_test_base import TankTestBase, setUpModule, temp_env_var
+
+
+class TestDecorators(TankTestBase):
+    """
+    Basic environment tests
+    """
+
+    def test_temp_env_var_that_didnt_exist(self):
+        """
+        Check if temp_env_var sets and restores the variable
+        """
+        # Create a unique env var and make sure it doesn't currectly exist.
+        env_var_name = "ENV_VAR_" + uuid.uuid4().hex
+        self.assertFalse(env_var_name in os.environ)
+
+        # Temporarily set the env var.
+        with temp_env_var(**{env_var_name: "test_value"}):
+            self.assertTrue(env_var_name in os.environ)
+            self.assertEquals(os.environ[env_var_name], "test_value")
+
+        # Make sure it is gone.
+        self.assertFalse(env_var_name in os.environ)
+
+    def test_temp_env_var_that_already_exist(self):
+        """
+        Check if temp_env_var sets and restores the variable
+        """
+        # Create a unique env var and make sure it doesn't currectly exist.
+        env_var_name = "ENV_VAR_" + uuid.uuid4().hex
+        self.assertFalse(env_var_name in os.environ)
+
+        # Temporarily set the env var.
+        with temp_env_var(**{env_var_name: "test_value"}):
+
+            # Make sure it is set.
+            self.assertTrue(env_var_name in os.environ)
+            self.assertEquals(os.environ[env_var_name], "test_value")
+
+            # Override the existing variable with a new one
+            with temp_env_var(**{env_var_name: "test_value_2"}):
+
+                # Make sure it was overriden
+                self.assertTrue(env_var_name in os.environ)
+                self.assertEquals(os.environ[env_var_name], "test_value_2")
+
+            # Make sure the original one was restore.
+            self.assertTrue(env_var_name in os.environ)
+            self.assertEquals(os.environ[env_var_name], "test_value")
+
+        # Make sure it is gone.
+        self.assertFalse(env_var_name in os.environ)


### PR DESCRIPTION
This branch fixes include path resolution both for template includes and environment includes using environment variables. The code has been refactored in one new location and is shared by both implementations. Previous functionality has been preserved, documented clearly and unit tested.

Also introduced was a context manager that allows to temporarily set an environment variable during unit test.