### PR TITLE
#30254: Adds a "minimum_version" setting to bundle framework requirements.

### DIFF
--- a/python/tank/commands/console_utils.py
+++ b/python/tank/commands/console_utils.py
@@ -79,29 +79,60 @@ def ask_yn_question(question):
 ##########################################################################################
 # displaying of info in the terminal, ascii-graphcics style
 
-def format_bundle_info(log, descriptor):
+def format_bundle_info(log, descriptor, required_updates=None):
     """
-    Formats a release notes summary output for an app, engine or core
-    """
+    Formats a release notes summary output for an app, engine or core.
 
+    :param log: A logging handle.
+    :param descriptor: The descriptor to summarize.
+    :param required_updates: A list of bundle names that require updating.
+    """
     # yay we can install! - get release notes
     (summary, url) = descriptor.changelog
+
+    if required_updates:
+        add_padding = "     "
+    else:
+        add_padding = ""
+
     if summary is None:
         summary = "No details provided."
 
-
     log.info("/%s" % ("-" * 70))
-    log.info("| Item:        %s" % descriptor)
+    log.info("| Item:        %s%s" % (add_padding, descriptor))
     log.info("|")
 
-    str_to_wrap = "Description: %s" % descriptor.description
-    for x in textwrap.wrap(str_to_wrap, width=68, initial_indent="| ", subsequent_indent="|              "):
-        log.info(x)
-    log.info("|")
+    str_to_wrap = "Description: %s%s" % (add_padding, descriptor.description)
+    description = textwrap.wrap(
+        str_to_wrap,
+        width=68,
+        initial_indent="| ",
+        subsequent_indent="|              %s" % add_padding,
+    )
 
-    str_to_wrap = "Change Log:  %s" % summary
-    for x in textwrap.wrap(str_to_wrap, width=68, initial_indent="| ", subsequent_indent="|              "):
+    for x in description:
         log.info(x)
+
+    log.info("|")
+    str_to_wrap = "Change Log:  %s%s" % (add_padding, summary)
+    change_log = textwrap.wrap(
+        str_to_wrap,
+        width=68,
+        initial_indent="| ",
+        subsequent_indent="|              %s" % add_padding,
+    )
+
+    for x in change_log:
+        log.info(x)
+
+    if required_updates:
+        log.info("|")
+        name = required_updates[0]
+        fw_str = "| Required Updates: %s" % name
+        log.info(fw_str)
+
+        for name in required_updates[1:]:
+            log.info("|                   %s" % name)
 
     log.info("\%s" % ("-" * 70))
 

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -19,7 +19,7 @@ from . import constants
 from ..errors import TankError, TankNoDefaultValueError
 from ..template import TemplateString
 from .bundle import resolve_default_value
-from ..util.version import is_version_newer, is_version_number
+from ..util.version import is_version_older, is_version_number
 from ..log import LogManager
 
 # We're potentially running here in an environment with
@@ -195,7 +195,10 @@ def validate_and_return_frameworks(descriptor, environment):
                 if min_version and fw_version and fw_version != "Undefined":
                     # If either were malformed, then we just skip the check.
                     if is_version_number(min_version) and is_version_number(fw_version):
-                        min_version_satisfied = is_version_newer(fw_version, min_version)
+                        # Example:  v1.0.1 is NOT older than v1.0.0, set to True
+                        #           v1.0.0 is NOT older than v1.0.0, set to True
+                        #           v0.9.0 IS older than v1.0.0, set to False
+                        min_version_satisfied = not is_version_older(fw_version, min_version)
                     else:
                         core_logger.warning(
                             "Not checking minimum framework version compliance "

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -145,9 +145,8 @@ def validate_and_return_frameworks(descriptor, environment):
     # check that each framework required by this app is defined in the environment
     required_fw_instance_names = []
 
-    # Framework version pattern. Groups 1, 2, and 3 correspond to
-    # major, minor, and incremental version numbers, respectively.
-    fw_version_pattern = re.compile(r"v(\d+)[.](\d+)[.](\d+)$")
+    # Framework version pattern. 
+    fw_version_pattern = re.compile(r"v(\d+[.]\d+[.]\d+)$")
 
     for fw in required_frameworks:
         # the required_frameworks structure in the info.yml
@@ -193,17 +192,16 @@ def validate_and_return_frameworks(descriptor, environment):
 
                 if min_version and fw_version:
                     # Check to make sure the version strings aren't malformed.
-                    # We expect v\d+.\d+.\d+ pattern.
+                    # We expect v\d+.\d+.\d+ pattern. Group 1 of the match will
+                    # be the version without the "v" at the head.
                     req_match = re.match(fw_version_pattern, min_version)
                     fw_match = re.match(fw_version_pattern, fw_version)
 
                     # If either were malformed, then we just have to skip the check.
                     if req_match and fw_match:
-                        sub_pat = re.compile(r"[^.\d]")
-                        min_version = re.sub(sub_pat, "", min_version)
-                        fw_version = StrictVersion(re.sub(sub_pat, "", fw_version))
+                        fw_version = StrictVersion(fw_match.group(1))
 
-                        if min_version > fw_version:
+                        if req_match.group(1) > fw_version:
                             min_version_satisfied = False
 
                 if min_version_satisfied:

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import re
+
 from distutils.version import LooseVersion
 
 def is_version_head(version):
@@ -75,3 +77,21 @@ def is_version_older(a, b):
         b = b[1:]
 
     return LooseVersion(a) < LooseVersion(b)
+
+def is_version_number(version):
+    """
+    Tests whether the given string is a properly formed
+    version number (ex: v1.2.3). The test is made using
+    the pattern r"v\d+.\d+.\d+$"
+
+    :param str version: The version string to test.
+
+    :rtype: bool
+    """
+    match = re.match(r"v\d+.\d+.\d+$", version)
+
+    if match:
+        return True
+    else:
+        return False
+

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -249,3 +249,6 @@ configuration:
 requires_shotgun_fields:
 
 required_context: [project, entity]
+
+frameworks:
+    - {"name": "test_framework", "version": "v1.x.x", "minimum_version": "v1.0.0"}

--- a/tests/fixtures/config/bundles/test_framework/framework.py
+++ b/tests/fixtures/config/bundles/test_framework/framework.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+class TestFramework(sgtk.platform.Framework):
+    
+    ##########################################################################################
+    # init and destroy
+            
+    def init_framework(self):
+        self.log_debug("%s: Initializing..." % self)
+    
+    def destroy_framework(self):
+        self.log_debug("%s: Destroying..." % self)
+    
+    

--- a/tests/fixtures/config/bundles/test_framework/info.yml
+++ b/tests/fixtures/config/bundles/test_framework/info.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# Metadata defining the behavior and requirements for this framework
+
+# expected fields in the configuration file for this engine
+configuration:
+
+# the Shotgun fields that this engine needs in order to operate correctly
+requires_shotgun_fields:
+
+# More verbose description of this item 
+display_name: "Test Framework"
+description: "A bogus test framework."
+
+# Required minimum versions for this item to run
+requires_shotgun_version:
+
+# the frameworks required to run this app
+frameworks:

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -1,6 +1,13 @@
 # this is a comment at the top of the file
 include: ./empty_config.yml
 
+frameworks:
+    test_framework_v1.x.x:
+        location:
+            type: dev
+            path: '{PIPELINE_CONFIG}/config/bundles/test_framework'
+            version: v1.0.0
+
 engines:
   # this is a comment after the engines section
     test_engine:

--- a/tests/fixtures/config/env/test_dump.yml
+++ b/tests/fixtures/config/env/test_dump.yml
@@ -1,5 +1,12 @@
 include: ./empty_config.yml
 
+frameworks:
+    test_framework_v1.x.x:
+        location:
+            type: dev
+            path: '{PIPELINE_CONFIG}/config/bundles/test_framework'
+            version: v1.0.0
+
 engines:
     test_engine:
         location: {'type': 'dev', 'path': '{PIPELINE_CONFIG}/config/bundles/test_engine'}

--- a/tests/fixtures/config/env/test_post_update_new_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_new_parser.yml
@@ -1,6 +1,13 @@
 # this is a comment at the top of the file
 include: ./empty_config.yml
 
+frameworks:
+  test_framework_v1.x.x:
+    location:
+      type: dev
+      path: '{PIPELINE_CONFIG}/config/bundles/test_framework'
+      version: v1.0.0
+
 engines:
   # this is a comment after the engines section
   test_engine:

--- a/tests/fixtures/config/env/test_post_update_old_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_old_parser.yml
@@ -59,4 +59,8 @@ engines:
           test_str: b
     debug_logging: false
     location: {path: '{PIPELINE_CONFIG}/config/bundles/test_engine', type: dev}
+frameworks:
+  test_framework_v1.x.x:
+    location: {path: '{PIPELINE_CONFIG}/config/bundles/test_framework', type: dev,
+      version: v1.0.0}
 include: ./empty_config.yml


### PR DESCRIPTION
If a bundle requires a minimum version of a specific framework, that can be specified in its `info.yml`.

```
# the frameworks required to run this app
frameworks:
    - {"name": "tk-framework-widget", "version": "v0.2.x", "minimum_version": "v0.2.3"}
```

When `tank updates` is run and a bundle is updated, an additional step is taken to ensure that any required frameworks are also updated to at least the `minimum_version` requirement specified in the bundle's `info.yml`. This update occurs automatically, and without user confirmation, to ensure that the newly-updated bundle will function properly.