### PR TITLE
Fix a bug where Shotgun crashes when self.__log_handler is None

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1250,7 +1250,7 @@ class Engine(TankBundle):
 
         :param msg: Message to log.
         """
-        if not self.__has_018_logging_support() and self.__log_handler.inside_dispatch:
+        if not self.__has_018_logging_support() and self.__log_handler and self.__log_handler.inside_dispatch:
             # special case: We are in legacy mode and all log messages are
             # dispatched to the log_xxx methods because this engine does not have an
             # _emit_log_message implementation. This is fine because typically old


### PR DESCRIPTION
So, this is a pretty simple change and we've had this problem crop up in production a couple of times. So far we've fixed it by editing the source but I figure a more permanent solution is needed.