### PR TITLE
For #43043, interpreter files fix.

### DIFF
--- a/python/tank/bootstrap/constants.py
+++ b/python/tank/bootstrap/constants.py
@@ -19,7 +19,7 @@ BUNDLE_METADATA_FILE = "info.yml"
 # if major changes happen to the way cloud based configs are handled
 # by the system, for example requiring any existing deployed cloud
 # configs to be re-deployed, this version number should be incremented.
-BOOTSTRAP_LOGIC_GENERATION = 5
+BOOTSTRAP_LOGIC_GENERATION = 6
 
 # config file with information about which core to use
 CONFIG_CORE_DESCRIPTOR_FILE = "core_api.yml"

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -143,9 +143,9 @@ class TestInterpreterFilesWriter(TankTestBase):
             sys_executable = "/Applications/Shotgun.v1.4.3.app/Contents/MacOS/Shotgun"
             python_exe = os.path.join(sys_prefix, "bin", "python")
         else:
-            sys_prefix = "/opt/Shotgun.v.1.4.3/python"
+            sys_prefix = "/opt/Shotgun.v.1.4.3/Python"
             sys_executable = "/opt/Shotgun.v.1.4.3/Shotgun"
-            python_exe = os.path.join(sys_prefix, "python")
+            python_exe = os.path.join(sys_prefix, "bin", "python")
 
         interpreter = self._writer_interpreter_file(sys_executable, sys_prefix)
 


### PR DESCRIPTION
This is a really bad hack. We're looking to see if we are running inside the Shogun Desktop and if we are then we're using the Python that is package with it.

The reason we are doing this is because we need the interpreter files written out during bootstrapping to be using the ones from the Shotgun Desktop. We could have introduced a way on the ToolkitManager to specify the interpreter to use for the current platform for descriptor based configuration, but we're trying to kill the interpreter files in the first place mid-term, so introducing an API that allows the caller to specify which one to use feels backwards in the first place.

This feels like the lesser of two evils, even tough as I type this I've thrown up a bit in my mouth.