### PR TITLE
[minor] Adds better error protection in app store download

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -503,14 +503,21 @@ class IODescriptorAppStore(IODescriptorBase):
         )
 
         # write a stats record to the tank app store
-        data = {}
-        data["description"] = "%s: %s %s was downloaded" % (self._sg_connection.base_url, self._name, self._version)
-        data["event_type"] = self._DOWNLOAD_STATS_EVENT_TYPE[self._type]
-        data["entity"] = version
-        data["user"] = script_user
-        data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
-        data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
-        sg.create("EventLogEntry", data)
+        try:
+            data = {}
+            data["description"] = "%s: %s %s was downloaded" % (
+                self._sg_connection.base_url,
+                self._name,
+                self._version
+            )
+            data["event_type"] = self._DOWNLOAD_STATS_EVENT_TYPE[self._type]
+            data["entity"] = version
+            data["user"] = script_user
+            data["project"] = constants.TANK_APP_STORE_DUMMY_PROJECT
+            data["attribute_name"] = constants.TANK_CODE_PAYLOAD_FIELD
+            sg.create("EventLogEntry", data)
+        except Exception, e:
+            log.warning("Could not write app store download receipt: %s" % e)
 
     #############################################################################
     # searching for other versions


### PR DESCRIPTION
Adds better protection from a case when the downloads succeed but the writing of event log entries fail. This is an unusual case but has been encountered in the wild.