### PR TITLE
#40630 adds file url support to hook.get_publish_path()

### DIFF
--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -16,6 +16,7 @@ import os
 import sys
 import logging
 import threading
+import urllib
 from .util.loader import load_plugin
 from . import LogManager
 from .errors import (
@@ -246,10 +247,22 @@ class Hook(object):
                                 "not contain a valid path definition" % sg_data)
 
             local_path = path_field.get("local_path")
-            if local_path is None:
+            url = path_field.get("url")
+            if local_path:
+                paths.append(local_path)
+
+            elif url and url.startswith("file://"):
+                # this is a url pointing at a local file
+                # strip off the file:// part
+                paths.append(
+                    urllib.unquote(
+                        url[len("file://"):]
+                    )
+                )
+
+            else:
                 raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
                                 "not contain a valid path definition" % sg_data)
-            paths.append(local_path)
 
         return paths
 

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -15,6 +15,7 @@ Defines the base class for all Tank Hooks.
 import os
 import sys
 import logging
+import urlparse
 import threading
 import urllib
 from .util.loader import load_plugin
@@ -242,27 +243,42 @@ class Hook(object):
         paths = []
         for sg_data in sg_publish_data_list:
             path_field = sg_data.get("path")
+
             if path_field is None:
                 raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
                                 "not contain a valid path definition" % sg_data)
 
-            local_path = path_field.get("local_path")
-            url = path_field.get("url")
-            if local_path:
-                paths.append(local_path)
+            resolved_path = None
 
-            elif url and url.startswith("file://"):
-                # this is a url pointing at a local file
-                # strip off the file:// part
-                paths.append(
-                    urllib.unquote(
-                        url[len("file://"):]
-                    )
+            if "local_path" in path_field:
+                # first, look for a local file link
+                resolved_path = path_field["local_path"]
+
+            elif "url" in path_field:
+                # secondly, look for a file:// style url
+
+                url = path_field["url"]
+                # url = "file:///path/to/some/file.txt"
+                results = urlparse.urlparse(url)
+                # ParseResult(
+                # scheme='file',
+                # netloc='',
+                # path='/path/to/some/file.txt',
+                # params='',
+                # query='',
+                # fragment=''
+                # )
+
+                if results.scheme == "file":
+                    resolved_path = urllib.unquote(results.path)
+
+            if resolved_path is None:
+                raise TankError(
+                    "Cannot resolve path from publish! The shotgun dictionary %s does "
+                    "not contain a valid path definition" % sg_data
                 )
-
             else:
-                raise TankError("Cannot resolve path from publish! The shotgun dictionary %s does "
-                                "not contain a valid path definition" % sg_data)
+                paths.append(resolved_path)
 
         return paths
 

--- a/tests/core_tests/test_hook.py
+++ b/tests/core_tests/test_hook.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank_test.tank_test_base import *
+
+import sgtk
+
+class TestHookGetPublishPath(TankTestBase):
+    
+    def test_get_publish_path_url(self):
+        """
+        Tests the hook.get_publish_path method
+        """
+        hook = sgtk.Hook(parent=None)
+
+        sg_dict = {
+            "code": "foo",
+            "path": {"url": "file:///foo%20/bar.baz"}
+        }
+
+        self.assertEqual(hook.get_publish_path(sg_dict), "/foo /bar.baz")
+
+        self.assertEqual(
+            hook.get_publish_paths([sg_dict, sg_dict]),
+            ["/foo /bar.baz", "/foo /bar.baz"]
+        )
+
+
+    def test_get_publish_path_raises(self):
+        """
+        Tests the hook.get_publish_path method
+        """
+        hook = sgtk.Hook(parent=None)
+
+        sg_dict = {
+            "code": "foo",
+        }
+
+        self.assertRaises(sgtk.TankError, hook.get_publish_path, sg_dict)
+        self.assertRaises(sgtk.TankError, hook.get_publish_paths, [sg_dict, sg_dict])
+
+        sg_dict = {
+            "code": "foo",
+            "path": {"url": "https://www.foo.bar"}
+        }
+
+        self.assertRaises(sgtk.TankError, hook.get_publish_path, sg_dict)
+        self.assertRaises(sgtk.TankError, hook.get_publish_paths, [sg_dict, sg_dict])
+
+        sg_dict = {
+            "code": "foo",
+            "path": {"other_field": "stuff"}
+        }
+
+        self.assertRaises(sgtk.TankError, hook.get_publish_path, sg_dict)
+        self.assertRaises(sgtk.TankError, hook.get_publish_paths, [sg_dict, sg_dict])
+
+    def test_get_publish_path_local_file_link(self):
+        """
+        Tests the hook.get_publish_path method
+        """
+        hook = sgtk.Hook(parent=None)
+
+        sg_dict = {
+            "code": "foo",
+            "path": {"local_path": "/local/path/to/file.ext"}
+        }
+
+        self.assertEqual(
+            hook.get_publish_path(sg_dict),
+            "/local/path/to/file.ext"
+        )
+
+        self.assertEqual(
+            hook.get_publish_paths([sg_dict, sg_dict]),
+            ["/local/path/to/file.ext", "/local/path/to/file.ext"]
+        )


### PR DESCRIPTION
This adds url support to `hook.get_publish_path()` and `hook.get_publish_paths()`. Practically speaking, this means that we can now publish items with a `file:///path` style url (rather than relying on local storage based paths) and then recall them via the loader later on.