### PR TITLE
For #41246, system-wide proxy cant be disabled

### DIFF
--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -104,7 +104,10 @@ class DefaultsManager(object):
 
         :returns: String containing the default http proxy, None by default.
         """
-        return self._user_settings.shotgun_proxy or self._system_settings.http_proxy
+        if self._user_settings.shotgun_proxy is None:
+            return self._system_settings.http_proxy
+        else:
+            return self._user_settings.shotgun_proxy
 
     def get_login(self):
         """

--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -10,6 +10,7 @@
 
 from . import session_cache
 
+
 class DefaultsManager(object):
     """
     The defaults manager allows a client of the Shotgun Authenticator class
@@ -22,7 +23,7 @@ class DefaultsManager(object):
     host.
 
     If a setting isn't found, the DefaultsManager will fall back to the value stored inside
-    ``config.ini`` See :ref:`centralizing_settings` for more information.
+    ``toolkit.ini`` See :ref:`centralizing_settings` for more information.
 
     If, however, you want to implement a custom behavior around how defaults
     are managed, simply derive from this class and pass your custom instance
@@ -32,7 +33,9 @@ class DefaultsManager(object):
     def __init__(self):
         # Breaks circular dependency between util and authentication framework
         from ..util.user_settings import UserSettings
+        from ..util.system_settings import SystemSettings
         self._user_settings = UserSettings()
+        self._system_settings = SystemSettings()
 
     def is_host_fixed(self):
         """
@@ -87,13 +90,21 @@ class DefaultsManager(object):
         Called by the authentication system when it needs to retrieve the
         proxy settings to use for a Shotgun connection.
 
-        The format should be the same as is being used in the Shotgun API.
-        For more information, see the Shotgun API documentation:
-        https://github.com/shotgunsoftware/python-api/wiki/Reference%3A-Methods#shotgun
+        .. note:: If the centralized settings do not specify an HTTP proxy, Toolkit will rely on
+            Python's `urllib.getproxies <https://docs.python.org/2/library/urllib.html#urllib.getproxies>`_
+            to find an HTTP proxy.
+
+            There is a restriction when looking for proxy information from Mac OS X System Configuration or
+            Windows Systems Registry: in these cases, Toolkit does not support the use of proxies
+            which require authentication (username and password).
+
+        The returned format will be the same as is being used in the Shotgun API.
+        For more information, see the `Shotgun API documentation
+        <http://developer.shotgunsoftware.com/python-api/reference.html#shotgun>`_.
 
         :returns: String containing the default http proxy, None by default.
         """
-        return self._user_settings.shotgun_proxy
+        return self._user_settings.shotgun_proxy or self._system_settings.http_proxy
 
     def get_login(self):
         """

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -741,11 +741,12 @@ class IODescriptorAppStore(IODescriptorBase):
             return config_data[constants.APP_STORE_HTTP_PROXY]
 
         settings = UserSettings()
-        if settings.is_app_store_proxy_set():
+        if settings.app_store_proxy is not None:
             return settings.app_store_proxy
 
         # Use the http proxy from the connection so we don't have to run
-        # the connection hook again.
+        # the connection hook again or look up the system settings as they
+        # will have been previously looked up to create the connection to Shotgun.
         return self._sg_connection.config.raw_http_proxy
 
     @LogManager.log_timing

--- a/python/tank/util/defaults_manager.py
+++ b/python/tank/util/defaults_manager.py
@@ -61,10 +61,12 @@ class CoreDefaultsManager(DefaultsManager):
         """
         from . import shotgun
         http_proxy = shotgun.get_associated_sg_config_data().get("http_proxy")
-        if http_proxy is not None:
-            return http_proxy
-        else:
+        # If we don't have anything in shotgun.yml, we fallback on the
+        # toolkit.ini and system settings.
+        if http_proxy is None:
             return super(CoreDefaultsManager, self).get_http_proxy()
+        else:
+            return http_proxy
 
     def get_user_credentials(self):
         """

--- a/python/tank/util/defaults_manager.py
+++ b/python/tank/util/defaults_manager.py
@@ -60,7 +60,11 @@ class CoreDefaultsManager(DefaultsManager):
                   None if not necessary.
         """
         from . import shotgun
-        return shotgun.get_associated_sg_config_data().get("http_proxy") or super(CoreDefaultsManager, self).get_http_proxy()
+        http_proxy = shotgun.get_associated_sg_config_data().get("http_proxy")
+        if http_proxy is not None:
+            return http_proxy
+        else:
+            return super(CoreDefaultsManager, self).get_http_proxy()
 
     def get_user_credentials(self):
         """

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -23,7 +23,7 @@ class LocalFileStorageManager(object):
     Class that encapsulates logic for resolving local storage paths.
 
     Toolkit needs to store cache data, logs and other items at runtime.
-    Some of this data is global, other is per site or per configuraiton.
+    Some of this data is global, other is per site or per configuration.
 
     This class provides a consistent and centralized interface for resolving
     such paths and also handles compatibility across generations of path
@@ -31,6 +31,17 @@ class LocalFileStorageManager(object):
 
     .. note:: All paths returned by this class are local to the currently running
               user and typically private or with limited access settings for other users.
+
+              If the current user's home directory is not an appropriate location to store
+              your user files, you can use the ``SHOTGUN_HOME`` environment variable to
+              override the root location of the files. In that case, the location for the
+              user files on each platform will be:
+
+              - Logging:     ``$SHOTGUN_HOME/logs``
+              - Cache:       ``$SHOTGUN_HOME``
+              - Persistent:  ``$SHOTGUN_HOME/data``
+              - Preferences: ``$SHOTGUN_HOME/preferences``
+
 
     :constant CORE_V17: Indicates compatibility with Core 0.17 or earlier
     :constant CORE_V18: Indicates compatibility with Core 0.18 or later

--- a/python/tank/util/system_settings.py
+++ b/python/tank/util/system_settings.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+System settings management.
+"""
+
+
+import urllib
+
+
+class SystemSettings(object):
+    """
+    Handles loading the system settings.
+    """
+
+    @property
+    def http_proxy(self):
+        """
+        Retrieves the operating system http proxy.
+
+        First, the method scans the environment for variables named http_proxy, in case insensitive way.
+        If both lowercase and uppercase environment variables exist (and disagree), lowercase is preferred.
+
+        When the method cannot find such environment variables:
+        - for Mac OS X, it will look for proxy information from Mac OS X System Configuration,
+        - for Windows, it will look for proxy information from Windows Systems Registry.
+
+        .. note:: There is a restriction when looking for proxy information from
+                  Mac OS X System Configuration or Windows Systems Registry:
+                  in these cases, the Toolkit does not support the use of proxies
+                  which require authentication (username and password).
+        """
+        # Get the dictionary of scheme to proxy server URL mappings; for example:
+        #     {"http": "http://foo:bar@74.50.63.111:80", "https": "http://74.50.63.111:443"}
+        # "getproxies" scans the environment for variables named <scheme>_proxy, in case insensitive way.
+        # When it cannot find it, for Mac OS X it looks for proxy information from Mac OSX System Configuration,
+        # and for Windows it looks for proxy information from Windows Systems Registry.
+        # If both lowercase and uppercase environment variables exist (and disagree), lowercase is preferred.
+        # Note the following restriction: "getproxies" does not support the use of proxies which
+        # require authentication (user and password) when looking for proxy information from
+        # Mac OSX System Configuration or Windows Systems Registry.
+        system_proxies = urllib.getproxies()
+
+        # Get the http proxy when it exists in the dictionary.
+        proxy = system_proxies.get("http")
+
+        if proxy:
+            # Remove any spurious "http://" from the http proxy string.
+            proxy = proxy.replace("http://", "", 1)
+
+        return proxy

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -17,7 +17,7 @@ import ConfigParser
 import urllib
 
 from .local_file_storage import LocalFileStorageManager
-from .errors import EnvironmentVariableFileLookupError
+from .errors import EnvironmentVariableFileLookupError, TankError
 from .. import LogManager
 from .singleton import Singleton
 
@@ -27,7 +27,13 @@ logger = LogManager.get_logger(__name__)
 
 class UserSettings(Singleton):
     """
