### PR TITLE
#39632: Engine settings are recached during context change.

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -804,6 +804,9 @@ class Engine(TankBundle):
             old_context = self.context
             self.__env = new_env
             self._set_context(new_context)
+            self._set_settings(
+                new_env.get_engine_settings(self.__engine_instance_name),
+            )
             self.__load_apps(reuse_existing_apps=True, old_context=old_context)
 
             # Call the post_context_change method to allow for any engine

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -802,11 +802,10 @@ class Engine(TankBundle):
             # apps for the new context, and will pull apps that have already
             # been loaded from the __application_pool, which is persistent.
             old_context = self.context
+            new_engine_settings = new_env.get_engine_settings(self.__engine_instance_name)
             self.__env = new_env
             self._set_context(new_context)
-            self._set_settings(
-                new_env.get_engine_settings(self.__engine_instance_name),
-            )
+            self._set_settings(new_engine_settings)
             self.__load_apps(reuse_existing_apps=True, old_context=old_context)
 
             # Call the post_context_change method to allow for any engine


### PR DESCRIPTION
Previously, we were recaching app settings, but we were NOT doing so for engine settings. That's a bug, and this resolves it.