### PR TITLE
#42005 App store descriptor label support.

### DIFF
--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -99,6 +99,10 @@ are on the following form::
 
     sgtk:descriptor:app_store?name=tk-core&version=v12.3.4
 
+App store may also have an optional ``label`` parameter. This indicates that the descriptor is tracking
+against a particular label in the app store and will not download updates which do not have the label assigned.
+
+
 Shotgun
 ============
 

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -100,7 +100,22 @@ are on the following form::
     sgtk:descriptor:app_store?name=tk-core&version=v12.3.4
 
 App store may also have an optional ``label`` parameter. This indicates that the descriptor is tracking
-against a particular label in the app store and will not download updates which do not have the label assigned.
+against a particular label in the app store and will not download updates which do not have the label assigned:
+
+    {
+        type: app_store,
+        name: tk-core,
+        version: v12.3.4,
+        label: v2018.3
+    }
+
+    sgtk:descriptor:app_store?name=tk-core&version=v12.3.4&label=v2018.3
+
+A label can for example be used by plugins that are bundled with DCCs to only receive app store updates
+targeting that particular DCC version. If you for example are running a plugin bundled together with
+v2017 of a DCC, the plugin can be set up to track against the latest released version of
+``sgtk:descriptor:app_store?name=tk-config-dcc&label=v2017``. In this case, when the descriptor is checking
+for the latest available version in the app store, only versions labelled with v2017 will be taken into account.
 
 
 Shotgun

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -100,7 +100,7 @@ are on the following form::
     sgtk:descriptor:app_store?name=tk-core&version=v12.3.4
 
 App store may also have an optional ``label`` parameter. This indicates that the descriptor is tracking
-against a particular label in the app store and will not download updates which do not have the label assigned:
+against a particular label in the app store and will not download updates which do not have the label assigned::
 
     {
         type: app_store,

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -93,6 +93,24 @@ class IODescriptorAppStore(IODescriptorBase):
         Descriptor.CORE: "TankAppStore_CoreApi_Download",
     }
 
+    _VERSION_FIELDS_TO_CACHE = [
+        "id",
+        "code",
+        "sg_status_list",
+        "description",
+        "tag_list",
+        "sg_detailed_release_notes",
+        "sg_documentation",
+        constants.TANK_CODE_PAYLOAD_FIELD
+    ]
+
+    _BUNDLE_FIELDS_TO_CACHE = [
+        "id",
+        "sg_system_name",
+        "sg_status_list",
+        "sg_deprecation_message"
+    ]
+
     def __init__(self, descriptor_dict, sg_connection, bundle_type):
         """
         Constructor
@@ -107,15 +125,14 @@ class IODescriptorAppStore(IODescriptorBase):
         self._validate_descriptor(
             descriptor_dict,
             required=["type", "name", "version"],
-            optional=[]
+            optional=["label"]
         )
 
         self._sg_connection = sg_connection
         self._type = bundle_type
         self._name = descriptor_dict.get("name")
         self._version = descriptor_dict.get("version")
-        # cached metadata - loaded on demand
-        self.__cached_metadata = None
+        self._label = descriptor_dict.get("label")
 
     def __str__(self):
         """
@@ -133,127 +150,143 @@ class IODescriptorAppStore(IODescriptorBase):
         # Toolkit App Store Framework tk-framework-shotgunutils v1.2.3
         # Toolkit App Store Core v1.2.3
         if self._type == Descriptor.CORE:
-            return "Toolkit App Store Core %s" % self._version
+            str = "Toolkit App Store Core %s" % self._version
         else:
             display_name = display_name_lookup[self._type]
-            return "Toolkit App Store %s %s %s" % (display_name, self._name, self._version)
+            str = "Toolkit App Store %s %s %s" % (display_name, self._name, self._version)
 
-    def _get_app_store_metadata(self):
+        if self._label:
+            str += " [label %s]" % self._label
+
+        return str
+
+    def __load_cached_app_store_metadata(self, path):
         """
-        Returns a metadata dictionary.
-        Tries to use a cache if possible.
+        Loads the metadata for a path in the app store
+
+        :param path: path to bundle location on disk
+        :return: metadata dictionary or None if not found
         """
-        if not self.__cached_metadata:
+        cache_file = os.path.join(path, METADATA_FILE)
+        if os.path.exists(cache_file):
+            fp = open(cache_file, "rt")
+            try:
+                metadata = pickle.load(fp)
+            finally:
+                fp.close()
+        else:
+            log.debug(
+                "%r Could not find cached metadata file %s - "
+                "will proceed with empty app store metadata." % (self, cache_file)
+            )
+            metadata = {}
 
