### PR TITLE
For #41692: Doesn’t attempt to match plugin_ids if there isn’t one to match.

### DIFF
--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -686,7 +686,7 @@ class ConfigurationResolver(object):
         :param value: pattern string to check or None
         :return: True if matching false if not
         """
-        if value is None:
+        if value is None or self._plugin_id is None:
             return False
 
         # first split by comma and strip whitespace

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -205,6 +205,14 @@ class TestPluginMatching(TestResolverBase):
         self.assertTrue(resolver._match_plugin_id("foo.maya"))
         self.assertFalse(resolver._match_plugin_id("foo.nuke"))
 
+        # If the value is None then we always get back False.
+        self.assertFalse(resolver._match_plugin_id(None))
+
+        # Always False return, even when _plugin_id is None and the value is None.
+        resolver._plugin_id = None
+        self.assertFalse(resolver._match_plugin_id(None))
+        self.assertFalse(resolver._match_plugin_id("foo.maya"))
+
     @patch("os.path.exists", return_value=True)
     def test_single_matching_id(self, _):
         """


### PR DESCRIPTION
The resolver's default for plugin_id is None. If it's in that state then it shouldn't try go match against that None with fnmatch.