-    Handles finding and loading the user settings for Toolkit.
+    Handles finding and loading the user settings for Toolkit. The settings are cached in memory
+    so the user settings object can be instantiated multiple times without any issue.
+
+    All the settings are returned as strings. If a setting is missing from the file, ``None`` will
+    be returned. If the setting is present but has no value, an empty string will be returned.
+
+    As of this writing, settings can only be updated by editing the ``ini`` file manually.
     """
 
     _LOGIN = "Login"
@@ -36,101 +42,137 @@ class UserSettings(Singleton):
         """
         Singleton initialization.
         """
-        path = self._compute_config_location()
-        logger.debug("Reading user settings from %s" % path)
+        self._path = self._compute_config_location()
+        logger.debug("Reading user settings from %s", self._path)
 
-        self._user_config = self._load_config(path)
+        self._user_config = self._load_config(self._path)
 
         # Log the default settings
-        logger.debug("Default site: %s" % (self.default_site or "<missing>",))
-        logger.debug("Default login: %s" % (self.default_login or "<missing>",))
+        logger.debug("Default site: %s", self._to_display_value(self.default_site))
+        logger.debug("Default login: %s", self._to_display_value(self.default_login))
 
-        self._settings_proxy = self._get_settings_proxy()
-        self._system_proxy = None
-        if self._settings_proxy:
-            logger.debug("Shotgun proxy (from settings): %s" % self._get_filtered_proxy(self._settings_proxy))
-        else:
-            self._system_proxy = self._get_system_proxy()
-            if self._system_proxy:
-                logger.debug("Shotgun proxy (from system): %s" % self._get_filtered_proxy(self._system_proxy))
-            else:
-                logger.debug("Shotgun proxy: <missing>")
+        proxy = self._get_filtered_proxy(self.shotgun_proxy)
+        logger.debug("Shotgun proxy: %s", self._to_display_value(proxy))
 
         proxy = self._get_filtered_proxy(self.app_store_proxy)
-        if self.is_app_store_proxy_set():
-            logger.debug("App Store proxy: %s" % (proxy or "<empty>",))
-        else:
-            logger.debug("App Store proxy: <missing>")
+        logger.debug("App Store proxy: %s", self._to_display_value(proxy))
 
     @property
     def shotgun_proxy(self):
         """
-        :returns: The default proxy.
+        Retrieves the value from the ``http_proxy`` setting.
         """
 
         # Return the configuration settings http proxy string when it is specified;
         # otherwise, return the operating system http proxy string.
-        return self._settings_proxy or self._system_proxy
-
-    def is_app_store_proxy_set(self):
-        """
-        :returns: ``True`` if ``app_store_http_proxy`` is set, ``False`` otherwise.
-        """
-        return self._is_setting_found("app_store_http_proxy")
+        return self.get_setting(self._LOGIN, "http_proxy")
 
     @property
     def app_store_proxy(self):
         """
-        :returns: The app store specific proxy. If ``None``, it means the setting is absent from the
-            file or set to an empty value. Use `is_app_store_proxy_set` to disambiguate.
+        Retrieves the value from the ``app_store_http_proxy`` setting.
         """
-        # If the config parser returned a falsy value, it meant that the app_store_http_proxy
-        # setting was present but empty. We'll advertise that fact as None instead.
-        return self._get_value("app_store_http_proxy") or None
+        return self.get_setting(self._LOGIN, "app_store_http_proxy")
 
     @property
     def default_site(self):
         """
-        :returns: The default site.
+        Retrieves the value from the ``default_site`` setting.
         """
-        return self._get_value("default_site")
+        return self.get_setting(self._LOGIN, "default_site")
 
     @property
     def default_login(self):
         """
-        :returns: The default login.
+        Retrieves the value from the ``default_login`` setting.
         """
-        return self._get_value("default_login")
+        return self.get_setting(self._LOGIN, "default_login")
 
-    def _get_value(self, key):
+    def get_setting(self, section, name):
         """
-        Retrieves a value from the ``config.ini`` file. If the value is not set, returns the default.
-        Since all values are strings inside the file, you can optionally cast the data to another type.
+        Provides access to any setting, including ones in user defined sections.
 
-        :param key: Name of the setting within the Login section.
+        :param str section: Name of the section to retrieve the setting from. Do not include the brackets.
+        :param str name: Name of the setting under the provided section.
 
-        :returns: The appropriately type casted value if the value is found, default otherwise.
+        :returns: The setting's value if found, ``None`` if the setting is missing from the file or
+            an empty string if the setting is present but has no value associated.
+        :rtype: str
         """
-        if not self._is_setting_found(key):
+        if not self._user_config.has_section(section) or not self._user_config.has_option(section, name):
             return None
+
+        value = os.path.expanduser(
+            os.path.expandvars(
+                self._user_config.get(section, name)
+            )
+        )
+        return value.strip()
+
+    # Unfortunately here for get_boolean_setting and get_integer_setting we're replicating some of the
+    # logic from the ConfigParser class. We have to do this because ConfigParser doesn't expand environment
+    # variables which is a requirement here, so get_setting does the job of using expandvars so everything
+    # gets expanded and then the get_*_setting methods so the necessary casting.
+
+    # This is taken from RawConfigParser. Values are copied in case future Python implementation
+    # rename this. (like Python 3, not that this is going to be an issue in the foreseable future. :p)
+    _boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
+                       '0': False, 'no': False, 'false': False, 'off': False}
+
+    def get_boolean_setting(self, section, name):
+        """
+        Provides access to any setting, including ones in user defined sections, and casts it
+        into a boolean.
+
+        Values ``1``, ``yes``, ``true`` and ``on`` are converted to ``True`` while ``0``, ``no``,
+        ``false``and ``off`` are converted to false. Case is insensitive.
+
+        :param str section: Name of the section to retrieve the setting from. Do not include the brackets.
+        :param str name: Name of the setting under the provided section.
+
+        :returns: Boolean if the value is valid, None if not set.
+        :rtype: bool
+
+        :raises TankError: Raised if the value is not one of the accepted values.
+        """
+        value = self.get_setting(section, name)
+        if value is None:
+            return None
+
+        if value.lower() in self._boolean_states:
+            return self._boolean_states[value.lower()]
         else:
-            # Read the value, remove any extra whitespace.
-            value = os.path.expandvars(self._user_config.get(self._LOGIN, key))
-            return value.strip()
+            raise TankError(
+                "Invalid value '%s' in '%s' for setting '%s' in section '%s': expecting one of '%s'." % (
+                    value, self._path, name, section, "', '".join(self._boolean_states.keys())
+                )
+            )
 
-    def _is_setting_found(self, key):
+    def get_integer_setting(self, section, name):
         """
-        Checks if the setting is in the file.
+        Provides access to any setting, including ones in user defined sections, and casts it
+        into an integer.
 
-        :param key: Name of the setting within the Login section.
+        :param str section: Name of the section to retrieve the setting from. Do not include the brackets.
+        :param str name: Name of the setting under the provided section.
 
-        :returns: True if found, False otherwise.
+        :returns: Boolean if the value is valid, None if not set.
+        :rtype: bool
+
+        :raises TankError: Raised if the value is not one of the accepted values.
         """
-        if not self._user_config.has_section(self._LOGIN):
-            return False
-        elif not self._user_config.has_option(self._LOGIN, key):
-            return False
-        return True
+        value = self.get_setting(section, name)
+        if value is None:
+            return None
+
+        try:
+            return int(value)
+        except ValueError:
+            raise TankError(
+                "Invalid value '%s' in '%s' for setting '%s' in section '%s': expecting integer." % (
+                    value, self._path, name, section
+                )
+            )
 
     def _evaluate_env_var(self, var_name):
         """
@@ -160,7 +202,7 @@ class UserSettings(Singleton):
         """
         Retrieves the location of the ``config.ini`` file. It will look in multiple locations:
 
-            - The ``SGTK_CONFIG_LOCATION`` environment variable.
+            - The ``SGTK_PREFERENCES_LOCATION`` environment variable.
             - The ``SGTK_DESKTOP_CONFIG_LOCATION`` environment variable.
             - The Shotgun folder.
             - The Shotgun Desktop folder.
@@ -227,50 +269,17 @@ class UserSettings(Singleton):
         else:
             return proxy
 
-    def _get_settings_proxy(self):
+    def _to_display_value(self, value):
         """
-        Retrieves the configuration settings http proxy.
+        Converts the value into a meaningful value for the user if the setting is missing or
+        empty.
 
