### PR TITLE
#41300 storage followup

### DIFF
--- a/python/tank/util/shotgun/publish_resolve.py
+++ b/python/tank/util/shotgun/publish_resolve.py
@@ -221,6 +221,7 @@ def resolve_publish_path(tk, sg_publish_data):
         # local file link
         path = __resolve_local_file_link(tk, path_field)
         if path is None:
+
             raise PublishPathNotDefinedError(
                 "Publish %s (id %s) has a local file link that could not be resolved "
                 "on this os platform." % (sg_publish_data["code"], sg_publish_data["id"])
@@ -270,17 +271,6 @@ def __resolve_local_file_link(tk, attachment_data):
 
     # see if we have a path for this storage
     local_path = attachment_data.get("local_path")
-    if local_path is None:
-        raise PublishPathNotDefinedError(
-            "Publish '%s' does not have a path defined "
-            "for this platform. Windows Path: '%s', Mac Path: '%s', "
-            "Linux Path: '%s'" % (
-                attachment_data["name"],
-                attachment_data["local_path_windows"],
-                attachment_data["local_path_mac"],
-                attachment_data["local_path_linux"],
-            )
-        )
 
     # Check override env vars:
     #
@@ -342,7 +332,7 @@ def __resolve_local_file_link(tk, attachment_data):
                 this_os_storage_root = storage[storage_field]
                 this_os_full_path = attachment_data[path_field]
 
-                if this_os_full_path:
+                if this_os_storage_root:
                     # the path is defined on this os. Normalize it by
                     # chopping off the root
 

--- a/python/tank/util/shotgun/publish_resolve.py
+++ b/python/tank/util/shotgun/publish_resolve.py
@@ -114,11 +114,27 @@ def resolve_publish_path(tk, sg_publish_data):
       ``SHOTGUN_PATH_LINUX=/prod`` in order to hint the way the path should be
       resolved.
 
-    - If you wanted to use more than one environment variable, this is possible
-      by extending the above syntax with a name, for example ``SHOTGUN_PATH_LINUX_SECONDARY``.
+    - If you wanted to use more than one set of environment variables, this is possible
+      by extending the above syntax with a suffix:
 
-    - In addition, all existing local storage definitions will be downloaded
-      and used in the same way.
+        - If you have a storage for renders, you could for example define
+          ``SHOTGUN_PATH_LINUX_RENDERS``, ``SHOTGUN_PATH_MAC_RENDERS`` and
+          ``SHOTGUN_PATH_WINDOWS_RENDERS`` in order to provide a translation
+          mechanism for all ``file://`` urls published that refer to data
+          inside your render storage.
+
+        - If you have a storage for editorial data, you could for example define
+          ``SHOTGUN_PATH_LINUX_EDITORIAL``, ``SHOTGUN_PATH_MAC_EDITORIAL`` and
+          ``SHOTGUN_PATH_WINDOWS_EDITORIAL`` in order to provide another translation
+          mechanism for those roots.
+
+      Once you have standardized on these environment variables, you could consider
+      converting them into a Shotgun local storages. Once they are defined in the
+      Shotgun preferences, they will be automatically picked up and no
+      environment variables would be needed.
+
+    - In addition to the above, all local storages defined in the Shotgun
+      preferences will be handled the same way.
 
     - If a local storage has been defined, but an operating system is missing,
       this can be supplied via an environment variable. For example, if there

--- a/python/tank/util/shotgun/publish_resolve.py
+++ b/python/tank/util/shotgun/publish_resolve.py
@@ -79,41 +79,88 @@ def resolve_publish_path(tk, sg_publish_data):
     Local file storage mappings in Shotgun are global and affect
     all machines, all users and all projects.
 
-    .. note:: If no storage has been defined for the current operating system,
+    If a local storage doesn't define the operating system platform
+    you are currently using, you can augment it by adding an
+    environment variable. For example, if there
+    is a local storage named ``Renders`` that is defined on Linux and Windows,
+    you can extend to support mac by creating an environment variable named
+    ``SHOTGUN_PATH_MAC_RENDERS``. The general syntax for this is
+    ``SHOTGUN_PATH_WINDOWS|MAC|LINUX_STORAGENAME``.
+
+    .. note:: If you define a ``SHOTGUN_PATH_MAC_RENDERS`` environment variable
+              and there is a local storage ``Renders`` with a mac path set,
+              the local storage value will be used and a warning will be logged.
+
+    .. note:: If no storage can be resolved for the current operating system,
               a :class:`~sgtk.util.PublishPathNotDefinedError` is raised.
+
 
     **Resolving file urls**
 
-    The method also supports the resolution of ``file://`` urls. Such urls
-    are not multi platform and the local storages and environment variables
-    will therefore be used to try to resolve such paths in case of ambiguity.
+    The method also supports the resolution of ``file://`` urls. Contrary to
+    local file storage objects in Shotgun (see above), these paths are not
+    stored in a multi-os representation but are just defined on the operating
+    system where they were created.
 
-    - First, local storage settings will be downloaded from Shotgun and added to
-      a path translation table.
+    If you are trying to resolve a ``file://`` url on an os platform different
+    from the one where where the url was created, the method will attempt to
+    resolve it into a valid path using several different approaches:
 
-    - Next, any environment variables of the form ``SHOTGUN_PATH_WINDOWS|MAC|LINUX``
-      or ``SHOTGUN_PATH_WINDOWS|MAC|LINUX_STORAGENAME`` will be added
-      to the translation table.
+    - First, it will look for the three environment variables ``SHOTGUN_PATH_WINDOWS``,
+      ``SHOTGUN_PATH_MAC``, and ``SHOTGUN_PATH_LINUX``. If these are defined,
+      the method will attempt to translate the path this way. For example, if
+      you are trying to resolve ``file:///prod/proj_x/assets/bush/file.txt`` on
+      windows, you could set up ``SHOTGUN_PATH_WINDOWS=P:\prod`` and
+      ``SHOTGUN_PATH_LINUX=/prod`` in order to hint the way the path should be
+      resolved.
 
-    - The ``file://`` path will be compared against all the existing roots
-      for all operating systems. The first match detected will be used to translate
-      the path into the current operating system platform.
+    - If you wanted to use more than one environment variable, this is possible
+      by extending the above syntax with a name, for example ``SHOTGUN_PATH_LINUX_SECONDARY``.
+
+    - In addition, all existing local storage definitions will be downloaded
+      and used in the same way.
+
+    - If a local storage has been defined, but an operating system is missing,
+      this can be supplied via an environment variable. For example, if there
+      is a local storage named ``Renders`` that is defined on Linux and Windows,
+      you can extend to support mac by creating an environment variable named
+      ``SHOTGUN_PATH_MAC_RENDERS``. The general syntax for this is
+      ``SHOTGUN_PATH_WINDOWS|MAC|LINUX_STORAGENAME``.
 
     - If no root matches, the file path will be returned as is.
 
-    For example, you have published the file ``/projects/some/file.txt`` on Linux
-    and generated a publish with the url ``file:///projects/some/file.txt``. You have
-    either a local storage or environment variable set up with the following paths:
+    .. note::   For example, you have published the file ``/projects/some/file.txt`` on Linux
+                and a Shotgun publish with the url ``file:///projects/some/file.txt`` was generated.
+                The Linux path ``/projects`` equates to ``Q:\projects`` on Windows
+                and hence you want the full path to be translated to
+                ``Q:\\projects\\some\\file.txt``. All of the setups below would handle this:
 
-    - Linux Path: ``/projects``
-    - Windows Path: ``Q:\projects``
-    - Mac Path: ``/projects``
+                - A general environment based override:
 
-    When running on Windows, the ``file://`` url will therefore be translated to
-    ``Q:\\projects\\some\\file.txt``.
+                    - ``SHOTGUN_PATH_LINUX=/projects``
+                    - ``SHOTGUN_PATH_WINDOWS=Q:\projects``
+                    - ``SHOTGUN_PATH_MAC=/projects``
 
-    .. note:: If no value has been defined for the current operating system,
-              a :class:`~sgtk.util.PublishPathNotDefinedError` is raised.
+                - A Shotgun local storage "Projects" set up with:
+
+                    - Linux Path: ``/projects``
+                    - Windows Path: ``Q:\projects``
+                    - Mac Path: ``/projects``
+
+                - A Shotgun local storage "Projects" augmented with an environment variable:
+
+                    - Linux Path: ``/projects``
+                    - Windows Path: ``<blank>``
+                    - Mac Path: ``/projects``
+                    - ``SHOTGUN_PATH_WINDOWS_PROJECTS=Q:\projects``
+
+
+    .. note:: If you have a local storage ``Renders`` defined in Shotgun with
+       a Linux path set and also a ``SHOTGUN_PATH_LINUX_RENDERS`` environment
+       variable defined, the storage will take precedence, the environment
+       variable will be ignored and a warning will be logged. Generally speaking,
+       local storage definitions always take precedence over environment variables.
+
 
     **Customization examples**
 
@@ -149,7 +196,7 @@ def resolve_publish_path(tk, sg_publish_data):
 
     # first offer the resolve to the core hook
     #
-    # note that we run this before the built-in logic beacuse we want to be able to add support
+    # note that we run this before the built-in logic because we want to be able to add support
     # for handling uploaded files (or something else) in the future, yet at the same time,
     # by doing that we don't want to break any client integration. By putting the hook first,
     # this is possible. If we put the hook last, we could affect the conditions under which
@@ -172,7 +219,13 @@ def resolve_publish_path(tk, sg_publish_data):
 
     elif path_field["link_type"] == "local":
         # local file link
-        return __resolve_local_file_link(tk, path_field)
+        path = __resolve_local_file_link(tk, path_field)
+        if path is None:
+            raise PublishPathNotDefinedError(
+                "Publish %s (id %s) has a local file link that could not be resolved "
+                "on this os platform." % (sg_publish_data["code"], sg_publish_data["id"])
+            )
+        return path
 
     elif path_field["link_type"] == "web":
         # url link
@@ -189,16 +242,12 @@ def resolve_publish_path(tk, sg_publish_data):
 def __resolve_local_file_link(tk, attachment_data):
     """
     Resolves the given local path attachment into a local path.
-
-    If no storage has been defined for the current operating system,
-    a :class:`~sgtk.util.PublishPathNotDefinedError` is raised.
+    For details, see :meth:`resolve_publish_path`.
 
     :param tk: :class:`~sgtk.Sgtk` instance
     :param attachment_data: Shotgun Attachment dictionary.
 
-    :returns: A local path to file or file sequence.
-
-    :raises: :class:`~sgtk.util.PublishPathNotDefinedError` if the path isn't defined.
+    :returns: A local path to file or file sequence or None if it cannot be resolved.
     """
     # local file link data looks like this:
     #
@@ -233,6 +282,82 @@ def __resolve_local_file_link(tk, attachment_data):
             )
         )
 
