### PR TITLE
For $43057: Corrects the path given to create_descriptor for path-type configs.

### DIFF
--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -317,10 +317,11 @@ class ConfigurationResolver(object):
                     log.debug("Config isn't setup for %s: %s", sys.platform, pc)
                     cfg_descriptor = None
                 else:
+                    cfg_path = os.path.join(current_os_path, "config")
                     cfg_descriptor = create_descriptor(
                         sg_connection,
                         Descriptor.CONFIG,
-                        dict(path=current_os_path, type="path"),
+                        dict(path=cfg_path, type="path"),
                     )
             elif uri:
                 log.debug("Using descriptor uri: %s", uri)


### PR DESCRIPTION
This then corrects an issue with accessing the config's roots data as stored in roots.yml. This bug only affected descriptors created for classic-style configs by way of the bootstrap api's config resolver class.