### PR TITLE
#40550 Updates the SW launcher to make products and versions first class properties

### DIFF
--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -556,16 +556,19 @@ slash and using slashes as its path separator. Sgtk will translate it into a val
         description: A config centric path that points to a square icon png file.
 
 
-The tank_type data type
+The publish_type data type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use this when you want a setting which expects a **Tank Type** - these are typically used
-when publishing data to Shotgun. Value is a string matching TankType.code::
+Use this when you want a setting which expects a **Publish Type** - these are typically used
+when publishing data to Shotgun. Value is a string matching ``PublishedFileType.code``::
 
 
-    published_script_tank_type:
-        type: tank_type
-        description: The string value of the TankType used for published Nuke scripts.
+    published_script_type:
+        type: publish_type
+        description: The Published file type for published Nuke scripts.
+
+.. note:: The equivalent ``tank_type`` data type is also supported for backwards compatibility.
+
 
 The shotgun_entity_type data type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -766,10 +769,10 @@ You must supply values dict that describes the data type of the list items::
 
 Optionally you can also specify an **allows_empty** option if an empty list is a valid value::
 
-    tank_types:
+    publish_types:
         type: list
         allows_empty: True
-        values: {type: tank_type}
+        values: {type: pubish_type}
 
 You would then be able to specify an empty list in your environment configuration::
 

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -151,8 +151,9 @@ class CachedConfiguration(Configuration):
             # point (e.g like a dev or path descriptor). Assume a worst case
             # in this case - that the config that is cached locally is
             # not the same as the source descriptor it is based on.
-            log.debug("The installed config is not immutable, so it is per "
-                      "definition always out of date.")
+            log.info("Your configuration contains dev or path descriptors. "
+                     "Triggering full config rebuild.")
+
             return self.LOCAL_CFG_DIFFERENT
 
         else:

--- a/python/tank/commands/migrate_entities.py
+++ b/python/tank/commands/migrate_entities.py
@@ -1062,7 +1062,7 @@ class PublishedFileEntityMigrator(EntityMigrator):
     """
     FIELD_MAPPINGS = {"downstream_tank_published_files":"downstream_published_files",
                       "upstream_tank_published_files":"upstream_published_files",
-                      "tank_type":"published_file_type"}
+                      "tank_type": "published_file_type"}
     
     def __init__(self, log, sg, sg_project, migrate_tank_primary_storage=True):
         """

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -633,10 +633,15 @@ class IODescriptorBase(object):
             log.debug("Clone cache for %r: No need to copy, source and target are same." % self)
             return False
 
+        # Cache the source cache path because we're about to create the destination folder,
+        # which might be a bundle cache root.
+        source_cache_path = self.get_path()
+        log.debug("Source cache is located at %s", source_cache_path)
+
         # and to the actual I/O
         # pass an empty skip list to ensure we copy things like the .git folder
         filesystem.ensure_folder_exists(new_cache_path, permissions=0777)
