### PR TITLE
40401 register publish url bug

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -1124,7 +1124,7 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     published_file_entity_type = get_published_file_entity_type(tk)
 
     # Check if path is a url or a straight file path.  Path
-    # is assumed to be a url if it has a scheme or netloc, e.g.:
+    # is assumed to be a url if it has a scheme:
     #
     #     scheme://netloc/path
     #
@@ -1136,8 +1136,6 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
         # schemes are unlikely!
         if len(res.scheme) > 1 or not res.scheme.isalpha():
             path_is_url = True
-    elif res.netloc:
-        path_is_url = True
         
     code = ""
     if path_is_url:

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -444,6 +444,27 @@ class TestShotgunRegisterPublish(TankTestBase):
         self.assertEqual(sg_dict["path"], {'url': 'file:///path/to/file%20with%20spaces.png'})
         self.assertEqual("pathcache" not in sg_dict, True)
 
+    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    def test_local_paths(self, create_mock):
+        """Tests the passing of local paths."""
+
+        for local_path in [
+            "/path/to/file with spaces.png",
+            "//path/to/file with spaces.png",
+        ]:
+            tank.util.register_publish(
+                self.tk,
+                self.context,
+                local_path,
+                self.name,
+                self.version)
+
+            create_data = create_mock.call_args
+            args, kwargs = create_data
+            sg_dict = args[1]
+
+            self.assertEqual(sg_dict["path"], {"local_path": local_path})
+            self.assertEqual("pathcache" not in sg_dict, True)
 
 class TestShotgunDownloadUrl(TankTestBase):
 

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -448,23 +448,31 @@ class TestShotgunRegisterPublish(TankTestBase):
     def test_local_paths(self, create_mock):
         """Tests the passing of local paths."""
 
+        # Various paths we support, Unix and Windows styles
         for local_path in [
             "/path/to/file with spaces.png",
+            "C:/path/to/file with spaces.png",
+            "e:/path/to/file with spaces.png",
             "//path/to/file with spaces.png",
+            r"\path\to\file with spaces.png",
+            r"C:\path\to\file with spaces.png",
+            r"e:\path\to\file with spaces.png",
+            r"\\path\to\file with spaces.png",
         ]:
             tank.util.register_publish(
                 self.tk,
                 self.context,
                 local_path,
                 self.name,
-                self.version)
+                self.version
+            )
 
             create_data = create_mock.call_args
             args, kwargs = create_data
             sg_dict = args[1]
 
             self.assertEqual(sg_dict["path"], {"local_path": local_path})
-            self.assertEqual("pathcache" not in sg_dict, True)
+            self.assertTrue("pathcache" not in sg_dict)
 
 class TestShotgunDownloadUrl(TankTestBase):
 


### PR DESCRIPTION
Fix to not consider `//something/foo/bar` paths as urls but as regular paths.

* Removed the test checking the `netloc` if the `scheme` is empty.
* Added some unit tests.