-        :returns: The configuration settings http proxy string or ``None`` when it is not specified.
+        :returns: If None, returns ``<missing>``. If an empty string, returns ``<empty>`. Otherwise
+            returns the value as is.
         """
-
-        return self._get_value("http_proxy")
-
-    def _get_system_proxy(self):
-        """
-        Retrieves the operating system http proxy.
-
-        First, the method scans the environment for variables named http_proxy, in case insensitive way.
-        If both lowercase and uppercase environment variables exist (and disagree), lowercase is preferred.
-
-        When the method cannot find such environment variables:
-        - for Mac OS X, it will look for proxy information from Mac OS X System Configuration,
-        - for Windows, it will look for proxy information from Windows Systems Registry.
-
-        .. note:: There is a restriction when looking for proxy information from
-                  Mac OS X System Configuration or Windows Systems Registry:
-                  in these cases, the Toolkit does not support the use of proxies
-                  which require authentication (username and password).
-
-        :returns: The operating system http proxy string or ``None`` when it is not defined.
-        """
-
-        # Get the dictionary of scheme to proxy server URL mappings; for example:
-        #     {"http": "http://foo:bar@74.50.63.111:80", "https": "http://74.50.63.111:443"}
-        # "getproxies" scans the environment for variables named <scheme>_proxy, in case insensitive way.
-        # When it cannot find it, for Mac OS X it looks for proxy information from Mac OSX System Configuration,
-        # and for Windows it looks for proxy information from Windows Systems Registry.
-        # If both lowercase and uppercase environment variables exist (and disagree), lowercase is preferred.
-        # Note the following restriction: "getproxies" does not support the use of proxies which
-        # require authentication (user and password) when looking for proxy information from
-        # Mac OSX System Configuration or Windows Systems Registry.
-        system_proxies = urllib.getproxies()
-
-        # Get the http proxy when it exists in the dictionary.
-        proxy = system_proxies.get("http")
-
-        if proxy:
-            # Remove any spurious "http://" from the http proxy string.
-            proxy = proxy.replace("http://", "", 1)
-
-        return proxy
+        if value is None:
+            return "<missing>"
+        elif value is "":
+            return "<empty>"
+        else:
+            return value

--- a/tests/authentication_tests/test_auth_settings.py
+++ b/tests/authentication_tests/test_auth_settings.py
@@ -121,7 +121,7 @@ class DefaultsManagerTest(TankTestBase):
     )
     def test_shotgun_yml_over_global(self, *unused_mocks):
         """
-        Make sure that shotgun.yml always overrides config.ini
+        Make sure that shotgun.yml always overrides toolkit.ini
         """
         instance = UserSettings._instance = Mock()
         instance.shotgun_proxy = self._CONFIG_HTTP_PROXY
@@ -148,3 +148,39 @@ class DefaultsManagerTest(TankTestBase):
 
         dm = CoreDefaultsManager()
         self.assertIs(dm.get_http_proxy(), self._CONFIG_HTTP_PROXY)
+
+    @patch(
+        "tank.util.system_settings.SystemSettings.http_proxy",
+        new_callable=PropertyMock,
+        return_value="192.168.10.1"
+    )
+    def test_disabling_global_proxy(self, _):
+        """
+        Make sure that toolkit.ini can disable the system level proxy.
+        """
+        instance = UserSettings._instance = Mock()
+        instance.shotgun_proxy = ""
+
+        dm = CoreDefaultsManager()
+        self.assertEqual(dm.get_http_proxy(), "")
+
+    @patch(
+        "tank.util.shotgun.get_associated_sg_config_data",
+        return_value={
+            "http_proxy": ""
+        }
+    )
+    @patch(
+        "tank.util.system_settings.SystemSettings.http_proxy",
+        new_callable=PropertyMock,
+        return_value="192.168.10.1"
+    )
+    def test_shotgun_yml_empty_string_can_override_global_proxy(self, *_):
+        """
+        Make sure that shotgun.yml can disable the system level proxy.
+        """
+        instance = UserSettings._instance = Mock()
+        instance.shotgun_proxy = None
+
+        dm = CoreDefaultsManager()
+        self.assertIs(dm.get_http_proxy(), "")

--- a/tests/authentication_tests/test_auth_settings.py
+++ b/tests/authentication_tests/test_auth_settings.py
@@ -13,9 +13,10 @@ Tests settings retrieval through the DefaultsManager
 """
 
 from __future__ import with_statement
-from mock import patch, Mock
+from mock import patch, Mock, PropertyMock
 
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import setUpModule # noqa
 
 from tank.util import CoreDefaultsManager
 from tank.authentication import DefaultsManager
@@ -54,9 +55,9 @@ class DefaultsManagerTest(TankTestBase):
         "tank.authentication.session_cache.get_current_user",
         return_value=_SESSION_CACHE_USER
     )
-    def test_no_global_settings(self, *unused_mocks):
+    def test_no_settings(self, *unused_mocks):
         """
-        Test the behaviour of the defaults manager when there are no global settings.
+        Test the behaviour of the defaults manager when there are no settings.
         """
         instance = UserSettings._instance = Mock()
         instance.shotgun_proxy = None
@@ -68,6 +69,25 @@ class DefaultsManagerTest(TankTestBase):
         self.assertEqual(dm.get_host(), self._SESSION_CACHE_HOST)
         self.assertEqual(dm.get_login(), self._SESSION_CACHE_USER)
         self.assertIs(dm.get_http_proxy(), None)
+
+    def test_with_system_settings(self, *unused_mocks):
+        """
+        Test the behaviour of the defaults manager when there are no settings.
+        """
+        # Mock user settings singleton.
+        instance = UserSettings._instance = Mock()
+        instance.shotgun_proxy = None
+        instance.default_site = self._CONFIG_HOST
+        instance.default_login = self._CONFIG_USER
+        instance.app_store_proxy = None
+
+        with patch(
+            "tank.util.system_settings.SystemSettings.http_proxy",
+            new_callable=PropertyMock,
+            return_value="192.168.10.1"
+        ):
+            dm = DefaultsManager()
+            self.assertIs(dm.get_http_proxy(), "192.168.10.1")
 
     @patch(
         "tank.authentication.session_cache.get_current_host",

--- a/tests/python/mock.py
+++ b/tests/python/mock.py
@@ -1,22 +1,40 @@
 # mock.py
 # Test tools for mocking and patching.
-# Copyright (C) 2007-2012 Michael Foord & the mock team
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
-
-# mock 0.8.0
+#
+# mock 1.0.1
 # http://www.voidspace.org.uk/python/mock/
-
-# Released subject to the BSD License
-# Please see http://www.voidspace.org.uk/python/license.shtml
-
-# Scripts maintained at http://www.voidspace.org.uk/python/index.shtml
-# Comments, suggestions and bug reports welcome.
-
+#
+# Copyright (c) 2007-2013, Michael Foord & the mock team
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 __all__ = (
     'Mock',
     'MagicMock',
-    'mocksignature',
     'patch',
     'sentinel',
     'DEFAULT',
@@ -26,10 +44,12 @@ __all__ = (
     'FILTER_DIR',
     'NonCallableMock',
     'NonCallableMagicMock',
+    'mock_open',
+    'PropertyMock',
 )
 
 
-__version__ = '0.8.0rc2'
+__version__ = '1.0.1'
 
 
 import pprint
@@ -43,7 +63,7 @@ except ImportError:
     inspect = None
 
 try:
-    from functools import wraps
+    from functools import wraps as original_wraps
 except ImportError:
     # Python 2.4 compatibility
     def wraps(original):
@@ -51,8 +71,21 @@ except ImportError:
             f.__name__ = original.__name__
             f.__doc__ = original.__doc__
             f.__module__ = original.__module__
+            wrapped = getattr(original, '__wrapped__', original)
+            f.__wrapped__ = wrapped
             return f
         return inner
+else:
+    if sys.version_info[:2] >= (3, 2):
+        wraps = original_wraps
+    else:
+        def wraps(func):
+            def inner(f):
+                f = original_wraps(func)(f)
+                wrapped = getattr(func, '__wrapped__', func)
+                f.__wrapped__ = wrapped
+                return f
+            return inner
 
 try:
     unicode
@@ -136,42 +169,7 @@ DescriptorTypes = (
 )
 
 
-# getsignature and mocksignature heavily "inspired" by
-# the decorator module: http://pypi.python.org/pypi/decorator/
-# by Michele Simionato
-
-def _getsignature(func, skipfirst):
-    if inspect is None:
-        raise ImportError('inspect module not available')
-
-    if inspect.isclass(func):
-        func = func.__init__
-        # will have a self arg
-        skipfirst = True
-    elif not (inspect.ismethod(func) or inspect.isfunction(func)):
-        func = func.__call__
-
-    regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
-
-    # instance methods need to lose the self argument
-    if getattr(func, self, None) is not None:
-        regargs = regargs[1:]
-
-    _msg = "_mock_ is a reserved argument name, can't mock signatures using _mock_"
-    assert '_mock_' not in regargs, _msg
-    if varargs is not None:
-        assert '_mock_' not in varargs, _msg
-    if varkwargs is not None:
-        assert '_mock_' not in varkwargs, _msg
-    if skipfirst:
-        regargs = regargs[1:]
-
-    signature = inspect.formatargspec(regargs, varargs, varkwargs, defaults,
-                                      formatvalue=lambda value: "")
-    return signature[1:-1], func
-
-
-def _getsignature2(func, skipfirst, instance=False):
+def _getsignature(func, skipfirst, instance=False):
     if inspect is None:
         raise ImportError('inspect module not available')
 
@@ -188,11 +186,19 @@ def _getsignature2(func, skipfirst, instance=False):
         except AttributeError:
             return
 
-    try:
-        regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
-    except TypeError:
-        # C function / method, possibly inherited object().__init__
-        return
+    if inPy3k:
+        try:
+            argspec = inspect.getfullargspec(func)
+        except TypeError:
+            # C function / method, possibly inherited object().__init__
+            return
+        regargs, varargs, varkw, defaults, kwonly, kwonlydef, ann = argspec
+    else:
+        try:
+            regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+        except TypeError:
+            # C function / method, possibly inherited object().__init__
+            return
 
     # instance methods and classmethods need to lose the self argument
     if getattr(func, self, None) is not None:
@@ -201,8 +207,14 @@ def _getsignature2(func, skipfirst, instance=False):
         # this condition and the above one are never both True - why?
         regargs = regargs[1:]
 
-    signature = inspect.formatargspec(regargs, varargs, varkwargs, defaults,
-                                      formatvalue=lambda value: "")
+    if inPy3k:
+        signature = inspect.formatargspec(
+            regargs, varargs, varkw, defaults,
+            kwonly, kwonlydef, ann, formatvalue=lambda value: "")
+    else:
+        signature = inspect.formatargspec(
+            regargs, varargs, varkwargs, defaults,
+            formatvalue=lambda value: "")
     return signature[1:-1], func
 
 
@@ -210,7 +222,7 @@ def _check_signature(func, mock, skipfirst, instance=False):
     if not _callable(func):
         return
 
-    result = _getsignature2(func, skipfirst, instance)
+    result = _getsignature(func, skipfirst, instance)
     if result is None:
         return
     signature, func = result
@@ -270,12 +282,12 @@ def _instance_callable(obj):
 def _set_signature(mock, original, instance=False):
     # creates a function with signature (*args, **kwargs) that delegates to a
     # mock. It still does signature checking by calling a lambda with the same
-    # signature as the original. This is effectively mocksignature2.
+    # signature as the original.
     if not _callable(original):
         return
 
     skipfirst = isinstance(original, ClassTypes)
-    result = _getsignature2(original, skipfirst, instance)
+    result = _getsignature(original, skipfirst, instance)
     if result is None:
         # was a C function (e.g. object().__init__ ) that can't be mocked
         return
@@ -283,51 +295,18 @@ def _set_signature(mock, original, instance=False):
     signature, func = result
 
     src = "lambda %s: None" % signature
-    context = {'_mock_': mock}
-    checksig = eval(src, context)
+    checksig = eval(src, {})
     _copy_func_details(func, checksig)
 
     name = original.__name__
     if not _isidentifier(name):
         name = 'funcopy'
-    context = {'checksig': checksig, 'mock': mock}
+    context = {'_checksig_': checksig, 'mock': mock}
     src = """def %s(*args, **kwargs):
-    checksig(*args, **kwargs)
+    _checksig_(*args, **kwargs)
     return mock(*args, **kwargs)""" % name
     exec (src, context)
     funcopy = context[name]
-    _setup_func(funcopy, mock)
-    return funcopy
-
-
-def mocksignature(func, mock=None, skipfirst=False):
-    """
-    mocksignature(func, mock=None, skipfirst=False)
-
-    Create a new function with the same signature as `func` that delegates
-    to `mock`. If `skipfirst` is True the first argument is skipped, useful
-    for methods where `self` needs to be omitted from the new function.
-
-    If you don't pass in a `mock` then one will be created for you.
-
-    The mock is set as the `mock` attribute of the returned function for easy
-    access.
-
-    `mocksignature` can also be used with classes. It copies the signature of
-    the `__init__` method.
-
-    When used with callable objects (instances) it copies the signature of the
-    `__call__` method.
-    """
-    if mock is None:
-        mock = Mock()
-    signature, func = _getsignature(func, skipfirst)
-    src = "lambda %(signature)s: _mock_(%(signature)s)" % {
-        'signature': signature
-    }
-
-    funcopy = eval(src, dict(_mock_=mock))
-    _copy_func_details(func, funcopy)
     _setup_func(funcopy, mock)
     return funcopy
 
@@ -372,7 +351,7 @@ def _setup_func(funcopy, mock):
     funcopy.assert_any_call = assert_any_call
     funcopy.reset_mock = reset_mock
 
-    mock._mock_signature = funcopy
+    mock._mock_delegate = funcopy
 
 
 def _is_magic(name):
@@ -385,7 +364,7 @@ class _SentinelObject(object):
         self.name = name
 
     def __repr__(self):
-        return '<SentinelObject "%s">' % self.name
+        return 'sentinel.%s' % self.name
 
 
 class _Sentinel(object):
@@ -403,6 +382,8 @@ class _Sentinel(object):
 sentinel = _Sentinel()
 
 DEFAULT = sentinel.DEFAULT
+_missing = sentinel.MISSING
+_deleted = sentinel.DELETED
 
 
 class OldStyleClass:
@@ -429,16 +410,16 @@ _allowed_names = set(
 )
 
 
-def _mock_signature_property(name):
+def _delegating_property(name):
     _allowed_names.add(name)
     _the_name = '_mock_' + name
     def _get(self, name=name, _the_name=_the_name):
-        sig = self._mock_signature
+        sig = self._mock_delegate
         if sig is None:
             return getattr(self, _the_name)
         return getattr(sig, name)
     def _set(self, value, name=name, _the_name=_the_name):
-        sig = self._mock_signature
+        sig = self._mock_delegate
         if sig is None:
             self.__dict__[_the_name] = value
         else:
@@ -536,7 +517,7 @@ class NonCallableMock(Base):
 
         __dict__['_mock_children'] = {}
         __dict__['_mock_wraps'] = wraps
-        __dict__['_mock_signature'] = None
+        __dict__['_mock_delegate'] = None
 
         __dict__['_mock_called'] = False
         __dict__['_mock_call_args'] = None
@@ -596,8 +577,8 @@ class NonCallableMock(Base):
 
     def __get_return_value(self):
         ret = self._mock_return_value
-        if self._mock_signature is not None:
-            ret = self._mock_signature.return_value
+        if self._mock_delegate is not None:
+            ret = self._mock_delegate.return_value
 
         if ret is DEFAULT:
             ret = self._get_child_mock(
@@ -608,8 +589,8 @@ class NonCallableMock(Base):
 
 
     def __set_return_value(self, value):
-        if self._mock_signature is not None:
-            self._mock_signature.return_value = value
+        if self._mock_delegate is not None:
+            self._mock_delegate.return_value = value
         else:
             self._mock_return_value = value
             _check_and_set_parent(self, value, None, '()')
@@ -625,22 +606,22 @@ class NonCallableMock(Base):
             return type(self)
         return self._spec_class
 
-    called = _mock_signature_property('called')
-    call_count = _mock_signature_property('call_count')
-    call_args = _mock_signature_property('call_args')
-    call_args_list = _mock_signature_property('call_args_list')
-    mock_calls = _mock_signature_property('mock_calls')
+    called = _delegating_property('called')
+    call_count = _delegating_property('call_count')
+    call_args = _delegating_property('call_args')
+    call_args_list = _delegating_property('call_args_list')
+    mock_calls = _delegating_property('mock_calls')
 
 
     def __get_side_effect(self):
-        sig = self._mock_signature
+        sig = self._mock_delegate
         if sig is None:
             return self._mock_side_effect
         return sig.side_effect
 
     def __set_side_effect(self, value):
         value = _try_iter(value)
-        sig = self._mock_signature
+        sig = self._mock_delegate
         if sig is None:
             self._mock_side_effect = value
         else:
@@ -659,6 +640,8 @@ class NonCallableMock(Base):
         self.method_calls = _CallList()
 
         for child in self._mock_children.values():
+            if isinstance(child, _SpecState):
+                continue
             child.reset_mock()
 
         ret = self._mock_return_value
@@ -698,7 +681,9 @@ class NonCallableMock(Base):
             raise AttributeError(name)
 
         result = self._mock_children.get(name)
-        if result is None:
+        if result is _deleted:
+            raise AttributeError(name)
+        elif result is None:
             wraps = None
             if self._mock_wraps is not None:
                 # XXXX should we get the attribute without triggering code
@@ -772,9 +757,7 @@ class NonCallableMock(Base):
 
 
     def __dir__(self):
-        """Filter the output of `dir(mock)` to only useful members.
-        XXXX
-        """
+        """Filter the output of `dir(mock)` to only useful members."""
         extras = self._mock_methods or []
         from_type = dir(type(self))
         from_dict = list(self.__dict__)
@@ -805,13 +788,16 @@ class NonCallableMock(Base):
             if not _is_instance_mock(value):
                 setattr(type(self), name, _get_method(name, value))
                 original = value
-                real = lambda *args, **kw: original(self, *args, **kw)
-                value = mocksignature(value, real, skipfirst=True)
+                value = lambda *args, **kw: original(self, *args, **kw)
             else:
                 # only set _new_name and not name so that mock_calls is tracked
                 # but not method calls
                 _check_and_set_parent(self, value, None, name)
                 setattr(type(self), name, value)
+                self._mock_children[name] = value
+        elif name == '__class__':
+            self._spec_class = value
+            return
         else:
             if _check_and_set_parent(self, value, name, name):
                 self._mock_children[name] = value
@@ -826,7 +812,16 @@ class NonCallableMock(Base):
                 # not set on the instance itself
                 return
 
-        return object.__delattr__(self, name)
+        if name in self.__dict__:
+            object.__delattr__(self, name)
+
+        obj = self._mock_children.get(name, _missing)
+        if obj is _deleted:
+            raise AttributeError(name)
+        if obj is not _missing:
+            del self._mock_children[name]
+        self._mock_children[name] = _deleted
+
 
 
     def _format_mock_call_signature(self, args, kwargs):
@@ -875,7 +870,7 @@ class NonCallableMock(Base):
         The `mock_calls` list is checked for the calls.
 
         If `any_order` is False (the default) then the calls must be
-        sequentially. There can be extra calls before or after the
+        sequential. There can be extra calls before or after the
         specified calls.
 
         If `any_order` is True then the calls can be in any order, but
@@ -909,7 +904,7 @@ class NonCallableMock(Base):
         `assert_called_with` and `assert_called_once_with` that only pass if
         the call is the most recent one."""
         kall = call(*args, **kwargs)
-        if not kall in self.call_args_list:
+        if kall not in self.call_args_list:
             expected_string = self._format_mock_call_signature(args, kwargs)
             raise AssertionError(
                 '%s call not found' % expected_string
@@ -1034,7 +1029,10 @@ class CallableMixin(Base):
                 raise effect
 
             if not _callable(effect):
-                return next(effect)
+                result = next(effect)
+                if _is_exception(result):
+                    raise result
+                return result
 
             ret_val = effect(*args, **kwargs)
             if ret_val is DEFAULT:
@@ -1069,27 +1067,28 @@ class Mock(CallableMixin, NonCallableMock):
       `spec_set` will raise an `AttributeError`.
 
     * `side_effect`: A function to be called whenever the Mock is called. See
-      the :attr:`Mock.side_effect` attribute. Useful for raising exceptions or
+      the `side_effect` attribute. Useful for raising exceptions or
       dynamically changing return values. The function is called with the same
-      arguments as the mock, and unless it returns :data:`DEFAULT`, the return
+      arguments as the mock, and unless it returns `DEFAULT`, the return
       value of this function is used as the return value.
 
       Alternatively `side_effect` can be an exception class or instance. In
       this case the exception will be raised when the mock is called.
 
       If `side_effect` is an iterable then each call to the mock will return
-      the next value from the iterable.
+      the next value from the iterable. If any of the members of the iterable
+      are exceptions they will be raised instead of returned.
 
     * `return_value`: The value returned when the mock is called. By default
       this is a new Mock (created on first access). See the
-      :attr:`Mock.return_value` attribute.
+      `return_value` attribute.
 
-    * `wraps`: Item for the mock object to wrap. If `wraps` is not None
-      then calling the Mock will pass the call through to the wrapped object
-      (returning the real result and ignoring `return_value`). Attribute
-      access on the mock will return a Mock object that wraps the corresponding
-      attribute of the wrapped object (so attempting to access an attribute that
-      doesn't exist will raise an `AttributeError`).
+    * `wraps`: Item for the mock object to wrap. If `wraps` is not None then
+      calling the Mock will pass the call through to the wrapped object
+      (returning the real result). Attribute access on the mock will return a
+      Mock object that wraps the corresponding attribute of the wrapped object
+      (so attempting to access an attribute that doesn't exist will raise an
+      `AttributeError`).
 
       If the mock has an explicit `return_value` set then calls are not passed
       to the wrapped object and the `return_value` is returned instead.
@@ -1131,17 +1130,18 @@ def _is_started(patcher):
 class _patch(object):
 
     attribute_name = None
+    _active_patches = set()
 
     def __init__(
             self, getter, attribute, new, spec, create,
-            mocksignature, spec_set, autospec, new_callable, kwargs
+            spec_set, autospec, new_callable, kwargs
         ):
         if new_callable is not None:
             if new is not DEFAULT:
                 raise ValueError(
                     "Cannot use 'new' and 'new_callable' together"
                 )
-            if autospec is not False:
+            if autospec is not None:
                 raise ValueError(
                     "Cannot use 'autospec' and 'new_callable' together"
                 )
@@ -1153,7 +1153,6 @@ class _patch(object):
         self.spec = spec
         self.create = create
         self.has_local = False
-        self.mocksignature = mocksignature
         self.spec_set = spec_set
         self.autospec = autospec
         self.kwargs = kwargs
@@ -1163,7 +1162,7 @@ class _patch(object):
     def copy(self):
         patcher = _patch(
             self.getter, self.attribute, self.new, self.spec,
-            self.create, self.mocksignature, self.spec_set,
+            self.create, self.spec_set,
             self.autospec, self.new_callable, self.kwargs
         )
         patcher.attribute_name = self.attribute_name
@@ -1206,6 +1205,7 @@ class _patch(object):
 
             # can't use try...except...finally because of Python 2.4
             # compatibility
+            exc_info = tuple()
             try:
                 try:
                     for patching in patched.patchings:
@@ -1224,11 +1224,13 @@ class _patch(object):
                         # the patcher may have been started, but an exception
                         # raised whilst entering one of its additional_patchers
                         entered_patchers.append(patching)
+                    # Pass the exception to __exit__
+                    exc_info = sys.exc_info()
                     # re-raise the exception
                     raise
             finally:
                 for patching in reversed(entered_patchers):
-                    patching.__exit__()
+                    patching.__exit__(*exc_info)
 
         patched.patchings = [self]
         if hasattr(func, 'func_code'):
@@ -1268,17 +1270,40 @@ class _patch(object):
         new_callable = self.new_callable
         self.target = self.getter()
 
+        # normalise False to None
+        if spec is False:
+            spec = None
+        if spec_set is False:
+            spec_set = None
+        if autospec is False:
+            autospec = None
+
+        if spec is not None and autospec is not None:
+            raise TypeError("Can't specify spec and autospec")
+        if ((spec is not None or autospec is not None) and
+            spec_set not in (True, None)):
+            raise TypeError("Can't provide explicit spec_set *and* spec or autospec")
+
         original, local = self.get_original()
 
-        if new is DEFAULT and autospec is False:
+        if new is DEFAULT and autospec is None:
             inherit = False
-            if spec_set == True:
-                spec_set = original
-            elif spec == True:
+            if spec is True:
                 # set spec to the object we are replacing
                 spec = original
+                if spec_set is True:
+                    spec_set = original
+                    spec = None
+            elif spec is not None:
+                if spec_set is True:
+                    spec_set = spec
+                    spec = None
+            elif spec_set is True:
+                spec_set = original
 
-            if (spec or spec_set) is not None:
+            if spec is not None or spec_set is not None:
+                if original is DEFAULT:
+                    raise TypeError("Can't use 'spec' with create=True")
                 if isinstance(original, ClassTypes):
                     # If we're patching out a class and there is a spec
                     inherit = True
@@ -1287,8 +1312,15 @@ class _patch(object):
             _kwargs = {}
             if new_callable is not None:
                 Klass = new_callable
-            elif (spec or spec_set) is not None:
-                if not _callable(spec or spec_set):
+            elif spec is not None or spec_set is not None:
+                this_spec = spec
+                if spec_set is not None:
+                    this_spec = spec_set
+                if _is_list(this_spec):
+                    not_callable = '__call__' not in this_spec
+                else:
+                    not_callable = not _callable(this_spec)
+                if not_callable:
                     Klass = NonCallableMagicMock
 
             if spec is not None:
@@ -1307,23 +1339,27 @@ class _patch(object):
             if inherit and _is_instance_mock(new):
                 # we can only tell if the instance should be callable if the
                 # spec is not a list
-                if (not _is_list(spec or spec_set) and not
-                    _instance_callable(spec or spec_set)):
+                this_spec = spec
+                if spec_set is not None:
+                    this_spec = spec_set
+                if (not _is_list(this_spec) and not
+                    _instance_callable(this_spec)):
                     Klass = NonCallableMagicMock
 
                 _kwargs.pop('name')
                 new.return_value = Klass(_new_parent=new, _new_name='()',
                                          **_kwargs)
-        elif autospec is not False:
+        elif autospec is not None:
             # spec is ignored, new *must* be default, spec_set is treated
             # as a boolean. Should we check spec is not None and that spec_set
-            # is a bool? mocksignature should also not be used. Should we
-            # check this?
+            # is a bool?
             if new is not DEFAULT:
                 raise TypeError(
                     "autospec creates the mock for you. Can't specify "
                     "autospec and new."
                 )
+            if original is DEFAULT:
+                raise TypeError("Can't use 'autospec' with create=True")
             spec_set = bool(spec_set)
             if autospec is True:
                 autospec = original
@@ -1336,8 +1372,6 @@ class _patch(object):
             raise TypeError("Can't pass kwargs to a mock we aren't creating")
 
         new_attr = new
-        if self.mocksignature:
-            new_attr = mocksignature(original, new)
 
         self.temp_original = original
         self.is_local = local
@@ -1355,7 +1389,7 @@ class _patch(object):
         return new
 
 
-    def __exit__(self, *_):
+    def __exit__(self, *exc_info):
         """Undo the patch."""
         if not _is_started(self):
             raise RuntimeError('stop called on unstarted patcher')
@@ -1373,10 +1407,20 @@ class _patch(object):
         del self.target
         for patcher in reversed(self.additional_patchers):
             if _is_started(patcher):
-                patcher.__exit__()
+                patcher.__exit__(*exc_info)
 
-    start = __enter__
-    stop = __exit__
+
+    def start(self):
+        """Activate a patch, returning any created mock."""
+        result = self.__enter__()
+        self._active_patches.add(self)
+        return result
+
+
+    def stop(self):
+        """Stop an active patch."""
+        self._active_patches.discard(self)
+        return self.__exit__()
 
 
 
@@ -1392,30 +1436,34 @@ def _get_target(target):
 
 def _patch_object(
         target, attribute, new=DEFAULT, spec=None,
-        create=False, mocksignature=False, spec_set=None, autospec=False,
+        create=False, spec_set=None, autospec=None,
         new_callable=None, **kwargs
     ):
     """
     patch.object(target, attribute, new=DEFAULT, spec=None, create=False,
-                 mocksignature=False, spec_set=None)
+                 spec_set=None, autospec=None, new_callable=None, **kwargs)
 
     patch the named member (`attribute`) on an object (`target`) with a mock
     object.
 
-    Arguments new, spec, create, mocksignature and spec_set have the same
-    meaning as for patch.
+    `patch.object` can be used as a decorator, class decorator or a context
+    manager. Arguments `new`, `spec`, `create`, `spec_set`,
+    `autospec` and `new_callable` have the same meaning as for `patch`. Like
+    `patch`, `patch.object` takes arbitrary keyword arguments for configuring
+    the mock object it creates.
+
+    When used as a class decorator `patch.object` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
     """
     getter = lambda: target
     return _patch(
-        getter, attribute, new, spec, create, mocksignature,
+        getter, attribute, new, spec, create,
         spec_set, autospec, new_callable, kwargs
     )
 
 
-def _patch_multiple(target, spec=None, create=False,
-        mocksignature=False, spec_set=None, autospec=False,
-        new_callable=None, **kwargs
-    ):
+def _patch_multiple(target, spec=None, create=False, spec_set=None,
+                    autospec=None, new_callable=None, **kwargs):
     """Perform multiple patches in a single call. It takes the object to be
     patched (either as an object or a string to fetch the object by importing)
     and keyword arguments for the patches::
@@ -1423,11 +1471,18 @@ def _patch_multiple(target, spec=None, create=False,
         with patch.multiple(settings, FIRST_PATCH='one', SECOND_PATCH='two'):
             ...
 
-    Like `patch` it can be used as a decorator, class decorator or a context
-    manager. The arguments `spec`, `spec_set`, `create`, `mocksignature`,
+    Use `DEFAULT` as the value if you want `patch.multiple` to create
+    mocks for you. In this case the created mocks are passed into a decorated
+    function by keyword, and a dictionary is returned when `patch.multiple` is
+    used as a context manager.
+
+    `patch.multiple` can be used as a decorator, class decorator or a context
+    manager. The arguments `spec`, `spec_set`, `create`,
     `autospec` and `new_callable` have the same meaning as for `patch`. These
-    arguments will be applied to *all* the patches being done by
-    `patch.multiple`.
+    arguments will be applied to *all* patches done by `patch.multiple`.
+
+    When used as a class decorator `patch.multiple` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
     """
     if type(target) in (unicode, str):
         getter = lambda: _importer(target)
@@ -1442,13 +1497,13 @@ def _patch_multiple(target, spec=None, create=False,
     items = list(kwargs.items())
     attribute, new = items[0]
     patcher = _patch(
-        getter, attribute, new, spec, create, mocksignature, spec_set,
+        getter, attribute, new, spec, create, spec_set,
         autospec, new_callable, {}
     )
     patcher.attribute_name = attribute
     for attribute, new in items[1:]:
         this_patcher = _patch(
-            getter, attribute, new, spec, create, mocksignature, spec_set,
+            getter, attribute, new, spec, create, spec_set,
             autospec, new_callable, {}
         )
         this_patcher.attribute_name = attribute
@@ -1458,22 +1513,25 @@ def _patch_multiple(target, spec=None, create=False,
 
 def patch(
         target, new=DEFAULT, spec=None, create=False,
-        mocksignature=False, spec_set=None, autospec=False,
-        new_callable=None, **kwargs
+        spec_set=None, autospec=None, new_callable=None, **kwargs
     ):
     """
     `patch` acts as a function decorator, class decorator or a context
     manager. Inside the body of the function or with statement, the `target`
-    (specified in the form `'package.module.ClassName'`) is patched
-    with a `new` object. When the function/with statement exits the patch is
-    undone.
+    is patched with a `new` object. When the function/with statement exits
+    the patch is undone.
 
-    The `target` is imported and the specified attribute patched with the new
-    object, so it must be importable from the environment you are calling the
-    decorator from.
+    If `new` is omitted, then the target is replaced with a
+    `MagicMock`. If `patch` is used as a decorator and `new` is
+    omitted, the created mock is passed in as an extra argument to the
+    decorated function. If `patch` is used as a context manager the created
+    mock is returned by the context manager.
 
-    If `new` is omitted, then a new `MagicMock` is created and passed in as an
-    extra argument to the decorated function.
+    `target` should be a string in the form `'package.module.ClassName'`. The
+    `target` is imported and the specified object replaced with the `new`
+    object, so the `target` must be importable from the environment you are
+    calling `patch` from. The target is imported when the decorated function
+    is executed, not at decoration time.
 
     The `spec` and `spec_set` keyword arguments are passed to the `MagicMock`
     if patch is creating one for you.
@@ -1488,43 +1546,35 @@ def patch(
     A more powerful form of `spec` is `autospec`. If you set `autospec=True`
     then the mock with be created with a spec from the object being replaced.
     All attributes of the mock will also have the spec of the corresponding
-    attribute of the object being replaced. Methods and functions being mocked
-    will have their arguments checked and will raise a `TypeError` if they are
-    called with the wrong signature (similar to `mocksignature`). For mocks
-    replacing a class, their return value (the 'instance') will have the same
-    spec as the class.
+    attribute of the object being replaced. Methods and functions being
+    mocked will have their arguments checked and will raise a `TypeError` if
+    they are called with the wrong signature. For mocks replacing a class,
+    their return value (the 'instance') will have the same spec as the class.
 
     Instead of `autospec=True` you can pass `autospec=some_object` to use an
     arbitrary object as the spec instead of the one being replaced.
 
-    If `mocksignature` is True then the patch will be done with a function
-    created by mocking the one being replaced. If the object being replaced is
-    a class then the signature of `__init__` will be copied. If the object
-    being replaced is a callable object then the signature of `__call__` will
-    be copied.
-
     By default `patch` will fail to replace attributes that don't exist. If
-    you pass in 'create=True' and the attribute doesn't exist, patch will
+    you pass in `create=True`, and the attribute doesn't exist, patch will
     create the attribute for you when the patched function is called, and
     delete it again afterwards. This is useful for writing tests against
     attributes that your production code creates at runtime. It is off by by
     default because it can be dangerous. With it switched on you can write
     passing tests against APIs that don't actually exist!
 
-    Patch can be used as a TestCase class decorator. It works by
+    Patch can be used as a `TestCase` class decorator. It works by
     decorating each test method in the class. This reduces the boilerplate
     code when your test methods share a common patchings set. `patch` finds
     tests by looking for method names that start with `patch.TEST_PREFIX`.
     By default this is `test`, which matches the way `unittest` finds tests.
     You can specify an alternative prefix by setting `patch.TEST_PREFIX`.
 
-    Patch can be used with the with statement, if this is available in your
-    version of Python. Here the patching applies to the indented block after
-    the with statement. If you use "as" then the patched object will be bound
-    to the name after the "as"; very useful if `patch` is creating a mock
-    object for you.
+    Patch can be used as a context manager, with the with statement. Here the
+    patching applies to the indented block after the with statement. If you
+    use "as" then the patched object will be bound to the name after the
+    "as"; very useful if `patch` is creating a mock object for you.
 
-    `patch` also takes arbitrary keyword arguments. These will be passed to
+    `patch` takes arbitrary keyword arguments. These will be passed to
     the `Mock` (or `new_callable`) on construction.
 
     `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
