### PR TITLE
#40780 SoftwareLauncher interface tweaks

### DIFF
--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -69,3 +69,7 @@ INSTALLED_DESCRIPTOR_TYPE = "installed"
 # environment variable that can be used to override the
 # configuration loaded when a bootstrap/plugin is starting up.
 CONFIG_OVERRIDE_ENV_VAR = "TK_BOOTSTRAP_CONFIG_OVERRIDE"
+
+# environment variable that is used to indicate a specific
+# pipeline configuration to be used.
+PIPELINE_CONFIG_ID_ENV_VAR = "SHOTGUN_PIPELINE_CONFIGURATION_ID"

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -80,6 +80,31 @@ class ToolkitManager(object):
         self._plugin_id = None
         self._pre_engine_start_callback = None
 
+        # look for the standard env var SHOTGUN_PIPELINE_CONFIGURATION_ID
+        # and in case this is set, use it as a default
+        if constants.PIPELINE_CONFIG_ID_ENV_VAR in os.environ:
+            pipeline_config_str = os.environ[constants.PIPELINE_CONFIG_ID_ENV_VAR]
+            log.debug(
+                "Detected %s environment variable set to '%s'" % (
+                    constants.PIPELINE_CONFIG_ID_ENV_VAR,
+                    pipeline_config_str
+                )
+            )
+            # try to convert it to an integer
+            try:
+                pipeline_config_id = int(pipeline_config_str)
+            except ValueError:
+                log.error(
+                    "Environment variable %s value '%s' is not "
+                    "an integer number and will be ignored." % (
+                        constants.PIPELINE_CONFIG_ID_ENV_VAR,
+                        pipeline_config_str
+                    )
+                )
+            else:
+                log.debug("Setting pipeline configuration to %s" % pipeline_config_id)
+                self.pipeline_configuration = pipeline_config_id
+
         log.debug("%s instantiated" % self)
 
     def __repr__(self):

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import logging
+import pprint
 import traceback
 import inspect
 import weakref
@@ -1012,6 +1013,10 @@ class Engine(TankBundle):
 
             # run the actual payload callback
             return callback(*args, **kwargs)
