### PR TITLE
#39255: Only log metrics for custom core hooks once per session

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -282,6 +282,7 @@ class MetricsDispatchWorkerThread(Thread):
             },
             "metrics": [m.data for m in metrics]
         }
+        self._engine.log_debug("Logging metrics: %s" % ([m.data for m in metrics],))
         payload_json = json.dumps(payload)
 
         header = {'Content-Type': 'application/json'}


### PR DESCRIPTION
These changes ensure custom core hook and custom core hook methods have metrics logged only once during a user's session. The `PipelineConfiguration` now has a class member that keeps track of the already logged hook and `hook.method` names.

The original plan was to add an option to the `log_metric()` calls to tell the system to only log this metric once. This would require one of 2 approaches.

1. The metrics system itself knows how to identify the metric to be logged by hashing it somehow (introspecting the data which it doesn't really know about and varies depending on the type of metric) 
2. The `log_metric()` methods would need to be supplied with a key to help identify the metric in the cache. This approach would require changing code in several places in core since we have `log_metric()` convenience methods in all the bundle types and the api. 

Either of these is doable, but a bit more work than this small, isolated change. Maybe this is sufficient for now and if we find we need to repeat this somewhere else in the code, then we back this out and revisit? I'm fine either way. Let's discuss.

Also, the custom core hook method was not respecting the blacklist so I added that in. The custom hook method also now includes the hook name and method so it can be distinguished from the old-style hook_name only calls.