### PR TITLE
Removes some volatility from some unit tests with pypy.

### DIFF
--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -497,10 +497,14 @@ class IODescriptorBase(object):
         uri = constants.DESCRIPTOR_URI_SEPARATOR.join(uri_chunks)
 
         qs_chunks = []
-        for (param, value) in descriptor_dict.iteritems():
+        # Sort keys so that the uri is the same across invocations.
+        for param in sorted(descriptor_dict):
             if param == "type":
                 continue
-            qs_chunks.append("%s=%s" % (param, urllib.quote(str(value))))
+            qs_chunks.append("%s=%s" % (
+                param,
+                urllib.quote(str(descriptor_dict[param])))
+            )
         qs = "&".join(qs_chunks)
 
         return "%s?%s" % (uri, qs)

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -842,7 +842,6 @@ class TestResolvedConfiguration(TankTestBase):
         self.assertEqual(config.has_local_bundle_cache, False)
 
 
-
 class TestResolvedLatestConfiguration(TankTestBase):
     """
     Ensures that resolving a descriptor with no version specified returns the right Configuration object.
@@ -873,7 +872,7 @@ class TestResolvedLatestConfiguration(TankTestBase):
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
+            "sgtk:descriptor:app_store?name=latest_test&version=v0.1.0"
         )
 
         os.makedirs(
@@ -887,7 +886,7 @@ class TestResolvedLatestConfiguration(TankTestBase):
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
+            "sgtk:descriptor:app_store?name=latest_test&version=v0.1.1"
         )
 
         # make sure direct lookup also works
@@ -898,7 +897,7 @@ class TestResolvedLatestConfiguration(TankTestBase):
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.0&name=latest_test"
+            "sgtk:descriptor:app_store?name=latest_test&version=v0.1.0"
         )
 
         config = self._resolver.resolve_configuration(
@@ -908,10 +907,8 @@ class TestResolvedLatestConfiguration(TankTestBase):
 
         self.assertEquals(
             config.descriptor.get_uri(),
-            "sgtk:descriptor:app_store?version=v0.1.1&name=latest_test"
+            "sgtk:descriptor:app_store?name=latest_test&version=v0.1.1"
         )
-
-
 
 
 class TestResolveWithFilter(TestResolverBase):

--- a/tests/core_tests/test_template.py
+++ b/tests/core_tests/test_template.py
@@ -377,13 +377,18 @@ class TestReadTemplates(TankTestBase):
         """Check a template key which uses choices."""
         # check old-style (list) choices
         key = self.tk.templates["nuke_shot_render_stereo"].keys["eye"]
-        self.assertEquals(["Right", "Left"], key.choices)
-        self.assertEquals({"Right":"Right", "Left":"Left"}, key.labelled_choices)
-        
+        # Order of the choices is not guaranteed, so enforce it.
+        self.assertEquals(["Left", "Right"], sorted(key.choices))
+        self.assertEquals({"Right": "Right", "Left": "Left"}, key.labelled_choices)
+
         # check new-style (dict) choices
         key = self.tk.templates["maya_shot_work"].keys["maya_extension"]
-        self.assertEquals(["ma", "mb"], key.choices)
-        self.assertEquals({'ma':'Maya Ascii (.ma)', 'mb':'Maya Binary (.mb)'}, key.labelled_choices)
+        # Order of the choices is not guaranteed, so enforce it.
+        self.assertEquals(["ma", "mb"], sorted(key.choices))
+        self.assertEquals(
+            {"ma": "Maya Ascii (.ma)", "mb": "Maya Binary (.mb)"},
+            key.labelled_choices
+        )
 
     def test_exclusions(self):
         key = self.tk.templates["asset_work_area"].keys["Asset"]

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -12,9 +12,10 @@ import os
 import tempfile
 import uuid
 import sgtk
+import tank
 
-from tank_test.tank_test_base import *
-
+from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import setUpModule # noqa
 
 
 class TestApi(TankTestBase):
@@ -31,7 +32,6 @@ class TestApi(TankTestBase):
         fh = open(os.path.join(path, "info.yml"), "wt")
         fh.write("# unit test placeholder file\n\n")
         fh.close()
-
 
     def test_factory(self):
         """
@@ -104,7 +104,7 @@ class TestApi(TankTestBase):
             {"type": "app_store", "name": "tk-testbundlefactory"},
             resolve_latest=True
         )
-        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.1.6&name=tk-testbundlefactory")
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?name=tk-testbundlefactory&version=v0.1.6")
 
         # if we add a new local version, this will be picked up as latest
         app_root_path = os.path.join(
@@ -121,7 +121,7 @@ class TestApi(TankTestBase):
             {"type": "app_store", "name": "tk-testbundlefactory"},
             resolve_latest=True
         )
-        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.2.3&name=tk-testbundlefactory")
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?name=tk-testbundlefactory&version=v0.2.3")
 
         # we can do a direct lookup even when the version flag is set
         # but it will result in a latest version translation
@@ -131,8 +131,7 @@ class TestApi(TankTestBase):
             {"type": "app_store", "version": "v9999.1.6", "name": "tk-testbundlefactory"},
             resolve_latest=True
         )
