### PR TITLE
Adds dry_run flag to register_publish

### DIFF
--- a/python/tank/util/shotgun.py
+++ b/python/tank/util/shotgun.py
@@ -887,8 +887,8 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
             file_path,
             name,
             version_number,
-            comment = 'Initial layout composition.',
-            published_file_type = 'Layout Scene'
+            comment= Initial layout composition.',
+            published_file_type='Layout Scene'
         )
 
         {'code': 'layout.v001.ma',
@@ -912,6 +912,35 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
          'task': None,
          'type': 'PublishedFile',
          'version_number': 1}
+
+    When using the ``dry_run`` option, the returned data will look something like this::
+
+        >>> file_path = '/studio/demo_project/sequences/Sequence-1/shot_010/Anm/publish/layout.v001.ma'
+        >>> name = 'layout'
+        >>> version_number = 1
+        >>>
+        >>> sgtk.util.register_publish(
+            tk,
+            context,
+            file_path,
+            name,
+            version_number,
+            comment='Initial layout composition.',
+            published_file_type='Layout Scene'
+            dry_run=True
+        )
+
+        {'code': 'layout.v001.ma',
+         'description': 'Initial layout composition.',
+         'entity': {'id': 2, 'name': 'shot_010', 'type': 'Shot'},
+         'path': {'local_path': '/studio/demo_project/sequences/Sequence-1/shot_010/Anm/publish/layout.v001.ma'},
+         'project': {'id': 4, 'name': 'Demo Project', 'type': 'Project'},
+         'task': None,
+         'type': 'PublishedFile',
+         'version_number': 1}
+
+    Be aware that the data may be different if the ``before_register_publish``
+    hook has been overridden.
 
     **Parameters**
 
@@ -1442,6 +1471,8 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
     data = tk.execute_core_hook(constants.TANK_PUBLISH_HOOK_NAME, shotgun_data=data, context=context)
 
     if dry_run:
+        # add the publish type to be as consistent as possible
+        data["type"] = published_file_entity_type
         log.debug("Dry run. Simply returning the data that would be sent to SG: %s" % pprint.pformat(data))
         return data
     else:

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -428,9 +428,26 @@ class TestShotgunRegisterPublish(TankTestBase):
         real_create = self.tk.shotgun.create 
         self.tk.shotgun.create = create_mock
 
+        # dry run
+        publish_data = tank.util.register_publish(
+            self.tk,
+            self.context,
+            seq_path,
+            self.name,
+            self.version,
+            dry_run=True
+        )
+        self.assertIsInstance(publish_data, dict)
+
         # mock sg.create, check it for path value
         try:
-            tank.util.register_publish(self.tk, self.context, seq_path, self.name, self.version)
+            tank.util.register_publish(
+                self.tk,
+                self.context,
+                seq_path,
+                self.name,
+                self.version
+            )
         finally:
             self.tk.shotgun.create = real_create
 
@@ -451,12 +468,24 @@ class TestShotgunRegisterPublish(TankTestBase):
     def test_url_paths(self, create_mock):
         """Tests the passing of urls via the path."""
 
-        tank.util.register_publish(
+        # dry run
+        publish_data = tank.util.register_publish(
             self.tk,
             self.context,
             "file:///path/to/file with spaces.png",
             self.name,
-            self.version)
+            self.version,
+            dry_run=True
+        )
+        self.assertIsInstance(publish_data, dict)
+
+        publish_data = tank.util.register_publish(
+            self.tk,
+            self.context,
+            "file:///path/to/file with spaces.png",
+            self.name,
+            self.version
+        )
 
         create_data = create_mock.call_args
         args, kwargs = create_data
@@ -475,12 +504,24 @@ class TestShotgunRegisterPublish(TankTestBase):
     def test_url_paths_host(self, create_mock):
         """Tests the passing of urls via the path."""
 
-        tank.util.register_publish(
+        # dry run.
+        publish_data = tank.util.register_publish(
             self.tk,
             self.context,
             "https://site.com",
             self.name,
-            self.version)
+            self.version,
+            dry_run=True
+        )
+        self.assertIsInstance(publish_data, dict)
+
+        publish_data = tank.util.register_publish(
+            self.tk,
+            self.context,
+            "https://site.com",
+            self.name,
+            self.version
+        )
 
         create_data = create_mock.call_args
         args, kwargs = create_data
