### PR TITLE
Fix to GAME_20144. Switching sites after credentials have expired was…

### DIFF
--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -244,7 +244,7 @@ class ShotgunAuthenticator(object):
         # Make sure we don't already have a user logged in through single
         # sign-on or provided by a DefaultsManager-derived instance.
         user = self.get_default_user()
-        if user:
+        if user and not user.are_credentials_expired():
             return user
 
         # Prompt the client for user credentials and connection information


### PR DESCRIPTION
… causing the app to exit/logout and crash, reorganized code so that credentials are checked for expiration and credentials are saved in the default user data if authenticated

These changes are related to jira ticket: https://jira.autodesk.com/browse/GAME-20144
and is an alternative and replacement for the removed code in
https://git.autodesk.com/dynamite/stingray-engine/pull/353

These changes are also related to ticket https://jira.autodesk.com/browse/GAME-19079 and its pull request https://git.autodesk.com/dynamite/stingray-engine/pull/341. This pull request is an improvement and refinement that replaces that code. It lowers the fix to check for expired credentials when requesting the logged in user from the stingray-dynamite codebase down into tk-core.