-        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?version=v0.2.3&name=tk-testbundlefactory")
-
+        self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?name=tk-testbundlefactory&version=v0.2.3")
 
     def test_alt_cache_root(self):
         """
@@ -164,7 +163,6 @@ class TestApi(TankTestBase):
         self._touch_info_yaml(app_root_path)
         self.assertEqual(d.get_path(), app_root_path)
 
-
     def _test_uri(self, uri, location_dict):
 
         computed_dict = sgtk.descriptor.descriptor_uri_to_dict(uri)
@@ -176,7 +174,7 @@ class TestApi(TankTestBase):
         """
         Test dict/uri syntax and conversion
         """
-        uri = "sgtk:descriptor:app_store?version=v0.1.2&name=tk-bundle"
+        uri = "sgtk:descriptor:app_store?name=tk-bundle&version=v0.1.2"
         dict = {"type": "app_store", "version": "v0.1.2", "name": "tk-bundle"}
         self._test_uri(uri, dict)
 
@@ -184,7 +182,7 @@ class TestApi(TankTestBase):
         dict = {"type": "path", "path": "/foo/bar"}
         self._test_uri(uri, dict)
 
-        uri = "sgtk:descriptor:app_store?version=v0.1.2&name=tk-bundle"
+        uri = "sgtk:descriptor:app_store?name=tk-bundle&version=v0.1.2"
         dict = {"type": "app_store", "version": "v0.1.2", "name": "tk-bundle"}
         self._test_uri(uri, dict)
 
@@ -195,6 +193,3 @@ class TestApi(TankTestBase):
         uri = "sgtk:descriptor:git?path=git%40github.com%3Ashotgunsoftware/tk-core.git&version=v0.1.2"
         dict = {"type": "git", "version": "v0.1.2", "path": "git@github.com:shotgunsoftware/tk-core.git"}
         self._test_uri(uri, dict)
-
-
-

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -188,9 +188,9 @@ class TestAppStoreLabels(TankTestBase):
             Descriptor.FRAMEWORK,
             {"name": "tk-framework-main", "version": "v1.0.0", "type": "app_store"}
         )
-        self.assertEqual(desc.get_uri(), "sgtk:descriptor:app_store?version=v1.0.0&name=tk-framework-main")
+        self.assertEqual(desc.get_uri(), "sgtk:descriptor:app_store?name=tk-framework-main&version=v1.0.0")
         desc2 = desc.find_latest_version()
-        self.assertEqual(desc2.get_uri(), "sgtk:descriptor:app_store?version=v3.0.1&name=tk-framework-main")
+        self.assertEqual(desc2.get_uri(), "sgtk:descriptor:app_store?name=tk-framework-main&version=v3.0.1")
 
         # i am version 2016.3.45 so i am only getting 1.0.1
         desc = create_descriptor(
@@ -200,12 +200,12 @@ class TestAppStoreLabels(TankTestBase):
         )
         self.assertEqual(
             desc.get_uri(),
-            "sgtk:descriptor:app_store?version=v1.0.0&name=tk-framework-main&label=2016.3.45"
+            "sgtk:descriptor:app_store?label=2016.3.45&name=tk-framework-main&version=v1.0.0"
         )
         desc2 = desc.find_latest_version()
         self.assertEqual(
             desc2.get_uri(),
-            "sgtk:descriptor:app_store?version=v1.0.1&name=tk-framework-main&label=2016.3.45"
+            "sgtk:descriptor:app_store?label=2016.3.45&name=tk-framework-main&version=v1.0.1"
         )
 
         # i am version 2017.3.45 so i am getting 2.0.1
@@ -216,12 +216,12 @@ class TestAppStoreLabels(TankTestBase):
         )
         self.assertEqual(
             desc.get_uri(),
-            "sgtk:descriptor:app_store?version=v1.0.0&name=tk-framework-main&label=2017.3.45"
+            "sgtk:descriptor:app_store?label=2017.3.45&name=tk-framework-main&version=v1.0.0"
         )
         desc2 = desc.find_latest_version()
         self.assertEqual(
             desc2.get_uri(),
-            "sgtk:descriptor:app_store?version=v2.0.1&name=tk-framework-main&label=2017.3.45"
+            "sgtk:descriptor:app_store?label=2017.3.45&name=tk-framework-main&version=v2.0.1"
         )
 
         # i am version 2018.3.45 so i am getting 3.0.1
@@ -232,10 +232,10 @@ class TestAppStoreLabels(TankTestBase):
         )
         self.assertEqual(
             desc.get_uri(),
-            "sgtk:descriptor:app_store?version=v1.0.0&name=tk-framework-main&label=2018.3.45"
+            "sgtk:descriptor:app_store?label=2018.3.45&name=tk-framework-main&version=v1.0.0"
         )
         desc2 = desc.find_latest_version()
         self.assertEqual(
             desc2.get_uri(),
-            "sgtk:descriptor:app_store?version=v3.0.1&name=tk-framework-main&label=2018.3.45"
+            "sgtk:descriptor:app_store?label=2018.3.45&name=tk-framework-main&version=v3.0.1"
         )


### PR DESCRIPTION
Running the tests with `pypy`  revealed that we relied on some behaviour that is not common to every Python implementation, like `pypy` and `python3`. This aims to fix this behaviour.