### PR TITLE
For #42768, studio bugs

### DIFF
--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -54,6 +54,8 @@ if "TANK_CURRENT_PC" not in os.environ:
 # first import the log manager since a lot of modules require this.
 from .log import LogManager
 
+from .pipelineconfig_utils import get_python_interpreter_for_config, get_core_python_path_for_config
+
 # make sure that all sub-modules are imported at the same as the main module
 from . import authentication
 from . import bootstrap
@@ -67,7 +69,6 @@ from . import util
 # core functionality
 from .api import Tank, tank_from_path, tank_from_entity, set_authenticated_user, get_authenticated_user
 from .api import Sgtk, sgtk_from_path, sgtk_from_entity
-from .pipelineconfig_utils import get_python_interpreter_for_config
 
 from .context import Context
 

--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -54,8 +54,6 @@ if "TANK_CURRENT_PC" not in os.environ:
 # first import the log manager since a lot of modules require this.
 from .log import LogManager
 
-from .pipelineconfig_utils import get_python_interpreter_for_config, get_core_python_path_for_config
-
 # make sure that all sub-modules are imported at the same as the main module
 from . import authentication
 from . import bootstrap
@@ -69,6 +67,7 @@ from . import util
 # core functionality
 from .api import Tank, tank_from_path, tank_from_entity, set_authenticated_user, get_authenticated_user
 from .api import Sgtk, sgtk_from_path, sgtk_from_entity
+from .pipelineconfig_utils import get_python_interpreter_for_config, get_core_python_path_for_config
 
 from .context import Context
 

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -8,12 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import inspect
 
 from .import_handler import CoreImportHandler
 
-from .. import LogManager, get_core_python_path_for_config
+from ..log import LogManager
+from ..pipelineconfig_utils import get_core_python_path_for_config
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -13,7 +13,7 @@ import inspect
 
 from .import_handler import CoreImportHandler
 
-from .. import LogManager
+from .. import LogManager, get_core_python_path_for_config
 
 log = LogManager.get_logger(__name__)
 
@@ -76,7 +76,7 @@ class Configuration(object):
                         the tk instance with.
         """
         path = self._path.current_os
-        core_path = os.path.join(path, "install", "core", "python")
+        core_path = get_core_python_path_for_config(path)
 
         # swap the core out
         CoreImportHandler.swap_core(core_path)

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -128,34 +128,6 @@ class ToolkitManager(object):
         repr += " Base %s >" % self._base_config_descriptor
         return repr
 
-    @classmethod
-    def get_core_python_path(cls):
-        """
-        Computes the path to the current Toolkit core.
-
-        The current Toolkit core is defined as the core that gets imported when you type
-
-            import sgtk
-
-        and the python path is derived from the ``__file__`` attribute on the module.
-
-        For example, if the ``sgtk`` module was found at ``/path/to/config/install/core/python/sgtk``,
-        the return path would be ``/path/to/config/install/core/python``
-
-        This can be useful if you want to hand down to a subprocess the location of the current
-        process's core, since ``sys.path`` and the ``PYTHONPATH`` are not updated after
-        bootstrapping.
-
-        :returns: Path to the current core.
-        :rtype str:
-        """
-        import sgtk
-        sgtk_file = inspect.getfile(sgtk)
-        tank_folder = os.path.dirname(sgtk_file)
-        python_folder = os.path.dirname(tank_folder)
-        return python_folder
-
-
     def _get_pipeline_configuration(self):
         """
         The pipeline configuration that is should be operated on.
@@ -1116,3 +1088,27 @@ class ToolkitManager(object):
         log.debug("Logging user activity metric: module '%s', action '%s'" % (module, action))
 
         log_user_activity_metric(module, action)
+
+    @staticmethod
+    def get_core_python_path():
+        """
+        Computes the path to the current Toolkit core.
+
+        The current Toolkit core is defined as the core that gets imported when you type
+        ``import sgtk`` and the python path is derived from that module.
+
+        For example, if the ``sgtk`` module was found at ``/path/to/config/install/core/python/sgtk``,
+        the return path would be ``/path/to/config/install/core/python``
+
+        This can be useful if you want to hand down to a subprocess the location of the current
+        process's core, since ``sys.path`` and the ``PYTHONPATH`` are not updated after
+        bootstrapping.
+
+        :returns: Path to the current core.
+        :rtype: str
+        """
+        import sgtk
+        sgtk_file = inspect.getfile(sgtk)
+        tank_folder = os.path.dirname(sgtk_file)
+        python_folder = os.path.dirname(tank_folder)
+        return python_folder

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -18,7 +18,6 @@ from ..authentication import ShotgunAuthenticator
 from ..pipelineconfig import PipelineConfiguration
 from .. import LogManager
 from ..errors import TankError
-from ..util import ShotgunPath
 from ..util.version import is_version_older
 
 log = LogManager.get_logger(__name__)
@@ -570,7 +569,7 @@ class ToolkitManager(object):
         :type project: Dictionary with keys ``type`` and ``id``.
 
         :returns: List of pipeline configurations.
