### PR TITLE
For #41850, desktop banners

### DIFF
--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -92,10 +92,20 @@ class Configuration(object):
         # by creating a pipeline configuration object directly
         # and pass that into the factory method.
 
-        pc = pipelineconfig.PipelineConfiguration(path, self.descriptor)
+        if self._does_pipelineconfigution_supports_descriptor(pipelineconfig.PipelineConfiguration):
+            pc = pipelineconfig.PipelineConfiguration(path, self.descriptor)
+        else:
+            pc = pipelineconfig.PipelineConfiguration(path)
         tk = api.tank_from_path(pc)
 
         log.debug("Bootstrapped into tk instance %r (%r)" % (tk, tk.pipeline_configuration))
         log.debug("Core API code located here: %s" % inspect.getfile(tk.__class__))
 
         return tk
+
+    def _does_pipelineconfigution_supports_descriptor(self, pipeline_configuration):
+        """
+        :returns: True if the __init__ method accepts a descriptor object, False otherwise.
+        """
+        # The name of the arguments are at index 0. Do not use .args since this is a 2.6+ feature.
+        return "descriptor" in inspect.getargspec(pipeline_configuration.__init__)[0]

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -92,7 +92,11 @@ class Configuration(object):
         # by creating a pipeline configuration object directly
         # and pass that into the factory method.
 
-        if self._does_pipelineconfigution_supports_descriptor(pipelineconfig.PipelineConfiguration):
+        # Previous versions of the PipelineConfiguration API didn't support having a descriptor
+        # passed in, so we'll have to be backwards compatible with these. If the pipeline
+        # configuration does support the get_configuration_descriptor method however, we can
+        # pass the descriptor in.
+        if hasattr(pipelineconfig.PipelineConfiguration, "get_configuration_descriptor"):
             pc = pipelineconfig.PipelineConfiguration(path, self.descriptor)
         else:
             pc = pipelineconfig.PipelineConfiguration(path)
@@ -102,10 +106,3 @@ class Configuration(object):
         log.debug("Core API code located here: %s" % inspect.getfile(tk.__class__))
 
         return tk
-
-    def _does_pipelineconfigution_supports_descriptor(self, pipeline_configuration):
-        """
-        :returns: True if the __init__ method accepts a descriptor object, False otherwise.
-        """
-        # The name of the arguments are at index 0. Do not use .args since this is a 2.6+ feature.
-        return "descriptor" in inspect.getargspec(pipeline_configuration.__init__)[0]

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -42,12 +42,6 @@ class PipelineConfiguration(object):
     to construct this object, do not create directly via the constructor.
     """
 
-    # Do NOT rename or reorder these arguments. It is vital that any assumptions made about the
-    # parameters here in the past remain true in the future. There is code in the ToolkitManager
-    # that strives to be backwards compatible with older version of this class that didn't have
-    # the descriptor parameter. The only way we have to know if the class supports the descriptor
-    # argument is by inspecting it with the inspect module. Renaming the descriptor argument in this
-    # method would completely break that test.
     def __init__(self, pipeline_configuration_path, descriptor=None):
         """
         Constructor. Do not call this directly, use the factory methods

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -42,6 +42,12 @@ class PipelineConfiguration(object):
     to construct this object, do not create directly via the constructor.
     """
 
+    # Do NOT rename or reorder these arguments. It is vital that any assumptions made about the
+    # parameters here in the past remain true in the future. There is code in the ToolkitManager
+    # that strives to be backwards compatible with older version of this class that didn't have
+    # the descriptor parameter. The only way we have to know if the class supports the descriptor
+    # argument is by inspecting it with the inspect module. Renaming the descriptor argument in this
+    # method would completely break that test.
     def __init__(self, pipeline_configuration_path, descriptor=None):
         """
         Constructor. Do not call this directly, use the factory methods

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -65,7 +65,7 @@ class PipelineConfiguration(object):
         # validate that the current code version matches or is compatible with
         # the code that is locally stored in this config!!!!
         our_associated_api_version = self.get_associated_core_version()
-        print our_associated_api_version
+
         # and get the version of the API currently in memory
         current_api_version = pipelineconfig_utils.get_currently_running_api_version()
         

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -65,11 +65,11 @@ class PipelineConfiguration(object):
         # validate that the current code version matches or is compatible with
         # the code that is locally stored in this config!!!!
         our_associated_api_version = self.get_associated_core_version()
-        
+        print our_associated_api_version
         # and get the version of the API currently in memory
         current_api_version = pipelineconfig_utils.get_currently_running_api_version()
         
-        if our_associated_api_version is not None and \
+        if our_associated_api_version not in [None, "unknown", "HEAD"] and \
            is_version_older(current_api_version, our_associated_api_version):
             # currently running API is too old!
             current_api_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
Allows to instantiate a pipeline configuration from an older core. Older versions of the API didn't support being instantiated with the descriptor object passed in.