+    # Check override env vars:
+    #
+    # For local storages, it is possible to amend an existing
+    # storage using environment variables. For example, if a
+    # primary storage exists, but only has paths defined on
+    # windows and linux, a mac storage path defined by setting
+    # a SHOTGUN_PATH_MAC_PRIMARY.
+    #
+    # Similarly, if a SHOTGUN_PATH_WINDOWS_PRIMARY path is defined
+    # for this storage, it will be ignored and a warning is logged.
+    #
+
+    # look for override env var for our local os
+    storage_name = attachment_data["local_storage"]["name"].upper()
+    storage_id = attachment_data["local_storage"]["id"]
+    os_name = {"win32": "WINDOWS", "linux2": "LINUX", "darwin": "MAC"}[sys.platform]
+    env_var_name = "SHOTGUN_PATH_%s_%s" % (os_name, storage_name)
+    log.debug("Looking for override env var '%s'" % env_var_name)
+
+    if env_var_name in os.environ:
+
+        log.debug(
+            "Detected override %s='%s'" % (env_var_name, os.environ[env_var_name])
+        )
+        # if we already have this set in the local storage,
+        # issue a warning
+        if local_path:
+            log.warning(
+                "Discovered environment variable %s, however the operating system root is "
+                "already defined in Shotgun and the environment variable will "
+                "be ignored." % env_var_name
+            )
+
+        else:
+
+            # we have an override
+            override_root = os.environ[env_var_name]
+
+            # normalize path
+            override_root = ShotgunPath.normalize(override_root)
+            log.debug(
+                "Applying override '%s' to path '%s' "
+                "(storage %s)" % (override_root, local_path, storage_name)
+            )
+
+            # get the local storage that we are augmenting
+            storage = [s for s in get_cached_local_storages(tk) if s["id"] == storage_id][0]
+
+            # find a storage where the path is defined
+            # we know that it must be defined for at least one os :)
+            storage_field_map = {
+                "windows_path": "local_path_windows",
+                "linux_path": "local_path_mac",
+                "mac_path": "local_path_linux"
+            }
+
+            for (storage_field, path_field) in storage_field_map.iteritems():
+                this_os_storage_root = storage[storage_field]
+                this_os_full_path = attachment_data[path_field]
+
+                if this_os_full_path:
+                    # the path is defined on this os. Normalize it by
+                    # chopping off the root
+
+                    # chop off the root from the path and append override root
+                    local_path = override_root + os.path.sep + this_os_full_path[len(this_os_storage_root):]
+                    log.debug(
+                        "Transforming '%s' and root '%s' via env var '%s' into '%s'" % (
+                            this_os_full_path,
+                            this_os_storage_root,
+                            override_root,
+                            local_path
+                        )
+                    )
+                    break
+
     # normalize
     local_path = ShotgunPath.normalize(local_path)
     log.debug("Resolved local file link: '%s'" % local_path)
