### PR TITLE
#40596 fixed bug with register publish not handling urls with spaces

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -19,6 +19,7 @@ import sys
 import uuid
 import urllib2
 import urlparse
+import urllib
 import pprint
 import time
 import threading
@@ -1161,7 +1162,9 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
 
     # handle the path definition
     if path_is_url:
-        data["path"] = {"url": path}
+        # for quoting logic, see bugfix here:
+        # http://svn.python.org/view/python/trunk/Lib/urllib.py?r1=71780&r2=71779&pathrev=71780
+        data["path"] = {"url": urllib.quote(path, safe="%/:=&?~#+!$,;'@()*[]")}
     else:
 
         # Make path platform agnostic.

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -1164,6 +1164,9 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     if path_is_url:
         # for quoting logic, see bugfix here:
         # http://svn.python.org/view/python/trunk/Lib/urllib.py?r1=71780&r2=71779&pathrev=71780
+        #
+        # note: by appling a safe pattern like this, we guarantee that already quoted paths
+        #       are not touched, e.g. quote('foo bar') == quote('foo%20bar')
         data["path"] = {"url": urllib.quote(path, safe="%/:=&?~#+!$,;'@()*[]")}
     else:
 

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -15,7 +15,7 @@ import threading
 import urlparse
 import unittest2 as unittest
 
-from mock import patch
+from mock import patch, call
 
 import tank
 from tank import context, errors
@@ -367,6 +367,24 @@ class TestShotgunRegisterPublish(TankTestBase):
 
         self.assertEqual(expected_path, actual_path)
         self.assertEqual(expected_path_cache, actual_path_cache)
+
+    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    def test_url_paths(self, create_mock):
+        """Tests the passing of urls via the path."""
+
+        tank.util.register_publish(
+            self.tk,
+            self.context,
+            "file:///path/to/file with spaces.png",
+            self.name,
+            self.version)
+
+        create_data = create_mock.call_args
+        args, kwargs = create_data
+        sg_dict = args[1]
+
+        self.assertEqual(sg_dict["path"], {'url': 'file:///path/to/file%20with%20spaces.png'})
+        self.assertEqual("pathcache" not in sg_dict, True)
 
 
 class TestShotgunDownloadUrl(TankTestBase):


### PR DESCRIPTION
Register publish now quotes urls, as required by the sg server.

Note: this solution does not transform already transformed strings, so should be safe to deploy even to scenarios where this bug has been worked around outside of core, e.g.

```python 
>>> path = "foo bar"
>>> urllib.quote(path, safe="%/:=&?~#+!$,;'@()*[]")
'foo%20bar'
>>> urllib.quote('foo%20bar', safe="%/:=&?~#+!$,;'@()*[]")
'foo%20bar'
```