### PR TITLE
#41090 Fixes to hook.disk_location and inheritance

### DIFF
--- a/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
+++ b/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class AnotherTestHook(HookBaseClass):
+    
+    def test_inheritance_disk_location(self):
+
+        # get test data from base class using disk_location
+        disk_location_base = super(AnotherTestHook, self).test_disk_location()
+        # test our disk_location
+        our_disk_location = os.path.join(self.disk_location, "toolkitty.png")
+
+        return disk_location_base, our_disk_location

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -304,13 +304,57 @@ class TestExecuteHook(TestApplication):
 
     def test_disk_location(self):
         """
-        tests the built-in get_instance() method
+        tests the hook.disk_location property
         """
         app = self.engine.apps["test_app"]
         disk_location = app.execute_hook_method("test_hook_std", "test_disk_location")
         self.assertEquals(
             disk_location,
             os.path.join(self.pipeline_config_root, "config", "hooks", "toolkitty.png")
+        )
+
+    def test_inheritance_disk_location(self):
+        """
+        tests the hook.disk_location property in a multi inheritance scenarios
+        """
+        app = self.engine.apps["test_app"]
+
+        hook = app.create_hook_instance(
+            "{config}/config_test_hook.py:{config}/more_hooks/config_test_hook.py"
+        )
+
+        (disk_location_1, disk_location_2) = hook.test_inheritance_disk_location()
+
+        self.assertEquals(
+            disk_location_1,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "toolkitty.png"
+            )
+        )
+        self.assertEquals(
+            disk_location_2,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "more_hooks",
+                "toolkitty.png"
+            )
+        )
+
+        # edge case: also make sure that if we call the method externally,
+        # we get the location of self
+        self.assertEquals(
+            hook.disk_location,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "more_hooks"
+            )
         )
 
     def test_self_format(self):


### PR DESCRIPTION
Fixes a bug (affecting the new publisher) which would only happen when you have complex inheritance chains for hooks. We now commonly apply the following sort of pattern:

```
some_hook: {self}/collector.py:{self}/maya.basic/collector.py
```

If the `disk_location` is called from within `{self}/collector.py`, we expect the path returned to be `{self}` and when we call it from within `{self}/maya.basic/collector.py`, we expect it to be `{self}/maya.basic`. This was not previously the case - in the past, it would always return the path to the leaf class, e.g. in this case the path `{self}/maya.basic`.

This fix addresses this. In the case `disk_location` is called from outside a hook, we always return the disk location of `self`, eg. the location of the leaf hook in the inheritance.

