### PR TITLE
#37237: Support OS http proxy fallback for Shotgun proxy and App Store proxy.

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -88,7 +88,7 @@ following order:
     - Linux: ``~/shotgun/desktop/config/config.ini``
 
 .. note::
-    When ``http_proxy`` or ``app_store_http_proxy`` are not specified in this file,
+    When ``http_proxy`` or ``app_store_http_proxy`` are not present in this file,
     the Shotgun Toolkit will try to retrieve the operating system http proxy.
 
     First, the environment will be scanned for variables named ``http_proxy``, in case insensitive way.

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -50,8 +50,9 @@ Here's an example:
 
         # If specified, the Toolkit will use these proxy settings to connect to
         # the Shotgun site and the Toolkit App Store. The proxy string should be of the
-        # forms 123.123.123.123, 123.123.123.123:8888 or
-        # username:pass@123.123.123.123:8888.
+        # forms 123.123.123.123, 123.123.123.123:8888 or username:pass@123.123.123.123:8888.
+        # If the setting is present in the file but not set, then no proxy will be used
+        # to connect to the Shotgun site and the Toolkit App Store.
         # Empty by default.
         #
         http_proxy=123.234.345.456:8888
@@ -87,8 +88,8 @@ following order:
     - Linux: ``~/shotgun/desktop/config/config.ini``
 
 .. note::
-    When the http proxy is not specified in this file, the Shotgun Toolkit will try to retrieve
-    the operating system http proxy.
+    When ``http_proxy`` or ``app_store_http_proxy`` are not specified in this file,
+    the Shotgun Toolkit will try to retrieve the operating system http proxy.
 
     First, the environment will be scanned for variables named ``http_proxy``, in case insensitive way.
     If both lowercase and uppercase environment variables exist (and disagree), lowercase will be preferred.

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -78,8 +78,10 @@ class UserSettingsTests(unittest.TestCase):
         settings = UserSettings()
         self.assertIsNone(settings.default_site)
         self.assertIsNone(settings.default_login)
+        self.assertFalse(settings.is_shotgun_proxy_set())
         self.assertIsNone(settings.shotgun_proxy)
         self.assertFalse(settings.is_app_store_proxy_set())
+        self.assertIsNone(settings.app_store_proxy)
 
     @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
         "default_site": "site",
@@ -94,6 +96,7 @@ class UserSettingsTests(unittest.TestCase):
         settings = UserSettings()
         self.assertEqual(settings.default_site, "site")
         self.assertEqual(settings.default_login, "login")
+        self.assertTrue(settings.is_shotgun_proxy_set())
         self.assertEqual(settings.shotgun_proxy, "http_proxy")
         self.assertTrue(settings.is_app_store_proxy_set())
         self.assertEqual(settings.app_store_proxy, "app_store_http_proxy")
@@ -107,17 +110,23 @@ class UserSettingsTests(unittest.TestCase):
 
         with patch.dict(os.environ, {"http_proxy": "http://" + http_proxy}):
             settings = UserSettings()
+            self.assertFalse(settings.is_shotgun_proxy_set())
             self.assertEqual(settings.shotgun_proxy, http_proxy)
+            self.assertFalse(settings.is_app_store_proxy_set())
+            self.assertEqual(settings.app_store_proxy, http_proxy)
 
     @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
         # Config parser represent empty settings as empty strings
+        "http_proxy": "",
         "app_store_http_proxy": ""
     }))
-    def test_app_store_to_none(self, mock):
+    def test_proxy_to_none(self, mock):
         """
-        Tests a file with a present but empty app store proxy setting.
+        Tests a file with present but empty Shotgun proxy and app store proxy settings.
         """
         settings = UserSettings()
+        self.assertTrue(settings.is_shotgun_proxy_set())
+        self.assertEqual(settings.shotgun_proxy, None)
         self.assertTrue(settings.is_app_store_proxy_set())
         self.assertEqual(settings.app_store_proxy, None)
 


### PR DESCRIPTION
For `http_proxy` and `app_store_http_proxy`:

- When present in the user settings file, but empty, do not specify an http proxy.
- When not present in the user settings file, fall back on the operating system http proxy.
