### PR TITLE
For #42066: Includes descriptors when getting configs from ToolkitManager.

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -18,7 +18,6 @@ from ..authentication import ShotgunAuthenticator
 from ..pipelineconfig import PipelineConfiguration
 from .. import LogManager
 from ..errors import TankError
-from ..descriptor import Descriptor, create_descriptor, TankDescriptorError
 from ..util import ShotgunPath
 
 log = LogManager.get_logger(__name__)
@@ -547,6 +546,8 @@ class ToolkitManager(object):
              only the one with the lowest id is available, unless one or more of them is a Toolkit
              Classic Primary, in which case the Toolkit Classic Primary with the lowest id will
              be returned.
+           - A :class:`~sgtk.descriptor.Descriptor` object must be able to be created from the
+             pipeline configuration.
            - All sandboxes are available.
 
         In practice, this means that if there are 3 primaries, two of them using plugin ids and
@@ -565,10 +566,10 @@ class ToolkitManager(object):
         :type project: Dictionary with keys ``type`` and ``id``.
 
         :returns: List of pipeline configurations.
-        :rtype: List of dictionaries with keys ``type``, ``id``, ``name`` and ``project``. The pipeline
-            configurations will always be sorted such as the primary pipeline configuration, if available,
-            will be first. Then the remaining pipeline configurations will be sorted by ``name`` field
-            (case insensitive), then the ``project`` field and finally then ``id`` field.
+        :rtype: List of dictionaries with keys ``type``, ``id``, ``name``, ``project``, and ``descriptor``. 
+            The pipeline configurations will always be sorted such as the primary pipeline configuration,
+            if available, will be first. Then the remaining pipeline configurations will be sorted by
+            ``name`` field (case insensitive), then the ``project`` field and finally then ``id`` field.
         """
         if isinstance(self.pipeline_configuration, int):
             raise TankBootstrapError("Can't enumerate pipeline configurations matching a specific id.")
@@ -585,41 +586,12 @@ class ToolkitManager(object):
             current_login=self._sg_user.login,
             sg_connection=self._sg_connection,
         ):
-            try:
-                path = ShotgunPath.from_shotgun_dict(pc)
-                config_path = path.current_os
-            except TankError:
-                log.warning(
-                    "Unable to determine config path for %s: %s",
-                    sys.platform,
-                    pc,
-                )
-                cfg_descriptor = None
-            except ValueError:
-                log.warning(
-                    "The PipelineConfiguration %s is not configured for the "
-                    "current platform %s.",
-                    pc,
-                    sys.platform,
-                )
-                cfg_descriptor = None
-            else:
-                try:
-                    cfg_descriptor = create_descriptor(
-                        self._sg_connection,
-                        Descriptor.CONFIG,
-                        dict(path=config_path, type="path"),
-                    )
-                except TankDescriptorError:
-                    log.warning("Unable to create a Descriptor for config %s", pc)
-                    cfg_descriptor = None
-
             pcs.append({
                 "id": pc["id"],
                 "type": pc["type"],
                 "name": pc["code"],
                 "project": pc["project"],
-                "descriptor": cfg_descriptor,
+                "descriptor": pc["config_descriptor"],
             })
 
         return pcs

--- a/python/tank/util/shotgun_path.py
+++ b/python/tank/util/shotgun_path.py
@@ -146,7 +146,7 @@ class ShotgunPath(object):
         elif sys.platform == "darwin":
             macosx_path = path
         else:
-            return ValueError("Unsupported platform '%s'." % sys.platform)
+            raise ValueError("Unsupported platform '%s'." % sys.platform)
 
         return cls(windows_path, linux_path, macosx_path)
 
@@ -337,7 +337,7 @@ class ShotgunPath(object):
         elif sys.platform == "darwin":
             return self.macosx
         else:
-            return ValueError("Unsupported platform '%s'." % sys.platform)
+            raise ValueError("Unsupported platform '%s'." % sys.platform)
 
     def _set_current_os(self, value):
         """
@@ -350,7 +350,7 @@ class ShotgunPath(object):
         elif sys.platform == "darwin":
             self.macosx = value
         else:
-            return ValueError("Unsupported platform '%s'." % sys.platform)
+            raise ValueError("Unsupported platform '%s'." % sys.platform)
 
     current_os = property(_get_current_os, _set_current_os)
 

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -103,7 +103,7 @@ class TestUserRestriction(TestResolverBase):
         Ensures we can find the sandbox for the requested user.
         """
 
-        # Make sure we can find he pipeline configuration for a specific user.
+        # Make sure we can find the pipeline configuration for a specific user.
         configs = self.resolver.find_matching_pipeline_configurations(
             pipeline_config_name=None,
             current_login="john.smith",
@@ -850,6 +850,9 @@ class TestResolveWithFilter(TestResolverBase):
         self.assertEqual(len(pcs), 3)
         for pc in pcs:
             self.assertTrue(pc["code"] == "Primary" or pc["users"][0]["id"] == self._john_smith["id"])
+            # Make sure everything has a descriptor. The filter step in the find
+            # method should always give us back pcs with descriptors included.
+            self.assertIsNotNone(pc["config_descriptor"])
 
         # Ensure we are resolving only the primary sandbox.
         pcs = self.resolver.find_matching_pipeline_configurations(


### PR DESCRIPTION
Also resolves a bug in shotgun_path where we were returning exceptions instead of raising them.