-            # make sure we have the app payload
-            self.ensure_local()
+        return metadata
 
-            # try to load from cache file
-            # cache is typically downloaded on app installation but in some legacy cases
-            # this is not happening so don't assume file exists
-            cache_file = os.path.join(self.get_path(), METADATA_FILE)
-            if os.path.exists(cache_file):
-                fp = open(cache_file, "rt")
-                try:
-                    self.__cached_metadata = pickle.load(fp)
-                finally:
-                    fp.close()
-            else:
-                log.debug(
-                    "%r Could not find cached metadata file %s - "
-                    "will proceed with empty app store metadata." % (self, cache_file)
-                )
-                self.__cached_metadata = {}
-
-        # finally return the data!
-        return self.__cached_metadata
-
-    def __refresh_app_store_metadata(self):
+    @LogManager.log_timing
+    def __refresh_metadata(self, sg_bundle_data=None, sg_version_data=None):
         """
-        Rebuilds the app store metadata cache
-        """
-        # make sure we have the app payload
-        self.ensure_local()
+        Refreshes the metadata cache on disk. The metadata cache contains
+        app store information such as deprecation status, label information
+        and release note data.
 
-        # and cache the file
-        cache_file = os.path.join(self.get_path(), METADATA_FILE)
-        self.__cache_app_store_metadata(cache_file)
+        For performance, the metadata can be provided by the caller. If
+        not provided, the method will retrieve it from the app store.
 
-    def __cache_app_store_metadata(self, path):
-        """
-        Fetches metadata about the app from the toolkit app store. Writes it to disk.
+        If the descriptor resides in a read-only bundle cache, for example
+        baked into a DCC distribution, the cache will not be updated.
 
-        :param path: Path to write the cache file to.
+        :param sg_bundle_data, sg_version_data: Shotgun data to cache
         :returns: A dictionary with keys 'sg_bundle_data' and 'sg_version_data',
                   containing Shotgun metadata.
         """
-        # get the appropriate shotgun app store types and fields
-        bundle_entity_type = self._APP_STORE_OBJECT[self._type]
-        version_entity_type = self._APP_STORE_VERSION[self._type]
-        link_field = self._APP_STORE_LINK[self._type]
+        log.debug("Attempting to refresh app store metadata for %r" % self)
 
-        # connect to the app store
-        (sg, _) = self.__create_sg_app_store_connection()
+        # see if a cached version exists
+        local_bundle_path = self.get_path()
 
-        if self._type == self.CORE:
-            # special handling of core since it doesn't have a high-level
-            # 'bundle' entity
-            sg_bundle_data = None
+        if local_bundle_path is None:
+            # if we don't have bundle cached locally yet, skip
+            log.debug("Bundle does not exist on disk yet. Skipping metadata caching")
+            return
 
-            sg_version_data = sg.find_one(
-                constants.TANK_CORE_VERSION_ENTITY_TYPE,
-                [["code", "is", self._version]],
-                ["description",
-                 "sg_detailed_release_notes",
-                 "sg_documentation",
-                 constants.TANK_CODE_PAYLOAD_FIELD]
-            )
-            if sg_version_data is None:
-                raise TankDescriptorError(
-                    "The App store does not have a version '%s' of Core!" % self._version
-                )
+        cache_file = os.path.join(self.get_path(), METADATA_FILE)
+        log.debug("Will attempt to refresh cache in %s" % cache_file)
+
+        if sg_version_data:  # no none-check for sg_bundle_data param since this is none for tk-core
+            log.debug("Will cache pre-fetched cache data.")
         else:
-            # engines, apps etc have a 'bundle level entity' in the app store,
-            # e.g. something representing the app or engine.
-            # then a version entity representing a particular version
-            sg_bundle_data = sg.find_one(
-                bundle_entity_type,
-                [["sg_system_name", "is", self._name]],
-                ["sg_status_list", "sg_deprecation_message"]
-            )
+            log.debug("Connecting to Shotgun to retrieve metadata for %r" % self)
 
