### PR TITLE
41460 push config failure handling

### DIFF
--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -23,17 +23,18 @@ import os
 import datetime
 import shutil
 
-# core configuration files which are associated with the core API installation and not
+# Core configuration files which are associated with the core API installation and not
 # the pipeline configuration.
-CORE_API_FILES = ["interpreter_Linux.cfg", 
-                  "interpreter_Windows.cfg",
-                  "interpreter_Darwin.cfg", 
-                  "shotgun.yml"]
+CORE_API_FILES = [
+    "interpreter_Linux.cfg",
+    "interpreter_Windows.cfg",
+    "interpreter_Darwin.cfg",
+    "shotgun.yml"
+]
 
-# core configuration files which are associated with a particular
-# pipeline config and should not be moved
+# Core configuration files which are associated with a particular
+# pipeline config and should not be moved.
 CORE_PC_FILES = ["install_location.yml", "pipeline_configuration.yml"]
-
 
 
 class PushPCAction(Action):
@@ -41,17 +42,118 @@ class PushPCAction(Action):
     Action that pushes a config from one pipeline configuration up to its parent
     """
     def __init__(self):
-        Action.__init__(self, 
-                        "push_configuration", 
-                        Action.TK_INSTANCE, 
-                        ("Pushes any configuration changes made here to another configuration. "
-                         "This is typically used when you have cloned your production configuration "
-                         "into a staging sandbox, updated the apps in this sandbox and want to push "
-                         "those updates back to your production configuration."), 
-                        "Configuration")
-        
-    def run_interactive(self, log, args):
+        Action.__init__(
+            self,
+            "push_configuration",
+            Action.TK_INSTANCE,
+            ("Pushes any configuration changes made here to another configuration. "
+            "This is typically used when you have cloned your production configuration "
+            "into a staging sandbox, updated the apps in this sandbox and want to push "
+            "those updates back to your production configuration."),
+            "Configuration"
+        )
+        # This method can be executed via the API
+        self.supports_api = True
+        # Parameters we need
+        self.parameters = {
+            "target_id": {
+                "description": "Id of the target Pipeline Configuration to push to.",
+                "default": None,
+                "type": "int"
+            },
+            "use_symlink": {
+                "description": "Use a symbolic link to copy the data over.",
+                "default": False,
+                "type": "bool"
+            },
+        }
+        # Keep track of we are running in interactive mode or not.
+        self._is_interactive = False
+        # Just a cache to query SG only once.
+        self._pipeline_configs = None
 
+    def run_noninteractive(self, log, parameters):
+        """
+        Tank command API accessor.
+        Called when someone runs a tank command through the core API.
+
+        :param log: std python logger
+        :param parameters: dictionary with tank command parameters
+        """
+
+        self._preflight()
+        # validate params and run the action
+        self._run(log, **(self._validate_parameters(parameters)))
+
+    def run_interactive(self, log, args):
+        """
+        Tank command accessor.
+        
+        :param log: Standard python logger.
+        :param args: Command line args.
+        """
+        self._is_interactive = True
+        self._preflight()
+
+        if len(args) == 1 and args[0] == "--symlink":
+            use_symlink = True
+        else:
+            use_symlink = False
+        
+        current_pc_name = self.tk.pipeline_configuration.get_name()
+        current_pc_id = self.tk.pipeline_configuration.get_shotgun_id()
+
+        log.info(
+            "This command will push the configuration in the current pipeline configuration "
+            "('%s') to another pipeline configuration in the project. By default, the data "
+            "will be copied to the target config folder. If pass a --symlink parameter, it will "
+            "create a symlink instead." % current_pc_name
+        )
+        log.info("")
+        log.info("Your existing configuration will be backed up.")
+        
+        if use_symlink:
+            log.info("")
+            log.info("A symlink will be used.")
+        log.info("")
+        
+        log.info("The following pipeline configurations are available to push to:")
+        path_hash = {}
+        for pc in self._pipeline_configs:
+            # skip self
+            if pc["id"] == current_pc_id:
+                continue
+            local_path = ShotgunPath.from_shotgun_dict(pc).current_os
+            path_hash[pc["id"]] = local_path
+            log.info(" - [%d] %s (%s)" % (pc["id"], pc["code"], local_path))
+        log.info("")
+        
+        answer = raw_input(
+            "Please type in the id of the configuration to push to (ENTER to exit): "
+        )
+        if answer == "":
+            raise TankError("Aborted by user.")
+        try:
+            target_pc_id = int(answer)
+        except:
+            raise TankError("Please enter a number!")
+
+        self._run(
+            log,
+            **(self._validate_parameters({
+                "target_id": target_pc_id,
+                "use_symlink": use_symlink,
+            }))
+        )
+
+    def _preflight(self):
+        """
+        Performs actions needed in both interactive/non interactive modes.
+
+        Validate we can run a push in the current context.
+
+        :raises: TankError if pushing is invalid.
+        """
         # get list of all PCs for this project
         if self.tk.pipeline_configuration.is_site_configuration():
             raise TankError("You can't push the site configuration.")
@@ -61,60 +163,51 @@ class PushPCAction(Action):
 
         project_id = self.tk.pipeline_configuration.get_project_id()
 
-        current_pc_name = self.tk.pipeline_configuration.get_name()
-        current_pc_id = self.tk.pipeline_configuration.get_shotgun_id()
-        pipeline_configs = self.tk.shotgun.find(constants.PIPELINE_CONFIGURATION_ENTITY,
-                                                [["project", "is", {"type": "Project", "id": project_id}]],
-                                                ["code", "linux_path", "windows_path", "mac_path"])
+        self._pipeline_configs = self.tk.shotgun.find(
+            constants.PIPELINE_CONFIGURATION_ENTITY,
+            [["project", "is", {"type": "Project", "id": project_id}]],
+            ["code", "linux_path", "windows_path", "mac_path"]
+        )
 
-        if len(args) == 1 and args[0] == "--symlink":
-            use_symlink = True
+        # We should have at least one pipeline config (the current one)
+        # We need a second one to push to, obviously...
+        if len(self._pipeline_configs) == 1:
+            raise TankError(
+                "Only one pipeline configuration for this project! Need at least two "
+                "configurations in order to push. Please start by cloning a pipeline "
+                "configuration inside of Shotgun."
+            )
+
+
+    def _run(self, log, target_id, use_symlink=False):
+        """
+        Push the current pipeline configuration to the one with the given id.
+
+        :param log: A standard logger instance.
+        :param int target_id: The target pipeline config id.
+        :param bool use_symlink: Whether a symlink should be used
+        :raises: TankError on failure.
+        """
+
+        # If using symlink, check they are available, which is not the case on
+        # Windows.
+        if use_symlink and not getattr(os, "symlink", None):
+            raise TankError(
+                "Symbolic links are supported on this platform"
+            )
+
+        if target_id == self.tk.pipeline_configuration.get_shotgun_id():
+            raise TankError(
+                "The target pipeline config id must be different from the current one"
+            )
+
+        for config in self._pipeline_configs:
+            if config["id"] == target_id:
+                target_pc_path = ShotgunPath.from_shotgun_dict(config).current_os
+                break
         else:
-            use_symlink = False
-        
-        if len(pipeline_configs) == 1:
-            raise TankError("Only one pipeline configuration for this project! Need at least two "
-                            "configurations in order to push. Please start by cloning a pipeline "
-                            "configuration inside of Shotgun.")
+            raise TankError("Id %d is not a valid pipeline config id" % target_id)
 
-    
-        log.info("This command will push the configuration in the current pipeline configuration "
-                 "('%s') to another pipeline configuration in the project. By default, the data "
-                 "will be copied to the target config folder. If pass a --symlink parameter, it will "
-                 "create a symlink instead." % current_pc_name) 
-                 
-        log.info("")
-        log.info("Your existing configuration will be backed up.")
-        
-        if use_symlink:
-            log.info("")
-            log.info("A symlink will be used.")
-        
-        log.info("")
-        
-        log.info("The following pipeline configurations are available to push to:")
-        path_hash = {}
-        for pc in pipeline_configs:
-            # skip self
-            if pc["id"] == current_pc_id:
-                continue
-            local_path = ShotgunPath.from_shotgun_dict(pc).current_os
-            path_hash[pc["id"]] = local_path
-            log.info(" - [%d] %s (%s)" % (pc["id"], pc["code"], local_path))
-        log.info("")
-        
-        answer = raw_input("Please type in the id of the configuration to push to (ENTER to exit): " )
-        if answer == "":
-            raise TankError("Aborted by user.")
-        try:
-            target_pc_id = int(answer)
-        except:
-            raise TankError("Please enter a number!")
-        
-        if target_pc_id not in [ x["id"] for x in pipeline_configs]:
-            raise TankError("Id was not found in the list!")
-
-        target_pc_path = path_hash[target_pc_id]
         target_pc = PipelineConfiguration(target_pc_path)
         
         # check that both pcs are using the same core version
@@ -122,11 +215,13 @@ class PushPCAction(Action):
         source_core_version = self.tk.pipeline_configuration.get_associated_core_version()
         
         if target_core_version != source_core_version:
-            raise TankError("The configuration you are pushing to is using Core API %s and "
-                            "the configuration you are pushing from is using Core API %s. "
-                            "This is not supported - before pushing the changes, make sure "
-                            "that both configurations are using the "
-                            "same Core API!" % (target_core_version, source_core_version))
+            raise TankError(
+                "The configuration you are pushing to is using Core API %s and "
+                "the configuration you are pushing from is using Core API %s. "
+                "This is not supported - before pushing the changes, make sure "
+                "that both configurations are using the "
+                "same Core API!" % (target_core_version, source_core_version)
+            )
         
         # check that there are no dev descriptors
         dev_desc = None
@@ -143,21 +238,33 @@ class PushPCAction(Action):
                         dev_desc = desc
                         break
         if dev_desc:
-            log.warning("Looks like you have one or more dev locations set up in your "
-                        "configuration! We strongly recommend that you do not use dev locations "
-                        "in any production based configs. Dev descriptors are for development "
-                        "purposes only. You can easily switch a dev location using the "
-                        "'tank switch_app' command.")
-            if not console_utils.ask_yn_question("Okay to proceed?"):
+            log.warning(
+                "Looks like you have one or more dev locations set up in your "
+                "configuration! We strongly recommend that you do not use dev locations "
+                "in any production based configs. Dev descriptors are for development "
+                "purposes only. You can easily switch a dev location using the "
+                "'tank switch_app' command."
+            )
+            # Assume "yes" in non interactive mode
+            if self._is_interactive and not console_utils.ask_yn_question("Okay to proceed?"):
                 raise TankError("Aborted.")
         
         date_suffix = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         
         source_path = os.path.join(self.tk.pipeline_configuration.get_path(), "config")
-        target_tmp_path = os.path.join(target_pc_path, "config.tmp.%s" % date_suffix)
-        symlink_path = os.path.join(target_pc_path, "config.%s" % date_suffix)
+        # Protect ourself against an edge case which happens mostly in unit tests
+        # if multiple pushes are attempted within less than a second, which is the
+        # granularity of our date_suffix used for uniqueness.
+        target_tmp_path = filesystem.get_unused_path(
+            os.path.join(target_pc_path, "config.tmp.%s" % date_suffix)
+        )
+        symlink_path = filesystem.get_unused_path(
+            os.path.join(target_pc_path, "config.%s" % date_suffix)
+        )
         target_path = os.path.join(target_pc_path, "config")
-        target_backup_path = os.path.join(target_pc_path, "config.bak.%s" % date_suffix)
+        target_backup_path = filesystem.get_unused_path(
+            os.path.join(target_pc_path, "config.bak.%s" % date_suffix)
+        )
 
         log.debug("Will push the config from %s to %s" % (source_path, target_path))
         log.info("Hold on, pushing config...")
@@ -209,43 +316,88 @@ class PushPCAction(Action):
                     shutil.copy(curr_config_path, new_config_path)
                 
             except Exception, e:
-                raise TankError("Could not copy into temporary target folder '%s'. The target config "
-                                "has not been altered. Check permissions and try again! "
-                                "Error reported: %s" % (target_tmp_path, e))
+                raise TankError(
+                    "Could not copy into temporary target folder '%s'. The target config "
+                    "has not been altered. Check permissions and try again! "
+                    "Error reported: %s" % (target_tmp_path, e)
+                )
             
             # backup original config
+            created_backup_path = None
             try:
                 if os.path.islink(target_path):
-                    # if we are symlinked, no need to back up
-                    # just delete the current symlink
+                    # If we are symlinked, no need to back up: just delete the
+                    # current symlink.
+                    # If remove fails, we don't have to worry about restoring the
+                    # original `target_path`: if it failed, it is still there...
                     os.remove(target_path)
-                    created_backup = False
                 else:
-                    # move data to backup folder
-                    shutil.move(target_path, target_backup_path)
-                    created_backup = True
+                    # Move data to backup folder
+                    # Try using os.rename first, which is a lot more efficient than
+                    # copying all files over, as it just updates inode tables on Unix.
+                    # If it fails, fall back to copying files and deleting them
+                    # only after everything was copied over.
+                    # We basically replicates what shutil.move does, but we use
+                    # shutil.copytree and shutil.rmtree to ensure we only delete
+                    # data after everything was copied over in the backup folder.
+                    try:
+                        os.rename(target_path, target_backup_path)
+                    except OSError, e:
+                        log.debug("Falling back on copying folder...:%s" % e)
+                        # Didn't work fall back to copying files
+                        shutil.copytree(target_path, target_backup_path)
+                        shutil.rmtree(target_path)
+                    else:
+                        # Only happens if either os.rename or copytree/rmtree worked.
+                        created_backup_path = target_backup_path
             except Exception, e:
-                raise TankError("Could not move target folder from '%s' to '%s'. "
-                                "Error reported: %s" % (target_path, target_backup_path, e))
+                raise TankError(
+                    "Could not move target folder from '%s' to '%s'. "
+                    "Error reported: %s" % (target_path, target_backup_path, e)
+                )
                 
             # lastly, move new config into place
             if use_symlink:
                 try:
+                    # If the symlink path exists, shutil.move will move the
+                    # tmp folder inside it, instead of renaming the tmp folder with
+                    # the target path, leading to invalid config. So check this
+                    # and report it.
+                    if os.path.exists(symlink_path):
+                        raise RuntimeError("Target %s folder already exists..." % symlink_path)
                     shutil.move(target_tmp_path, symlink_path)
+                    # It seems that when given a basename as the source for the
+                    # link, symlink creates the link in the target directory, so
+                    # this works without having to change the current directory?
                     os.symlink(os.path.basename(symlink_path), target_path)
                 except Exception, e:
-                    raise TankError("Could not move new config folder from '%s' to '%s' or create symlink."
-                                    "Error reported: %s" % (target_tmp_path, symlink_path, e))                
+                    raise TankError(
+                        "Could not move new config folder from '%s' to '%s' or create symlink."
+                        "Error reported: %s" % (target_tmp_path, symlink_path, e)
+                    )
             else:
                 try:
+                    # If the target path still exists, shutil.move will move the
+                    # tmp folder inside it, instead of renaming the tmp folder with
+                    # the target path, leading to invalid config. So check this
+                    # and report it.
+                    if os.path.exists(target_path):
+                        raise RuntimeError("Target %s folder already exists..." % target_path)
                     shutil.move(target_tmp_path, target_path)
                 except Exception, e:
-                    raise TankError("Could not move new config folder from '%s' to '%s'. "
-                                    "Error reported: %s" % (target_tmp_path, target_path, e))
+                    raise TankError(
+                        "Could not move new config folder from '%s' to '%s'. "
+                        "Error reported: %s" % (target_tmp_path, target_path, e)
+                    )
         
         finally:
             os.umask(old_umask)
-        
+            if created_backup_path:
+                log.info(
+                    "Your old configuration has been backed up "
+                    "into the following folder: %s" % created_backup_path
+                )
+
         ##########################################################################################
         # Post Process Phase
         
@@ -264,10 +416,6 @@ class PushPCAction(Action):
                         log.info("Downloading App %s..." % app)
                         desc.download_local()
 
+        log.info("")
         log.info("Push Complete!")
         log.info("")
-        if created_backup:
-            log.info("Your old configuration has been backed up into the following folder: %s" % target_backup_path)
-        log.info("")
-        
-

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1896,7 +1896,7 @@ class Engine(TankBundle):
         at window creation in order to allow newly created dialogs to apply app specific
         styles easily.
         
-        If the `SGTK_QSS_FILE_WATCHER` env variable is set to "1", the style sheet
+        If the `SHOTGUN_QSS_FILE_WATCHER` env variable is set to "1", the style sheet
         will be reloaded and re-applied if changed. This can be useful when developing
         apps to do some interactive styling but shouldn't be used in production.
 
@@ -1919,7 +1919,7 @@ class Engine(TankBundle):
         # Set a style sheet file watcher which can be used for interactive styling.
         # File watchers can cause problems in production when accessing shared
         # storage, so we only set it if explicitly asked to do so.
-        if os.getenv("SGTK_QSS_FILE_WATCHER", False) == "1":
+        if os.getenv("SHOTGUN_QSS_FILE_WATCHER", False) == "1":
             try:
                 self._add_stylesheet_file_watcher(qss_file, widget)
             except Exception, e:

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -265,6 +265,9 @@ def move_folder(src, dst, folder_permissions=0775):
     First copies all content into target. Then deletes
     all content from sources. Skips files that won't delete.
 
+    .. note::
+        The source folder itself is not deleted, it is just emptied, if possible.
+
     :param src: Source path to copy from
     :param dst: Destination to copy to
     :param folder_permissions: permissions to use for new folders
@@ -403,3 +406,44 @@ def safe_delete_folder(path):
             log.warning("Could not delete %s: %s" % (path, e))
     else:
         log.warning("Could not delete: %s. Folder does not exist" % path)
+
+def get_unused_path(base_path):
+    """
+    Return an unused file path from the given base path by appending if needed
+    a number at the end of the basename of the path, right before the first ".",
+    if any.
+    
+    For example, "/tmp/foo_1.bar.blah" would be returned for "/tmp/foo.bar.blah"
+    if it already exists.
+
+    If the given path does not exist, the original path is returned.
+
+    .. note::
+        The returned path is not _reserved_, so it is possible that other processes
+        could create the returned path before it is used by the caller.
+
+    :param str base_path: Target path.
+    :returns: A string.
+    """
+    if not os.path.exists(base_path):
+        # Bail out quickly if everything is fine with the path
+        return base_path
+
+    # Split the base path and find an unused path
+    folder, basename = os.path.split(base_path)
+    # Split the basename at the first ".", if any. Make sure we always have at least
+    # two entries.
+    base_parts = basename.split(".", 1) + [""]
+    numbering = 0
+    while True:
+        numbering += 1
+        name = "%s_%d%s" % (
+            base_parts[0], numbering, ".%s" % base_parts[1] if base_parts[1] else ""
+        )
+        path = os.path.join(folder, name)
+        log.debug("Checking if %s exists..." % path)
+        if not os.path.exists(path):
+            break
+    return path
+
+

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -306,6 +306,16 @@ class TankTestBase(unittest.TestCase):
         os.makedirs(self.project_root)
         os.makedirs(self.pipeline_config_root)
 
+        # copy tank util scripts
+        shutil.copy(
+            os.path.join(self.tank_source_path, "setup", "root_binaries", "tank"),
+            os.path.join(self.pipeline_config_root, "tank")
+        )
+        shutil.copy(
+            os.path.join(self.tank_source_path, "setup", "root_binaries", "tank.bat"),
+            os.path.join(self.pipeline_config_root, "tank.bat")
+        )
+
         # project level config directories
         self.project_config = os.path.join(self.pipeline_config_root, "config")
 

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -86,3 +86,35 @@ class TestFileSystem(TankTestBase):
 
         # check that the folder is deleted successfully
         self.assertFalse(os.path.exists(dst_folder))
+
+    def test_unused_path(self):
+        """
+        Test the get_unused_path helper
+        """
+        test_folder = os.path.join(self.tank_temp, "unused_tests")
+
+        # Basic test with a simple name
+        path = os.path.join(test_folder, "foo")
+        self.assertEqual(fs.get_unused_path(path), path)
+        # Create the target path and check it is detected
+        fs.ensure_folder_exists(path)
+        self.assertEqual(fs.get_unused_path(path), "%s_1" % path)
+
+        # Test we insert the number in the right place if we have some "." in the
+        # base path.
+        path = os.path.join(test_folder, "foo.0020.exr")
+        self.assertEqual(fs.get_unused_path(path), path)
+        fs.touch_file(path)
+        self.assertEqual(fs.get_unused_path(path), os.path.join(test_folder, "foo_1.0020.exr"))
+
+        # Test multiple iterations
+        fs.touch_file(os.path.join(test_folder, "foo_1.0020.exr"))
+        fs.touch_file(os.path.join(test_folder, "foo_2.0020.exr"))
+        fs.touch_file(os.path.join(test_folder, "foo_3.0020.exr"))
+        fs.touch_file(os.path.join(test_folder, "foo_4.0020.exr"))
+        self.assertEqual(fs.get_unused_path(path), os.path.join(test_folder, "foo_5.0020.exr"))
+
+        # Clean up
+        fs.safe_delete_folder(test_folder)
+
+


### PR DESCRIPTION
Fix a problem when running a "push_config", and ensure the target pipeline config is not corrupted if its backup failed.

* Allowed the "push_config" command to be run from the API and added unit tests for it, so the problem and its fix could be tested.
* Fixed an edge case where the same backup target could be used if multiple push to the same target were run within a second (mainly for unit testing).
* Reformatted push_pc.py code to be as much as possible on the left (which is the reason why we avoid to have long lines), and closer to our latest conventions.
* Issue an error if the symlink option is used on a platform not supporting it (Windows).
* Improved comments in a couple of places.
* Revisited backup _move_: try to use `os.rename` first (which is what `shutil.move` does), fallback on `shutil.copytree` and then `shutil.rmtree` so there is always a valid config folder available.
* Ensure the user always knows that a backup is available if it is the case, even in case of errors.
* Added  `filesystem.get_unused_path` helper and added unit tests for it.
* Added a note to `filesystem.move_folder` mentioning that the directory being moved is *not* removed, which is different from the expected behavior.

* Renamed `SGTK_QSS_FILE_WATCHER` env variable to `SHOTGUN_QSS_FILE_WATCHER` to follow latest conventions.
