### PR TITLE
Copy symlink instead of their destination when copying config.

### DIFF
--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -238,7 +238,10 @@ def copy_folder(src, dst, folder_permissions=0775, skip_list=None):
         dstname = os.path.join(dst, name)
 
         try:
-            if os.path.isdir(srcname):
+            if os.path.islink(srcname):
+                link_to = os.readlink(srcname)
+                os.symlink(link_to, dstname)
+            elif os.path.isdir(srcname):
                 files.extend(copy_folder(srcname, dstname, folder_permissions))
             else:
                 shutil.copy(srcname, dstname)


### PR DESCRIPTION
In our template config we have symlinks pointing to default or common folders/files. We'd like the symlinks to be copied at project setup. Up to now those symlinks are followed.