### PR TITLE
#44167 reorder validate logging

### DIFF
--- a/python/tank/commands/cache_apps.py
+++ b/python/tank/commands/cache_apps.py
@@ -66,10 +66,11 @@ class CacheAppsAction(Action):
         num_downloads = 0
 
         for env_name in self.tk.pipeline_configuration.get_environments():
-            env = self.tk.pipeline_configuration.get_environment(env_name)
             log.info("")
             log.info("Environment %s" % env_name)
             log.info("------------------------------------------")
+            env = self.tk.pipeline_configuration.get_environment(env_name)
+
             for eng in env.get_engines():
                 desc = env.get_engine_descriptor(eng)
                 if not desc.exists_local():

--- a/python/tank/commands/cache_apps.py
+++ b/python/tank/commands/cache_apps.py
@@ -69,7 +69,11 @@ class CacheAppsAction(Action):
             log.info("")
             log.info("Environment %s" % env_name)
             log.info("------------------------------------------")
+
             env = self.tk.pipeline_configuration.get_environment(env_name)
+
+            log.info("Environment path: %s" % (env.disk_location))
+            log.info("")
 
             for eng in env.get_engines():
                 desc = env.get_engine_descriptor(eng)

--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -226,7 +226,12 @@ class PushPCAction(Action):
         # check that there are no dev descriptors
         dev_desc = None
         for env_name in self.tk.pipeline_configuration.get_environments():
-            env = self.tk.pipeline_configuration.get_environment(env_name)
+            try:
+                env = self.tk.pipeline_configuration.get_environment(env_name)
+            except Exception as e:
+                raise TankError("Failed to load environment %s,"
+                                " run 'tank validate' for more details, got error: %s" % (env_name, e))
+
             for eng in env.get_engines():
                 desc = env.get_engine_descriptor(eng)
                 if desc.is_dev():

--- a/python/tank/commands/update.py
+++ b/python/tank/commands/update.py
@@ -262,15 +262,25 @@ def check_for_updates(log,
         env_filenames = []
         for filename in os.listdir(env_path):
             if filename.endswith(".yml"):
-                if env_name is None or ("%s.yml" % env_name) == filename: 
+                if env_name is None or ("%s.yml" % env_name) == filename:
                     # matching the env filter (or no filter set)
                     log.info("> found %s" % filename) 
                     env_filenames.append(os.path.join(env_path, filename))
         
         # now process them one after the other
-        for env_filename in env_filenames: 
+        for env_filename in env_filenames:
+            log.info("")
+            log.info("")
+            log.info("======================================================================")
+            log.info("Environment %s..." % env_name)
+            log.info("======================================================================")
+            log.info("")
+
             env_obj = WritableEnvironment(env_filename, pc)
             env_obj.set_yaml_preserve_mode(preserve_yaml)
+
+            log.info("Environment path: %s" % (env_obj.disk_location))
+            log.info("")
             
             processed_items += _process_environment(tk, 
                                                     log, 
@@ -288,8 +298,18 @@ def check_for_updates(log,
             env_names_to_process = [env_name]
     
         for env_name in env_names_to_process:
+            log.info("")
+            log.info("")
+            log.info("======================================================================")
+            log.info("Environment %s..." % env_name)
+            log.info("======================================================================")
+
+
             env_obj = pc.get_environment(env_name, writable=True)
             env_obj.set_yaml_preserve_mode(preserve_yaml)
+
+            log.info("Environment path: %s" % (env_obj.disk_location))
+            log.info("")
             
             processed_items += _process_environment(tk, 
                                                     log, 
@@ -356,13 +376,6 @@ def _process_environment(tk,
     :returns: list of updated items
     """
     items = []
-        
-    log.info("")
-    log.info("")
-    log.info("======================================================================")
-    log.info("Environment %s..." % environment_obj.name)
-    log.info("======================================================================")
-    log.info("")
     
     if engine_instance_name is None:
         # process all engines

--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -89,6 +89,7 @@ class ValidateConfigAction(Action):
             log.info("------------------------------------------")
 
             env = self.tk.pipeline_configuration.get_environment(env_name)
+            log.info("Environment path: %s" % (env.disk_location))
             _process_environment(log, self.tk, env)
     
         log.info("")
@@ -259,8 +260,6 @@ def _process_environment(log, tk, env):
     :param tk: A toolkit api instance.
     :param env: An environment instance.
     """
-
-    log.info("Environment path: %s" % (env.disk_location))
 
     for e in env.get_engines():
         s = env.get_engine_settings(e)

--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -84,6 +84,8 @@ class ValidateConfigAction(Action):
     
         # validate environments
         for env_name in parameters["envs"]:
+            log.info("")
+            log.info("Processing environment %s.yml" % env_name)
             env = self.tk.pipeline_configuration.get_environment(env_name)
             _process_environment(log, self.tk, env)
     
@@ -255,8 +257,6 @@ def _process_environment(log, tk, env):
     :param tk: A toolkit api instance.
     :param env: An environment instance.
     """
-
-    log.info("Processing environment %s" % env)
 
     for e in env.get_engines():
         s = env.get_engine_settings(e)

--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -85,7 +85,9 @@ class ValidateConfigAction(Action):
         # validate environments
         for env_name in parameters["envs"]:
             log.info("")
-            log.info("Processing environment %s.yml" % env_name)
+            log.info("Environment %s" % env_name)
+            log.info("------------------------------------------")
+
             env = self.tk.pipeline_configuration.get_environment(env_name)
             _process_environment(log, self.tk, env)
     
@@ -257,6 +259,8 @@ def _process_environment(log, tk, env):
     :param tk: A toolkit api instance.
     :param env: An environment instance.
     """
+
+    log.info("Environment path: %s" % (env.disk_location))
 
     for e in env.get_engines():
         s = env.get_engine_settings(e)


### PR DESCRIPTION
A continuation of merged pull request https://github.com/shotgunsoftware/tk-core/pull/506

Francis asked if I can add similar logging for `tank push_configuration`. As the previous changes were to just move the logging forward in time, and push_configuration didn't already have this logging, I thought the best option might be to just catch the exception when the loading of the environment fails and provide a better output.
Note changes to push_pc.py