### PR TITLE
#42750 fixes backwards compatibility for shotgun envs

### DIFF
--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -73,3 +73,6 @@ CONFIG_OVERRIDE_ENV_VAR = "TK_BOOTSTRAP_CONFIG_OVERRIDE"
 # environment variable that is used to indicate a specific
 # pipeline configuration to be used.
 PIPELINE_CONFIG_ID_ENV_VAR = "SHOTGUN_PIPELINE_CONFIGURATION_ID"
+
+# the shotgun engine always has this name
+SHOTGUN_ENGINE_NAME = "tk-shotgun"

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -875,6 +875,7 @@ class ToolkitManager(object):
         else:
             log.debug("Configuration has local bundle cache, skipping bundle caching.")
 
+        log.debug("Initialized core %s" % tk)
         return tk
 
     def _start_engine(self, tk, engine_name, entity, progress_callback=None):

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -940,7 +940,9 @@ class ToolkitManager(object):
                 )
 
             # start engine via legacy pathway
-            engine = tank.platform.start_shotgun_engine(tk, entity["type"], ctx)
+            # note the local import due to core swapping.
+            from tank.platform import engine
+            engine = engine.start_shotgun_engine(tk, entity["type"], ctx)
 
         else:
             # no legacy cases

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -19,6 +19,7 @@ from ..pipelineconfig import PipelineConfiguration
 from .. import LogManager
 from ..errors import TankError
 from ..util import ShotgunPath
+from ..util.version import is_version_older
 
 log = LogManager.get_logger(__name__)
 
@@ -371,6 +372,7 @@ class ToolkitManager(object):
         self._log_startup_message(engine_name, entity)
 
         tk = self._bootstrap_sgtk(engine_name, entity)
+
         engine = self._start_engine(tk, engine_name, entity)
 
         self._report_progress(self.progress_callback, self._BOOTSTRAP_COMPLETED, "Engine launched.")
@@ -919,7 +921,30 @@ class ToolkitManager(object):
 
         # perform absolute import to ensure we get the new swapped core.
         import tank
-        engine = tank.platform.start_engine(engine_name, tk, ctx)
+
+        # handle legacy cases
+        if engine_name == constants.SHOTGUN_ENGINE_NAME and is_version_older(tk.version, "v0.18.77"):
+
+            # bootstrapping into a shotgun engine with an older core
+            # we perform this special check to make sure that we correctly pick up
+            # the shotgun_xxx.yml environment files, even for older cores.
+            # new cores handles all this inside the tank.platform.start_shotgun_engine
+            # business logic.
+            log.debug(
+                "Target core version is %s. Starting shotgun engine via legacy pathway." % tk.version
+            )
+
+            if entity is None:
+                raise TankBootstrapError(
+                    "Legacy shotgun environments do not support bootstrapping into a site context."
+                )
+
+            # start engine via legacy pathway
+            engine = tank.platform.start_shotgun_engine(tk, entity["type"], ctx)
+
+        else:
+            # no legacy cases
+            engine = tank.platform.start_engine(engine_name, tk, ctx)
 
         log.debug("Launched engine %r" % engine)
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -2694,9 +2694,11 @@ def _start_engine(engine_name, tk, old_context, new_context):
                 elif new_context.project is not None:
                     entity_type = "Project"
                 else:
-                    # Empty context, in which case we know the start_shotgun_engine
-                    # won't do what we need.
-                    raise
+                    # Empty context, in which case we know the start_shotgun_engine won't do what we need.
+                    raise TankError(
+                        "Legacy shotgun environment configuration "
+                        "does not support context '%s'" % new_context
+                    )
 
                 core_logger.debug("Starting Shotgun engine in legacy mode...")
                 return start_shotgun_engine(tk, entity_type, new_context)


### PR DESCRIPTION
Fixes a subtle issue where you would get errors when bootstrapping into an older project using the latest desktop server. The latest core has updated its `start_engine` so that it correctly handles both modern and legacy cases, however if you have an older core for a project you won't have these changes and the `shotgun_xxx.yml` legacy env files will therefore not be considered.

This fix ensures that the bootstrap logic runs the old shotgun-specific engine startup logic for old cores to ensure that we pick up `shotgun_xxx.yml` envs exactly the way it's done in the `tank` command.