### PR TITLE
Updated from_path call to support pipeline configurations with no path using descriptors

### DIFF
--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -87,19 +87,20 @@ def _from_entity(entity_type, entity_id, force_reread_shotgun_cache):
     # figure out if we are running a tank command / api from a local
     # pipeline config or from a studio level install
     config_context_path = _get_configuration_context()
+    config_context_id = _get_configuration_id()
 
-    if config_context_path:
+    if config_context_id and config_context_path:
         # we are running the tank command or python core API directly from a configuration
         #
         # make sure that the tank command we are launching from belong to a shotgun project
         # that the input entity type/id is associated with.
-        if config_context_path not in [x["path"] for x in all_pc_data]:
+        if config_context_id not in [x["id"] for x in all_pc_data]:
             # the tank command / api proxy that this session was launched for is *not*
             # associated with the given entity type and entity id!
-            raise TankError("The pipeline configuration in '%s' is is associated with a different "
+            raise TankError("The pipeline configuration in '%s' with id %s is is associated with a different "
                             "project from %s %s. To see which pipeline configurations are available "
                             "for a project, open the pipeline configurations page "
-                            "in Shotgun." % (config_context_path, entity_type, entity_id))
+                            "in Shotgun." % (config_context_path, config_context_id, entity_type, entity_id))
 
         # ok we got a pipeline config matching the tank command from which we launched.
         # because we found the pipeline config in the list of PCs for this project,
@@ -221,21 +222,21 @@ def _from_path(path, force_reread_shotgun_cache):
     # figure out if we are running a tank command / api from a
     # local pipeline config or from a studio level install
     config_context_path = _get_configuration_context()
+    config_context_id = _get_configuration_id()
 
-    if config_context_path:
+    if config_context_id and config_context_path:
 
         # we are running the tank command or python core API directly from a configuration
         #
-        # now if this tank command is associated with the path, the registered path should be in
+        # now if this tank command is associated with the id, the registered id should be in
         # in the pipeline configuration data coming from
-        if config_context_path not in [x["path"] for x in all_pc_data]:
-
+        if config_context_id not in [x["id"] for x in all_pc_data]:
             pcs_msg = ", ".join([
                             "'%s' (Pipeline config id %s, Project id %s)" % (x["path"], x["id"], x["project_id"])
                             for x in all_pc_data])
 
             raise TankError("You are trying to start Toolkit using the pipeline configuration "
-                            "located in '%s'. The path '%s' you are trying to load is not "
+                            "located in '%s' with id '%s'. The path '%s' you are trying to load is not "
                             "associated with that configuration. Instead, it is "
                             "associated with the following pipeline configurations: %s. "
                             "Please use the tank command or Toolkit API in any of those "
@@ -244,7 +245,7 @@ def _from_path(path, force_reread_shotgun_cache):
                             "the 'tank move_configuration command'. It can also occur if you "
                             "are trying to use a tank command associated with one Project "
                             "to try to operate on a Shot or Asset that belongs to another "
-                            "project." % (config_context_path, path, pcs_msg))
+                            "project." % (config_context_path, config_context_id, path, pcs_msg))
 
         # okay so this pipeline config is valid!
         return PipelineConfiguration(config_context_path)
@@ -312,6 +313,30 @@ def _get_configuration_context():
         # associated with the project that the pipeline config is associated with.
         val = pipelineconfig_utils.get_config_install_location(curr_pc_path)
 
+    return val
+
+
+def _get_configuration_id():
+    """
+    Returns a id if the API was invoked via a configuration context, otherwise None.
+
+    If this session was involved (tank command or python API) from a studio level API,
+    e.g. with no connection to any config, None is returned.
+
+    In the case the session was started via a python proxy API or tank command
+    connected to a configuration, the id to that configuration root is returned.
+    The id returned should reflect the exact value stored in the pipeline configuration
+    entry in shotgun.
+
+    :returns: id or None
+    """
+    # default for studio level tank command/API
+    val = None
+    if "TANK_CURRENT_PC" in os.environ:
+        config_path = os.environ["TANK_CURRENT_PC"]
+        pc = PipelineConfiguration(config_path)
+        data = pc._get_metadata()
+        val = data["pc_id"]
     return val
 
 


### PR DESCRIPTION
With the new zero config and descriptors setup, the python api can no longer check if a path is part of a particular pipeline configuration. This is because paths are currently being used to do the check, and when using a descriptor the pipeline configuration has no path set. This becomes extremely obvious in the error message that occurs stating that the path is "None":

`# Error: TankError: file C:\...\pipeline_config_factory.py line 247: You are trying to start Toolkit using the pipeline configuration located in 'C:\...\p180c71.basic.desktop\cfg'. The path 'R:\...\scene.ma' you are trying to load is not associated with that configuration. Instead, it is associated with the following pipeline configurations: 'None' (Pipeline config id 71, Project id 180). `

This small suggested change switches the check to look at ID which we know is always unique rather than a path. This fixes the issues with using descriptors while also providing a likely safer way of verifying a path is part of a pipeline configuration. We already have the ID for associated pipeline configurations so we only have to add a small piece of code to get the ID for the current pipeline configuration.