### PR TITLE
For 38647, fix for engines that don't have Qt available.

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1446,6 +1446,9 @@ class Engine(TankBundle):
         #
         #       ``tank/platform/qt/fonts/OpenSans/OpenSans-*.ttf``
 
+        if not self.has_ui:
+            return
+
         from sgtk.platform.qt import QtGui
 
         # if the fonts have been loaded, no need to do anything else


### PR DESCRIPTION
Engines without Qt available, like tk-shell and tk-shotgun, will crash with the new font code. I've added a check for has_ui.