### PR TITLE
39348 Use utf-8 encoding when parsing strings from yaml

### DIFF
--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -86,3 +86,7 @@ from .hook import Hook, get_hook_baseclass
 from .commands import list_commands, get_command, SgtkSystemCommand
 
 from .templatekey import TemplateKey, SequenceKey, IntegerKey, StringKey, TimestampKey
+
+# Make sure Toolkit specific patches get applied to the yaml and
+# ruamel_yaml modules before anything else imports them.
+from .util import yaml_patcher

--- a/python/tank/util/yaml_patcher.py
+++ b/python/tank/util/yaml_patcher.py
@@ -46,10 +46,17 @@ yaml.add_constructor(
 
 # ruamel_yaml is not supported on Python 2.5 and lower.
 if not sys.version_info < (2, 6):
-    from tank_vendor import ruamel_yaml
-    # Set the utf-8 constructor as the default scalar
-    # constructor in the ruamel_yaml module
-    ruamel_yaml.add_constructor(
-        ruamel_yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
-        construct_yaml_str_as_utf8
-    )
+    try:
+        from tank_vendor import ruamel_yaml
+        # Set the utf-8 constructor as the default scalar
+        # constructor in the ruamel_yaml module
+        ruamel_yaml.add_constructor(
+            ruamel_yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
+            construct_yaml_str_as_utf8
+        )
+
+    except ImportError:
+        # This can happen with older versions (<= v1.3.20) of
+        # tk-framework-desktopstartup that do not have the ruamel_yaml
+        # module added to the local core installation.
+        pass

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -32,6 +32,11 @@ configuration:
     test_bool: 
         type: bool    
 
+    test_unicode:
+        type: str
+        description: "жå膨張ξύተጎዳلالسابق素的巨®"
+        default_value: "жå膨張ξύተጎዳلالسابق素的巨®"
+
     test_template:
         type: template
         required_fields: [name,version]

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -144,6 +144,9 @@ class TestGetSetting(TestApplication):
         # test resource
         self.assertEqual(self.test_resource, self.app.get_setting("test_icon"))
 
+        # Test unicode gets encoded correctly
+        self.assertIsInstance(self.app.get_setting("test_unicode"), str)
+
         # Test a simple list
         test_list = self.app.get_setting("test_simple_list")
         self.assertEqual(4, len(test_list))

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# Added utf-8 coding specification above for non-ascii characters 
+# that appear later in this file that were added for tests to verify 
+# the yaml parsers are using utf-8 encoding, not ascii.
+
 import os
 
 from tank.errors import TankError
@@ -305,6 +310,7 @@ class TestUpdateEnvironment(TankTestBase):
                         "test_complex_dictionary":{"test_list": {"foo":"bar"}},
                         "test_complex_list":{"foo":"bar"},
                         "test_very_complex_list":{"test_list":{"foo":"bar"}},
+                        "test_encoding": "כי膨胀ндүที่ขย™",
                         }
         
         
@@ -331,6 +337,7 @@ class TestUpdateEnvironment(TankTestBase):
         env_app_settings["location"] = new_location
         env_app_settings["foo"] = "bar"
         env_app_settings["test_simple_dictionary"]["foo"] = "bar"
+        env_app_settings["test_encoding"] = "כי膨胀ндүที่ขย™"
         for item in env_app_settings["test_complex_dictionary"]["test_list"]:
             item["foo"] = "bar"
         for item in env_app_settings["test_complex_list"]:
@@ -346,6 +353,7 @@ class TestUpdateEnvironment(TankTestBase):
         
         settings_before["foo"] = "bar"
         settings_before["test_simple_dictionary"]["foo"] = "bar"
+        settings_before["test_encoding"] = "כי膨胀ндүที่ขย™"
         for item in settings_before["test_complex_dictionary"]["test_list"]:
             item["foo"] = "bar"
         for item in settings_before["test_complex_list"]:


### PR DESCRIPTION
Use utf-8 encoding when creating Python str objects from yaml unicode to allow for the storage of non-ascii characters in environment configuration and bundle manifest yaml files. This overrides the default behavior of the yaml and ruamel_yaml modules, which use 'ascii' encoding instead.  Handle ImportError exceptions from older versions of tk-framework-desktopstartup (<= v1.3.20) that do not have the ruamel_yaml module installed.
