### PR TITLE
Uses creatordate when sorting version tags of a git repo.

### DIFF
--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -240,7 +240,7 @@ class IODescriptorGitTag(IODescriptorGit):
             # clone the repo, find the latest tag (chronologically)
             # for the repository, across all branches
             commands = [
-                "for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1"
+                "for-each-ref refs/tags --sort=-creatordate --format='%(refname:short)' --count=1"
             ]
             latest_tag = self._tmp_clone_then_execute_git_commands(commands)
 


### PR DESCRIPTION
This will choose taggerdate or committerdate for us, depending on tag type.

Quick test results show the sorting working:

```
>>> dd = sgtk.descriptor.io_descriptor.git_tag.IODescriptorGitTag(dict(type="git", path="https://github.com/shotgunsoftware/tk-multi-shotgunpanel.git", version="v1.2.7"), 0)
>>> dd
<IODescriptorGitTag sgtk:descriptor:git?path=https%3A//github.com/shotgunsoftware/tk-multi-shotgunpanel.git&version=v1.2.7>
>>> dd.get_latest_version()
<IODescriptorGitTag sgtk:descriptor:git?path=https%3A//github.com/shotgunsoftware/tk-multi-shotgunpanel.git&version=v1.3.1>
```