@@ -511,6 +552,18 @@ class TestShotgunRegisterPublish(TankTestBase):
 
         # Various paths we support, Unix and Windows styles
         for local_path in values:
+
+            # dry run.
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                local_path,
+                self.name,
+                self.version,
+                dry_run=True
+            )
+            self.assertIsInstance(publish_data, dict)
+
             tank.util.register_publish(
                 self.tk,
                 self.context,
@@ -574,6 +627,18 @@ class TestShotgunRegisterPublish(TankTestBase):
 
         # Various paths we support, Unix and Windows styles
         for (local_path, path_dict) in values.iteritems():
+
+            # dry run.
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                local_path,
+                self.name,
+                self.version,
+                dry_run=True
+            )
+            self.assertIsInstance(publish_data, dict)
+
             tank.util.register_publish(
                 self.tk,
                 self.context,
@@ -600,6 +665,17 @@ class TestShotgunRegisterPublish(TankTestBase):
         # Publish with an invalid Version, no PublishEntity should have been
         # created
         with self.assertRaises(tank.util.ShotgunPublishError) as cm:
+            # dry run
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                "bad_version",
+                self.name,
+                { "id" : -1, "type" : "Version" },
+                dry_run=True
+            )
+            self.assertIsInstance(publish_data, dict)
+
             tank.util.register_publish(
                 self.tk,
                 self.context,
@@ -607,6 +683,7 @@ class TestShotgunRegisterPublish(TankTestBase):
                 self.name,
                 { "id" : -1, "type" : "Version" }
             )
+
         self.assertIsNone(cm.exception.entity)
 
         # Force failure after the PublishedFile was created and check we get it
@@ -619,14 +696,27 @@ class TestShotgunRegisterPublish(TankTestBase):
             "tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload_thumbnail",
             new=raise_value_error) as mock:
             with self.assertRaises(tank.util.ShotgunPublishError) as cm:
+                # dry run
+                publish_data = tank.util.register_publish(
+                    self.tk,
+                    self.context,
+                    "Constant failure",
+                    self.name,
+                    self.version,
+                    dependencies=[-1],
+                    dry_run=True
+                )
+                self.assertIsInstance(publish_data, dict)
+
                 tank.util.register_publish(
                     self.tk,
                     self.context,
                     "Constant failure",
                     self.name,
                     self.version,
-                    dependencies= [-1]
+                    dependencies=[-1]
                 )
+
         self.assertIsInstance(cm.exception.entity, dict)
         self.assertTrue(cm.exception.entity["type"]==tank.util.get_published_file_entity_type(self.tk))
 
@@ -637,14 +727,27 @@ class TestShotgunRegisterPublish(TankTestBase):
             "tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload_thumbnail",
             new=raise_io_error) as mock:
             with self.assertRaises(tank.util.ShotgunPublishError) as cm:
+                # dry run
+                publish_data = tank.util.register_publish(
+                    self.tk,
+                    self.context,
+                    "dummy_path.txt",
+                    self.name,
+                    self.version,
+                    dependencies=[-1],
+                    dry_run=True
+                )
+                self.assertIsInstance(publish_data, dict)
+
                 tank.util.register_publish(
                     self.tk,
                     self.context,
                     "dummy_path.txt",
                     self.name,
                     self.version,
-                    dependencies= [-1]
+                    dependencies=[-1]
                 )
+
         self.assertIsInstance(cm.exception.entity, dict)
         self.assertTrue(cm.exception.entity["type"]==tank.util.get_published_file_entity_type(self.tk))
 


### PR DESCRIPTION
This PR adds an optional `dry_run` flag to the `register_publish` method. This is to be used to get the publish data `dict` that would be used to create a published file entry in SG. The need for this arises from our inability to filter publishes by file via the SG api. We use this method to get the publish data `dict`, then run a `find()` filtering on everything else. And then the client code can compare the returned publishes with the path in question. So this is essentially a way to ensure the find filters match the data that would be used to create a published file entry. 