### PR TITLE
#40780 Adds minimum version tools to SoftwareLauncher

### DIFF
--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -129,7 +129,6 @@ class SoftwareLauncher(object):
         self.__engine_settings = settings
         self.__engine_descriptor = descriptor
         self.__engine_name = engine_name
-        self.__minimum_supported_version = None
 
     ##########################################################################################
     # properties
@@ -234,21 +233,16 @@ class SoftwareLauncher(object):
         """
         return self.sgtk.shotgun
 
-    def _get_minimum_supported_version(self):
+    @property
+    def minimum_supported_version(self):
         """
         The minimum software version that is supported by the launcher.
         Returned as a string, for example "2015" or "2015.3.sp3".
         Returns ``None`` if no constraint has been set.
         Also see related method :meth:`~is_version_supported`.
         """
-        return self.__minimum_supported_version
-
-    def _set_minimum_supported_version(self, version):
-        # setter for minimum_supported_version
-        self.__minimum_supported_version = version
-
-    minimum_supported_version = property(_get_minimum_supported_version, _set_minimum_supported_version)
-
+        # returns none by default, subclassed by implementing classes
+        return None
 
     ##########################################################################################
     # abstract methods

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -101,7 +101,7 @@ class TestEngineLauncher(TankTestBase):
             self.assertIsInstance(swv, SoftwareVersion)
             self.assertEqual(swv.version, scan_versions[i])
 
-    def get_standard_plugin_environment(self):
+    def test_get_standard_plugin_environment(self):
 
         for entity in [self.shot, self.project, self.task]:
 
@@ -113,7 +113,7 @@ class TestEngineLauncher(TankTestBase):
             self.assertEqual(env["SHOTGUN_ENTITY_TYPE"], entity["type"])
             self.assertEqual(env["SHOTGUN_ENTITY_ID"], str(entity["id"]))
 
-    def get_standard_plugin_environment_empty(self):
+    def test_get_standard_plugin_environment_empty(self):
 
         ctx = self.tk.context_empty()
         launcher = create_engine_launcher(self.tk, ctx, self.engine_name)
@@ -122,6 +122,35 @@ class TestEngineLauncher(TankTestBase):
         self.assertEqual(env["SHOTGUN_SITE"], "http://unit_test_mock_sg")
         self.assertTrue("SHOTGUN_ENTITY_TYPE" not in env)
         self.assertTrue("SHOTGUN_ENTITY_ID" not in env)
+
+    def test_minimum_version(self):
+
+        launcher = create_engine_launcher(self.tk, self.context, self.engine_name)
+        # if no version has been set, anything goes
+        self.assertEqual(launcher.is_version_supported("foo"), True)
+        self.assertEqual(launcher.is_version_supported("v1204"), True)
+
+        self.assertEqual(launcher.minimum_supported_version, None)
+
+        launcher.minimum_supported_version = "2017.2"
+        self.assertEqual(launcher.minimum_supported_version, "2017.2")
+        self.assertEqual(launcher.is_version_supported("2017"), False)
+        self.assertEqual(launcher.is_version_supported("2017.2"), True)
+        self.assertEqual(launcher.is_version_supported("2017.2.sp1"), True)
+        self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
+        self.assertEqual(launcher.is_version_supported("2017.3"), True)
+        self.assertEqual(launcher.is_version_supported("2018"), True)
+        self.assertEqual(launcher.is_version_supported("2018.1"), True)
+
+        launcher.minimum_supported_version = "2017.2sp1"
+        self.assertEqual(launcher.minimum_supported_version, "2017.2sp1")
+        self.assertEqual(launcher.is_version_supported("2017"), False)
+        self.assertEqual(launcher.is_version_supported("2017.2"), False)
+        self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
+        self.assertEqual(launcher.is_version_supported("2017.3"), True)
+        self.assertEqual(launcher.is_version_supported("2018"), True)
+        self.assertEqual(launcher.is_version_supported("2018.1"), True)
+
 
     def test_launcher_prepare_launch(self):
         prep_path = "/some/path/to/an/executable"

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -11,6 +11,7 @@
 import os
 
 from tank_test.tank_test_base import *
+from mock import PropertyMock, patch
 import tank
 
 from tank.platform import create_engine_launcher
@@ -126,30 +127,37 @@ class TestEngineLauncher(TankTestBase):
     def test_minimum_version(self):
 
         launcher = create_engine_launcher(self.tk, self.context, self.engine_name)
+
         # if no version has been set, anything goes
         self.assertEqual(launcher.is_version_supported("foo"), True)
         self.assertEqual(launcher.is_version_supported("v1204"), True)
 
         self.assertEqual(launcher.minimum_supported_version, None)
 
-        launcher.minimum_supported_version = "2017.2"
-        self.assertEqual(launcher.minimum_supported_version, "2017.2")
-        self.assertEqual(launcher.is_version_supported("2017"), False)
-        self.assertEqual(launcher.is_version_supported("2017.2"), True)
-        self.assertEqual(launcher.is_version_supported("2017.2.sp1"), True)
-        self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
-        self.assertEqual(launcher.is_version_supported("2017.3"), True)
-        self.assertEqual(launcher.is_version_supported("2018"), True)
-        self.assertEqual(launcher.is_version_supported("2018.1"), True)
+        # mock the property
+        min_version_method = "sgtk.platform.software_launcher.SoftwareLauncher.minimum_supported_version"
+        with patch(min_version_method, new_callable=PropertyMock) as min_version_mock:
 
-        launcher.minimum_supported_version = "2017.2sp1"
-        self.assertEqual(launcher.minimum_supported_version, "2017.2sp1")
-        self.assertEqual(launcher.is_version_supported("2017"), False)
-        self.assertEqual(launcher.is_version_supported("2017.2"), False)
-        self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
-        self.assertEqual(launcher.is_version_supported("2017.3"), True)
-        self.assertEqual(launcher.is_version_supported("2018"), True)
-        self.assertEqual(launcher.is_version_supported("2018.1"), True)
+            min_version_mock.return_value = "2017.2"
+
+            self.assertEqual(launcher.minimum_supported_version, "2017.2")
+            self.assertEqual(launcher.is_version_supported("2017"), False)
+            self.assertEqual(launcher.is_version_supported("2017.2"), True)
+            self.assertEqual(launcher.is_version_supported("2017.2.sp1"), True)
+            self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
+            self.assertEqual(launcher.is_version_supported("2017.3"), True)
+            self.assertEqual(launcher.is_version_supported("2018"), True)
+            self.assertEqual(launcher.is_version_supported("2018.1"), True)
+
+            min_version_mock.return_value = "2017.2sp1"
+
+            self.assertEqual(launcher.minimum_supported_version, "2017.2sp1")
+            self.assertEqual(launcher.is_version_supported("2017"), False)
+            self.assertEqual(launcher.is_version_supported("2017.2"), False)
+            self.assertEqual(launcher.is_version_supported("2017.2sp1"), True)
+            self.assertEqual(launcher.is_version_supported("2017.3"), True)
+            self.assertEqual(launcher.is_version_supported("2018"), True)
+            self.assertEqual(launcher.is_version_supported("2018.1"), True)
 
 
     def test_launcher_prepare_launch(self):


### PR DESCRIPTION
Adds the following methods to the `SoftwareLauncher` class:

![image](https://cloud.githubusercontent.com/assets/337710/23259229/043ac12c-f9c4-11e6-8446-ea8e6c9af5f5.png)
