### PR TITLE
Addendum for #42679, can't jump into more recent core.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,7 +39,7 @@ exclude =
     python/tank_vendor,
     # Otherwise you'll have a lot of 'xxx' imported but unused
     python/tank/__init__.py,
-    python/tank/*/__init__.py
+    python/tank/*/__init__.py,
     tests/python
 
 # toolkit exceptions

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -110,7 +110,6 @@ class CachedConfiguration(Configuration):
             return self.LOCAL_CFG_MISSING
 
         if self._config_writer.is_transaction_pending():
-            log.warning("It seems the configuration was not written properly on disk.")
             return self.LOCAL_CFG_INVALID
 
         # Pass 2:

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -9,8 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
-import stat
 
 from . import constants
 
@@ -25,6 +23,7 @@ from .configuration_writer import ConfigurationWriter
 from .. import LogManager
 
 log = LogManager.get_logger(__name__)
+
 
 class CachedConfiguration(Configuration):
     """
@@ -110,6 +109,10 @@ class CachedConfiguration(Configuration):
         if not os.path.exists(sg_config_file):
             return self.LOCAL_CFG_MISSING
 
+        if self._config_writer.is_transaction_pending():
+            log.warning("It seems the configuration was not written properly on disk.")
+            return self.LOCAL_CFG_INVALID
+
         # Pass 2:
         # local config exists. See if it is up to date.
         # get the path to a potential config metadata file
@@ -172,6 +175,8 @@ class CachedConfiguration(Configuration):
         This method fails gracefully and attempts to roll back to a
         stable state on failure.
         """
+
+        self._config_writer.start_transaction()
 
         # make sure a scaffold is in place
         self._config_writer.ensure_project_scaffold()
@@ -247,7 +252,7 @@ class CachedConfiguration(Configuration):
                 log.debug("Previous core restore complete...")
         else:
             # remove backup folders now that the update has completed successfully
-            # note: config_path points at a config folder inside a timestamped 
+            # note: config_path points at a config folder inside a timestamped
             # backup folder. It's this parent folder we want to clean up.
             self._cleanup_backup_folders(os.path.dirname(config_backup_path) if config_backup_path else None,
                                          core_backup_path)
@@ -257,6 +262,8 @@ class CachedConfiguration(Configuration):
 
         # make sure tank command and interpreter files are up to date
         self._config_writer.create_tank_command()
+
+        self._config_writer.end_transaction()
 
     @property
     def has_local_bundle_cache(self):

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -563,7 +563,12 @@ class ConfigurationWriter(object):
         ):
             # ... in which case we'll look for the special file telling us the configuration
             # is completed.
-            return os.path.exists(self._get_configuration_transaction_filename())
+            if os.path.exists(self._get_configuration_transaction_filename()):
+                log.debug("Found transactional marker, configuration is complete.")
+                return False
+            else:
+                log.warning("It seems the configuration was not written properly on disk.")
+                return True
         else:
             # ... if the folder doesn't exist than we don't even have a config at the moment.
             log.debug("No transaction folder was found. Assuming valid.")
@@ -571,13 +576,14 @@ class ConfigurationWriter(object):
 
     def start_transaction(self):
         """
-        Wipes the transaction marker from configuration.
+        Wipes the transaction marker from the configuration.
         """
 
         filesystem.ensure_folder_exists(self._get_configuration_transaction_folder())
 
         # Remove our coherency token if it exists.
         if os.path.exists(self._get_configuration_transaction_filename()):
+            log.debug("Removing transactional marker.")
             filesystem.safe_delete_file(self._get_configuration_transaction_filename())
 
     def end_transaction(self):
@@ -586,6 +592,7 @@ class ConfigurationWriter(object):
         to disk.
         """
         # Write back the coherency token.
+        log.debug("Writing the transactional marker.")
         filesystem.touch_file(self._get_configuration_transaction_filename())
 
     def _get_configuration_transaction_folder(self):

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -47,7 +47,6 @@ class ConfigurationWriter(object):
         """
         self._path = path
         self._sg_connection = sg
-        self._transaction_start = None
 
     @property
     def path(self):
@@ -556,7 +555,7 @@ class ConfigurationWriter(object):
         Checks if the configuration was previously in the process of being updated but then stopped.
 
         .. note::
-            Configurations written with previous versions of Toolkit are assumed to completed/
+            Configurations written with previous versions of Toolkit are assumed to completed.
 
         :returns: True if the configuration was not finished being written on disk, False if it was.
         """

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -608,7 +608,7 @@ class ToolkitManager(object):
 
         :rtype: (str, :class:`sgtk.descriptor.ConfigDescriptor`)
         """
