### PR TITLE
#43927 Improved core update message

### DIFF
--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -180,6 +180,9 @@ class CoreUpdateAction(Action):
         elif status == TankCoreUpdater.UPDATE_POSSIBLE:
 
             (summary, url) = installer.get_release_notes()
+
+            log.info("")
+            log.info("Newer version %s is available." % new_version)
             log.info("")
             log.info("Change Summary:")
             for x in textwrap.wrap(summary, width=60):
@@ -192,7 +195,7 @@ class CoreUpdateAction(Action):
                      "this will affect the other projects as well.")
             log.info("")
 
-            if suppress_prompts or console_utils.ask_yn_question("Update to this version of the Core API?"):
+            if suppress_prompts or console_utils.ask_yn_question("Update to %s of the Core API?" % new_version):
                 # install it!
                 installer.do_install()
 


### PR DESCRIPTION
The version of core the user is updating to is now clearer from the message printed out to the command line.

example of new message:

```
You are currently running version v0.18.93 of the Shotgun Pipeline Toolkit

Newer version v0.18.100 is available.

Change Summary:
The ToolkitManager can now be used to bootstrap into
projects using core v0.15.20.

Detailed Release Notes:
https://support.shotgunsoftware.com/hc/en-us/articles/219039838#v0.18.100

Please note that if this is a shared core used by more than one project, this
will affect the other projects as well.

Update to v0.18.100 of the Core API? [yn]
```

new and changed bits are

`Newer version v0.18.100 is available.`

and

`Update to v0.18.100 of the Core API? [yn]`