### PR TITLE
For #38859, SHOTGUN_HOME support in Shotgun Desktop.

### DIFF
--- a/python/tank_vendor/shotgun_authentication/session_cache.py
+++ b/python/tank_vendor/shotgun_authentication/session_cache.py
@@ -60,7 +60,11 @@ def _get_cache_location():
 
     :returns: Path to the OS specific cache folder.
     """
-    if sys.platform == "darwin":
+    shotgun_home = os.environ.get("SHOTGUN_HOME")
+    if shotgun_home:
+        root = os.path.expanduser(os.path.expandvars(shotgun_home))
+        root = os.path.abspath(root)
+    elif sys.platform == "darwin":
         root = os.path.expanduser("~/Library/Caches/Shotgun")
     elif sys.platform == "win32":
         root = os.path.join(os.environ["APPDATA"], "Shotgun")

--- a/tests/shotgun_authentication_tests/test_session_cache.py
+++ b/tests/shotgun_authentication_tests/test_session_cache.py
@@ -9,10 +9,34 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from __future__ import with_statement
+import os
+
+import unittest2
 
 from tank_test.tank_test_base import *
 
 from tank_vendor.shotgun_authentication import session_cache
+
+
+class SessionCacheLocationTests(unittest2.TestCase):
+    """
+    Separate test for getting cache location since this method is mocked in the TankTestBase.
+    """
+    def test_get_session_cache_location(self):
+        """
+        Makes sure session cache is overidable with SHOTGUN_HOME env var and that env vars
+        and ~ are substituted.
+        """
+        old_sg_home = os.environ.get("SHOTGUN_HOME")
+        try:
+            os.environ["TK_SHOTGUN_HOME_TEST"] = "shotgun_home_test"
+            os.environ["SHOTGUN_HOME"] = "~/$TK_SHOTGUN_HOME_TEST"
+            self.assertEqual(session_cache._get_cache_location(), os.path.expanduser("~/shotgun_home_test"))
+        finally:
+            if old_sg_home is not None:
+                os.environ["SHOTGUN_HOME"] = old_sg_home
+            else:
+                del os.environ["SHOTGUN_HOME"]
 
 
 class SessionCacheTests(TankTestBase):


### PR DESCRIPTION
Session cache is now SHOTGUN_HOME aware. This will allow the desktop to fetch the session tokens from a custom folder. This will need to be integrated inside tk-framework-desktopstartup.