-        filesystem.copy_folder(self.get_path(), new_cache_path, skip_list=[])
+        filesystem.copy_folder(source_cache_path, new_cache_path, skip_list=[])
         return True
 
     ###############################################################################################

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -27,6 +27,7 @@ TANK_SCHEMA_VALID_TYPES = [
     "list",
     "dict",
     "tank_type",
+    "publish_type",
     "template",
     "hook",
     "shotgun_entity_type",
@@ -38,6 +39,7 @@ TANK_SCHEMA_VALID_TYPES = [
 # Types from the list above that expect "str" values.
 TANK_SCHEMA_STRING_TYPES = [
     "tank_type",
+    "publish_type",
     "template",
     "hook",
     "shotgun_entity_type",

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -896,6 +896,8 @@ class Engine(TankBundle):
         - ``description`` - a one line description of the command, suitable for a tooltip.
           If no description is passed, the one provided in the app manifest will be used.
 
+        - ``title`` - Title to appear on shotgun action menu (e.g. "Create Folders")
+
         - ``type`` - The type of command - hinting where it should appear. Options vary between
           engines and the following three are supported:
 
@@ -907,15 +909,29 @@ class Engine(TankBundle):
             - ``node`` - For applications that have a specific node menu (like Nuke),
               place the command there.
 
+        **Grouping commands into collections**
+
+        It is possible to group several commands into a collection. Such a collection is called
+        a *group*.  For example, you may have three separate commands to launch Maya 2017,
+        Maya 2016 and Maya 2015, all under a 'Launch Maya' group. It is up to each engine to
+        implement this specification in a suitable way but typically, it would be displayed as a
+        "Launch Maya" menu with three sub menu items to represent each version of Maya.
+
+        Each group has a concept of a group default - this is what would get executed if you click
+        on the 'Launch Maya' group.
+
+        To register commands with groups, pass the following two parameters in the properties
+        dictionary:
+
         - ``group`` - The name for a group this command should be considered a member of.
 
-        - ``group_default`` - Boolean value indicating whether this command should represent the group
-          as a whole. Setting this value to True indicates that this is the command to run and display
-          in applications that show a single button for each command group.
+        - ``group_default`` - Boolean value indicating whether this command should represent the
+          group as a whole.
 
-        Specifically for the Shotgun engine, the following parameters are supported:
+        .. note:: It is up to each engine to implement grouping and group defaults in an appropriate way. Some engines may not support grouping.
 
-        - ``title`` - Title to appear on shotgun action menu (e.g. "Create Folders")
+
+        The following properties are supported for the Shotgun engine specifically:
 
         - ``deny_permissions`` - List of permission groups to exclude this
           menu item for (e.g. ``["Artist"]``)
@@ -963,28 +979,29 @@ class Engine(TankBundle):
         if "icon" not in properties and self.__currently_initializing_app:
             properties["icon"] = self.__currently_initializing_app.descriptor.icon_256
 
-        # check for duplicates!
         if name in self.__commands:
-            # already something in the dict with this name
+            # Duplicate command name detected! Attempt to make commands unique by prepending the
+            # a prefix derived from information in the properties.
             existing_item = self.__commands[name]
-            if existing_item["properties"].get("app"):
-                # we know the app for the existing item.
-                # so prefix with app name
-                prefix = existing_item["properties"].get("app").instance_name
-                new_name_for_existing = "%s:%s" % (prefix, name)
+            command_prefix = _get_command_prefix(existing_item["properties"])
+            if command_prefix:
+                new_name_for_existing = "%s:%s" % (command_prefix, name)
                 self.__commands[new_name_for_existing] = existing_item
-                self.__commands[new_name_for_existing]["properties"]["prefix"] = prefix 
+                # Record the command prefix in the properties dictionary for future reference.
+                self.__commands[new_name_for_existing]["properties"]["prefix"] = command_prefix
                 del(self.__commands[name])
-                # add it to our list
+                # Record the original command name to make sure any additional commands
+                # registered with this name are treated as duplicates and fully prefixed.
                 self.__commands_that_need_prefixing.append(name)
                       
         if name in self.__commands_that_need_prefixing:
-            # try to append a prefix if possible
-            if properties.get("app"):
-                prefix = properties.get("app").instance_name
-                name = "%s:%s" % (prefix, name)
-                # also add a prefix key in the properties dict
-                properties["prefix"] = prefix
+            # At least one instance of this command name has already been detected.
+            # Resolve the duplicate command by application name and/or group name.
+            command_prefix = _get_command_prefix(properties)
+            if command_prefix:
+                name = "%s:%s" % (command_prefix, name)
+                # Record the command prefix in the properties dictionary for future reference.
+                properties["prefix"] = command_prefix
 
         # now define command wrappers to capture metrics logging
         # on command execution. The toolkit callback system supports
@@ -2903,3 +2920,21 @@ def __pick_environment(engine_name, tk, context):
 
     return env_name
 
+def _get_command_prefix(properties):
+    """
+    If multiple commands are registered with the same name, attempt to construct a unique
+    prefix from other information in the command's properties dictionary to distinguish one
+    command from another. Uses the properties' ``app`` and/or ``group`` keys to create the
+    prefix.
+
+    :param dict properties: Arbitrary key/value information related to a registered command.
+    :returns: A unique identifier for the command as a str.
+    """
+    prefix_parts = []
+    if properties.get("app"):
+        # First, distinguish commands by app name.
+        prefix_parts.append(properties["app"].instance_name)
+    if properties.get("group"):
+        # Second, distinguish commands by group name.
+        prefix_parts.append(properties["group"])
+    return ":".join(prefix_parts)

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -441,6 +441,17 @@ class SoftwareVersion(object):
         self._path = path
         self._icon_path = icon
 
+    def __repr__(self):
+        """
+        Returns unique str representation of the software version
+        """
+        return "<SoftwareVersion 0x%08x: %s %s, path: %s>" % (
+            id(self),
+            self.product,
+            self.version,
+            self.path
+        )
+
     @property
     def version(self):
         """

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -247,7 +247,7 @@ class SoftwareLauncher(object):
     ##########################################################################################
     # abstract methods
 
-    def scan_software(self, versions=None):
+    def scan_software(self, versions=None, products=None):
         """
         Performs a scan for software installations.
 
@@ -256,6 +256,13 @@ class SoftwareLauncher(object):
                               for all versions. A version string is
                               DCC-specific but could be something
                               like "2017", "6.3v7" or "1.2.3.52"
+
+        :param list products: List of strings representing product names
+                              to search for. If set to None or [], search
+                              for all products. A product string is
+                              DCC-specific but could be something
+                              like "Houdini FX", "Houdini Core" or "Houdini"
+
         :returns: List of :class:`SoftwareVersion` instances
         """
         raise NotImplementedError
@@ -360,12 +367,14 @@ class SoftwareVersion(object):
     Container class that stores properties of a DCC that
     are useful for Toolkit Engine Startup functionality.
     """
-    def __init__(self, version, display_name, path, icon=None):
+    def __init__(self, version, product, display_name, path, icon=None):
         """
         Constructor.
 
         :param str version: Explicit version of the DCC represented
                             (e.g. 2017)
+        :param str version: Explicit product name of the DCC represented
+                            (e.g. Houdini Apprentice)
         :param str display_name: Name to use for any graphical displays
         :param str path: Full path to the DCC executable.
         :param str icon: (optional) Full path to a 256x256 (or smaller)
@@ -373,6 +382,7 @@ class SoftwareVersion(object):
                          this SoftwareVersion.
         """
         self._version = version
+        self._product = product
         self._display_name = display_name
         self._path = path
         self._icon_path = icon
@@ -385,6 +395,16 @@ class SoftwareVersion(object):
         :returns: String version
         """
         return self._version
+
+    @property
+    def product(self):
+        """
+        An explicit product name of the DCC represented by this Software Version.
+
+        :return: String product name
+        """
+
+        return self._product
 
     @property
     def display_name(self):

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -111,8 +111,6 @@ class SoftwareLauncher(object):
             search for. If set to None or [], search for all products. A product
             string is DCC-specific but could be something like "Houdini FX",
             "Houdini Core" or "Houdini"
-
-        :returns: List of :class:`SoftwareVersion` instances
         """
         # get the engine settings
         settings = env.get_engine_settings(engine_name)
@@ -377,10 +375,10 @@ class SoftwareLauncher(object):
 
     def is_version_supported(self, sw_version):
         """
-        Inspects the supplied :class:`SoftwareVersion` object to see if aligns
-        with this launcher's known product and version limitation. Will check
-        the :meth:`~minimum_supported_version` as well as the list of product
-        and version filters.
+        Inspects the supplied :class:`SoftwareVersion` object to see if it
+        aligns with this launcher's known product and version limitation. Will
+        check the :meth:`~minimum_supported_version` as well as the list of
+        product and version filters.
 
         :param sw_version: :class:`SoftwareVersion` object to test against the
             launcher's product and version limitations.
@@ -427,7 +425,7 @@ class SoftwareVersion(object):
 
         :param str version: Explicit version of the DCC represented
                             (e.g. 2017)
-        :param str version: Explicit product name of the DCC represented
+        :param str product: Explicit product name of the DCC represented
                             (e.g. Houdini Apprentice)
         :param str display_name: Name to use for any graphical displays
         :param str path: Full path to the DCC executable.
@@ -464,7 +462,8 @@ class SoftwareVersion(object):
     @property
     def product(self):
         """
-        An explicit product name of the DCC represented by this Software Version.
+        An explicit product name for the DCC represented by this Software
+        Version. Example: "Houdini Fx"
 
         :return: String product name
         """

--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -931,7 +931,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     published_file_type = kwargs.get("published_file_type")
     if not published_file_type:
         # check for legacy name:
-        published_file_type = kwargs.get('tank_type')
+        published_file_type = kwargs.get("tank_type")
     update_entity_thumbnail = kwargs.get("update_entity_thumbnail", False)
     update_task_thumbnail = kwargs.get("update_task_thumbnail", False)
     created_by_user = kwargs.get("created_by")
@@ -1244,7 +1244,7 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     if published_file_type:
         if published_file_entity_type == "PublishedFile":
             data["published_file_type"] = published_file_type
-        else:# == TankPublishedFile
+        else: # == TankPublishedFile
             data["tank_type"] = published_file_type
 
     if version_entity:

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -97,6 +97,12 @@ configuration:
     test_icon:
         type: config_path
 
+    test_tank_type:
+        type: tank_type
+
+    test_publish_type:
+        type: publish_type
+
     test_simple_dictionary:
         type: dict
         items:

--- a/tests/fixtures/config/bundles/test_engine/startup.py
+++ b/tests/fixtures/config/bundles/test_engine/startup.py
@@ -18,7 +18,7 @@ class TestLauncher(SoftwareLauncher):
     """
     SoftwareLauncher stub for unit testing.
     """
-    def scan_software(self, versions=None):
+    def _scan_software(self):
         """
         Performs a scan for software installations.
 
@@ -30,13 +30,17 @@ class TestLauncher(SoftwareLauncher):
         :returns: List of :class:`SoftwareVersion` instances
         """
         sw_versions = []
-        for version in versions or []:
+        for version in range(0, 10):
             sw_path = "/path/to/unit/test/app/%s/executable"
             sw_icon = "%s/icons/exec.png" % os.path.dirname(sw_path)
-            sw_versions.append(SoftwareVersion(
-                version, "Unit Test App",
-                sw_path, sw_icon,
-            ))
+            sw_versions.append(
+                SoftwareVersion(
+                    version,
+                    "Unit Test App",  # product
+                    sw_path,
+                    sw_icon,
+                )
+            )
         return sw_versions
 
     def prepare_launch(self, exec_path, args, file_to_open=None):

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -24,6 +24,8 @@ engines:
                 test_bool: true
                 test_template: maya_publish_name
                 test_icon: "foo/bar.png"
+                test_tank_type: Render Scene Tank
+                test_publish_type: Render Scene
 
                 #
 

--- a/tests/fixtures/config/env/test_post_update_new_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_new_parser.yml
@@ -24,6 +24,9 @@ engines:
         test_bool: true
         test_template: maya_publish_name
         test_icon: foo/bar.png
+        test_tank_type: Render Scene Tank
+        test_publish_type: Render Scene
+
                 #
 
         test_hook_std: config_test_hook

--- a/tests/fixtures/config/env/test_post_update_old_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_old_parser.yml
@@ -44,9 +44,11 @@ engines:
         test_icon: foo/bar.png
         test_int: 1
         test_no_schema: 1234.5678
+        test_publish_type: Render Scene
         test_simple_dictionary: {test_int: 1, test_str: a}
         test_simple_list: [a, b, c, d]
         test_str: a
+        test_tank_type: Render Scene Tank
         test_template: maya_publish_name
         test_very_complex_list:
         - test_list:

--- a/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
+++ b/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class AnotherTestHook(HookBaseClass):
+    
+    def test_inheritance_disk_location(self):
+
+        # get test data from base class using disk_location
+        disk_location_base = super(AnotherTestHook, self).test_disk_location()
+        # test our disk_location
+        our_disk_location = os.path.join(self.disk_location, "toolkitty.png")
+
+        return disk_location_base, our_disk_location

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -304,13 +304,57 @@ class TestExecuteHook(TestApplication):
 
     def test_disk_location(self):
         """
-        tests the built-in get_instance() method
+        tests the hook.disk_location property
         """
         app = self.engine.apps["test_app"]
         disk_location = app.execute_hook_method("test_hook_std", "test_disk_location")
         self.assertEquals(
             disk_location,
             os.path.join(self.pipeline_config_root, "config", "hooks", "toolkitty.png")
+        )
+
+    def test_inheritance_disk_location(self):
+        """
+        tests the hook.disk_location property in a multi inheritance scenarios
+        """
+        app = self.engine.apps["test_app"]
+
+        hook = app.create_hook_instance(
+            "{config}/config_test_hook.py:{config}/more_hooks/config_test_hook.py"
+        )
+
+        (disk_location_1, disk_location_2) = hook.test_inheritance_disk_location()
+
+        self.assertEquals(
+            disk_location_1,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "toolkitty.png"
+            )
+        )
+        self.assertEquals(
+            disk_location_2,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "more_hooks",
+                "toolkitty.png"
+            )
+        )
+
+        # edge case: also make sure that if we call the method externally,
+        # we get the location of self
+        self.assertEquals(
+            hook.disk_location,
+            os.path.join(
+                self.pipeline_config_root,
+                "config",
+                "hooks",
+                "more_hooks"
+            )
         )
 
     def test_self_format(self):


### PR DESCRIPTION
This allows the version/product matching logic to live in the `is_version_supported` method which now accepts a `SoftwareVersion` object. This means that the engines, by default, don't have to implement any custom filtering logic. The engines all now have the following basic form:

```
def scan_software(self):
        software_versions = []

        for sw_version in self._find_software_versions():
            if self.is_version_supported(sw_version):
                self.logger.debug("Accepting %s", sw_version)
                software_versions.append(sw_version)
            else:
                self.logger.debug("Rejecting %s", sw_version)
                continue

        return software_versions
```