### PR TITLE
For #40152, adds legacy pipeline configuration support in bootstrap

### DIFF
--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -31,6 +31,13 @@ class Configuration(object):
         """
         self._path = path
 
+    @property
+    def path(self):
+        """
+        Path to the pipeline configuration.
+        """
+        return self._path
+
     def status(self):
         """
         Compares the actual configuration installed on disk against the

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -31,13 +31,6 @@ class Configuration(object):
         """
         self._path = path
 
-    @property
-    def path(self):
-        """
-        Path to the pipeline configuration.
-        """
-        return self._path
-
     def status(self):
         """
         Compares the actual configuration installed on disk against the

--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -62,6 +62,10 @@ DESKTOP_PYTHON_LINUX = "/opt/Shotgun/Python/bin/python"
 BAKED_DESCRIPTOR_TYPE = "baked"
 BAKED_DESCRIPTOR_FOLDER_NAME = "baked"
 
+# Name fo the special installed descriptor that is used for Toolkit Classic
+# based pipeline configurations.
+INSTALLED_DESCRIPTOR_TYPE = "installed"
+
 # environment variable that can be used to override the
 # configuration loaded when a bootstrap/plugin is starting up.
 CONFIG_OVERRIDE_ENV_VAR = "TK_BOOTSTRAP_CONFIG_OVERRIDE"

--- a/python/tank/bootstrap/installed_configuration.py
+++ b/python/tank/bootstrap/installed_configuration.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from .configuration import Configuration
+
+from .. import LogManager
+
+log = LogManager.get_logger(__name__)
+
+
+class InstalledConfiguration(Configuration):
+    """
+    Represents a Toolkit pipeline configuration that is installed at a specific location via the
+    ``mac_path``, ``linux_path`` and ``windows_path`` fields.
+    """
+
+    def __init__(self, path):
+        """
+        :param path: ShotgunPath object describing the path to this configuration
+        """
+        super(InstalledConfiguration, self).__init__(path)
+
+    def __str__(self):
+        """
+        User friendly representation of the configuration.
+        """
+        return "Installed Configuration at %s" % (self._path.current_os,)
+
+    def __repr__(self):
+        """
+        Low level representation of the configuration.
+        """
+        return "<%s>" % str(self)
+
+    def status(self):
+        """
+        Installed configurations are always up-to-date.
+
+        :returns: LOCAL_CFG_UP_TO_DATE
+        """
+        log.debug("%s is always up to date:" % self)
+
+        return self.LOCAL_CFG_UP_TO_DATE
+
+    def update_configuration(self):
+        """
+        No need to update anything, as this configuration type is always up-to-date.
+        """
+        pass

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -90,6 +90,9 @@ class ConfigurationResolver(object):
             if not os.path.exists(config_path):
                 raise TankBootstrapError("Cannot locate legacy pipeline configuration at '%s'!" % (config_path,))
 
+            # Convert into a ShotgunPath.
+            config_path = ShotgunPath.from_current_os_path(config_path)
+
             return InstalledConfiguration(config_path)
 
         elif config_descriptor["type"] == constants.BAKED_DESCRIPTOR_TYPE:

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -21,6 +21,7 @@ from ..descriptor import Descriptor, create_descriptor, descriptor_uri_to_dict
 from .errors import TankBootstrapError
 from .baked_configuration import BakedConfiguration
 from .cached_configuration import CachedConfiguration
+from .installed_configuration import InstalledConfiguration
 from ..util import filesystem
 from ..util import ShotgunPath
 from ..util import LocalFileStorageManager
@@ -84,7 +85,14 @@ class ConfigurationResolver(object):
             # convert to dict so we can introspect
             config_descriptor = descriptor_uri_to_dict(config_descriptor)
 
-        if config_descriptor["type"] == constants.BAKED_DESCRIPTOR_TYPE:
+        if config_descriptor["type"] == constants.INSTALLED_DESCRIPTOR_TYPE:
+            config_path = config_descriptor["path"]
+            if not os.path.exists(config_path):
+                raise TankBootstrapError("Cannot locate legacy pipeline configuration at '%s'!" % (config_path,))
+
+            return InstalledConfiguration(config_path)
+
+        elif config_descriptor["type"] == constants.BAKED_DESCRIPTOR_TYPE:
 
             # special case -- this is a full configuration scaffold that
             # has been pre-baked and can be used directly at runtime
