### PR TITLE
#39255 Only log metrics for custom core hooks once per session

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -116,10 +116,12 @@ class Sgtk(object):
                                                                              parent=self, 
                                                                              **kwargs)
 
-    def log_metric(self, action):
+    def log_metric(self, action, log_once=False):
         """Log a core metric.
 
         :param action: Action string to log, e.g. 'Init'
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. Defaults to ``False``.
 
         Logs a user activity metric as performed within core. This is
         a convenience method that auto-populates the module portion of
@@ -130,7 +132,7 @@ class Sgtk(object):
 
         """
         full_action = "%s %s" % ('tk-core', action)
-        log_user_activity_metric('tk-core', full_action)
+        log_user_activity_metric('tk-core', full_action, log_once=log_once)
 
 
     ################################################################################################

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -903,10 +903,8 @@ class PipelineConfiguration(object):
                hook_name not in constants.TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST):
 
                 # only log once since some custom hooks can be called many times
-                parent.log_metric(
-                    "custom hook %s" % (hook_name,),
-                    log_once=True
-                )
+                action = "custom hook %s" % (hook_name,)
+                parent.log_metric(action, log_once=True)
 
         try:
             return_value = hook.execute_hook(hook_path, parent, **kwargs)
@@ -953,10 +951,8 @@ class PipelineConfiguration(object):
 
                 # only log once since some custom hooks can be called many
                 # times like cache_location.get_path_cache_path
-                parent.log_metric(
-                    "custom hook method %s" % (hook_method_display,),
-                    log_once=True
-                )
+                action = "custom hook method %s" % (hook_method_display,)
+                parent.log_metric(action, log_once=True)
 
         try:
             return_value = hook.execute_hook_method(hook_paths, parent, method_name, **kwargs)

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -901,7 +901,12 @@ class PipelineConfiguration(object):
             # some hooks are always custom. ignore those and log the rest.
             if (hasattr(parent, "log_metric") and
                hook_name not in constants.TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST):
-                parent.log_metric("custom hook %s" % (hook_name,))
+
+                # only log once since some custom hooks can be called many times
+                parent.log_metric(
+                    "custom hook %s" % (hook_name,),
+                    log_once=True
+                )
 
         try:
             return_value = hook.execute_hook(hook_path, parent, **kwargs)
@@ -934,14 +939,24 @@ class PipelineConfiguration(object):
         file_name = "%s.py" % hook_name
         hooks_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "hooks"))
         hook_paths = [os.path.join(hooks_path, file_name)]
+
+        # the hook.method display name used when logging the metric
+        hook_method_display = "%s.%s" % (hook_name, method_name)
         
         # now add a custom hook if that exists.
         hook_folder = self.get_core_hooks_location()        
         hook_path = os.path.join(hook_folder, file_name)
         if os.path.exists(hook_path):
             hook_paths.append(hook_path)
-            if hasattr(parent, 'log_metric'):
-                parent.log_metric("custom hook %s" % (hook_name,))
+            if (hasattr(parent, 'log_metric') and
+               hook_name not in constants.TANK_LOG_METRICS_CUSTOM_HOOK_BLACKLIST):
+
+                # only log once since some custom hooks can be called many
+                # times like cache_location.get_path_cache_path
+                parent.log_metric(
+                    "custom hook method %s" % (hook_method_display,),
+                    log_once=True
+                )
 
         try:
             return_value = hook.execute_hook_method(hook_paths, parent, method_name, **kwargs)

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -251,12 +251,14 @@ class Application(TankBundle):
     ##########################################################################################
     # internal API
 
-    def log_metric(self, action, log_version=False):
+    def log_metric(self, action, log_version=False, log_once=False):
         """Logs an app metric.
 
         :param action: Action string to log, e.g. 'Execute Action'
         :param log_version: If True, also log a user attribute metric for the
             version of the app. Default is `False`.
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. Defaults to ``False``.
 
         Logs a user activity metric as performed within an app. This is a
         convenience method that auto-populates the module portion of
@@ -273,11 +275,12 @@ class Application(TankBundle):
         # module: tk-multi-loader2
         # action: (tk-maya) tk-multi-loader2 - Load...
         full_action = "(%s) %s %s" % (self.engine.name, self.name, action)
-        log_user_activity_metric(self.name, full_action)
+        log_user_activity_metric(self.name, full_action, log_once=log_once)
 
         if log_version:
             # log the app version as a user attribute
-            log_user_attribute_metric("%s version" % (self.name,), self.version)
+            log_user_attribute_metric(
+                "%s version" % (self.name,), self.version, log_once=log_once)
 
 def get_application(engine, app_folder, descriptor, settings, instance_name, env):
     """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -34,7 +34,8 @@ from .errors import (
     TankEngineEventError,
 )
 
