### PR TITLE
For #41850, banner updates

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -168,6 +168,18 @@ class Sgtk(object):
     # properties
 
     @property
+    def configuration_descriptor(self):
+        """
+        The configuration descriptor represents the source of the environments associated
+        with this pipeline configuration.
+
+        .. note::
+            If this is a Toolkit Classic pipeline configuration, no descriptor will be associated
+            with the pipeline configuration.
+        """
+        return self.__pipeline_config.get_configuration_descriptor()
+
+    @property
     def bundle_cache_fallback_paths(self):
         """
         List of paths to the fallback bundle caches for the pipeline configuration.

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -91,7 +91,8 @@ class Configuration(object):
         # now bypass some of the very extensive validation going on
         # by creating a pipeline configuration object directly
         # and pass that into the factory method.
-        pc = pipelineconfig.PipelineConfiguration(path)
+
+        pc = pipelineconfig.PipelineConfiguration(path, self.descriptor)
         tk = api.tank_from_path(pc)
 
         log.debug("Bootstrapped into tk instance %r (%r)" % (tk, tk.pipeline_configuration))

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -506,8 +506,8 @@ class ToolkitManager(object):
         :param entity: An entity link. If the entity is not a project, the project for that entity will be resolved.
         :type project: Dictionary with keys ``type`` and ``id``, or ``None`` for the site
 
-        :returns: Path to the pipeline configuration.
-        :rtype: str
+        :returns: Path and descriptor of the pipeline configuration.
+        :rtype: tuple
         """
         config = self._get_configuration(entity, self.progress_callback)
 
@@ -529,7 +529,7 @@ class ToolkitManager(object):
 
         self._report_progress(self.progress_callback, self._BOOTSTRAP_COMPLETED, "Engine ready.")
 
-        return path
+        return path, config.descriptor
 
     def get_pipeline_configurations(self, project):
         """

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -506,8 +506,10 @@ class ToolkitManager(object):
         :param entity: An entity link. If the entity is not a project, the project for that entity will be resolved.
         :type project: Dictionary with keys ``type`` and ``id``, or ``None`` for the site
 
-        :returns: Path and descriptor of the pipeline configuration.
-        :rtype: tuple
+        :returns: Path to the fully realized pipeline configuration on disk and to the descriptor that
+            spawned it.
+
+        :rtype: (str, :class:`sgtk.descriptor.Descriptor`)
         """
         config = self._get_configuration(entity, self.progress_callback)
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -509,7 +509,7 @@ class ToolkitManager(object):
         :returns: Path to the fully realized pipeline configuration on disk and to the descriptor that
             spawned it.
 
-        :rtype: (str, :class:`sgtk.descriptor.Descriptor`)
+        :rtype: (str, :class:`sgtk.descriptor.ConfigDescriptor`)
         """
         config = self._get_configuration(entity, self.progress_callback)
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -41,7 +41,7 @@ class PipelineConfiguration(object):
     to construct this object, do not create directly via the constructor.
     """
 
-    def __init__(self, pipeline_configuration_path):
+    def __init__(self, pipeline_configuration_path, descriptor=None):
         """
         Constructor. Do not call this directly, use the factory methods
         in pipelineconfig_factory.
@@ -53,6 +53,8 @@ class PipelineConfiguration(object):
         is handled on the OS level.
         """
         self._pc_root = pipeline_configuration_path
+
+        self._descriptor = descriptor
 
         # validate that the current code version matches or is compatible with
         # the code that is locally stored in this config!!!!
@@ -770,6 +772,14 @@ class PipelineConfiguration(object):
             constraint_pattern=constraint_pattern
         )
 
+    def get_configuration_descriptor(self):
+        """
+        Returns the descriptor that was used to create this pipeline configuration.
+
+        .. note:: In Toolkit Classic, this value will always be ``None`` since pipeline configurations
+            are not based off a descriptor.
+        """
+        return self._descriptor
 
     ########################################################################################
     # configuration disk locations

