### PR TITLE
For #39874, missing app store key handling

### DIFF
--- a/python/tank/descriptor/__init__.py
+++ b/python/tank/descriptor/__init__.py
@@ -16,7 +16,7 @@ from .descriptor_core import CoreDescriptor
 from .descriptor_bundle import AppDescriptor, FrameworkDescriptor, EngineDescriptor
 from .descriptor_config import ConfigDescriptor
 
-from .errors import TankAppStoreConnectionError, TankAppStoreError, TankDescriptorError
+from .errors import TankAppStoreConnectionError, TankAppStoreError, TankDescriptorError, InvalidAppStoreCredentialsError
 
 from .descriptor import create_descriptor
 from .io_descriptor import descriptor_dict_to_uri, descriptor_uri_to_dict

--- a/python/tank/descriptor/errors.py
+++ b/python/tank/descriptor/errors.py
@@ -14,11 +14,13 @@ All custom exceptions that this module emits are defined here.
 
 from ..errors import TankError
 
+
 class TankDescriptorError(TankError):
     """
     Base class for all descriptor related errors.
     """
     pass
+
 
 class TankAppStoreError(TankDescriptorError):
     """
@@ -26,8 +28,15 @@ class TankAppStoreError(TankDescriptorError):
     """
     pass
 
+
 class TankAppStoreConnectionError(TankAppStoreError):
     """
     Errors indicating an error connecting to the Toolkit App Store.
     """
     pass
+
+
+class InvalidAppStoreCredentialsError(TankAppStoreConnectionError):
+    """
+    Error indicating no credentials for the Toolkit App Store were found in Shotgun.
+    """

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -27,10 +27,13 @@ from ..descriptor import Descriptor
 from ..errors import TankAppStoreConnectionError
 from ..errors import TankAppStoreError
 from ..errors import TankDescriptorError
+from ..errors import InvalidAppStoreCredentialsError
 
 from ... import LogManager
 from .. import constants
 from .base import IODescriptorBase
+
+from ...constants import SUPPORT_EMAIL
 
 # use api json to cover py 2.5
 from tank_vendor import shotgun_api3
@@ -685,6 +688,11 @@ class IODescriptorAppStore(IODescriptorBase):
                     filters=[["firstname", "is", script_name]],
                     fields=["type", "id"]
                 )
+            except shotgun_api3.AuthenticationFault:
+                raise InvalidAppStoreCredentialsError(
+                    "The Toolkit App Store credentials found in Shotgun are invalid.\n"
+                    "Please contact %s to resolve this issue." % SUPPORT_EMAIL
+                )
             # Connection errors can occur for a variety of reasons. For example, there is no
             # internet access or there is a proxy server blocking access to the Toolkit app store.
             except (httplib2.HttpLib2Error, httplib2.socks.HTTPError, httplib.HTTPException), e:
@@ -768,6 +776,12 @@ class IODescriptorAppStore(IODescriptorBase):
         html = response.read()
         data = json.loads(html)
 
+        if not data["script_name"] or not data["script_key"]:
+            raise InvalidAppStoreCredentialsError(
+                "Toolkit App Store credentials could not be retrieved from Shotgun.\n"
+                "Please contact %s to resolve this issue." % SUPPORT_EMAIL
+            )
+
         log.debug("Retrieved app store credentials for account '%s'." % data["script_name"])
 
         return data["script_name"], data["script_key"]
@@ -788,6 +802,9 @@ class IODescriptorAppStore(IODescriptorBase):
             # connect to the app store
             (sg, _) = self.__create_sg_app_store_connection()
             log.debug("...connection established: %s" % sg)
+        except InvalidAppStoreCredentialsError:
+            # Let this one bubble up, there's something wrong going on with the appstore credentials
+            raise
         except Exception, e:
             log.debug("...could not establish connection: %s" % e)
             can_connect = False

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -735,10 +735,7 @@ class IODescriptorAppStore(IODescriptorBase):
         try:
             config_data = shotgun.get_associated_sg_config_data()
         except UnresolvableCoreConfigurationError:
-            # This core is not part of a pipeline configuration, we're probably bootstrapping,
-            # so skip the check and simply return the regular proxy settings.
-            log.debug("No core configuration was found, using the current connection's proxy setting.")
-            return self._sg_connection.config.raw_http_proxy
+            config_data = None
 
         if config_data and constants.APP_STORE_HTTP_PROXY in config_data:
             return config_data[constants.APP_STORE_HTTP_PROXY]


### PR DESCRIPTION
Core now reports correctly when app store credentials are invalid or incomplete.