-from ..util import log_user_activity_metric, log_user_attribute_metric
+from ..util import log_user_activity_metric as util_log_user_activity_metric
+from ..util import log_user_attribute_metric as util_log_user_attribute_metric
 from ..util.metrics import MetricsDispatcher
 from ..log import LogManager
 
@@ -266,8 +267,8 @@ class Engine(TankBundle):
         self.log_metric("Init")
 
         # log the core and engine versions being used by the current user
-        log_user_attribute_metric("tk-core version", tk.version)
-        log_user_attribute_metric("%s version" % (self.name,), self.version)
+        util_log_user_attribute_metric("tk-core version", tk.version)
+        util_log_user_attribute_metric("%s version" % (self.name,), self.version)
 
         # if the engine supports logging metrics, begin dispatching logged metrics
         if self.metrics_dispatch_allowed:
@@ -465,10 +466,12 @@ class Engine(TankBundle):
             self.__global_progress_widget.close()
             self.__global_progress_widget = None
 
-    def log_metric(self, action):
+    def log_metric(self, action, log_once=False):
         """Log an engine metric.
 
         :param action: Action string to log, e.g. 'Init'
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. Defaults to ``False``.
 
         Logs a user activity metric as performed within an engine. This is
         a convenience method that auto-populates the module portion of
@@ -483,13 +486,15 @@ class Engine(TankBundle):
         # module: tk-maya
         # action: tk-maya - Init
         full_action = "%s %s" % (self.name, action)
-        log_user_activity_metric(self.name, full_action)
+        util_log_user_activity_metric(self.name, full_action, log_once=log_once)
 
-    def log_user_attribute_metric(self, attr_name, attr_value):
+    def log_user_attribute_metric(self, attr_name, attr_value, log_once=False):
         """Convenience class. Logs a user attribute metric.
 
         :param attr_name: The name of the attribute to set for the user.
         :param attr_value: The value of the attribute to set for the user.
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. Defaults to ``False``.
 
         This is a convenience wrapper around
         `tank.util.log_user_activity_metric()` that prevents engine subclasses
@@ -499,7 +504,7 @@ class Engine(TankBundle):
         will be backwards compatible.
 
         """
-        log_user_attribute_metric(attr_name, attr_value)
+        util_log_user_attribute_metric(attr_name, attr_value, log_once=log_once)
 
     def get_child_logger(self, name):
         """

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -202,10 +202,12 @@ class Framework(TankBundle):
     ##########################################################################################
     # internal API
 
-    def log_metric(self, action):
+    def log_metric(self, action, log_once=False):
         """Logs a framework metric.
 
         :param action: Action string to log, e.g. 'Execute Action'
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. Defaults to ``False``.
 
         Logs a user activity metric as performed within framework code. This is
         a convenience method that auto-populates the module portion of
@@ -219,8 +221,7 @@ class Framework(TankBundle):
         # module: tk-framework-perforce
         # action: (tk-maya) tk-framework-perforce - Connected
         full_action = "(%s) %s %s" % (self.engine.name, self.name, action)
-        log_user_activity_metric(self.name, full_action)
-
+        log_user_activity_metric(self.name, full_action, log_once=log_once)
 
 
 ###################################################################################################

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -45,6 +45,10 @@ class MetricsQueueSingleton(object):
     # keeps track of the single instance of the class
     __instance = None
 
+    # A set of log identifier strings used to check whether a metric has been
+    # logged already.
+    __logged_metrics = set()
+
     def __new__(cls, *args, **kwargs):
         """Ensures only one instance of the metrics queue exists."""
 
@@ -64,15 +68,33 @@ class MetricsQueueSingleton(object):
 
         return cls.__instance
 
-    def log(self, metric):
+    def log(self, metric, log_once=False):
         """Add the metric to the queue for dispatching.
 
