### PR TITLE
#43137 fixes issue with sg descriptor latest lookups

### DIFF
--- a/developer/build_bundle_cache.py
+++ b/developer/build_bundle_cache.py
@@ -30,7 +30,7 @@ sys.path.append(python_folder)
 # sgtk imports
 from sgtk import LogManager
 from sgtk.util import filesystem
-from sgtk.descriptor import Descriptor, create_descriptor
+from sgtk.descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
 
 from utils import (
     cache_apps, authenticate, add_authentication_options, OptionParserLineBreakingEpilog, cleanup_bundle_cache,
@@ -73,7 +73,7 @@ def _build_bundle_cache(sg_connection, target_path, config_descriptor_uri):
         Descriptor.CONFIG,
         config_descriptor_uri,
         # If the user hasn't specified the version to retrieve, resolve the latest from Shotgun.
-        resolve_latest="version" not in config_descriptor_uri
+        resolve_latest=is_descriptor_version_missing(config_descriptor_uri)
     )
 
     logger.info("Resolved config %r" % cfg_descriptor)

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -305,6 +305,7 @@ Factory Methods
 .. autofunction:: create_descriptor
 .. autofunction:: descriptor_dict_to_uri
 .. autofunction:: descriptor_uri_to_dict
+.. autofunction:: is_descriptor_version_missing
 
 
 AppDescriptor

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -17,7 +17,7 @@ import datetime
 from . import constants
 
 from .errors import TankBootstrapError
-from ..descriptor import Descriptor, create_descriptor
+from ..descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
 
 from ..util import filesystem
 from ..util import ShotgunPath
@@ -98,8 +98,8 @@ class ConfigurationWriter(object):
         else:
             # we have an exact core descriptor. Get a descriptor for it
             log.debug("Config has a specific core defined in core/core_api.yml: %s" % core_uri_or_dict)
-            # when core is specified, it is always a specific version
-            use_latest = False
+            # when core is specified, check if it defines a specific version or not
+            use_latest = is_descriptor_version_missing(core_uri_or_dict)
 
         core_descriptor = create_descriptor(
             self._sg_connection,

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -329,6 +329,7 @@ class ConfigurationResolver(object):
                     sg_connection,
                     Descriptor.CONFIG,
                     uri,
+                    resolve_latest=True
                 )
             else:
                 # If we have neither a uri, nor a path, then we can't get

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -18,7 +18,7 @@ import os
 import fnmatch
 import pprint
 
-from ..descriptor import Descriptor, create_descriptor, descriptor_uri_to_dict
+from ..descriptor import Descriptor, create_descriptor, descriptor_uri_to_dict, is_descriptor_version_missing
 from .errors import TankBootstrapError
 from .baked_configuration import BakedConfiguration
 from .cached_configuration import CachedConfiguration
@@ -168,16 +168,15 @@ class ConfigurationResolver(object):
             #
             # if a version token is omitted, we request that the latest version
             # should be resolved.
-            if "version" in config_descriptor:
-                log.debug("Base configuration has a version token defined. "
-                          "Will use this fixed version for the bootstrap.")
-                resolve_latest = False
-
-            else:
+            if is_descriptor_version_missing(config_descriptor):
                 log.debug("Base configuration descriptor does not have a "
                           "version token defined. Will attempt to determine "
                           "the latest version available.")
                 resolve_latest = True
+            else:
+                log.debug("Base configuration has a version token defined. "
+                          "Will use this fixed version for the bootstrap.")
+                resolve_latest = False
 
             cfg_descriptor = create_descriptor(
                 sg_connection,
@@ -329,7 +328,7 @@ class ConfigurationResolver(object):
                     sg_connection,
                     Descriptor.CONFIG,
                     uri,
-                    resolve_latest=True
+                    resolve_latest=is_descriptor_version_missing(uri)
                 )
             else:
                 # If we have neither a uri, nor a path, then we can't get

--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -257,7 +257,12 @@ class TankCoreUpdater(object):
 
         if not core_version:
             uri = "sgtk:descriptor:app_store?name=tk-core"
-            self._new_core_descriptor = create_descriptor(self._local_sg, Descriptor.CORE, uri, resolve_latest=True)
+            self._new_core_descriptor = create_descriptor(
+                self._local_sg,
+                Descriptor.CORE,
+                uri,
+                resolve_latest=True
+            )
         else:
             uri = "sgtk:descriptor:app_store?name=tk-core&version=%s" % core_version
             self._new_core_descriptor = create_descriptor(self._local_sg, Descriptor.CORE, uri)