-        config = self._get_configuration(entity, self.progress_callback)
+        config = self._get_updated_configuration(entity, self.progress_callback)
 
         path = config.path.current_os
 
@@ -804,7 +804,7 @@ class ToolkitManager(object):
 
     def _get_configuration(self, entity, progress_callback):
         """
-        Resolves the configuration to use.
+        Resolves the configuration to use without creating it on disk.
 
         :param entity: Shotgun entity used to resolve a project context.
         :type entity: Dictionary with keys ``type`` and ``id``, or ``None`` for the site.
@@ -899,6 +899,22 @@ class ToolkitManager(object):
 
         log.debug("Bootstrapping into configuration %r" % config)
 
+        return config
+
+    def _get_updated_configuration(self, entity, progress_callback):
+        """
+        Resolves the configuration and updates it.
+
+        :param entity: Shotgun entity used to resolve a project context.
+        :type entity: Dictionary with keys ``type`` and ``id``, or ``None`` for the site.
+        :param progress_callback: Callback function that reports back on the toolkit bootstrap progress.
+                                  Set to ``None`` to use the default callback function.
+
+        :returns: A :class:`sgtk.bootstrap.configuration.Configuration` instance.
+        """
+
+        config = self._get_configuration(entity, progress_callback)
+
         # see what we have locally
         status = config.status()
 
@@ -949,7 +965,7 @@ class ToolkitManager(object):
         if progress_callback is None:
             progress_callback = self.progress_callback
 
-        config = self._get_configuration(entity, progress_callback)
+        config = self._get_updated_configuration(entity, progress_callback)
 
         # we can now boot up this config.
         self._report_progress(progress_callback, self._STARTING_TOOLKIT_RATE, "Starting up Toolkit...")

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -119,9 +119,6 @@ class IODescriptorGitBranch(IODescriptorGit):
         The git repo will be cloned into the local cache and
         will then be adjusted to point at the relevant commit.
         """
-        import traceback
-        log.info("\n".join(traceback.format_stack()))
-
         if self.exists_local():
             # nothing to do!
             return

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -119,6 +119,9 @@ class IODescriptorGitBranch(IODescriptorGit):
         The git repo will be cloned into the local cache and
         will then be adjusted to point at the relevant commit.
         """
+        import traceback
+        traceback.print_stack()
+
         if self.exists_local():
             # nothing to do!
             return

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -120,7 +120,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         will then be adjusted to point at the relevant commit.
         """
         import traceback
-        traceback.print_stack()
+        log.info("\n".join(traceback.format_stack()))
 
         if self.exists_local():
             # nothing to do!

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -459,6 +459,9 @@ class TestWritePipelineConfigFile(TankTestBase):
 class TestTransaction(TankTestBase):
 
     def test_transactions(self):
+        """
+        Ensures the transaction flags are properly handled for a config.
+        """
 
         new_config_root = os.path.join(self.tank_temp, self.id())
 
@@ -476,8 +479,15 @@ class TestTransaction(TankTestBase):
         self.assertEqual(False, writer.is_transaction_pending())
 
         # Remove the transaction folder
-        shutil.rmtree(writer._get_configuration_transaction_folder())
+        writer._delete_state_file(writer._TRANSACTION_START_FILE)
+        writer._delete_state_file(writer._TRANSACTION_END_FILE)
         # Even if the marker is missing, the API should report no pending transactions since the
         # transaction folder doesn't even exist, which will happen for configurations written
         # with a previous version of core.
         self.assertEqual(False, writer.is_transaction_pending())
+
+        # We've deleted both the transaction files and now we're writing the end transaction file.
+        # If we're in that state, we'll assume something is broken and say its pending since the
+        # config was tinkered with.
+        writer.end_transaction()
+        self.assertEqual(True, writer.is_transaction_pending())

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -11,7 +11,6 @@
 from __future__ import with_statement
 
 import contextlib
-import shutil
 import os
 import sys
 
@@ -462,7 +461,6 @@ class TestTransaction(TankTestBase):
         """
         Ensures the transaction flags are properly handled for a config.
         """
-
         new_config_root = os.path.join(self.tank_temp, self.id())
 
         writer = ConfigurationWriter(


### PR DESCRIPTION
This fixes an issue that arose while testing the new flow configuration update in the Shotgun Desktop. Because a configuration update can now be killed at any time, it is possible to leave it in an inconherent state. To fix this, we're introducing start and end update files to tell the bootstrap is the configuration needs to be updated or not.

This also fixes a performance issue when resolving a configuration descriptor in ToolkitManager.resolve_descriptor.