-        :param ToolkitMetric metric: The metric to log.
+        If ``log_once`` is set to ``True``, this will only log the metric if it
+        is the first attempt to log it.
 
+        :param ToolkitMetric metric: The metric to log.
+        :param bool log_once: ``True`` if this metric should be ignored if it
+            has already been logged. ``False`` otherwise. Defaults to ``False``.
         """
+
+        # This assumes that supplied object's classes implement ``__repr__``
+        # to return consistent results when building objects with the same
+        # internal data. See the UserActivityMetric and UserAttributeMetric
+        # classes below.
+        metric_identifier = repr(metric)
+
+        if log_once and metric_identifier in self.__logged_metrics:
+            # the metric is already logged! nothing to do.
+            return
+
         self._lock.acquire()
         try:
             self._queue.append(metric)
+
+            # remember that we've logged this one already
+            self.__logged_metrics.add(metric_identifier)
         except:
             pass
         finally:
@@ -314,7 +336,7 @@ class ToolkitMetric(object):
         self._data = data
 
     def __str__(self):
-        """Readable representation of the metric."""
+        """Readable str representation of the metric."""
         return "%s: %s" % (self.__class__, self._data)
 
     @property
@@ -339,6 +361,10 @@ class UserActivityMetric(ToolkitMetric):
             "action": action,
         })
 
+    def __repr__(self):
+        """Official str representation of the user activity metric."""
+        return "%s.%s" % (self._data["module"], self._data["action"])
+
 
 class UserAttributeMetric(ToolkitMetric):
     """Convenience class for a user attribute metric."""
@@ -356,35 +382,42 @@ class UserAttributeMetric(ToolkitMetric):
             "attr_value": attr_value,
         })
 
+    def __repr__(self):
+        """Official str representation of the user attribute metric."""
+        return "%s.%s" % (self._data["attr_name"], self._data["attr_value"])
+
 
 ###############################################################################
 # metrics logging convenience functions
 
-def log_metric(metric):
+def log_metric(metric, log_once=False):
     """Log a Toolkit metric.
     
     :param ToolkitMetric metric: The metric to log.
+    :param bool log_once: ``True`` if this metric should be ignored if it has
+        already been logged. Defaults to ``False``.
 
     This method simply adds the metric to the dispatch queue.
-    
     """
-    MetricsQueueSingleton().log(metric)
+    MetricsQueueSingleton().log(metric, log_once=log_once)
 
-def log_user_activity_metric(module, action):
+def log_user_activity_metric(module, action, log_once=False):
     """Convenience method for logging a user activity metric.
 
     :param str module: The module the activity occured in.
     :param str action: The action the user performed.
-
+    :param bool log_once: ``True`` if this metric should be ignored if it has
+        already been logged. Defaults to ``False``.
     """
-    log_metric(UserActivityMetric(module, action))
+    log_metric(UserActivityMetric(module, action), log_once=log_once)
 
-def log_user_attribute_metric(attr_name, attr_value):
+def log_user_attribute_metric(attr_name, attr_value, log_once=False):
     """Convenience method for logging a user attribute metric.
 
     :param str attr_name: The name of the attribute.
     :param str attr_value: The value of the attribute to log.
-
+    :param bool log_once: ``True`` if this metric should be ignored if it has
+        already been logged. Defaults to ``False``.
     """
-    log_metric(UserAttributeMetric(attr_name, attr_value))
+    log_metric(UserAttributeMetric(attr_name, attr_value), log_once=log_once)
 

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -79,7 +79,7 @@ class MetricsQueueSingleton(object):
             has already been logged. ``False`` otherwise. Defaults to ``False``.
         """
 
-        # This assumes that supplied object's classes implement ``__repr__``
+        # This assumes that supplied object's classes implement __repr__
         # to return consistent results when building objects with the same
         # internal data. See the UserActivityMetric and UserAttributeMetric
         # classes below.


### PR DESCRIPTION
A more generic approach to providing a way to log a metric once per session. 

Adds a `log_once` boolean argument to all metric logging methods. The metrics queue now uses `repr` to identify metrics and keeps track of which metrics have been previously logged. When `log_once` is supplied as `True`, the metric will not be added to the queue if another metric with the same identifier was previously logged. 

Replaces PR #354.