### PR TITLE
Ticket/43998 unable to sign in again after invalid credentials

### DIFF
--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -199,7 +199,6 @@ class Saml2Sso(object):
     def __del__(self):
         """Destructor."""
         log.debug("==- __del__")
-        print "DESTRUCTOR"
 
     @property
     def _session(self):

--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -364,8 +364,9 @@ class Saml2Sso(object):
                 if url.startswith(session.host):
                     session.error = HTTP_AUTHENTICATE_REQUIRED
                 else:
-                    # If we are on the IdP portal site, we let it deal with the error.
-                    # So we just behave as if there had been no error.
+                    # If we are not on our site, we are on the Identity Provider (IdP) portal site.
+                    # We let it deal with the error.
+                    # Reset the error to None to disregard the error.
                     session.error = None
             else:
                 session.error = reply.attribute(QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute)

--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -33,6 +33,7 @@ log = LogManager.get_logger(__name__)
 # Error messages for events. . Also defined in slmodule/slutils.mu
 # @FIXME: Should import these from slmodule
 HTTP_CANT_CONNECT_TO_SHOTGUN = "Cannot Connect To Shotgun site."
+HTTP_AUTHENTICATE_REQUIRED = "Valid credentials are required."
 HTTP_AUTHENTICATE_SSO_NOT_UPPORTED = "SSO not supported or enabled on that site."
 HTTP_CANT_AUTHENTICATE_SSO_TIMEOUT = "Time out attempting to authenticate to SSO service."
 HTTP_CANT_AUTHENTICATE_SSO_NO_ACCESS = "You have not been granted access to the Shotgun site."
@@ -198,6 +199,7 @@ class Saml2Sso(object):
     def __del__(self):
         """Destructor."""
         log.debug("==- __del__")
+        print "DESTRUCTOR"
 
     @property
     def _session(self):
@@ -358,6 +360,14 @@ class Saml2Sso(object):
                 # This means that the SSO login worked, but that the user does
                 # have access to the site.
                 session.error = HTTP_CANT_AUTHENTICATE_SSO_NO_ACCESS
+            elif error is QtNetwork.QNetworkReply.NetworkError.AuthenticationRequiredError:
+                # This means that the user entered incorrect credentials.
+                if url.startswith(session.host):
+                    session.error = HTTP_AUTHENTICATE_REQUIRED
+                else:
+                    # If we are on the IdP portal site, we let it deal with the error.
+                    # So we just behave as if there had been no error.
+                    session.error = None
             else:
                 session.error = reply.attribute(QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute)
         elif url.startswith(session.host + URL_LOGIN_PATH):

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -199,7 +199,7 @@ class ShotgunSamlUser(ShotgunUser):
                 logger.warning("No further attempts to auto-renew in the background will be attempted.")
         except AuthenticationCancelled:
             logger.debug("Automatic SSO claim renewal was cancelled while processing.")
-            pass
+            raise
 
     def start_claims_renewal(self, preemtive_renewal_threshold=0.9):
         """


### PR DESCRIPTION
This fix addresses two incorrect behaviors:
- Entering incorrect credentials on the IdP login page (e.g. Okta, ADFS, Ping, etc.) would cause the QWebView page to be immediately closed and making the calling application (SG Desktop, script, etc.) to think that the authentication had been canceled by the user.
- The authentication being cancelled exception would be incorrectly trapped by an 'except' statement and would not be percolated back to the caller.