### PR TITLE
For #44082: Keeps track of the source entity as given to context factory functions.

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1103,7 +1103,7 @@ def _from_entity(tk, entity_type, entity_id, source_entity=None):
         task_context = _task_from_sg(tk, entity_id)
         context.update(task_context)
 
-    elif entity_type in ["PublishedFile", "TankPublishedFile", "Version"]:
+    elif entity_type in ["PublishedFile", "TankPublishedFile"]:
         
         sg_entity = tk.shotgun.find_one(entity_type, 
                                         [["id", "is", entity_id]], 
@@ -1212,7 +1212,7 @@ def _from_entity_dictionary(tk, entity_dictionary, source_entity=None):
             project = task["project"]
             entity = task["entity"]
             step = task["step"]
-    elif entity_type in ["PublishedFile", "TankPublishedFile", "Version"]:
+    elif entity_type in ["PublishedFile", "TankPublishedFile"]:
         # special case handling for published files:
         if entity_dictionary.get("task"):
             # construct a task context

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -713,6 +713,7 @@ class Context(object):
             "step": self.step,
             "task": self.task,
             "additional_entities": self.additional_entities,
+            "source_entity": self.source_entity,
             "_pc_path": self.tank.pipeline_configuration.get_path()
         }
 

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1083,7 +1083,7 @@ def from_entity(tk, entity_type, entity_id):
 
     # We have a special case when it comes to PublishedFile entities. We
     # look at what it's linked to and build a context based on that.
-    if entity_type in ["PublishedFile", "TankPublishedFile"]:
+    if entity_type in ["PublishedFile", "TankPublishedFile", "Version"]:
         sg_entity = tk.shotgun.find_one(
             entity_type, 
             [["id", "is", entity_id]], 
@@ -1185,7 +1185,7 @@ def from_entity_dictionary(tk, entity_dictionary):
     # the context. Note that the source_entity has already been recorded
     # above based on a copy of the entity dictionary, so we can safely
     # reassign entity_type, entity_id, and entity_dictionary as needed.
-    if entity_type in ["PublishedFile", "TankPublishedFile"]:
+    if entity_type in ["PublishedFile", "TankPublishedFile", "Version"]:
         if entity_dictionary.get("task"):
             # construct a task context
             entity_type = "Task",

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1169,6 +1169,16 @@ def from_entity_dictionary(tk, entity_dictionary):
     entity_type = entity_dictionary["type"]
     entity_id = entity_dictionary["id"]
 
+    # The special case logic for PublishedFile entities can result in
+    # us attempting to build a Context from what it's linked to, rather
+    # than the PublishedFile itself. That logic might result in the
+    # entity_type and entity_id variables being reassigned. Later in
+    # this method, there's the possibility that we're going to have to
+    # call through to from_entity, at which time we want to do so with
+    # the original entity type and id that was passed in by the caller.
+    original_entity_type = entity_type
+    original_entity_id = entity_id
+
     # We have a special case for PublishedFile entities. We need to
     # construct the context based on what the entity is linked to, while
     # the PublishedFile itself will be recorded as the source_entity of
@@ -1269,7 +1279,7 @@ def from_entity_dictionary(tk, entity_dictionary):
     if fallback_to_ctx_from_entity:
         # entity dict doesn't contain enough information to build a 
         # safe, valid context so fall back on 'from_entity':
-        return from_entity(tk, entity_type, entity_id)
+        return from_entity(tk, original_entity_type, original_entity_id)
 
     if task:
         # one final check if we have a task:

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1176,7 +1176,7 @@ def from_entity_dictionary(tk, entity_dictionary):
 
     :returns: :class:`Context`
     """
-    return _from_entity_dictionary(tk, entity_dictionary, source_entity=None)
+    return _from_entity_dictionary(tk, entity_dictionary)
 
 def _from_entity_dictionary(tk, entity_dictionary, source_entity=None):
     """

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -302,8 +302,13 @@ class Context(object):
         are situations where a context is interpreted from an input entity,
         such as when a PublishedFile entity is used to determine a context. In
         that case, the original PublishedFile becomes the source_entity, and
-        project, entity, task, and step are determined why what the
-        PublishedFile entity is linked to.
+        project, entity, task, and step are determined by what the
+        PublishedFile entity is linked to. A specific example of where this is
+        useful is in a pick_environment core hook. In that hook, an environment
+        is determined based on a provided Context object. In the case where we want
+        to provide a specific environment for a Context built from a PublishedFile
+        entity, the context's source_entity can be used to know for certain that it
+        was constructured from a PublishedFile.
 
         :returns: A Shotgun entity dictionary.
         :rtype: dict or None
@@ -1063,7 +1068,7 @@ def from_entity(tk, entity_type, entity_id):
 
     :returns: :class:`Context`
     """
-    return _from_entity(tk, entity_type, entity_id, source_entity=None)
+    return _from_entity(tk, entity_type, entity_id)
 
 def _from_entity(tk, entity_type, entity_id, source_entity=None):
     """

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -434,8 +434,83 @@ class TestFromEntity(TestContext):
                      "project": self.project,
                      "entity": self.shot,
                      "step": self.step}
+
+        self.publishedfile = dict(
+            id=2,
+            type="PublishedFile",
+            project=self.project,
+            entity=self.shot,
+            task=self.task,
+        )
+
+        self.version = dict(
+            id=3,
+            type="Version",
+            project=self.project,
+            entity=self.shot,
+        )
         
         self.add_to_sg_mock_db(self.task)