--- a/python/tank/platform/errors.py
+++ b/python/tank/platform/errors.py
@@ -27,11 +27,18 @@ class TankEngineInitError(errors.TankError):
     Exception that indicates that an engine could not start up.
     """
 
+
 class TankEngineEventError(errors.TankError):
     """
     Exception that is raised when there is a problem during engine event emission.
     """
-    pass
+
+
+class TankCurrentModuleNotFoundError(errors.TankError):
+    """
+    Exception that is raised when :meth:`sgtk.platform.current_bundle` couldn't
+    resolve a bundle.
+    """
 
 
 # backwards compatibility to ensure code that was calling internal

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -12,7 +12,7 @@ from __future__ import with_statement
 import os
 import sgtk
 
-from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import TankTestBase, SealedMock
 from tank_test.tank_test_base import setUpModule # noqa
 from tank.errors import TankError
 from tank.descriptor import CheckVersionConstraintsError
@@ -55,7 +55,10 @@ class TestDescriptorSupport(TankTestBase):
             "version": 456
         }
 
-        location_str = "sgtk:descriptor:shotgun?name=primary&entity_type=PipelineConfiguration&field=sg_config&version=456&project_id=123"
+        location_str = (
+            "sgtk:descriptor:shotgun?name=primary&entity_type="
+            "PipelineConfiguration&field=sg_config&version=456&project_id=123"
+        )
 
         faulty_location_1 = {
             "type": "shotgun",
@@ -75,7 +78,10 @@ class TestDescriptorSupport(TankTestBase):
             "version": "bar"
         }
 
-        path = os.path.join(self.install_root, "sg", "unit_test_mock_sg", "PipelineConfiguration.sg_config", "p123_primary", "v456")
+        path = os.path.join(
+            self.install_root, "sg", "unit_test_mock_sg",
+            "PipelineConfiguration.sg_config", "p123_primary", "v456"
+        )
         self._create_info_yaml(path)
 
         d = self.tk.pipeline_configuration.get_app_descriptor(location)
@@ -255,18 +261,6 @@ class TestDescriptorSupport(TankTestBase):
                                 desc._io_descriptor._find_latest_tag_by_pattern,
                                 ["v1.2.3", "v1.2.233", "v1.3.1"],
                                 "v1.x.2")
-
-
-class SealedMock(Mock):
-    """
-    Sealed mock ensures that no one is accessing something we have not planned for.
-    """
-    def __init__(self, **kwargs):
-        """
-        :param kwargs: Passed down directly to the base class as kwargs. Each keys are passed to the ``spec_set``
-            argument from the base class to seal the gettable and settable properties.
-        """
-        super(SealedMock, self).__init__(spec_set=kwargs.keys(), **kwargs)
 
 
 class TestConstraintValidation(TankTestBase):

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -742,6 +742,18 @@ class TankTestBase(unittest.TestCase):
         self.tk._Sgtk__pipeline_config = self.pipeline_configuration
 
 
+class SealedMock(mock.Mock):
+    """
+    Sealed mock ensures that no one is accessing something we have not planned for.
+    """
+    def __init__(self, **kwargs):
+        """
+        :param kwargs: Passed down directly to the base class as kwargs. Each keys are passed to the ``spec_set``
+            argument from the base class to seal the gettable and settable properties.
+        """
+        super(SealedMock, self).__init__(spec_set=kwargs.keys(), **kwargs)
+
+
 def _move_data(path):
     """
     Rename directory to backup name, if backup currently exists replace it.

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -103,12 +103,18 @@ if __name__ == "__main__":
                       action="store",
                       dest="test_root", 
                       help="Specify a folder where to look for tests.")
+    parser.add_option("--log-to-console", "-l",
+                      action="store_true",
+                      help="run tests and redirect logging output to the console.")
 
     (options, args) = parser.parse_args()
     
     test_name = None
     if args:
         test_name = args[0]
+
+    if options.log_to_console:
+        tank.LogManager().initialize_custom_handler()
      
     if options.test_root:
         # resolve path


### PR DESCRIPTION
Adds a bunch of features for the Shotgun Desktop and some unit tests goodies.
- The descriptor for the pipeline configuration is exposed for zero config based pipelines
- `sgtk.platform.get_logger` now fallbacks to `sgtk.LogManager.get_logger` when no current bundle is available.
- Exposed SealedMock in the tank_test module so other unit tests can use it.
- Unit tests can now output logging to the console with the `--log-to-console`

On the `Sgtk` class:
<img width="692" alt="screen shot 2017-05-03 at 12 48 56" src="https://cloud.githubusercontent.com/assets/8126447/25671699/f28c20ee-2ffe-11e7-91af-69d441d3a283.png">
