### PR TITLE
For #43057: Path fix when looking up the root.yml file from a ConfigDescriptor.

### DIFF
--- a/python/tank/descriptor/descriptor_config.py
+++ b/python/tank/descriptor/descriptor_config.py
@@ -133,6 +133,7 @@ class ConfigDescriptor(Descriptor):
         # get the roots definition
         root_file_path = os.path.join(
             self._io_descriptor.get_path(),
+            "config",
             "core",
             constants.STORAGE_ROOTS_FILE)
 


### PR DESCRIPTION
This is a curious bug, where the config-type Descriptor object wasn't building a proper roots.yml path. This meant that _get_roots_data() always returned an empty dict.