### PR TITLE
#40850 Tank Type -> Publish Type

### DIFF
--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -556,16 +556,19 @@ slash and using slashes as its path separator. Sgtk will translate it into a val
         description: A config centric path that points to a square icon png file.
 
 
-The tank_type data type
+The publish_type data type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use this when you want a setting which expects a **Tank Type** - these are typically used
-when publishing data to Shotgun. Value is a string matching TankType.code::
+Use this when you want a setting which expects a **Publish Type** - these are typically used
+when publishing data to Shotgun. Value is a string matching ``PublishedFileType.code``::
 
 
-    published_script_tank_type:
-        type: tank_type
-        description: The string value of the TankType used for published Nuke scripts.
+    published_script_type:
+        type: publish_type
+        description: The Published file type for published Nuke scripts.
+
+.. note:: The equivalent ``tank_type`` data type is also supported for backwards compatibility.
+
 
 The shotgun_entity_type data type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -766,10 +769,10 @@ You must supply values dict that describes the data type of the list items::
 
 Optionally you can also specify an **allows_empty** option if an empty list is a valid value::
 
-    tank_types:
+    publish_types:
         type: list
         allows_empty: True
-        values: {type: tank_type}
+        values: {type: pubish_type}
 
 You would then be able to specify an empty list in your environment configuration::
 

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -150,8 +150,9 @@ class CachedConfiguration(Configuration):
             # point (e.g like a dev or path descriptor). Assume a worst case
             # in this case - that the config that is cached locally is
             # not the same as the source descriptor it is based on.
-            log.debug("The installed config is not immutable, so it is per "
-                      "definition always out of date.")
+            log.info("Your configuration contains dev or path descriptors. "
+                     "Triggering full config rebuild.")
+
             return self.LOCAL_CFG_DIFFERENT
 
         else:

--- a/python/tank/commands/migrate_entities.py
+++ b/python/tank/commands/migrate_entities.py
@@ -1062,7 +1062,7 @@ class PublishedFileEntityMigrator(EntityMigrator):
     """
     FIELD_MAPPINGS = {"downstream_tank_published_files":"downstream_published_files",
                       "upstream_tank_published_files":"upstream_published_files",
-                      "tank_type":"published_file_type"}
+                      "tank_type": "published_file_type"}
     
     def __init__(self, log, sg, sg_project, migrate_tank_primary_storage=True):
         """

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -27,6 +27,7 @@ TANK_SCHEMA_VALID_TYPES = [
     "list",
     "dict",
     "tank_type",
+    "publish_type",
     "template",
     "hook",
     "shotgun_entity_type",
@@ -38,6 +39,7 @@ TANK_SCHEMA_VALID_TYPES = [
 # Types from the list above that expect "str" values.
 TANK_SCHEMA_STRING_TYPES = [
     "tank_type",
+    "publish_type",
     "template",
     "hook",
     "shotgun_entity_type",

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -862,7 +862,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     published_file_type = kwargs.get("published_file_type")
     if not published_file_type:
         # check for legacy name:
-        published_file_type = kwargs.get('tank_type')
+        published_file_type = kwargs.get("tank_type")
     update_entity_thumbnail = kwargs.get("update_entity_thumbnail", False)
     update_task_thumbnail = kwargs.get("update_task_thumbnail", False)
     created_by_user = kwargs.get("created_by")
@@ -1161,7 +1161,7 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     if published_file_type:
         if published_file_entity_type == "PublishedFile":
             data["published_file_type"] = published_file_type
-        else:# == TankPublishedFile
+        else: # == TankPublishedFile
             data["tank_type"] = published_file_type
 
     if version_entity:

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -97,6 +97,12 @@ configuration:
     test_icon:
         type: config_path
 
+    test_tank_type:
+        type: tank_type
+
+    test_publish_type:
+        type: publish_type
+
     test_simple_dictionary:
         type: dict
         items:

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -17,6 +17,8 @@ engines:
                 test_bool: true
                 test_template: maya_publish_name
                 test_icon: "foo/bar.png"
+                test_tank_type: Render Scene Tank
+                test_publish_type: Render Scene
 
                 #
 

--- a/tests/fixtures/config/env/test_post_update_new_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_new_parser.yml
@@ -17,6 +17,9 @@ engines:
         test_bool: true
         test_template: maya_publish_name
         test_icon: foo/bar.png
+        test_tank_type: Render Scene Tank
+        test_publish_type: Render Scene
+
                 #
 
         test_hook_std: config_test_hook

--- a/tests/fixtures/config/env/test_post_update_old_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_old_parser.yml
@@ -44,9 +44,11 @@ engines:
         test_icon: foo/bar.png
         test_int: 1
         test_no_schema: 1234.5678
+        test_publish_type: Render Scene
         test_simple_dictionary: {test_int: 1, test_str: a}
         test_simple_list: [a, b, c, d]
         test_str: a
+        test_tank_type: Render Scene Tank
         test_template: maya_publish_name
         test_very_complex_list:
         - test_list:


### PR DESCRIPTION
I noticed that we still refer to tank type in the documentation. Toolkit already supported a `publish_type` equivalent, this PR switches the docs over to use that term instead. Added simple unit tests. This is no attempt to update or extend the docs, it's just the minimal work to switch things across and stop mentioning tank.