### PR TITLE
For #41797, git descriptor failure on Windows

### DIFF
--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -130,7 +130,6 @@ class IODescriptorGit(IODescriptorBase):
                 try:
                     output = subprocess_check_output(
                         full_command,
-                        stderr=subprocess.STDOUT,
                         shell=True
                     )
 

--- a/python/tank/util/process.py
+++ b/python/tank/util/process.py
@@ -34,15 +34,20 @@ def subprocess_check_output(*popenargs, **kwargs):
     """
     Run command with arguments and return its output as a byte string.
 
-    A python 2.6 compatible subprocess.check_output call.
+    A somewhat-python 2.6 compatible subprocess.check_output call.
     Subprocess.check_output was added to Python 2.7. For docs, see
     https://docs.python.org/2/library/subprocess.html#subprocess.check_output
 
     Adopted from from http://stackoverflow.com/questions/2924310
 
+    This version however doesn't allow to override stderr, stdout and stdin. stdin
+    is always closed right after launch and stderr is always redirected to stdout. This
+    is done in order to avoid DUPLICATE_SAME_ACCESS errors on Windows. Learn more about
+    it here: https://bugs.python.org/issue3905.
+
     :returns: The output from the command
     :raises: If the return code was non-zero it raises a SubprocessCalledProcessError.
-             The CalledProcessError object will have the return code in the returncode
+             The SubprocessCalledProcessError object will have the return code in the returncode
              attribute and any output in the output attribute.
     """
     if "stdout" in kwargs or "stderr" in kwargs or "stdin" in kwargs:
@@ -52,8 +57,7 @@ def subprocess_check_output(*popenargs, **kwargs):
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
         *popenargs, **kwargs
     )
-    # Very important to close stdin on Windows
-    # https://bugs.python.org/issue3905
+    # Very important to close stdin on Windows. See issue mentioned above.
     process.stdin.close()
     output, unused_err = process.communicate()
     retcode = process.poll()

--- a/python/tank/util/process.py
+++ b/python/tank/util/process.py
@@ -1,14 +1,20 @@
 # Copyright (c) 2016 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import subprocess
+import pprint
+
+from ..log import LogManager
+
+logger = LogManager.get_logger(__name__)
+
 
 class SubprocessCalledProcessError(Exception):
     """
@@ -39,14 +45,33 @@ def subprocess_check_output(*popenargs, **kwargs):
              The CalledProcessError object will have the return code in the returncode
              attribute and any output in the output attribute.
     """
-    if "stdout" in kwargs:
-        raise ValueError("stdout argument not allowed, it will be overridden.")
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    if "stdout" in kwargs or "stderr" in kwargs or "stdin" in kwargs:
+        raise ValueError("stdout, stderr and stdin arguments not allowed, they will be overridden.")
+
+    process = subprocess.Popen(
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
+        *popenargs, **kwargs
+    )
+    # Very important to close stdin on Windows
+    # https://bugs.python.org/issue3905
+    process.stdin.close()
     output, unused_err = process.communicate()
     retcode = process.poll()
+
     if retcode:
+
+        logger.debug("Subprocess invocation failed:")
+        if popenargs:
+            logger.debug("Args  : %s", pprint.pformat(popenargs))
+        if kwargs:
+            logger.debug("Kwargs: %s", pprint.pformat(kwargs))
+        logger.debug("Return code: %d", retcode)
+        logger.debug("Process stdout/stderr:")
+        logger.debug(output)
+
         cmd = kwargs.get("args")
         if cmd is None:
             cmd = popenargs[0]
+
         raise SubprocessCalledProcessError(retcode, cmd, output=output)
     return output


### PR DESCRIPTION
Fixes a DUPLICATE_SAME_HANDLE error on Windows when running git commands from a GUI app launched from a shell.

This is method is only used by the git descriptor and part of the private API, so there's no risk of regressions.

More can be learned about this issue [here](https://bugs.python.org/issue3905).