-            if sg_bundle_data is None:
-                raise TankDescriptorError(
-                    "The App store does not contain an item named '%s'!" % self._name
+            # get the appropriate shotgun app store types and fields
+            bundle_entity_type = self._APP_STORE_OBJECT[self._type]
+            version_entity_type = self._APP_STORE_VERSION[self._type]
+            link_field = self._APP_STORE_LINK[self._type]
+
+            # connect to the app store
+            (sg, _) = self.__create_sg_app_store_connection()
+
+            if self._type == self.CORE:
+                # special handling of core since it doesn't have a high-level 'bundle' entity
+                sg_bundle_data = None
+
+                sg_version_data = sg.find_one(
+                    constants.TANK_CORE_VERSION_ENTITY_TYPE,
+                    [["code", "is", self._version]],
+                    self._VERSION_FIELDS_TO_CACHE
+                )
+                if sg_version_data is None:
+                    raise TankDescriptorError(
+                        "The App store does not have a version '%s' of Core!" % self._version
+                    )
+            else:
+                # engines, apps etc have a 'bundle level entity' in the app store,
+                # e.g. something representing the app or engine.
+                # then a version entity representing a particular version
+                sg_bundle_data = sg.find_one(
+                    bundle_entity_type,
+                    [["sg_system_name", "is", self._name]],
+                    self._BUNDLE_FIELDS_TO_CACHE
                 )
 
-            # now get the version
-            sg_version_data = sg.find_one(
-                version_entity_type,
-                [[link_field, "is", sg_bundle_data], ["code", "is", self._version]],
-                ["description",
-                 "sg_detailed_release_notes",
-                 "sg_documentation",
-                 constants.TANK_CODE_PAYLOAD_FIELD]
-            )
-            if sg_version_data is None:
-                raise TankDescriptorError(
-                    "The App store does not have a "
-                    "version '%s' of item '%s'!" % (self._version, self._name)
-                )
+                if sg_bundle_data is None:
+                    raise TankDescriptorError(
+                        "The App store does not contain an item named '%s'!" % self._name
+                    )
 
+                # now get the version
+                sg_version_data = sg.find_one(
+                    version_entity_type,
+                    [
+                        [link_field, "is", sg_bundle_data],
+                        ["code", "is", self._version]
+                    ],
+                    self._VERSION_FIELDS_TO_CACHE
+                )
+                if sg_version_data is None:
+                    raise TankDescriptorError(
+                        "The App store does not have a "
+                        "version '%s' of item '%s'!" % (self._version, self._name)
+                    )
+
+        # create metadata
         metadata = {
             "sg_bundle_data": sg_bundle_data,
             "sg_version_data": sg_version_data
         }
 
-        filesystem.ensure_folder_exists(os.path.dirname(path))
-        fp = open(path, "wt")
+        # try to write to location - but it may be located in a
+        # readonly bundle cache - if the caching fails, gracefully
+        # fall back and log
         try:
-            pickle.dump(metadata, fp)
-            log.debug("Wrote app store cache file '%s'" % path)
-        finally:
-            fp.close()
+            fp = open(cache_file, "wt")
+            try:
+                pickle.dump(metadata, fp)
+                log.debug("Wrote app store metadata cache '%s'" % cache_file)
+            finally:
+                fp.close()
+        except Exception, e:
+            log.debug("Did not update app store metadata cache '%s': %s" % (cache_file, e))
 
         return metadata
 
@@ -319,10 +352,18 @@ class IODescriptorAppStore(IODescriptorBase):
         """
         Returns information about deprecation.
 
+        May download the item from the app store in order
+        to retrieve the metadata.
+
         :returns: Returns a tuple (is_deprecated, message) to indicate
                   if this item is deprecated.
         """
-        metadata = self._get_app_store_metadata()
+        # make sure we have the app payload + metadata
+        self.ensure_local()
+        # grab metadata
+        metadata = self.__load_cached_app_store_metadata(
+            self.get_path()
+        )
         sg_bundle_data = metadata.get("sg_bundle_data") or {}
         if sg_bundle_data.get("sg_status_list") == "dep":
             msg = sg_bundle_data.get("sg_deprecation_message", "No reason given.")
@@ -340,12 +381,21 @@ class IODescriptorAppStore(IODescriptorBase):
         """
         Returns information about the changelog for this item.
 
+        May download the item from the app store in order
+        to retrieve the metadata.
+
         :returns: A tuple (changelog_summary, changelog_url). Values may be None
                   to indicate that no changelog exists.
         """
         summary = None
         url = None
-        metadata = self._get_app_store_metadata()
+
+        # make sure we have the app payload + metadata
+        self.ensure_local()
+        # grab metadata
+        metadata = self.__load_cached_app_store_metadata(
+            self.get_path()
+        )
         try:
             sg_version_data = metadata.get("sg_version_data") or {}
             summary = sg_version_data.get("description")
@@ -358,6 +408,7 @@ class IODescriptorAppStore(IODescriptorBase):
         """
         Retrieves this version to local repo.
         Will exit early if app already exists local.
+        Caches app store metadata.
         """
         if self.exists_local():
             # nothing to do!
@@ -365,13 +416,14 @@ class IODescriptorAppStore(IODescriptorBase):
 
         # cache into the primary location
         target = self._get_primary_cache_path()
+        # create folder
+        filesystem.ensure_folder_exists(target)
 
         # connect to the app store
         (sg, script_user) = self.__create_sg_app_store_connection()
 
         # fetch metadata from sg...
-        metadata_cache_file = os.path.join(target, METADATA_FILE)
-        metadata = self.__cache_app_store_metadata(metadata_cache_file)
+        metadata = self.__refresh_metadata()
 
         # now get the attachment info
         version = metadata.get("sg_version_data")
@@ -424,15 +476,39 @@ class IODescriptorAppStore(IODescriptorBase):
         all_versions = self._get_locally_cached_versions()
         log.debug("Found %d versions" % len(all_versions))
 
-        if len(all_versions) == 0:
+        if self._label:
+            # now filter the list of versions to only include things with
+            # the sought-after label
+            version_numbers = []
+            log.debug("culling out versions not labelled '%s'..." % self._label)
+            for (version_str, path) in all_versions.iteritems():
+                metadata = self.__load_cached_app_store_metadata(path)
+                try:
+                    if self._label in metadata["sg_version_data"]["tag_list"]:
+                        version_numbers.append(version_str)
+                except Exception, e:
+                    log.debug("Could not determine label metadata for %s. Ignoring." % path)
+
+        else:
+            # no label based filtering. all versions are valid.
+            version_numbers = all_versions.keys()
+
+        if len(version_numbers) == 0:
             return None
 
-        version_to_use = self._find_latest_tag_by_pattern(all_versions, constraint_pattern)
+        version_to_use = self._find_latest_tag_by_pattern(version_numbers, constraint_pattern)
         if version_to_use is None:
             return None
 
         # make a descriptor dict
-        descriptor_dict = {"type": "app_store", "name": self._name, "version": version_to_use}
+        descriptor_dict = {
+            "type": "app_store",
+            "name": self._name,
+            "version": version_to_use
+        }
+
+        if self._label:
+            descriptor_dict["label"] = self._label
 
         # and return a descriptor instance
         desc = IODescriptorAppStore(descriptor_dict, self._sg_connection, self._type)
@@ -441,9 +517,13 @@ class IODescriptorAppStore(IODescriptorBase):
         log.debug("Latest cached version resolved to %r" % desc)
         return desc
 
+    @LogManager.log_timing
     def get_latest_version(self, constraint_pattern=None):
         """
         Returns a descriptor object that represents the latest version.
+
+        This method will connect to the toolkit app store and download
+        metadata to determine the latest version.
 
         :param constraint_pattern: If this is specified, the query will be constrained
                by the given pattern. Version patterns are on the following forms:
@@ -484,22 +564,20 @@ class IODescriptorAppStore(IODescriptorBase):
             latest_filter = [["sg_status_list", "is_not", "rev"],
                              ["sg_status_list", "is_not", "bad"]]
 
-        is_deprecated = False
+        if self._label:
+            # only looks for items with the given tag
+            latest_filter.append(["tag_list", "is", self._label])
+
         if self._type != self.CORE:
             # find the main entry
             sg_bundle_data = sg.find_one(
                 self._APP_STORE_OBJECT[self._type],
                 [["sg_system_name", "is", self._name]],
-                ["id", "sg_status_list"]
+                self._BUNDLE_FIELDS_TO_CACHE
             )
 
             if sg_bundle_data is None:
                 raise TankDescriptorError("App store does not contain an item named '%s'!" % self._name)
-
-            # check if this has been deprecated in the app store
-            # in that case we should ensure that the metadata is refreshed later
-            if sg_bundle_data["sg_status_list"] == "dep":
-                is_deprecated = True
 
             # now get all versions
             link_field = self._APP_STORE_LINK[self._type]
@@ -507,18 +585,21 @@ class IODescriptorAppStore(IODescriptorBase):
             sg_data = sg.find(
                 entity_type,
                 [[link_field, "is", sg_bundle_data]] + latest_filter,
-                ["code"]
+                self._VERSION_FIELDS_TO_CACHE
             )
         else:
+
+            sg_bundle_data = None
+
             # now get all versions
             sg_data = sg.find(
                 constants.TANK_CORE_VERSION_ENTITY_TYPE,
                 filters=latest_filter,
-                fields=["code"]
+                fields=self._VERSION_FIELDS_TO_CACHE
             )
 
         if len(sg_data) == 0:
-            raise TankDescriptorError("Cannot find any versions for %s in the App store!" % self._name)
+            raise TankDescriptorError("Cannot find any versions for %s in the App store!" % self)
 
         version_numbers = [x.get("code") for x in sg_data]
         version_to_use = self._find_latest_tag_by_pattern(version_numbers, version_pattern)
@@ -527,20 +608,27 @@ class IODescriptorAppStore(IODescriptorBase):
                 "'%s' does not have a version matching the pattern '%s'. "
                 "Available versions are: %s" % (self.get_system_name(), version_pattern, ", ".join(version_numbers))
             )
+        # get the sg data for the given version
+        sg_data_for_version = [d for d in sg_data if d["code"] == version_to_use][0]
 
         # make a descriptor dict
-        descriptor_dict = {"type": "app_store", "name": self._name, "version": version_to_use}
+        descriptor_dict = {
+            "type": "app_store",
+            "name": self._name,
+            "version": version_to_use
+        }
+
+        if self._label:
+            descriptor_dict["label"] = self._label
 
         # and return a descriptor instance
         desc = IODescriptorAppStore(descriptor_dict, self._sg_connection, self._type)
         desc.set_cache_roots(self._bundle_cache_root, self._fallback_roots)
 
-        # now if this item has been deprecated, meaning that someone has gone in to the app
-        # store and updated the record's deprecation status, we want to make sure we download
-        # all this info the next time it is being requested. So we force clear the metadata
-        # cache.
-        if is_deprecated:
-            self.__refresh_app_store_metadata()
+        # if this item exists locally, attempt to update the metadata cache
+        # this ensures that if labels are added in the app store, these
+        # are correctly cached locally.
+        desc.__refresh_metadata(sg_bundle_data, sg_data_for_version)
 
         return desc
 
@@ -563,7 +651,9 @@ class IODescriptorAppStore(IODescriptorBase):
             latest_filter = [["sg_status_list", "is_not", "rev"],
                              ["sg_status_list", "is_not", "bad"]]
 
-        is_deprecated = False
+        if self._label:
+            # only looks for items with the given tag
+            latest_filter.append(["tag_list", "is", self._label])
 
         if self._type != self.CORE:
             # items other than core have a main entity that represents
@@ -573,16 +663,11 @@ class IODescriptorAppStore(IODescriptorBase):
             sg_bundle_data = sg.find_one(
                 self._APP_STORE_OBJECT[self._type],
                 [["sg_system_name", "is", self._name]],
-                ["id", "sg_status_list"]
+                self._BUNDLE_FIELDS_TO_CACHE
             )
 
             if sg_bundle_data is None:
                 raise TankDescriptorError("App store does not contain an item named '%s'!" % self._name)
-
-            # check if this has been deprecated in the app store
-            # in that case we should ensure that the cache is cleared later
-            if sg_bundle_data["sg_status_list"] == "dep":
-                is_deprecated = True
 
             # now get the version
             link_field = self._APP_STORE_LINK[self._type]
@@ -590,21 +675,24 @@ class IODescriptorAppStore(IODescriptorBase):
             sg_version_data = sg.find_one(
                 entity_type,
                 filters=[[link_field, "is", sg_bundle_data]] + latest_filter,
-                fields=["code"],
+                fields=self._VERSION_FIELDS_TO_CACHE,
                 order=[{"field_name": "created_at", "direction": "desc"}]
             )
 
         else:
+
+            sg_bundle_data = None
+
             # core API
             sg_version_data = sg.find_one(
                 constants.TANK_CORE_VERSION_ENTITY_TYPE,
                 filters=latest_filter,
-                fields=["code"],
+                fields=self._VERSION_FIELDS_TO_CACHE,
                 order=[{"field_name": "created_at", "direction": "desc"}]
             )
 
         if sg_version_data is None:
-            raise TankDescriptorError("Cannot find any versions for %s in the App store!" % self._name)
+            raise TankDescriptorError("Cannot find any versions for %s in the App store!" % self)
 
         version_str = sg_version_data.get("code")
         if version_str is None:
@@ -614,17 +702,17 @@ class IODescriptorAppStore(IODescriptorBase):
         descriptor_dict = {"type": "app_store",
                            "name": self._name,
                            "version": version_str}
+        if self._label:
+            descriptor_dict["label"] = self._label
 
         # and return a descriptor instance
         desc = IODescriptorAppStore(descriptor_dict, self._sg_connection, self._type)
         desc.set_cache_roots(self._bundle_cache_root, self._fallback_roots)
 
-        # now if this item has been deprecated, meaning that someone has gone in to the app
-        # store and updated the record's deprecation status, we want to make sure we download
-        # all this info the next time it is being requested. So we force clear the metadata
-        # cache.
-        if is_deprecated:
-            self.__refresh_app_store_metadata()
+        # if this item exists locally, attempt to update the metadata cache
+        # this ensures that if labels are added in the app store, these
+        # are correctly cached locally.
+        desc.__refresh_metadata(sg_bundle_data, sg_version_data)
 
         return desc
 

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -151,15 +151,15 @@ class IODescriptorAppStore(IODescriptorBase):
         # Toolkit App Store Framework tk-framework-shotgunutils v1.2.3
         # Toolkit App Store Core v1.2.3
         if self._type == Descriptor.CORE:
-            str = "Toolkit App Store Core %s" % self._version
+            display_name = "Toolkit App Store Core %s" % self._version
         else:
             display_name = display_name_lookup[self._type]
-            str = "Toolkit App Store %s %s %s" % (display_name, self._name, self._version)
+            display_name = "Toolkit App Store %s %s %s" % (display_name, self._name, self._version)
 
         if self._label:
-            str += " [label %s]" % self._label
+            display_name += " [label %s]" % self._label
 
-        return str
+        return display_name
 
     def __load_cached_app_store_metadata(self, path):
         """

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -307,9 +307,9 @@ class IODescriptorBase(object):
         one ones which are listing all its versions as subfolders under
         a root location.
 
-        :return: list of version strings
+        :return: dictionary of bundle paths, keyed by version string
         """
-        all_versions = set()
+        all_versions = {}
         for possible_cache_path in self._get_cache_paths():
             # get the parent folder for the current version path
             parent_folder = os.path.dirname(possible_cache_path)
@@ -323,9 +323,9 @@ class IODescriptorBase(object):
                     if os.path.isdir(version_full_path) and \
                             not version_folder.startswith("_") and \
                             not version_folder.startswith("."):
-                        all_versions.add(version_folder)
+                        all_versions[version_folder] = version_full_path
 
-        return list(all_versions)
+        return all_versions
 
 
     def copy(self, target_path):

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -271,7 +271,7 @@ class IODescriptorGitTag(IODescriptorGit):
         :returns: instance deriving from IODescriptorBase or None if not found
         """
         log.debug("Looking for cached versions of %r..." % self)
-        all_versions = self._get_locally_cached_versions()
+        all_versions = self._get_locally_cached_versions().keys()
         log.debug("Found %d versions" % len(all_versions))
 
         if len(all_versions) == 0:

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -263,7 +263,7 @@ class IODescriptorShotgunEntity(IODescriptorBase):
             log.warning("%s does not support version constraint patterns." % self)
 
         log.debug("Looking for cached versions of %r..." % self)
-        all_versions = self._get_locally_cached_versions()
+        all_versions = self._get_locally_cached_versions().keys()
         log.debug("Found %d versions" % len(all_versions))
 
         if len(all_versions) == 0:


### PR DESCRIPTION
Adds support for an optional label parameter for app store descriptors:

```
import sgtk

# Start up a Toolkit Manager
mgr = sgtk.bootstrap.ToolkitManager()

# Set the base configuration to the default config
# note that the version token is not specified
# The bootstrap will always try to use the latest version
mgr.base_configuration = "sgtk:descriptor:app_store?name=tk-config-default&label=v2018.2"

# now start up the maya engine for a given Shotgun object
e = mgr.bootstrap_engine("tk-engine")
```

The bootstrap above code will look for `tk-config-default` labelled `v2018.2` and use the latest one. This allows for a workflow where a single stream of updates can target several different plugin releases. The primary use case for this is that you want a single config to drive plugin based integration. Each plugin pulls the DCC version and uses this as the label. So a plugin running in DCC 2018.1 will look for `name=tk-config-default&label=v2018.1`, DCC 2018.2 will look for `name=tk-config-default&label=v2018.2` etc. This allows for a workflow where updates can target a particular set of releases and can be used to implement various branching workflows.




