### PR TITLE
For #43873, can't bootstrap into 0.15 core

### DIFF
--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -85,7 +85,13 @@ class Configuration(object):
         # the newly swapped in core code
         from .. import api
         from .. import pipelineconfig
-        api.set_authenticated_user(sg_user)
+
+        # It's possible we're bootstrapping into a core that doesn't support the authentication
+        # module, so test for the existence of the set_authenticated_user.
+        if hasattr(api, "set_authenticated_user"):
+            # FIXME: We should honor the script user from the config.
+            api.set_authenticated_user(sg_user)
+
         log.debug("Executing tank_from_path('%s')" % path)
 
         # now bypass some of the very extensive validation going on


### PR DESCRIPTION
Ensures set_authenticated_user is available before calling it. This won't be the case if you are jumping into a 0.15-based project.

Note that there is a FIXME in the code that we will address at a later date.