-        :rtype: List of dictionaries with keys ``type``, ``id``, ``name``, ``project``, and ``descriptor``. 
+        :rtype: List of dictionaries with keys ``type``, ``id``, ``name``, ``project``, and ``descriptor``.
             The pipeline configurations will always be sorted such as the primary pipeline configuration,
             if available, will be first. Then the remaining pipeline configurations will be sorted by
             ``name`` field (case insensitive), then the ``project`` field and finally then ``id`` field.

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import inspect
 
 from . import constants
 from .errors import TankBootstrapError
@@ -149,7 +150,8 @@ class ToolkitManager(object):
         :rtype str:
         """
         import sgtk
-        tank_folder = os.path.dirname(sgtk.__file__)
+        sgtk_file = inspect.getfile(sgtk)
+        tank_folder = os.path.dirname(sgtk_file)
         python_folder = os.path.dirname(tank_folder)
         return python_folder
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -127,6 +127,33 @@ class ToolkitManager(object):
         repr += " Base %s >" % self._base_config_descriptor
         return repr
 
+    @classmethod
+    def get_core_python_path(cls):
+        """
+        Computes the path to the current Toolkit core.
+
+        The current Toolkit core is defined as the core that gets imported when you type
+
+            import sgtk
+
+        and the python path is derived from the ``__file__`` attribute on the module.
+
+        For example, if the ``sgtk`` module was found at ``/path/to/config/install/core/python/sgtk``,
+        the return path would be ``/path/to/config/install/core/python``
+
+        This can be useful if you want to hand down to a subprocess the location of the current
+        process's core, since ``sys.path`` and the ``PYTHONPATH`` are not updated after
+        bootstrapping.
+
+        :returns: Path to the current core.
+        :rtype str:
+        """
+        import sgtk
+        tank_folder = os.path.dirname(sgtk.__file__)
+        python_folder = os.path.dirname(tank_folder)
+        return python_folder
+
+
     def _get_pipeline_configuration(self):
         """
         The pipeline configuration that is should be operated on.

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -25,7 +25,7 @@ class TankUnreadableFileError(TankError):
     """
 
 
-class TankMissingEnvironentFile(TankError):
+class TankMissingEnvironmentFile(TankError):
     """
     Exception that indicates that an environment file can't be found on disk.
     """

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -25,9 +25,15 @@ class TankUnreadableFileError(TankError):
     """
 
 
+class TankMissingEnvironentFile(TankError):
+    """
+    Exception that indicates that an environment file can't be found on disk.
+    """
+
+
 class TankFileDoesNotExistError(TankUnreadableFileError):
     """
-    Exceptions that indicates that a required file does not exist.
+    Exception that indicates that a required file does not exist.
     """
 
 

--- a/python/tank/errors.py
+++ b/python/tank/errors.py
@@ -25,12 +25,6 @@ class TankUnreadableFileError(TankError):
     """
 
 
-class TankMissingEnvironmentFile(TankError):
-    """
-    Exception that indicates that an environment file can't be found on disk.
-    """
-
-
 class TankFileDoesNotExistError(TankUnreadableFileError):
     """
     Exception that indicates that a required file does not exist.

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -169,8 +169,6 @@ def get_core_python_path_for_config(pipeline_config_path):
     """
     Returns the location of the Toolkit library associated with the given pipeline configuration.
 
-    This can used to update the PYTHONPATH and import the right version of Toolkit.
-
     :param pipeline_config_path: path to a pipeline configuration
 
     :returns: Path to location where the Toolkit Python library associated with the config resides.

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -162,22 +162,39 @@ def get_path_to_current_core():
                         "This can happen if you try to move or symlink the Toolkit API. The "
                         "Toolkit API is currently picked up from %s which is an "
                         "invalid location." % full_path_to_file)
-    return curr_os_core_root    
+    return curr_os_core_root
+
+
+def get_core_python_path_for_config(pipeline_config_path):
+    """
+    Returns the location of the Toolkit library associated with the given pipeline configuration.
+
+    This can used to update the PYTHONPATH and import the right version of Toolkit.
+
+    :param pipeline_config_path: path to a pipeline configuration
+
+    :returns: Path to location where the Toolkit Python library associated with the config resides.
+    :rtype: str
+    """
+    return os.path.join(_get_core_path_for_config(pipeline_config_path), "install", "core", "python")
 
 
 def get_core_path_for_config(pipeline_config_path):
     """
     Returns the core api install location associated with the given pipeline configuration.
+
     In the case of a localized PC, it just returns the given path.
     Otherwise, it resolves the location via the core_xxxx.cfg files.
     
     :param pipeline_config_path: path to a pipeline configuration
+
     :returns: Path to the studio location root or pipeline configuration root or None if not resolved
     """
     try:
         return _get_core_path_for_config(pipeline_config_path)
     except:
         return None
+
 
 def _get_core_path_for_config(pipeline_config_path):
     """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -33,6 +33,7 @@ from .errors import (
     TankEngineInitError,
     TankContextChangeNotSupportedError,
     TankEngineEventError,
+    TankMissingEnvironentFile
 )
 
 from ..util import log_user_activity_metric as util_log_user_activity_metric