--- a/python/tank/descriptor/__init__.py
+++ b/python/tank/descriptor/__init__.py
@@ -22,4 +22,4 @@ from .errors import (
 )
 
 from .descriptor import create_descriptor
-from .io_descriptor import descriptor_dict_to_uri, descriptor_uri_to_dict
+from .io_descriptor import descriptor_dict_to_uri, descriptor_uri_to_dict, is_descriptor_version_missing

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -38,16 +38,20 @@ def create_descriptor(
                            apps will be searched for. Note that when descriptors
                            download new content, it always ends up in the
                            bundle_cache_root.
-    :param resolve_latest: If true, the latest version will be determined and returned.
-                           If set to True, no version information need to be supplied with
-                           the descriptor dictionary/uri. Please note that setting this flag
+    :param resolve_latest: If true, the latest version may be determined and returned.
+                           If set to True, no version information needs to be supplied with
+                           the descriptor dictionary/uri for descriptor types which support
+                           a version number concept. Please note that setting this flag
                            to true will typically affect performance - an external connection
                            is often required in order to establish what the latest version is.
+
+                           If a version number is supplied as part of the descriptor with this
+                           flag set to True, no attempt to determine what the latest version is
+                           will be attempted.
 
                            If a remote connection cannot be established when attempting to determine
                            the latest version, a local scan will be carried out and the highest
                            version number that is cached locally will be returned.
-
     :param constraint_pattern: If resolve_latest is True, this pattern can be used to constrain
                            the search for latest to only take part over a subset of versions.
                            This is a string that can be on the following form:

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -16,6 +16,9 @@ from .io_descriptor import create_io_descriptor
 from .errors import TankDescriptorError
 from ..util import LocalFileStorageManager
 
+
+
+
 def create_descriptor(
         sg_connection,
         descriptor_type,
@@ -38,16 +41,13 @@ def create_descriptor(
                            apps will be searched for. Note that when descriptors
                            download new content, it always ends up in the
                            bundle_cache_root.
-    :param resolve_latest: If true, the latest version may be determined and returned.
+    :param resolve_latest: If true, the latest version will be determined and returned.
+
                            If set to True, no version information needs to be supplied with
                            the descriptor dictionary/uri for descriptor types which support
                            a version number concept. Please note that setting this flag
                            to true will typically affect performance - an external connection
                            is often required in order to establish what the latest version is.
-
-                           If a version number is supplied as part of the descriptor with this
-                           flag set to True, no attempt to determine what the latest version is
-                           will be attempted.
 
                            If a remote connection cannot be established when attempting to determine
                            the latest version, a local scan will be carried out and the highest

--- a/python/tank/descriptor/io_descriptor/__init__.py
+++ b/python/tank/descriptor/io_descriptor/__init__.py
@@ -8,4 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .factory import create_io_descriptor, descriptor_uri_to_dict, descriptor_dict_to_uri
+from .factory import (
+    create_io_descriptor,
+    descriptor_uri_to_dict,
+    descriptor_dict_to_uri,
+    is_descriptor_version_missing
+)

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -40,11 +40,16 @@ def create_io_descriptor(
                            apps will be searched for. Note that when descriptors
                            download new content, it always ends up in the
                            bundle_cache_root.
-    :param resolve_latest: If true, the latest version will be determined and returned.
-                           If set to True, no version information need to be supplied with
-                           the descriptor dictionary/uri. Please note that setting this flag
+    :param resolve_latest: If true, the latest version may be determined and returned.
+                           If set to True, no version information needs to be supplied with
+                           the descriptor dictionary/uri for descriptor types which support
+                           a version number concept. Please note that setting this flag
                            to true will typically affect performance - an external connection
                            is often required in order to establish what the latest version is.
+
+                           If a version number is supplied as part of the descriptor with this
+                           flag set to True, no attempt to determine what the latest version is
+                           will be attempted.
 
                            If a remote connection cannot be established when attempting to determine
                            the latest version, a local scan will be carried out and the highest
@@ -75,6 +80,7 @@ def create_io_descriptor(
 
     # at this point we didn't have a cache hit,
     # so construct the object manually
+    perform_latest_check = False
     if resolve_latest:
         # if someone is requesting a latest descriptor and not providing a version token
         # make sure to add an artificial one so that we can resolve it.
@@ -87,6 +93,8 @@ def create_io_descriptor(
             # key as part of the descriptor dictionary so that the descriptor
             # is valid
             descriptor_dict["version"] = "latest"
+            # indicate that we should go out and search for latest
+            perform_latest_check = True
 
     # factory logic
     if descriptor_dict.get("type") == "app_store":
@@ -116,7 +124,7 @@ def create_io_descriptor(
     # specify where to go look for caches
     descriptor.set_cache_roots(bundle_cache_root, fallback_roots)
 
-    if resolve_latest:
+    if perform_latest_check:
         # attempt to get "remote" latest first
         # and if that fails, fall back on the latest item
         # available in the local cache.

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -40,16 +40,13 @@ def create_io_descriptor(
                            apps will be searched for. Note that when descriptors
                            download new content, it always ends up in the
                            bundle_cache_root.
-    :param resolve_latest: If true, the latest version may be determined and returned.
+    :param resolve_latest: If true, the latest version will be determined and returned.
+
                            If set to True, no version information needs to be supplied with
                            the descriptor dictionary/uri for descriptor types which support
                            a version number concept. Please note that setting this flag
                            to true will typically affect performance - an external connection
                            is often required in order to establish what the latest version is.
-
-                           If a version number is supplied as part of the descriptor with this
-                           flag set to True, no attempt to determine what the latest version is
-                           will be attempted.
 
                            If a remote connection cannot be established when attempting to determine
                            the latest version, a local scan will be carried out and the highest
@@ -80,21 +77,10 @@ def create_io_descriptor(
 
     # at this point we didn't have a cache hit,
     # so construct the object manually
-    perform_latest_check = False
-    if resolve_latest:
+    if resolve_latest and is_descriptor_version_missing(descriptor_dict):
         # if someone is requesting a latest descriptor and not providing a version token
         # make sure to add an artificial one so that we can resolve it.
-        #
-        # We only do this for descriptor types that supports a version number concept
-        descriptors_using_version = ["app_store", "shotgun", "manual", "git", "git_branch"]
-
-        if "version" not in descriptor_dict and descriptor_dict.get("type") in descriptors_using_version:
-            # for the case of latest version, make sure we attach a version
-            # key as part of the descriptor dictionary so that the descriptor
-            # is valid
-            descriptor_dict["version"] = "latest"
-            # indicate that we should go out and search for latest
-            perform_latest_check = True
+        descriptor_dict["version"] = "latest"
 
     # factory logic
     if descriptor_dict.get("type") == "app_store":
@@ -124,7 +110,7 @@ def create_io_descriptor(
     # specify where to go look for caches
     descriptor.set_cache_roots(bundle_cache_root, fallback_roots)
 
-    if perform_latest_check:
+    if resolve_latest:
         # attempt to get "remote" latest first
         # and if that fails, fall back on the latest item
         # available in the local cache.
@@ -144,6 +130,59 @@ def create_io_descriptor(
         log.debug("Resolved latest to be %r" % descriptor)
 
     return descriptor
+
+
+def is_descriptor_version_missing(dict_or_uri):
+    """
+    Helper method which checks if a descriptor needs a version.
+
+    If the given descriptor dictionary or uri is one of the
+    types which requires a version token, and this token is not
+    defined, ``True`` will be returned, otherwise ``False``.
+
+    This is useful for a standard pattern which can be used used
+    where you want to allow users to configure toolkit
+    descriptors which track either the latest version or a specific one.
+    In this pattern, the user hints that they want to track latest
+    version by omitting the version token altogether.
+
+    The following standard pattern can then be implemented::
+
+        # determine if we should request the latest version
+        # of the given descriptor
+        if is_descriptor_version_missing(descriptor_uri):
+            # require the descriptor system to return
+            # the latest descriptor it can detect
+            resolve_latest = True
+        else:
+            # normal direct lookup of a particular
+            # descriptor version
+            resolve_latest = False
+
+        descriptor_obj = create_descriptor(
+            sg_connection,
+            Descriptor.CONFIG,
+            descriptor_uri,
+            resolve_latest=resolve_latest
+        )
+
+    :param dict_or_uri: A std descriptor dictionary dictionary or string
+    :return: Boolean to indicate if a required version token is missing
+    """
+    # resolve into both dict and uri form
+    if isinstance(dict_or_uri, basestring):
+        descriptor_dict = descriptor_uri_to_dict(dict_or_uri)
+    else:
+        # make a copy to make sure the original object is never altered
+        descriptor_dict = dict_or_uri
+
+    # We only do this for descriptor types that supports a version number concept
+    descriptors_using_version = ["app_store", "shotgun", "manual", "git", "git_branch"]
+
+    if "version" not in descriptor_dict and descriptor_dict.get("type") in descriptors_using_version:
+        return True
+    else:
+        return False
 
 
 def descriptor_uri_to_dict(uri):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -933,13 +933,13 @@ class TestResolvedLatestConfiguration(TankTestBase):
         )
 
         config = self._resolver.resolve_configuration(
-            {"type": "app_store", "name": "latest_test", "version": "v0.1.0"},
+            {"type": "app_store", "name": "latest_test", "version": "v0.1.1"},
             self.tk.shotgun
         )
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
+            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
         )
 
 

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -22,6 +22,7 @@ from tank_test.tank_test_base import TankTestBase
 
 
 class TestResolverBase(TankTestBase):
+
     def setUp(self):
         super(TestResolverBase, self).setUp()
 
@@ -870,6 +871,78 @@ class TestResolvedConfiguration(TankTestBase):
             sgtk.bootstrap.resolver.CachedConfiguration
         )
         self.assertEqual(config.has_local_bundle_cache, False)
+
+
+
+class TestResolvedLatestConfiguration(TankTestBase):
+    """
+    Ensures that resolving a descriptor with no version specified returns the right Configuration object.
+    """
+
+    def setUp(self):
+        super(TestResolvedLatestConfiguration, self).setUp()
+
+        self._tmp_bundle_cache = os.path.join(self.tank_temp, "bundle_cache")
+        self._resolver = sgtk.bootstrap.resolver.ConfigurationResolver(
+            plugin_id="tk-maya",
+            bundle_cache_fallback_paths=[self._tmp_bundle_cache]
+        )
+
+    def test_resolve_latest_cached_configuration(self):
+        """
+        Makes sure a cached configuration is resolved.
+        """
+
+        os.makedirs(
+            os.path.join(self._tmp_bundle_cache, "app_store", "latest_test", "v0.1.0")
+        )
+
+        config = self._resolver.resolve_configuration(
+            {"type": "app_store", "name": "latest_test"},
+            self.tk.shotgun
+        )
+
+        self.assertEquals(
+            config.descriptor.get_uri(),
+            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
+        )
+
+        os.makedirs(
+            os.path.join(self._tmp_bundle_cache, "app_store", "latest_test", "v0.1.1")
+        )
+
+        config = self._resolver.resolve_configuration(
+            {"type": "app_store", "name": "latest_test"},
+            self.tk.shotgun
+        )
+
+        self.assertEquals(
+            config.descriptor.get_uri(),
+            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
+        )
+
+        # make sure direct lookup also works
+        config = self._resolver.resolve_configuration(
+            {"type": "app_store", "name": "latest_test", "version": "v0.1.0"},
+            self.tk.shotgun
+        )
+
+        self.assertEquals(
+            config.descriptor.get_uri(),
+            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
+        )
+
+        config = self._resolver.resolve_configuration(
+            {"type": "app_store", "name": "latest_test", "version": "v0.1.1"},
+            self.tk.shotgun
+        )
+
+        self.assertEquals(
+            config.descriptor.get_uri(),
+            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
+        )
+
+
 
 
 class TestResolveWithFilter(TestResolverBase):

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -933,13 +933,13 @@ class TestResolvedLatestConfiguration(TankTestBase):
         )
 
         config = self._resolver.resolve_configuration(
-            {"type": "app_store", "name": "latest_test", "version": "v0.1.1"},
+            {"type": "app_store", "name": "latest_test", "version": "v0.1.0"},
             self.tk.shotgun
         )
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
+            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
         )
 
 

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -89,13 +89,7 @@ class TestApi(TankTestBase):
             {"type": "app_store", "name": "tk-testbundlefactory"}
         )
 
-        # we can do a direct lookup even when the version flag is set
-        d = sgtk.descriptor.create_descriptor(
-            self.tk.shotgun,
-            sgtk.descriptor.Descriptor.CONFIG,
-            {"type": "app_store", "version": "v0.1.6", "name": "tk-testbundlefactory"},
-            resolve_latest=True
-        )
+        # if we omit the version number, a latest check is carried out
         app_root_path = os.path.join(
             tank.util.LocalFileStorageManager.get_global_root(tank.util.LocalFileStorageManager.CACHE),
             "bundle_cache",
@@ -104,9 +98,6 @@ class TestApi(TankTestBase):
             "v0.1.6"
         )
         self._touch_info_yaml(app_root_path)
-        self.assertEqual(app_root_path, d.get_path())
-
-        # if we omit the version number, a latest check is carried out
         d = sgtk.descriptor.create_descriptor(
             self.tk.shotgun,
             sgtk.descriptor.Descriptor.CONFIG,
@@ -131,6 +122,17 @@ class TestApi(TankTestBase):
             resolve_latest=True
         )
         self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.2.3&name=tk-testbundlefactory")
+
+        # we can do a direct lookup even when the version flag is set
+        # but it will result in a latest version translation
+        d = sgtk.descriptor.create_descriptor(
+            self.tk.shotgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {"type": "app_store", "version": "v9999.1.6", "name": "tk-testbundlefactory"},
+            resolve_latest=True
+        )
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.2.3&name=tk-testbundlefactory")
+
 
     def test_alt_cache_root(self):
         """

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -76,10 +76,61 @@ class TestApi(TankTestBase):
         self.assertEqual(d2, d3)
         self.assertEqual(d1, d3)
 
+    def test_latest(self):
+        """
+        Basic test of resolve_latest flag
+        """
+        # descriptors without version tag are not allowed unless the latest flag is set
+        self.assertRaises(
+            sgtk.descriptor.TankDescriptorError,
+            sgtk.descriptor.create_descriptor,
+            self.tk.shotgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {"type": "app_store", "name": "tk-testbundlefactory"}
+        )
 
+        # we can do a direct lookup even when the version flag is set
+        d = sgtk.descriptor.create_descriptor(
+            self.tk.shotgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {"type": "app_store", "version": "v0.1.6", "name": "tk-testbundlefactory"},
+            resolve_latest=True
+        )
+        app_root_path = os.path.join(
+            tank.util.LocalFileStorageManager.get_global_root(tank.util.LocalFileStorageManager.CACHE),
+            "bundle_cache",
+            "app_store",
+            "tk-testbundlefactory",
+            "v0.1.6"
+        )
+        self._touch_info_yaml(app_root_path)
+        self.assertEqual(app_root_path, d.get_path())
 
+        # if we omit the version number, a latest check is carried out
+        d = sgtk.descriptor.create_descriptor(
+            self.tk.shotgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {"type": "app_store", "name": "tk-testbundlefactory"},
+            resolve_latest=True
+        )
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.1.6&name=tk-testbundlefactory")
 
-
+        # if we add a new local version, this will be picked up as latest
+        app_root_path = os.path.join(
+            tank.util.LocalFileStorageManager.get_global_root(tank.util.LocalFileStorageManager.CACHE),
+            "bundle_cache",
+            "app_store",
+            "tk-testbundlefactory",
+            "v0.2.3"
+        )
+        self._touch_info_yaml(app_root_path)
+        d = sgtk.descriptor.create_descriptor(
+            self.tk.shotgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {"type": "app_store", "name": "tk-testbundlefactory"},
+            resolve_latest=True
+        )
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.2.3&name=tk-testbundlefactory")
 
     def test_alt_cache_root(self):
         """

--- a/tests/descriptor_tests/test_io_descriptors.py
+++ b/tests/descriptor_tests/test_io_descriptors.py
@@ -22,6 +22,59 @@ class TestIODescriptors(TankTestBase):
     Testing the Shotgun deploy main API methods
     """
 
+    def test_version_resolve(self):
+        """
+        Tests the is_descriptor_version_missing method
+        """
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing(
+                {"type": "app_store", "version": "v1.1.1", "name": "tk-bundle"}
+            ),
+            False
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing(
+                {"type": "app_store", "name": "tk-bundle"}
+            ),
+            True
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing(
+                "sgtk:descriptor:app_store?version=v0.1.2&name=tk-bundle"
+            ),
+            False
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing(
+                "sgtk:descriptor:app_store?name=tk-bundle"
+            ),
+            True
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "dev", "path": "/tmp"}),
+            False
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "path", "path": "/tmp"}),
+            False
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "manual", "name": "foo"}),
+            True
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "shotgun", "name": "foo"}),
+            True
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "git", "path": "foo"}),
+            True
+        )
+        self.assertEqual(
+            sgtk.descriptor.is_descriptor_version_missing({"type": "git_branch", "path": "foo"}),
+            True
+        )
+
     def test_latest_cached(self):
         """
         Tests the find_latest_cached_version method


### PR DESCRIPTION
When a pipeline configuration was overridden in Shotgun, it had to be an absolute reference to a version. Omitting the version number keyword didn't work. This PR changes that.

- It adds a new helper method to standardize this pattern:

![image](https://user-images.githubusercontent.com/337710/27265497-e36e6d92-548e-11e7-8ac3-2325a53651e0.png)

- it updates several places where `"version"` is incorrectly hard coded and the logic is overly simplistic.
- it adds support for shotgun descriptors tracking latest
- it adds support for core definitions (in the config) which are tracking latest