@@ -382,9 +390,17 @@ class ConfigurationResolver(object):
             path = ShotgunPath.from_shotgun_dict(pipeline_config)
 
             if path.current_os:
+                # Emit a warning when both the OS field and descriptor field is set.
+                if pipeline_config.get("descriptor") or pipeline_config.get("sg_descriptor"):
+                    log.warning("Fields for path based and descriptor based pipeline configuration are both set. Using path based field.")
+
                 log.debug("Descriptor will be based off the path in the pipeline configuration")
-                descriptor = {"type": "path", "path": path.current_os}
+                descriptor = {"type": constants.INSTALLED_DESCRIPTOR_TYPE, "path": path.current_os}
             elif pipeline_config.get("descriptor"):
+                # Emit a warning when the sg_descriptor is set as well.
+                if pipeline_config.get("sg_descriptor"):
+                    log.warning("Both sg_descriptor and descriptor fields are set. Using descriptor field.")
+
                 log.debug("Descriptor will be based off the descriptor field in the pipeline configuration")
                 descriptor = pipeline_config.get("descriptor")
             elif pipeline_config.get("sg_descriptor"):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -9,13 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import mock
 from mock import patch
-import tempfile
-import uuid
 import sgtk
 
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import setUpModule, TankTestBase # noqa
 
 
 class TestResolver(TankTestBase):
@@ -123,7 +120,6 @@ class TestResolver(TankTestBase):
         # make sure we didn't talk to shotgun
         self.assertFalse(find_mock.called)
 
-
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_auto_resolve_query(self, find_mock):
         """
@@ -131,8 +127,6 @@ class TestResolver(TankTestBase):
         """
 
         def find_mock_impl(*args, **kwargs):
-
-
             # expect the following:
             # args:
             # ('PipelineConfiguration',
@@ -165,7 +159,6 @@ class TestResolver(TankTestBase):
         )
 
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_specific_resolve_query(self, find_mock):
@@ -208,7 +201,6 @@ class TestResolver(TankTestBase):
         )
 
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_auto_resolve_primary(self, find_mock):
@@ -284,8 +276,6 @@ class TestResolver(TankTestBase):
 
         self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
 
-
-
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_site_override(self, find_mock):
         """
@@ -328,7 +318,6 @@ class TestResolver(TankTestBase):
         )
 
         self.assertEqual(config._descriptor.get_dict(), {'path': 'pr_path', 'type': 'path'})
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_site_override_2(self, find_mock):
@@ -375,7 +364,6 @@ class TestResolver(TankTestBase):
         )
 
         self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_specific_resolve(self, find_mock):
@@ -438,7 +426,6 @@ class TestResolver(TankTestBase):
         )
 
         self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_pc_descriptor(self, find_mock):
@@ -509,8 +496,6 @@ class TestResolver(TankTestBase):
         )
 
 
-
-
 class TestResolverSiteConfig(TestResolver):
     """
     All Test Resoolver tests, just with the site config instead of a project config
@@ -526,7 +511,6 @@ class TestResolverSiteConfig(TestResolver):
             project_id=None,
             bundle_cache_fallback_paths=[self.install_root]
         )
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_auto_resolve_query(self, find_mock):
@@ -560,7 +544,6 @@ class TestResolverSiteConfig(TestResolver):
 
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
 
-
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_specific_resolve_query(self, find_mock):
         """
@@ -592,7 +575,6 @@ class TestResolverSiteConfig(TestResolver):
         )
 
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
-
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_site_override(self, find_mock):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -597,7 +597,7 @@ class TestResolverSiteConfig(TestResolver):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_site_override(self, find_mock):
         """
