### PR TITLE
#37767 Support for substring template keys

### DIFF
--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -411,7 +411,7 @@ class StringKey(TemplateKey):
             user_initials_backwards:
                 type: str
                 subset: '([A-Z])[a-z]* ([A-Z])[a-z]*'
-                subset_format: '{1} {0}'
+                subset_format: '{1}{0}'
 
             # in code, the above expression would compress the following input:
 

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -60,16 +60,16 @@ class TemplateKey(object):
                  abstract=False, 
                  length=None):
         """
-        :param name: Key name.
+        :param str name: Name by which the key will be referred.
         :param default: Default value for this key. If the default is a callable, it will be invoked
                         without any parameters whenever a default value is required.
         :param choices: List of possible values for this key. Can be either a list or a dictionary
                         of choice:label pairs.
-        :param shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
-        :param shotgun_field_name: For keys directly linked to a shotgun field, the field name.
-        :param exclusions: List of values which are not allowed.
-        :param abstract: Boolean indicating if the value is abstract.
-        :param length: If non-None, indicating that the value should be of a fixed length.
+        :param str shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
+        :param str shotgun_field_name: For keys directly linked to a shotgun field, the field name.
+        :param list exclusions: List of forbidden values.
+        :param bool abstract: Flagging that this should be treated as an abstract key.
+        :param int length: If non-None, indicating that the value should be of a fixed length.
         """
         self._name = name
         self._default = default
@@ -296,18 +296,19 @@ class StringKey(TemplateKey):
                  subset=None,
                  subset_format=None):
         """
-        :param name: Name by which the key will be referred.
-        :param default: Default value for the key.
-        :param choices: List of possible values for this key.
-        :param filter_by: Name of filter type to limit values for string. Currently
-                          only accepted values are 'alphanumeric', 'alpha', None and a regex string.
-        :param shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
-        :param shotgun_field_name: For keys directly linked to a shotgun field, the field name.
-        :param exclusions: List of forbidden values.
-        :param abstract: Flagging that this should be treated as an abstract key.
-        :param length: Integer value indicating the length of the key.
-        :param subset: Regular expression defining a subset of the value to use.
-        :param subset_format: String to express the formatting of subset tokens.
+        :param str name: Name by which the key will be referred.
+        :param str default: Default value for the key.
+        :param choices: List of possible values for this key. Can be either a list or a dictionary
+                        of choice:label pairs.
+        :param str filter_by: Name of filter type to limit values for string. Currently
+                              only accepted values are 'alphanumeric', 'alpha', None and a regex string.
+        :param str shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
+        :param str shotgun_field_name: For keys directly linked to a shotgun field, the field name.
+        :param list exclusions: List of forbidden values.
+        :param bool abstract: Flagging that this should be treated as an abstract key.
+        :param int length: If non-None, indicating that the value should be of a fixed length.
+        :param str subset: Regular expression defining a subset of the value to use.
+        :param str subset_format: String to express the formatting of subset tokens.
         """
         self._filter_by = filter_by
 
@@ -580,7 +581,7 @@ class TimestampKey(TemplateKey):
         format_spec="%Y-%m-%d-%H-%M-%S"
     ):
         """
-        :param name: Name by which the key will be referred.
+        :param str name: Name by which the key will be referred.
         :param default: Default value for this field. Acceptable values are:
 
                         - ``None``
@@ -590,10 +591,10 @@ class TimestampKey(TemplateKey):
                         - ``now``, which means the current time in the local timezone will be used
                           as the default value.
 
-        :param format_spec: Specification for formatting when casting to/from a string.
-                            The format follows the convention of :meth:`time.strftime`. The
-                            default value is ``%Y-%m-%d-%H-%M-%S``. Given June 24th, 2015 at
-                            9:20:30 PM, this will yield ``2015-06-24-21-20-30``.
+        :param str format_spec: Specification for formatting when casting to/from a string.
+                                The format follows the convention of :meth:`time.strftime`. The
+                                default value is ``%Y-%m-%d-%H-%M-%S``. Given June 24th, 2015 at
+                                9:20:30 PM, this will yield ``2015-06-24-21-20-30``.
         """
 
         # Can't use __repr__ because of a chicken and egg problem. The base class validates the
@@ -731,20 +732,20 @@ class IntegerKey(TemplateKey):
                  length=None,
                  strict_matching=None):
         """
-        :param name: Key's name.
-        :param default: Default value for this key.
-        :param choices: List of possible values for this key.
-        :param format_spec: Specification for formatting when casting to a string.
-                            The form is a zero followed the number of spaces to pad
-                            the value.
-        :param shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
-        :param shotgun_field_name: For keys directly linked to a shotgun field, the field name.
-        :param exclusions: List of forbidden values.
-        :param abstract: Bool, should this key be treated as abstract.
-        :param length: int, should this key be fixed length
-        :param strict_matching: Bool, indicates if the padding should be matching exactly the
-                                format_spec when parsing a string. Default behavior is to match
-                                exactly the padding when a format_spec is provided.
+        :param str name: Name by which the key will be referred.
+        :param int default: Default value for this key.
+        :param list choices: List of possible values for this key.
+        :param str format_spec: Specification for formatting when casting to a string.
+                                The form is a zero followed the number of spaces to pad
+                                the value.
+        :param str shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
+        :param str shotgun_field_name: For keys directly linked to a shotgun field, the field name.
+        :param list exclusions: List of forbidden values.
+        :param bool abstract: Flagging that this should be treated as an abstract key.
+        :param int length: If non-None, indicating that the value should be of a fixed length.
+        :param bool strict_matching: Indicates if the padding should be matching exactly the
+                                     format_spec when parsing a string. Default behavior is to match
+                                     exactly the padding when a format_spec is provided.
         """
         self._zero_padded = None
         self._minimum_width = None