@@ -1532,15 +1582,15 @@ def patch(
     """
     getter, attribute = _get_target(target)
     return _patch(
-        getter, attribute, new, spec, create, mocksignature,
+        getter, attribute, new, spec, create,
         spec_set, autospec, new_callable, kwargs
     )
 
 
 class _patch_dict(object):
     """
-    Patch a dictionary and restore the dictionary to its original state after
-    the test.
+    Patch a dictionary, or dictionary like object, and restore the dictionary
+    to its original state after the test.
 
     `in_dict` can be a dictionary or a mapping like container. If it is a
     mapping then it must at least support getting, setting and deleting items
@@ -1560,6 +1610,10 @@ class _patch_dict(object):
 
         with patch.dict('sys.modules', mymodule=Mock(), other_module=Mock()):
             ...
+
+    `patch.dict` can be used as a context manager, decorator or class
+    decorator. When used as a class decorator `patch.dict` honours
+    `patch.TEST_PREFIX` for choosing which methods to wrap.
     """
 
     def __init__(self, in_dict, values=(), clear=False, **kwargs):
@@ -1660,9 +1714,16 @@ def _clear_dict(in_dict):
             del in_dict[key]
 
 
+def _patch_stopall():
+    """Stop all active patches."""
+    for patch in list(_patch._active_patches):
+        patch.stop()
+
+
 patch.object = _patch_object
 patch.dict = _patch_dict
 patch.multiple = _patch_multiple
+patch.stopall = _patch_stopall
 patch.TEST_PREFIX = 'test'
 
 magic_methods = (
@@ -1727,16 +1788,14 @@ _calculate_return_value = {
     '__unicode__': lambda self: unicode(object.__str__(self)),
 }
 
-_side_effect_methods = {
-    '__eq__': lambda self: lambda other: self is other,
-    '__ne__': lambda self: lambda other: self is not other,
-}
-
 _return_values = {
+    '__lt__': NotImplemented,
+    '__gt__': NotImplemented,
+    '__le__': NotImplemented,
+    '__ge__': NotImplemented,
     '__int__': 1,
     '__contains__': False,
     '__len__': 0,
-    '__iter__': iter([]),
     '__exit__': False,
     '__complex__': 1j,
     '__float__': 1.0,
@@ -1764,29 +1823,44 @@ def _get_ne(self):
         return self is not other
     return __ne__
 
+def _get_iter(self):
+    def __iter__():
+        ret_val = self.__iter__._mock_return_value
+        if ret_val is DEFAULT:
+            return iter([])
+        # if ret_val was already an iterator, then calling iter on it should
+        # return the iterator unchanged
+        return iter(ret_val)
+    return __iter__
+
 _side_effect_methods = {
     '__eq__': _get_eq,
     '__ne__': _get_ne,
+    '__iter__': _get_iter,
 }
 
 
 
 def _set_return_value(mock, method, name):
-    return_value = DEFAULT
-    if name in _return_values:
-        return_value = _return_values[name]
-    elif name in _calculate_return_value:
+    fixed = _return_values.get(name, DEFAULT)
+    if fixed is not DEFAULT:
+        method.return_value = fixed
+        return
+
+    return_calulator = _calculate_return_value.get(name)
+    if return_calulator is not None:
         try:
-            return_value = _calculate_return_value[name](mock)
+            return_value = return_calulator(mock)
         except AttributeError:
             # XXXX why do we return AttributeError here?
             #      set it as a side_effect instead?
             return_value = AttributeError(name)
-    elif name in _side_effect_methods:
-        side_effect = _side_effect_methods[name](mock)
-        method.side_effect = side_effect
-    if return_value is not DEFAULT:
         method.return_value = return_value
+        return
+
+    side_effector = _side_effect_methods.get(name)
+    if side_effector is not None:
+        method.side_effect = side_effector(mock)
 
 
 
@@ -1971,8 +2045,10 @@ class _Call(tuple):
 
 
     def __eq__(self, other):
+        if other is ANY:
+            return True
         try:
-            len(other)
+            len_other = len(other)
         except TypeError:
             return False
 
@@ -1983,11 +2059,11 @@ class _Call(tuple):
             self_name, self_args, self_kwargs = self
 
         other_name = ''
-        if len(other) == 0:
+        if len_other == 0:
             other_args, other_kwargs = (), {}
-        elif len(other) == 3:
+        elif len_other == 3:
             other_name, other_args, other_kwargs = other
-        elif len(other) == 1:
+        elif len_other == 1:
             value, = other
             if isinstance(value, tuple):
                 other_args = value
@@ -2081,9 +2157,8 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     mock will use the corresponding attribute on the `spec` object as their
     spec.
 
-    Functions or methods being mocked will have their arguments checked in a
-    similar way to `mocksignature` to check that they are called with the
-    correct signature.
+    Functions or methods being mocked will have their arguments checked
+    to check that they are called with the correct signature.
 
     If `spec_set` is True then attempting to set attributes that don't exist
     on the spec object will raise an `AttributeError`.
@@ -2140,7 +2215,6 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         _parent._mock_children[_name] = mock
 
     if is_type and not instance and 'return_value' not in kwargs:
-        # XXXX could give a name to the return_value mock?
         mock.return_value = create_autospec(spec, spec_set, instance=True,
                                             _name='()', _parent=mock)
 
@@ -2150,7 +2224,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
             continue
 
         if isinstance(spec, FunctionTypes) and entry in FunctionAttributes:
-            # allow a mock to actually be a function from mocksignature
+            # allow a mock to actually be a function
             continue
 
         # XXXX do we need a better way of getting attributes without
@@ -2158,10 +2232,14 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         # object to mock it so we would rather trigger a property than mock
         # the property descriptor. Likewise we want to mock out dynamically
         # provided attributes.
-        # XXXX what about attributes that raise exceptions on being fetched
+        # XXXX what about attributes that raise exceptions other than
+        # AttributeError on being fetched?
         # we could be resilient against it, or catch and propagate the
         # exception when the attribute is fetched from the mock
-        original = getattr(spec, entry)
+        try:
+            original = getattr(spec, entry)
+        except AttributeError:
+            continue
 
         kwargs = {'spec': original}
         if spec_set:
@@ -2181,7 +2259,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
             skipfirst = _must_skip(spec, entry, is_type)
             _check_signature(original, new, skipfirst=skipfirst)
 
-        # so functions created with mocksignature become instance attributes,
+        # so functions created with _set_signature become instance attributes,
         # *plus* their underlying mock exists in _mock_children of the parent
         # mock. Adding to _mock_children may be unnecessary where we are also
         # setting as an instance attribute?
@@ -2196,7 +2274,6 @@ def _must_skip(spec, entry, is_type):
         if entry in getattr(spec, '__dict__', {}):
             # instance attribute - shouldn't skip
             return False
-        # can't use type because of old style classes
         spec = spec.__class__
     if not hasattr(spec, '__mro__'):
         # old style class: can't have descriptors anyway
@@ -2253,3 +2330,57 @@ FunctionAttributes = set([
     'func_globals',
     'func_name',
 ])
+
+
+file_spec = None
+
+
+def mock_open(mock=None, read_data=''):
+    """
+    A helper function to create a mock to replace the use of `open`. It works
+    for `open` called directly or used as a context manager.
+
+    The `mock` argument is the mock object to configure. If `None` (the
+    default) then a `MagicMock` will be created for you, with the API limited
+    to methods or attributes available on standard file handles.
+
+    `read_data` is a string for the `read` method of the file handle to return.
+    This is an empty string by default.
+    """
+    global file_spec
+    if file_spec is None:
+        # set on first use
+        if inPy3k:
+            import _io
+            file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
+        else:
+            file_spec = file
+
+    if mock is None:
+        mock = MagicMock(name='open', spec=open)
+
+    handle = MagicMock(spec=file_spec)
+    handle.write.return_value = None
+    handle.__enter__.return_value = handle
+    handle.read.return_value = read_data
+
+    mock.return_value = handle
+    return mock
+
+
+class PropertyMock(Mock):
+    """
+    A mock intended to be used as a property, or other descriptor, on a class.
+    `PropertyMock` provides `__get__` and `__set__` methods so you can specify
+    a return value when it is fetched.
+
+    Fetching a `PropertyMock` instance from an object calls the mock, with
+    no args. Setting it calls the mock with the value being set.
+    """
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
+
+    def __get__(self, obj, obj_type):
+        return self()
+    def __set__(self, obj, val):
+        self(val)

--- a/tests/util_tests/test_system_settings.py
+++ b/tests/util_tests/test_system_settings.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
+
+import os
+
+from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import setUpModule # noqa
+
+from mock import patch
+
+from tank.util.system_settings import SystemSettings
+
+
+class SystemSettingsTests(TankTestBase):
+    """
+    Tests functionality from the SystemSettings class.
+    """
+
+    def test_system_proxy(self):
+        """
+        Tests the fallback on the operating system http proxy.
+        """
+        http_proxy = "foo:bar@74.50.63.111:80"  # IP address of shotgunstudio.com
+
+        with patch.dict(os.environ, {"http_proxy": "http://" + http_proxy}):
+            settings = SystemSettings()
+            self.assertEqual(settings.http_proxy, http_proxy)

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -11,67 +11,61 @@
 from __future__ import with_statement
 
 import os
-import unittest2 as unittest
+import uuid
+
+from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import setUpModule # noqa
+
 from mock import patch
 
 from tank.util import EnvironmentVariableFileLookupError
 from tank.util.user_settings import UserSettings
+from sgtk import TankError
 
 
-class MockConfigParser(object):
+class UserSettingsTests(TankTestBase):
     """
-    Mocks the config parser object used internally by the UserSettings class.
-    """
-
-    def __init__(self, data):
-        """
-        Constructor.
-        """
-        self._data = {
-            "Login": data
-        }
-
-    def has_section(self, name):
-        """
-        Checks if a section [name] is present.
-        """
-        return name in self._data
-
-    def has_option(self, name, key):
-        """
-        Checks for setting key: inside [name].
-        """
-        return self.has_section(name) and key in self._data[name]
-
-    def get(self, name, key):
-        """
-        Retrieves setting from ini file.
-        """
-        return self._data[name][key]
-
-    def read(self, path):
-        """
-        Mocked to please the UserSettings implementation.
-        """
-        pass
-
-
-# Got get the tank test harness, we don't want part of the API mocked, we'll
-# mock the parsing and be done with it.
-class UserSettingsTests(unittest.TestCase):
-    """
-    Tests functionality around config.ini
+    Tests functionality around toolkit.ini
     """
 
     def setUp(self):
         """
         Make sure the singleton is reset at the beginning of this test.
         """
+        super(UserSettingsTests, self).setUp()
         UserSettings.clear_singleton()
         self.addCleanup(UserSettings.clear_singleton)
 
-    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({}))
-    def test_empty_file(self, mock):
+    def _mock_ini_file(self, login_section={}, custom_section={}):
+        """
+        Creates an ini file in a unique location with te user settings.
+
+        :param login_section: Dictionary of settings that will be stored in the [Login] section.
+        :param custom_section: Dictionary of settings that will be stored in the [Custom] section.
+        """
+        # Create a unique folder for this test.
+        folder = os.path.join(self.tank_temp, str(uuid.uuid4()))
+        os.makedirs(folder)
+
+        # Manually write the file as this is the format we're expecting the UserSettings
+        # to parse.
+
+        ini_file_location = os.path.join(folder, "toolkit.ini")
+        with open(ini_file_location, "w") as f:
+            f.writelines(["[Login]\n"])
+            for key, value in login_section.iteritems():
+                f.writelines(["%s=%s\n" % (key, value)])
+
+            f.writelines(["[Custom]\n"])
+            for key, value in custom_section.iteritems():
+                f.writelines(["%s=%s\n" % (key, value)])
+
+        # The setUp phase cleared the singleton. So set the preferences environment variable and
+        # instantiate the singleton, which will read the env var and open that location.
+        with patch.dict(os.environ, {"SGTK_PREFERENCES_LOCATION": ini_file_location}):
+            UserSettings()
+
+    def test_empty_file(self):
         """
         Tests a complete yaml file.
         """
@@ -79,56 +73,111 @@ class UserSettingsTests(unittest.TestCase):
         self.assertIsNone(settings.default_site)
         self.assertIsNone(settings.default_login)
         self.assertIsNone(settings.shotgun_proxy)
-        self.assertFalse(settings.is_app_store_proxy_set())
+        self.assertIsNone(settings.app_store_proxy)
 
-    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
-        "default_site": "site",
-        "default_login": "login",
-        "http_proxy": "http_proxy",
-        "app_store_http_proxy": "app_store_http_proxy"
-    }))
-    def test_filled_file(self, mock):
+    def test_filled_file(self):
         """
         Tests a complete yaml file.
         """
+        self._mock_ini_file({
+            "default_site": "site",
+            "default_login": "login",
+            "http_proxy": "http_proxy",
+            "app_store_http_proxy": "app_store_http_proxy"
+        })
+
         settings = UserSettings()
         self.assertEqual(settings.default_site, "site")
         self.assertEqual(settings.default_login, "login")
         self.assertEqual(settings.shotgun_proxy, "http_proxy")
-        self.assertTrue(settings.is_app_store_proxy_set())
         self.assertEqual(settings.app_store_proxy, "app_store_http_proxy")
 
-    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({}))
-    def test_system_proxy(self, mock):
+    def test_empty_settings(self):
         """
-        Tests the fallback on the operating system http proxy.
+        Tests a yaml file with the settings present but empty.
         """
-        http_proxy = "foo:bar@74.50.63.111:80"  # IP address of shotgunstudio.com
+        self._mock_ini_file({
+            "default_site": "",
+            "default_login": "",
+            "http_proxy": "",
+            "app_store_http_proxy": ""
+        })
 
-        with patch.dict(os.environ, {"http_proxy": "http://" + http_proxy}):
-            settings = UserSettings()
-            self.assertEqual(settings.shotgun_proxy, http_proxy)
-
-    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
-        # Config parser represent empty settings as empty strings
-        "app_store_http_proxy": ""
-    }))
-    def test_app_store_to_none(self, mock):
-        """
-        Tests a file with a present but empty app store proxy setting.
-        """
         settings = UserSettings()
-        self.assertTrue(settings.is_app_store_proxy_set())
-        self.assertEqual(settings.app_store_proxy, None)
+        self.assertEqual(settings.default_site, "")
+        self.assertEqual(settings.default_login, "")
+        self.assertEqual(settings.shotgun_proxy, "")
+        self.assertEqual(settings.app_store_proxy, "")
 
-    @patch("tank.util.user_settings.UserSettings._load_config", return_value=MockConfigParser({
-        # Config parser represent empty settings as empty strings
-        "default_site": "https://${SGTK_TEST_SHOTGUN_SITE}.shotgunstudio.com"
-    }))
-    def test_environment_variable_expansions(self, mock):
+    def test_custom_settings(self):
+        """
+        Tests that we can read settings in any section of the file.
+        """
+
+        self._mock_ini_file(
+            custom_section={
+                "custom_key": "custom_value"
+            }
+        )
+
+        self.assertEqual(
+            UserSettings().get_setting("Custom", "custom_key"),
+            "custom_value"
+        )
+
+    def test_boolean_setting(self):
+        """
+        Tests that we can read a setting into a boolean.
+        """
+        self._mock_ini_file(
+            custom_section={
+                "valid": "ON",
+                "invalid": "L"
+            }
+        )
+
+        self.assertEqual(
+            UserSettings().get_boolean_setting("Custom", "valid"), True
+        )
+        with self.assertRaisesRegexp(
+            TankError,
+            "Invalid value 'L' in '.*' for setting 'invalid' in section 'Custom': expecting one of .*."
+        ):
+            UserSettings().get_boolean_setting("Custom", "invalid")
+
+    def test_integer_setting(self):
+        """
+        Tests that we can read a setting into an integer
+        """
+
+        self._mock_ini_file(
+            custom_section={
+                "valid": "1",
+                "also_valid": "-1",
+                "invalid": "L"
+            }
+        )
+
+        self.assertEqual(
+            UserSettings().get_integer_setting("Custom", "valid"), 1
+        )
+        self.assertEqual(
+            UserSettings().get_integer_setting("Custom", "also_valid"), -1
+        )
+        with self.assertRaisesRegexp(
+            TankError,
+            "Invalid value 'L' in '.*' for setting 'invalid' in section 'Custom': expecting integer."
+        ):
+            UserSettings().get_integer_setting("Custom", "invalid")
+
+    def test_environment_variable_expansions(self):
         """
         Tests that setting an environment variable will be resolved.
         """
+        self._mock_ini_file({
+            # Config parser represent empty settings as empty strings
+            "default_site": "https://${SGTK_TEST_SHOTGUN_SITE}.shotgunstudio.com"
+        })
         with patch.dict(os.environ, {"SGTK_TEST_SHOTGUN_SITE": "shotgun_site"}):
             settings = UserSettings()
             self.assertEqual(settings.default_site, "https://shotgun_site.shotgunstudio.com")


### PR DESCRIPTION
Before starting the review: 
I've highlighted the bits that have changed between the zero config branch and this. Hopefully you don't need to review everything with as much scrutiny as it was originally.

When running a local Shotgun site, you maybe have a proxy setup to access the internet at the OS level. However, this proxy will not be required to access your local Shotgun site.

This fixes an issue where having such a system-wide proxy can prevent connection to your localsite as Toolkit uses it as a fallback for finding nothing in shotgun.yml and toolkit.ini.

It is now possible, just like for the app store proxy, to set an empty value inside toolkit.ini or shotgun.yml which will essentially set the proxy to an empty string and allow connections to Shotgun to be done without a proxy being used.

This branch actually integrates most of a commit from the `develop/zero_config` branch. This was done in order to reduce the number of issues when merging back since that code had been modified quite a bit in that branch.