### PR TITLE
#40003 Bug fix for global busy dialog

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -435,6 +435,11 @@ class Engine(TankBundle):
                     # set the message before the window is raised to avoid briefly
                     # showing default values
                     self.__global_progress_widget.set_contents(title, details)
+
+                    # if the user closes manually by clicking on the dialog,
+                    # make sure we remove the reference to it via the
+                    # clear_busy method.
+                    window.dialog_closed.connect(self.clear_busy)
                     
                     # kick it off        
                     window.show()


### PR DESCRIPTION
This change simply ensures `clear_busy()` is called if the user clicks the busy dialog while visible. Previously this didn't occur and the engine held a reference to a window that wrapped a closed busy dialog. This prevented the busy dialog from being shown again.