@@ -1005,17 +1006,16 @@ class SequenceKey(IntegerKey):
                  shotgun_field_name=None,
                  exclusions=None):
         """
-        :param name: Key's name.
-        :param default: Default value for this key.
-        :param choices: List of possible values for this key.
-        :param format_spec: Specification for formatting when casting to a string.
-                            The form is a zero followed the number of spaces to pad
-                            the value.
-        :param shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
-        :param shotgun_field_name: For keys directly linked to a shotgun field, the field name.
-        :param exclusions: List of forbidden values.
+        :param str name: Name by which the key will be referred.
+        :param str default: Default value for this key.
+        :param list choices: List of possible values for this key.
+        :param str format_spec: Specification for formatting when casting to a string.
+                                The form is a zero followed the number of spaces to pad
+                                the value.
+        :param str shotgun_entity_type: For keys directly linked to a shotgun field, the entity type.
+        :param str shotgun_field_name: For keys directly linked to a shotgun field, the field name.
+        :param str exclusions: List of forbidden values.
         """
-
         # determine the actual frame specs given the padding (format_spec)
         # and the allowed formats
         self._frame_specs = [self._resolve_frame_spec(x, format_spec) for x in self.VALID_FORMAT_STRINGS ]

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -307,7 +307,7 @@ class StringKey(TemplateKey):
         :param abstract: Flagging that this should be treated as an abstract key.
         :param length: Integer value indicating the length of the key.
         :param subset: Regular expression defining a subset of the value to use.
-        :param subset_format: String to express the order of subset tokens
+        :param subset_format: String to express the formatting of subset tokens.
         """
         self._filter_by = filter_by
 
@@ -365,7 +365,7 @@ class StringKey(TemplateKey):
         Returns a regular expression describing how values should be transformed
         when they are being injected into template paths and strings.
 
-        For format for a subset is a regular expression containing tokens,
+        The format for a subset is a regular expression containing regex groups,
         for example::
 
             # grabs capital letters of the two first words
@@ -397,8 +397,7 @@ class StringKey(TemplateKey):
     def subset_format(self):
         """
         Returns the ``subset_format`` string for the given template key. This string is used in conjunction with the
-        :meth:`subset` parameter and allows for the formatting of the values that are being extracted
-        as the subset::
+        :meth:`subset` parameter and allows for the formatting of the values that are being extracted::
 
             # grabs capital letters of the two first words
             user_initials_backwards:
@@ -439,11 +438,17 @@ class StringKey(TemplateKey):
         :param str_value: The string to translate.
         :returns: The translated value.
         """
-        # this is used by parser when transforming
+        # this is used by the parser when transforming
         # a path or string into an actual value.
         # in this case, we don't want to validate transforms
         # such as the substring regext transform, since these
         # may not be valid in both directions.
+        #
+        # for example, a regex that extracts the initials from
+        # a "Firstname Lastname" string will result in a value
+        # which will not match the regex that is used to
+        # extract it.
+        #
         if self.__validate(str_value, validate_transforms=False):
             value = self._as_value(str_value)
         else:
@@ -452,10 +457,10 @@ class StringKey(TemplateKey):
 
     def _as_string(self, value):
         """
-        Converts the given value to a string representation
+        Converts the given value to a string representation.
 
         :param value: value of any type to convert. Value is never None.
-        :return: string representation for this object.
+        :returns: string representation for this object.
         """
         str_value = value if isinstance(value, basestring) else str(value)
 
@@ -502,7 +507,7 @@ class StringKey(TemplateKey):
         Test if a value is valid for this key.
 
         :param value: Value to test
-        :param validate_transforms: If true, then validate that transforms which mutate the
+        :param validate_transforms: If true, then validate that transforms that mutate the
                                     value of a key are valid and can be applied.
         :returns: True if valid, false if not.
         """


### PR DESCRIPTION
Adds two new properties to string keys:

![image](https://cloud.githubusercontent.com/assets/337710/19724842/60c6adaa-9b7a-11e6-9c78-66f1e9ef5b45.png)

![image](https://cloud.githubusercontent.com/assets/337710/19724850/6cb99186-9b7a-11e6-8fe6-d3f731e99400.png)

More examples:

`templates.yml`

``` yaml
keys:
    initial:
        type: str
        subset: '([A-Z])[a-z]* ([A-Z])[a-z]*'
        subset_format: '{1}{0}'

strings:
    simple_test: "before_{initial}_after"
```

Code:

``` python
>>> tk.templates["simple_test"].apply_fields({"initial":"Manne Ohrstrom"})
'before_OM_after'

>>> tk.templates["simple_test"].keys["initial"].subset
'([A-Z])[a-z]* ([A-Z])[a-z]*'

>>> tk.templates["simple_test"].keys["initial"].subset_format
'{1}{0}'

>>> tk.templates["simple_test"].get_fields("before_OM_after")
{'initial': 'OM'}

>>> tk.templates["simple_test"].apply_fields({"initial":"Manne"})
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/mnt/wintermute/the_evil_mimes/install/core/python/tank/template.py", line 243, in apply_fields
    return self._apply_fields(fields, platform=platform)
  File "/mnt/wintermute/the_evil_mimes/install/core/python/tank/template.py", line 284, in _apply_fields
    processed_fields[key_name] = key.str_from_value(value, ignore_type=ignore_type)
  File "/mnt/wintermute/the_evil_mimes/install/core/python/tank/templatekey.py", line 215, in str_from_value
    raise TankError(self._last_error)
TankError: <Sgtk StringKey initial> Illegal value 'Manne' does not fit subset expression '([A-Z])[a-z]* ([A-Z])[a-z]*'
```