@@ -2679,7 +2680,7 @@ def _start_engine(engine_name, tk, old_context, new_context):
         # get environment and engine location
         try:
             (env, engine_descriptor) = get_env_and_descriptor_for_engine(engine_name, tk, new_context)
-        except TankEngineInitError:
+        except (TankEngineInitError, TankMissingEnvironentFile):
             # If we failed using the typical pick_environment approach, then we
             # need to check and see if this is the Shotgun engine. If it is, then
             # we can also try the legacy engine start method, which will make use

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -28,12 +28,11 @@ from ..util.qt_importer import QtImporter
 from ..util.loader import load_plugin
 from .. import hook
 
-from ..errors import TankError
+from ..errors import TankError, TankMissingEnvironmentFile
 from .errors import (
     TankEngineInitError,
     TankContextChangeNotSupportedError,
-    TankEngineEventError,
-    TankMissingEnvironentFile
+    TankEngineEventError
 )
 
 from ..util import log_user_activity_metric as util_log_user_activity_metric
@@ -2680,7 +2679,7 @@ def _start_engine(engine_name, tk, old_context, new_context):
         # get environment and engine location
         try:
             (env, engine_descriptor) = get_env_and_descriptor_for_engine(engine_name, tk, new_context)
-        except (TankEngineInitError, TankMissingEnvironentFile):
+        except (TankEngineInitError, TankMissingEnvironmentFile):
             # If we failed using the typical pick_environment approach, then we
             # need to check and see if this is the Shotgun engine. If it is, then
             # we can also try the legacy engine start method, which will make use

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -28,11 +28,12 @@ from ..util.qt_importer import QtImporter
 from ..util.loader import load_plugin
 from .. import hook
 
-from ..errors import TankError, TankMissingEnvironmentFile
+from ..errors import TankError
 from .errors import (
     TankEngineInitError,
     TankContextChangeNotSupportedError,
-    TankEngineEventError
+    TankEngineEventError,
+    TankMissingEnvironmentFile
 )
 
 from ..util import log_user_activity_metric as util_log_user_activity_metric

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -21,7 +21,7 @@ from tank_vendor import yaml
 from .bundle import resolve_default_value
 from . import constants
 from . import environment_includes
-from ..errors import TankError, TankUnreadableFileError, TankMissingEnvironentFile
+from ..errors import TankError, TankUnreadableFileError, TankMissingEnvironmentFile
 
 from ..util.yaml_cache import g_yaml_cache
 from .. import LogManager
@@ -200,11 +200,18 @@ class Environment(object):
         return g_yaml_cache.get(path)
 
     def __load_environment_data(self):
+        """
+        Loads the main environment data file.
+
+        :returns: Dictionary of the data.
+
+        :raises TankMissingEnvironmentFile: Raised if the environment file does not exist on disk.
+        """
         try:
             return self.__load_data(self._env_path)
         except TankUnreadableFileError:
             logger.exception("Missing environment file:")
-            raise TankMissingEnvironentFile("Missing environment file: %s" % self._env_path)
+            raise TankMissingEnvironmentFile("Missing environment file: %s" % self._env_path)
 
     ##########################################################################################
     # Properties
@@ -346,7 +353,7 @@ class Environment(object):
         :returns:           (list of tokens, file path)
         """
         # get the raw data:
-        root_yml_data = self.__load_data(self._env_path)
+        root_yml_data = self.__load_environment_data()
         
         # find the location for the engine:
         tokens, path = self.__find_location_for_bundle(self._env_path, root_yml_data, "engines", engine_name)

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -21,7 +21,8 @@ from tank_vendor import yaml
 from .bundle import resolve_default_value
 from . import constants
 from . import environment_includes
-from ..errors import TankError, TankUnreadableFileError, TankMissingEnvironmentFile
+from ..errors import TankError, TankUnreadableFileError
+from .errors import TankMissingEnvironmentFile
 
 from ..util.yaml_cache import g_yaml_cache
 from .. import LogManager

--- a/python/tank/platform/errors.py
+++ b/python/tank/platform/errors.py
@@ -40,6 +40,10 @@ class TankCurrentModuleNotFoundError(errors.TankError):
     resolve a bundle.
     """
 
+class TankMissingEnvironmentFile(errors.TankError):
+    """
+    Exception that indicates that an environment file can't be found on disk.
+    """
 
 # backwards compatibility to ensure code that was calling internal
 # parts of the API will still work.


### PR DESCRIPTION
Some clients have a damaged pipeline configurations with a shared core that doesn't have a `install/core/python` folder. We'll stop assuming that Toolkit is importable from that location and instead always follow the `core_<os>.yml` files.

It also introduces a method to know the location of the current core that is in use.

![screen shot 2017-05-18 at 15 02 10](https://cloud.githubusercontent.com/assets/8126447/26219249/268fb430-3bdc-11e7-850b-6fa9d5467afc.png)

Finally it fixes an issue with the shotgun engine when the associated entity doesn't have a matching environment file.

