### PR TITLE
 #38647 Fixes issue where busy dialog text is cut off

### DIFF
--- a/python/tank/platform/qt/busy_dialog.ui
+++ b/python/tank/platform/qt/busy_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>98</height>
+    <width>500</width>
+    <height>110</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/python/tank/platform/qt/ui_busy_dialog.py
+++ b/python/tank/platform/qt/ui_busy_dialog.py
@@ -11,7 +11,7 @@ from . import QtCore, QtGui
 class Ui_BusyDialog(object):
     def setupUi(self, BusyDialog):
         BusyDialog.setObjectName("BusyDialog")
-        BusyDialog.resize(418, 98)
+        BusyDialog.resize(500, 110)
         BusyDialog.setStyleSheet("/* Style for the window itself */\n"
 "#frame {\n"
 "border-color: #30A7E3;\n"


### PR DESCRIPTION
This change simply makes the busy dialog slightly larger. This seemed
preferable to making the font size smaller or trying to do anything dynamic.
I searched through all existing calls to this in our repos, and the given
case seems to be the longest message displayed. This will give us a little more
room to work with and we can do something a little smarter in the future if
need be.

Previous size:
<img width="435" alt="screen shot 2016-11-18 at 9 05 18 pm" src="https://cloud.githubusercontent.com/assets/2604646/20452218/dbe77770-add2-11e6-88a9-310f0f8de09c.png">

New size:
<img width="507" alt="screen shot 2016-11-18 at 9 00 44 pm" src="https://cloud.githubusercontent.com/assets/2604646/20452219/dc39dfe2-add2-11e6-8768-d6fb95e76c44.png">
