### PR TITLE
#39476: When there is no file system locations, hide some Jump buttons.

### DIFF
--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -313,10 +313,9 @@ class TankQDialog(TankDialogBase):
             self.ui.btn_shotgun.clicked.connect( self._on_shotgun )
             self.ui.btn_reload.clicked.connect( self._on_reload )
 
-            # When there is no file system locations, hide "Jump to File System" and "Jump to Shotgun" buttons.
+            # When there is no file system locations, hide the "Jump to File System" button.
             if not self._bundle.context.filesystem_locations:
                 self.ui.btn_file_system.setVisible(False)
-                self.ui.btn_shotgun.setVisible(False)
 
             if len(self._bundle.descriptor.configuration_schema) == 0:
                 # no configuration for this app!

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -312,7 +312,12 @@ class TankQDialog(TankDialogBase):
             self.ui.btn_file_system.clicked.connect( self._on_filesystem )
             self.ui.btn_shotgun.clicked.connect( self._on_shotgun )
             self.ui.btn_reload.clicked.connect( self._on_reload )
-            
+
+            # When there is no file system locations, hide "Jump to File System" and "Jump to Shotgun" buttons.
+            if not self._bundle.context.filesystem_locations:
+                self.ui.btn_file_system.setVisible(False)
+                self.ui.btn_shotgun.setVisible(False)
+
             if len(self._bundle.descriptor.configuration_schema) == 0:
                 # no configuration for this app!
                 self.ui.config_header.setVisible(False)


### PR DESCRIPTION
When there is no file system locations, hide `TankQDialog` _Jump to File System_ and _Jump to Shotgun_ buttons.

See the attached images with and without the buttons.

![tk_core_with_buttons](https://cloud.githubusercontent.com/assets/20173280/20814851/6c2d92ae-b7e9-11e6-8b18-65a8f72efad1.png)

![tk_core_without_buttons](https://cloud.githubusercontent.com/assets/20173280/20814859/7917cb74-b7e9-11e6-86f9-ec600e0a18ed.png)