-        When a user config is specified, this takes precedence over primary
+        When multiple primaries match, the latest one is picked.
         """
 
         def find_mock_impl(*args, **kwargs):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -203,7 +203,8 @@ class TestResolver(TankTestBase):
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_auto_resolve_primary(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_auto_resolve_primary(self, _, find_mock):
         """
         Resolve the primrary config when no configuration name is specified.
         """
@@ -231,10 +232,11 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_auto_resolve_user(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_auto_resolve_user(self, _, find_mock):
         """
         When a user config is specified, this takes precedence over primary
         """
@@ -274,10 +276,11 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_site_override(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_site_override(self, _, find_mock):
         """
         if both a site and a project config matches, the project config takes precedence
         """
@@ -317,10 +320,11 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'pr_path', 'type': 'path'})
+        self.assertEqual(config.path, 'pr_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_site_override_2(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_site_override_2(self, _, find_mock):
         """
         Picks the sandbox with the right plugin id.
         """
@@ -363,10 +367,11 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_specific_resolve(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_specific_resolve(self, _, find_mock):
         """
         Resolve the sandbox if no primary is present.
         """
@@ -394,10 +399,11 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_path_override(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_path_override(self, _, find_mock):
         """
         If pipeline config paths are defined, these take precedence over the descriptor field.
         """
@@ -425,7 +431,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_pc_descriptor(self, find_mock):
@@ -577,7 +583,8 @@ class TestResolverSiteConfig(TestResolver):
         self.assertEqual(config._descriptor.get_dict(), self.config_1)
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
-    def test_site_override(self, find_mock):
+    @patch("os.path.exists", return_value=True)
+    def test_site_override(self, _, find_mock):
         """
         When multiple primaries match, the latest one is picked.
         """
@@ -617,4 +624,4 @@ class TestResolverSiteConfig(TestResolver):
             current_login='john.smith'
         )
 
-        self.assertEqual(config._descriptor.get_dict(), {'path': 'sg_path', 'type': 'path'})
+        self.assertEqual(config.path, 'sg_path')

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -213,7 +213,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_auto_resolve_primary(self, find_mock):
         """
-        Resolve the right config to use in Shotgun when no pc is defined
+        Resolve the primrary config when no configuration name is specified.
         """
 
         def find_mock_impl(*args, **kwargs):
@@ -333,7 +333,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_site_override_2(self, find_mock):
         """
-        For a project, when a site is returned, this is still a relevant resolve solution
+        Picks the sandbox with the right plugin id.
         """
 
         def find_mock_impl(*args, **kwargs):
@@ -357,9 +357,9 @@ class TestResolver(TankTestBase):
                 'project': None,
                 'plugin_ids': "not matching plugin ids",
                 'sg_plugin_ids': None,
-                'windows_path': 'sg_path',
-                'linux_path': 'sg_path',
-                'mac_path': 'sg_path',
+                'windows_path': 'nm_path',
+                'linux_path': 'nm_path',
+                'mac_path': 'nm_path',
                 'sg_descriptor': None,
                 'descriptor': None
             }
@@ -380,7 +380,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_specific_resolve(self, find_mock):
         """
-        Resolve the right config to use in Shotgun when no pc is defined
+        Resolve the sandbox if no primary is present.
         """
 
         def find_mock_impl(*args, **kwargs):
@@ -411,7 +411,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_path_override(self, find_mock):
         """
-        If pipeline config paths are defined, these take precedence
+        If pipeline config paths are defined, these take precedence over the descriptor field.
         """
 
         def find_mock_impl(*args, **kwargs):
@@ -443,7 +443,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_pc_descriptor(self, find_mock):
         """
-        If pipeline config paths are defined, these take precedence
+        Descriptor field is used when set.
         """
 
         def find_mock_impl(*args, **kwargs):
@@ -477,7 +477,7 @@ class TestResolver(TankTestBase):
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_plugin_ids(self, find_mock):
         """
-        If pipeline config paths are defined, these take precedence
+        If no plugin id match, use the fallback.
         """
 
         def find_mock_impl(*args, **kwargs):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -232,7 +232,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)
@@ -276,7 +276,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)
@@ -320,7 +320,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'pr_path')
+        self.assertEqual(config._path.current_os, 'pr_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)
@@ -367,7 +367,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)
@@ -399,7 +399,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)
@@ -431,7 +431,7 @@ class TestResolver(TankTestBase):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_pc_descriptor(self, find_mock):
@@ -624,7 +624,7 @@ class TestResolverSiteConfig(TestResolver):
             current_login='john.smith'
         )
 
-        self.assertEqual(config.path, 'sg_path')
+        self.assertEqual(config._path.current_os, 'sg_path')
 
     @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     @patch("os.path.exists", return_value=True)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -32,6 +32,11 @@ sys.path = [python_path] + sys.path
 
 import unittest2 as unittest
 
+import tank
+
+tank.LogManager().initialize_base_file_handler("run_tests")
+
+
 class TankTestRunner(object):
     
     def __init__(self, test_root=None):


### PR DESCRIPTION
Fixes a bug where hardcoding a path in a pipeline configuration meant to indicate where the cached configuration was located. It should have pointed to an already installed configuration.

Note that PR #373 should be reviewed and merged prior to this PR in order to reduce the amount of noise in the unit tests.