@@ -242,47 +367,14 @@ def __resolve_local_file_link(tk, attachment_data):
 def __resolve_url_link(tk, attachment_data):
     """
     Resolves the given url attachment into a local path.
-
-    This supports the resolution of ``file://`` urls into paths. Such urls
-    are not multi platform and Shotgun local storages and environment variables
-    will be used to try to resolve such paths in case of ambiguity.
-
-    - First, local storage settings will be downloaded from Shotgun and added to
-      a path translation table.
-
-    - Next, any environment variables of the form ``SHOTGUN_PATH_WINDOWS|MAC|LINUX``
-      will be added to the translation table.
-
-    - Override environment variables of the form ``SHOTGUN_PATH_WINDOWS|MAC|LINUX_STORAGENAME``
-      will override any local storage paths.
-
-    - The ``file://`` path will be compared against all the existing roots
-      for all operating systems. The first match detected will be used to translate
-      the path into a file path for the current platform.
-
-    - If no root matches, the file path will be returned as is.
-
-    For example, you have published the file ``/projects/some/file.txt`` on Linux
-    and generated a publish with the url ``file:///projects/some/file.txt``. You have
-    either a local storage or environment variable set up with the following paths:
-
-    - Linux Path: ``/projects``
-    - Windows Path: ``Q:\projects``
-    - Mac Path: ``/projects``
-
-    When running on windows, the ``file://`` url will therefore be translated to
-    ``Q:\\projects\\some\\file.txt``.
-
-    If no value has been defined for the current operating system,
-    a :class:`~sgtk.util.PublishPathNotDefinedError` is raised.
+    For details, see :meth:`resolve_publish_path`.
 
     :param tk: :class:`~sgtk.Sgtk` instance
-    :param sg_publish_data: Dictionary containing Shotgun publish data.
+    :param attachment_data: Dictionary containing Shotgun publish data.
         Needs to at least contain a code, type, id and a path key.
 
     :returns: A local path to file or file sequence.
 
-    :raises: :class:`~sgtk.util.PublishPathNotDefinedError` if the path isn't defined.
     :raises: :class:`~sgtk.util.PublishPathNotSupported` if the path cannot be resolved.
     """
     log.debug("Attempting to resolve url attachment data "
@@ -389,27 +481,33 @@ def __resolve_url_link(tk, attachment_data):
             if platform == "WINDOWS":
                 if storage_lookup[storage_name].windows:
                     # this path was already defined by a sg local storage
-                    log.warning("Discovered env var %s, however a Shotgun local storage already "
-                                "defines '%s' to be '%s'. Your environment override "
-                                "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].windows))
+                    log.warning(
+                        "Discovered env var %s, however a Shotgun local storage already "
+                        "defines '%s' to be '%s'. Your environment override "
+                        "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].windows)
+                    )
                 else:
                     storage_lookup[storage_name].windows = os.environ[env_var]
 
             elif platform == "MAC":
                 if storage_lookup[storage_name].macosx:
                     # this path was already defined by a sg local storage
-                    log.warning("Discovered env var %s, however a Shotgun local storage already "
-                                "defines '%s' to be '%s'. Your environment override "
-                                "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].macosx))
+                    log.warning(
+                        "Discovered env var %s, however a Shotgun local storage already "
+                        "defines '%s' to be '%s'. Your environment override "
+                        "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].macosx)
+                    )
                 else:
                     storage_lookup[storage_name].macosx = os.environ[env_var]
 
             else:
                 if storage_lookup[storage_name].linux:
                     # this path was already defined by a sg local storage
-                    log.warning("Discovered env var %s, however a Shotgun local storage already "
-                                "defines '%s' to be '%s'. Your environment override "
-                                "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].linux))
+                    log.warning(
+                        "Discovered env var %s, however a Shotgun local storage already "
+                        "defines '%s' to be '%s'. Your environment override "
+                        "will be ignored." % (env_var, storage_name, storage_lookup[storage_name].linux)
+                    )
                 else:
                     storage_lookup[storage_name].linux = os.environ[env_var]
 


### PR DESCRIPTION
QA fixes for #41300 - handling of how storages are resolves when a publish is resolves into a path.

- Tweaks to sphinx docs with better examples and clearer docs.
- Added support for adding an os platform to a local storage at runtime via an env var so that you can augment a local storage that is missing an os platform at runtime. this brings symmetry to the operations you can perform across `file://` links and local storage publishes.