### PR TITLE
Skips problematic paths when finding dependent publishes.

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -18,7 +18,7 @@ import glob
 from . import folder
 from . import context
 from .util import shotgun, yaml_cache
-from .errors import TankError
+from .errors import TankError, TankMultipleMatchingTemplatesError
 from .path_cache import PathCache
 from .template import read_templates
 from . import constants
@@ -342,7 +342,7 @@ class Sgtk(object):
             msg += "The overlapping templates are:\n"
             for fields, template in zip(matched_fields, matched_templates):
                 msg += "%s\n%s\n" % (template, fields)
-            raise TankError(msg)
+            raise TankMultipleMatchingTemplatesError(msg)
 
     def paths_from_template(self, template, fields, skip_keys=None, skip_missing_optional_keys=False):
         """

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -63,3 +63,9 @@ class TankContextDeserializationError(TankError):
     Exception that indicates that something went wrong while deserializating a context.
     """
 
+
+class TankMultipleMatchingTemplatesError(TankError):
+    """
+    Exception that indicates that a path matches multiple templates.
+    """
+

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -763,7 +763,13 @@ def _group_by_storage(tk, list_of_paths):
     for path in list_of_paths:
 
         # use abstracted path if path is part of a sequence
-        abstract_path = _translate_abstract_fields(tk, path)
+        try:
+            abstract_path = _translate_abstract_fields(tk, path)
+        except TankError:
+            # This will happen if the path isn't valid due to a lack of
+            # clearly-matched template. In that case we skip it.
+            continue
+
         root_name, dep_path_cache = _calc_path_cache(tk, abstract_path)
 
         # make sure that the path is even remotely valid, otherwise skip

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -29,7 +29,7 @@ import tempfile
 from tank_vendor import shotgun_api3
 
 from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
-from ..errors import TankError
+from ..errors import TankError, TankMultipleMatchingTemplatesError
 from ..log import LogManager
 from .. import hook
 from . import constants
@@ -763,13 +763,7 @@ def _group_by_storage(tk, list_of_paths):
     for path in list_of_paths:
 
         # use abstracted path if path is part of a sequence
-        try:
-            abstract_path = _translate_abstract_fields(tk, path)
-        except TankError:
-            # This will happen if the path isn't valid due to a lack of
-            # clearly-matched template. In that case we skip it.
-            continue
-
+        abstract_path = _translate_abstract_fields(tk, path)
         root_name, dep_path_cache = _calc_path_cache(tk, abstract_path)
 
         # make sure that the path is even remotely valid, otherwise skip
@@ -1024,17 +1018,26 @@ def _translate_abstract_fields(tk, path):
     For example, the path /foo/bar/xyz.0003.exr will be transformed into
     /foo/bar/xyz.%04d.exr
     """
-    template = tk.template_from_path(path)
-    if template:
+    try:
+        template = tk.template_from_path(path)
+    except TankMultipleMatchingTemplatesError:
+        log.debug(
+            "Path matches multiple templates. Not translating abstract fields: %s" % path
+        )
+    else:
+        if template:
+            abstract_key_names = [k.name for k in template.keys.values() if k.is_abstract]
 
-        abstract_key_names = [k.name for k in template.keys.values() if k.is_abstract]
-
-        if len(abstract_key_names) > 0:
-            # we want to use the default values for abstract keys
-            cur_fields = template.get_fields(path)
-            for abstract_key_name in abstract_key_names:
-                del(cur_fields[abstract_key_name])
-            path = template.apply_fields(cur_fields)
+            if len(abstract_key_names) > 0:
+                # we want to use the default values for abstract keys
+                cur_fields = template.get_fields(path)
+                for abstract_key_name in abstract_key_names:
+                    del(cur_fields[abstract_key_name])
+                path = template.apply_fields(cur_fields)
+        else:
+            log.debug(
+                "Path does not match a template. Not translating abstract fields: %s" % path
+            )
     return path
 
 def _create_dependencies(tk, publish_entity, dependency_paths, dependency_ids):


### PR DESCRIPTION
If one of the paths listed as a possible dependency of a published file is malformed or doesn't conform to a single template, it is skipped. The previous behavior was an uncaught `TankError` that would errantly kill a publish.