### PR TITLE
Corrects Step entity message when unregister_folders is required.

### DIFF
--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -899,7 +899,16 @@ class PathCache(object):
                     msg += "is changed. In order to continue you can either change "
                     msg += "the %s back to its previous name or you can unregister " % entity["type"]
                     msg += "the currently associated folders by running the following command: "
-                    msg += "'tank %s %s unregister_folders' and then try again." % (entity["type"], entity["name"])                    
+
+                    # Steps are a special case. We need to tell the user to unregister the
+                    # the conflicting path directly rather than by entity.
+                    if entity["type"] == "Step":
+                        msg += "'tank unregister_folders %s' and then try again." % p
+                    else:
+                        msg += "'tank %s %s unregister_folders' and then try again." % (
+                            entity["type"],
+                            entity["name"]
+                        )                    
                     raise TankError(msg)
 
 

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -901,7 +901,12 @@ class PathCache(object):
                     msg += "the currently associated folders by running the following command: "
 
                     # Steps are a special case. We need to tell the user to unregister the
-                    # the conflicting path directly rather than by entity.
+                    # conflicting path directly rather than by entity. The reason for this is
+                    # is two fold: running the unregister on the folder directly will properly
+                    # handle the underlying Task folders beneath the Step. Also, we have some
+                    # logic that assumes an entity being unregistered has a Project, and that
+                    # isn't the case for Step entities. All in all, this is the right thing for
+                    # a user to do to resolve the renamed Step entity's folder situation.
                     if entity["type"] == "Step":
                         msg += "'tank unregister_folders %s' and then try again." % p
                     else:


### PR DESCRIPTION
Step entities are a special case. When we encounter the need for a user to unregister_folders on a Step, they should be instructed to unregister the folder path directly rather than by entity.