+        self.add_to_sg_mock_db(self.publishedfile)
+        self.add_to_sg_mock_db(self.version)
+
+    @patch("tank.util.login.get_current_user")
+    def test_from_linked_entity_types(self, get_current_user):
+        get_current_user.return_value = self.current_user
+
+        # PublishedFile and Version entities are special cased in the context
+        # factories. We need to make sure they create a context object that is
+        # built from what those entities are linked to, but with the original
+        # entity kept as the source_entity of the context.
+        result = context.from_entity(self.tk, self.publishedfile["type"], self.publishedfile["id"])
+        self.check_entity(self.project, result.project, check_name=False)
+        self.check_entity(self.shot, result.entity, check_name=False)
+        self.check_entity(self.task, result.task, check_name=False)
+        self.check_entity(
+            result.source_entity,
+            dict(
+                type=self.publishedfile["type"],
+                id=self.publishedfile["id"],
+            ),
+            check_name=False,
+        )
+
+        result = context.from_entity(self.tk, self.version["type"], self.version["id"])
+        self.check_entity(self.project, result.project, check_name=False)
+        self.check_entity(self.shot, result.entity, check_name=False)
+        self.check_entity(
+            result.source_entity,
+            dict(
+                type=self.version["type"],
+                id=self.version["id"],
+            ),
+            check_name=False,
+        )
+
+        result = context.from_entity_dictionary(self.tk, self.publishedfile)
+        self.check_entity(self.project, result.project, check_name=False)
+        self.check_entity(self.shot, result.entity, check_name=False)
+        self.check_entity(self.task, result.task, check_name=False)
+        self.check_entity(
+            result.source_entity,
+            dict(
+                type=self.publishedfile["type"],
+                id=self.publishedfile["id"],
+            ),
+            check_name=False,
+        )
+
+        result = context.from_entity_dictionary(self.tk, self.version)
+        self.check_entity(self.project, result.project, check_name=False)
+        self.check_entity(self.shot, result.entity, check_name=False)
+        self.check_entity(
+            result.source_entity,
+            dict(
+                type=self.version["type"],
+                id=self.version["id"],
+            ),
+            check_name=False,
+        )
 
     @patch("tank.util.login.get_current_user")
     def test_entity_from_cache(self, get_current_user):
@@ -621,11 +696,12 @@ class TestFromEntity(TestContext):
         self.assertEquals(self.task["content"], result.task["name"])
         self.assertEquals(3, len(result.task))
 
-    def check_entity(self, first_entity, second_entity):
+    def check_entity(self, first_entity, second_entity, check_name=True):
         "Checks two entity dictionaries have the same values for keys type, id and name."
         self.assertEquals(first_entity["type"], second_entity["type"])
         self.assertEquals(first_entity["id"],   second_entity["id"])
-        self.assertEquals(first_entity["name"], second_entity["name"])
+        if check_name:
+            self.assertEquals(first_entity["name"], second_entity["name"])
 
 
 class TestAsTemplateFields(TestContext):

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -442,17 +442,9 @@ class TestFromEntity(TestContext):
             entity=self.shot,
             task=self.task,
         )
-
-        self.version = dict(
-            id=3,
-            type="Version",
-            project=self.project,
-            entity=self.shot,
-        )
         
         self.add_to_sg_mock_db(self.task)
         self.add_to_sg_mock_db(self.publishedfile)
-        self.add_to_sg_mock_db(self.version)
 
     @patch("tank.util.login.get_current_user")
     def test_from_linked_entity_types(self, get_current_user):
@@ -475,18 +467,6 @@ class TestFromEntity(TestContext):
             check_name=False,
         )
 
-        result = context.from_entity(self.tk, self.version["type"], self.version["id"])
-        self.check_entity(self.project, result.project, check_name=False)
-        self.check_entity(self.shot, result.entity, check_name=False)
-        self.check_entity(
-            result.source_entity,
-            dict(
-                type=self.version["type"],
-                id=self.version["id"],
-            ),
-            check_name=False,
-        )
-
         result = context.from_entity_dictionary(self.tk, self.publishedfile)
         self.check_entity(self.project, result.project, check_name=False)
         self.check_entity(self.shot, result.entity, check_name=False)
@@ -496,18 +476,6 @@ class TestFromEntity(TestContext):
             dict(
                 type=self.publishedfile["type"],
                 id=self.publishedfile["id"],
-            ),
-            check_name=False,
-        )
-
-        result = context.from_entity_dictionary(self.tk, self.version)
-        self.check_entity(self.project, result.project, check_name=False)
-        self.check_entity(self.shot, result.entity, check_name=False)
-        self.check_entity(
-            result.source_entity,
-            dict(
-                type=self.version["type"],
-                id=self.version["id"],
             ),
             check_name=False,
         )
@@ -531,7 +499,6 @@ class TestFromEntity(TestContext):
         
         self.check_entity(self.step, result.step)
         self.assertEquals(3, len(result.step))
-
     
     @patch("tank.util.login.get_current_user")
     def test_step_higher_entity(self, get_current_user):


### PR DESCRIPTION
When constructing context objects from the factory functions provided in `sgtk.context`, we want to know what the source entity was, even if it was transformed into some other context. This transformation occurs for some entity types; most notably PublishedFile entities, where we want to construct a context based on what the PublishedFile is linked to. Keeping track of the source PublishedFile entity allows us to provide an environment specific to that entity type from pick_environment.

I added tests!