+
+        self.log_debug(
+            "Registering command '%s' with options:\n%s" % (name, pprint.pformat(properties))
+        )
 
         self.__commands[name] = {
             "callback": callback_wrapper,

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -312,20 +312,8 @@ class SoftwareLauncher(object):
         else:
             self.logger.debug("Unmanaged config. Not setting SHOTGUN_PIPELINE_CONFIGURATION_ID.")
 
-        # context
-        entity_dict = None
-
-        # see if there is a project
-        if self.context.project:
-            entity_dict = self.context.project
-
-        # if there is an entity then that takes precedence
-        if self.context.entity:
-            entity_dict = self.context.entity
-
-        # and if there is a Task that is even better
-        if self.context.task:
-            entity_dict = self.context.task
+        # get the most accurate entity, first see if there is a task, then entity then project
+        entity_dict = self.context.task or self.context.entity or self.context.project
 
         if entity_dict:
             env["SHOTGUN_ENTITY_TYPE"] = entity_dict["type"]

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -238,20 +238,15 @@ class SoftwareLauncher(object):
     ##########################################################################################
     # abstract methods
 
-    def scan_software(self, versions=None, display_name=None, icon=None):
+    def scan_software(self, versions=None):
         """
         Performs a scan for software installations.
 
         :param list versions: List of strings representing versions
-                              to search for. If set to None, search
+                              to search for. If set to None or [], search
                               for all versions. A version string is
                               DCC-specific but could be something
                               like "2017", "6.3v7" or "1.2.3.52"
-        :param str display_name : (optional) Name to use in graphical
-                                  displays to describe the
-                                  SoftwareVersions that were found.
-        :param icon: (optional) Path to a 256x256 (or smaller) png file
-                     that will represent every SoftwareVersion found.
         :returns: List of :class:`SoftwareVersion` instances
         """
         raise NotImplementedError

--- a/tests/fixtures/config/bundles/test_engine/startup.py
+++ b/tests/fixtures/config/bundles/test_engine/startup.py
@@ -18,7 +18,7 @@ class TestLauncher(SoftwareLauncher):
     """
     SoftwareLauncher stub for unit testing.
     """
-    def scan_software(self, versions=None, display_name=None, icon=None):
+    def scan_software(self, versions=None):
         """
         Performs a scan for software installations.
 
@@ -27,12 +27,6 @@ class TestLauncher(SoftwareLauncher):
                               for all versions. A version string is
                               DCC-specific but could be something
                               like "2017", "6.3v7" or "1.2.3.52".
-        :param str display_name : (optional) Name to use in graphical
-                                  displays to describe the
-                                  SoftwareVersions that were found.
-        :param icon: (optional) Path to a 256x256 (or smaller) png file
-                     to use in graphical displays for every SoftwareVersion
-                     found.
         :returns: List of :class:`SoftwareVersion` instances
         """
         sw_versions = []
@@ -40,8 +34,8 @@ class TestLauncher(SoftwareLauncher):
             sw_path = "/path/to/unit/test/app/%s/executable"
             sw_icon = "%s/icons/exec.png" % os.path.dirname(sw_path)
             sw_versions.append(SoftwareVersion(
-                version, (display_name or "Unit Test App"),
-                sw_path, (icon or sw_icon),
+                version, "Unit Test App",
+                sw_path, sw_icon,
             ))
         return sw_versions
 

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -26,21 +26,32 @@ class TestEngineLauncher(TankTestBase):
         self.setup_fixtures()
 
         # setup shot
-        seq = {"type":"Sequence", "name":"seq_name", "id":3}
+        seq = {"type": "Sequence", "name": "seq_name", "id": 3}
         seq_path = os.path.join(self.project_root, "sequences/Seq")
         self.add_production_path(seq_path, seq)
 
-        shot = {"type":"Shot", "name": "shot_name", "id":2,
-                "project": self.project}
+        self.shot = {"type": "Shot", "name": "shot_name", "id": 2, "project": self.project}
         shot_path = os.path.join(seq_path, "shot_code")
-        self.add_production_path(shot_path, shot)
+        self.add_production_path(shot_path, self.shot)
 
-        step = {"type":"Step", "name":"step_name", "id":4}
+        self.step = {"type": "Step", "name": "step_name", "id": 4}
         self.shot_step_path = os.path.join(shot_path, "step_name")
-        self.add_production_path(self.shot_step_path, step)
+        self.add_production_path(self.shot_step_path, self.step)
 
         self.context = self.tk.context_from_path(self.shot_step_path)
         self.engine_name = "test_engine"
+
+        self.task = {"type": "Task",
+                     "id": 23,
+                     "entity": self.shot,
+                     "step": self.step,
+                     "project": self.project}
+
+        entities = [self.task]
+
+        # Add these to mocked shotgun
+        self.add_to_sg_mock_db(entities)
+
 
     def test_create_launcher(self):
         """
@@ -90,6 +101,27 @@ class TestEngineLauncher(TankTestBase):
             self.assertIsInstance(swv, SoftwareVersion)
             self.assertEqual(swv.version, scan_versions[i])
 
+    def get_standard_plugin_environment(self):
+
+        for entity in [self.shot, self.project, self.task]:
+
+            ctx = self.tk.context_from_entity(entity["type"], entity["id"])
+            launcher = create_engine_launcher(self.tk, ctx, self.engine_name)
+            env = launcher.get_standard_plugin_environment()
+            self.assertEqual(env["SHOTGUN_PIPELINE_CONFIGURATION_ID"], "123")
+            self.assertEqual(env["SHOTGUN_SITE"], "http://unit_test_mock_sg")
+            self.assertEqual(env["SHOTGUN_ENTITY_TYPE"], entity["type"])
+            self.assertEqual(env["SHOTGUN_ENTITY_ID"], str(entity["id"]))
+
+    def get_standard_plugin_environment_empty(self):
+
+        ctx = self.tk.context_empty()
+        launcher = create_engine_launcher(self.tk, ctx, self.engine_name)
+        env = launcher.get_standard_plugin_environment()
+        self.assertEqual(env["SHOTGUN_PIPELINE_CONFIGURATION_ID"], "123")
+        self.assertEqual(env["SHOTGUN_SITE"], "http://unit_test_mock_sg")
+        self.assertTrue("SHOTGUN_ENTITY_TYPE" not in env)
+        self.assertTrue("SHOTGUN_ENTITY_ID" not in env)
 
     def test_launcher_prepare_launch(self):
         prep_path = "/some/path/to/an/executable"

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -84,17 +84,11 @@ class TestEngineLauncher(TankTestBase):
         self.assertEqual(sw_versions, [])
 
         scan_versions = [str(v) for v in range(10, 100, 20)]
-        scan_display = "UT Display Name"
-        scan_icon = "/some/path/to/a/ut/icon.png"
-        sw_versions = launcher.scan_software(
-            scan_versions, scan_display, scan_icon
-        )
+        sw_versions = launcher.scan_software(scan_versions)
         self.assertIsInstance(sw_versions, list)
         for i, swv in enumerate(sw_versions):
             self.assertIsInstance(swv, SoftwareVersion)
             self.assertEqual(swv.version, scan_versions[i])
-            self.assertEqual(swv.display_name, scan_display)
-            self.assertEqual(swv.icon, scan_icon)
 
 
     def test_launcher_prepare_launch(self):


### PR DESCRIPTION
- Drops the options `display_name` and `icon` from the `SoftwareLauncher.scan_software()` method. After building maya, photoshop and houdini, it seems better to drop these. It doesn't make sense that each engine is responsible for implementing the logic defining how name and icon overrides should happen. Separation of concerns - this should take place in the launch app. The scan software method should only do what it says on the tin -- scan for the given DCC and return a list of matches.

- Added `SoftwareLauncher.get_standard_plugin_environment()` that computes and returns the following env variables:
     - `SHOTGUN_SITE`: The current shotgun site url
     - `SHOTGUN_ENTITY_TYPE`: The current context
     - `SHOTGUN_ENTITY_ID`: The current context
     - `SHOTGUN_PIPELINE_CONFIGURATION_ID`: The current pipeline config id
**Note:** It is still up to each engine to call this method - the method does not modify the environment but rather returns a set of env tweaks that should be applied.

- The `SHOTGUN_PIPELINE_CONFIGURATION_ID` env var generated by `SoftwareLauncher.get_standard_plugin_environment()` is picked up by the bootstrap and used as a default pipeline configuration value by the toolkit manager if present. In practice, this means that application launch workflows where the `SoftwareLauncher.get_standard_plugin_environment()` is being called will automatically carry the pipeline configuration across when software is being launched.