### PR TITLE
For #43941: when using console authentication, immediately emit excep…

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -20,7 +20,7 @@ at any point.
 """
 from . import session_cache
 from .. import LogManager
-from .errors import AuthenticationError, AuthenticationCancelled
+from .errors import AuthenticationError, AuthenticationCancelled, ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
 
 from getpass import getpass
@@ -158,6 +158,13 @@ class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):
         :returns: The (hostname, login, plain text password) tuple.
         """
         print "%s, your current session has expired." % login
+
+        # Import at top-level causes an import error on DefaultsManager
+        from shotgun_shared import is_sso_enabled_on_site
+
+        if is_sso_enabled_on_site(hostname):
+            raise ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(hostname)
+
         print "Please enter your password to renew your session for %s" % hostname
         return hostname, login, self._get_password()
 
@@ -188,6 +195,13 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
         else:
             print "Please enter your login credentials."
             hostname = self._get_keyboard_input("Host", hostname)
+
+        # Import at top-level causes an import error on DefaultsManager
+        from shotgun_shared import is_sso_enabled_on_site
+
+        if is_sso_enabled_on_site(hostname):
+            raise ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(hostname)
+
         login = self._get_keyboard_input("Login", login)
         password = self._get_password()
         return hostname, login, password

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -20,7 +20,7 @@ at any point.
 """
 from . import session_cache
 from .. import LogManager
-from .errors import AuthenticationError, AuthenticationCancelled, ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled
+from .errors import AuthenticationError, AuthenticationCancelled, ConsoleLoginWithSSONotSupportedError
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
 
 from getpass import getpass
@@ -163,7 +163,7 @@ class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):
         from shotgun_shared import is_sso_enabled_on_site
 
         if is_sso_enabled_on_site(hostname):
-            raise ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(hostname)
+            raise ConsoleLoginWithSSONotSupportedError(hostname)
 
         print "Please enter your password to renew your session for %s" % hostname
         return hostname, login, self._get_password()
@@ -200,7 +200,7 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
         from shotgun_shared import is_sso_enabled_on_site
 
         if is_sso_enabled_on_site(hostname):
-            raise ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(hostname)
+            raise ConsoleLoginWithSSONotSupportedError(hostname)
 
         login = self._get_keyboard_input("Login", login)
         password = self._get_password()

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -41,6 +41,21 @@ class IncompleteCredentials(ShotgunAuthenticationError):
         )
 
 
+class ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(ShotgunAuthenticationError):
+    """
+    Thrown when attempting to use Username/Password pair to login onto
+    a SSO-enabled site.
+    """
+
+    def __init__(self, url):
+        """
+        :param str url: Url of the site where login was attempted.
+        """
+        ShotgunAuthenticationError.__init__(
+            self, "Authentication using username/password is not allowed on the console for a SSO-enabled Shotgun site: %s" % url
+        )
+
+
 class AuthenticationCancelled(ShotgunAuthenticationError):
     """
     Thrown when the user cancels authentication or session renewal.

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -41,7 +41,7 @@ class IncompleteCredentials(ShotgunAuthenticationError):
         )
 
 
-class ConsoleCannotUseUsernameAndPasswordWhenSSOEnabled(ShotgunAuthenticationError):
+class ConsoleLoginWithSSONotSupportedError(ShotgunAuthenticationError):
     """
     Thrown when attempting to use Username/Password pair to login onto
     a SSO-enabled site.

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -22,7 +22,7 @@ from . import session_cache
 from shotgun_shared import Saml2Sso
 from .errors import AuthenticationError
 from .ui.qt_abstraction import QtGui, QtCore
-from tank_vendor.shotgun_api3 import Shotgun, MissingTwoFactorAuthenticationFault
+from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
 from .. import LogManager
 
 logger = LogManager.get_logger(__name__)
@@ -127,35 +127,6 @@ class LoginDialog(QtGui.QDialog):
         url = self.ui.site.text().encode("utf-8")
         if self._check_sso_enabled(url):
             self._toggle_sso()
-
-    def _check_sso_enabled(self, url):
-        """
-        Check to see if the web site uses sso.
-
-        We want this method to fail as quickly as possible if there are any
-        issues. Failure is not considered critical, thus known exceptions are
-        silently ignored. At the moment this method is only used to make the
-        GUI show/hide some of the input fields.
-
-        :returns: a boolean indicating if SSO has been enabled or not.
-        """
-        try:
-            # Temporary shotgun instance, used only for the purpose of checking
-            # the site infos.
-            #
-            # The constructor of Shotgun requires either a username/login or
-            # key/scriptname pair or a session_token. The token is only used in
-            # calls which need to be authenticated. The 'info' call does not
-            # require authentication.
-            info = Shotgun(url, session_token="dummy", connect=False).info()
-            logger.debug("User authentication method for %s: %s" % (url, info["user_authentication_method"]))
-            if "user_authentication_method" in info:
-                return info["user_authentication_method"] == "saml2"
-        except Exception, e:
-            # Silently ignore exceptions
-            logger.debug("Unable to connect with %s, got exception '%s' assuming SSO is not enabled" % (url, e))
-
-        return False
 
     def _strip_whitespaces(self):
         """

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -20,6 +20,7 @@ at any point.
 from .ui import login_dialog
 from . import session_cache
 from shotgun_shared import Saml2Sso
+from shotgun_shared import is_sso_enabled_on_site
 from .errors import AuthenticationError
 from .ui.qt_abstraction import QtGui, QtCore
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
@@ -125,7 +126,7 @@ class LoginDialog(QtGui.QDialog):
         self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
 
         url = self.ui.site.text().encode("utf-8")
-        if self._check_sso_enabled(url):
+        if is_sso_enabled_on_site(url):
             self._toggle_sso()
 
     def _strip_whitespaces(self):

--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -151,11 +151,11 @@ class ShotgunAuthenticator(object):
         http_proxy = http_proxy or self._defaults_manager.get_http_proxy()
 
         # @FIXME: if imported at file scope, we get a ImportError
-        from .shotgun_shared import is_sso_enabled
+        from .shotgun_shared import cookies_include_sso_infos
 
         # Create a session user
         impl = user_impl.SessionUser(host, login, session_token, http_proxy, password=password, cookies=cookies)
-        if is_sso_enabled(cookies):
+        if cookies_include_sso_infos(cookies):
             return user.ShotgunSamlUser(impl)
         else:
             return user.ShotgunUser(impl)

--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -151,11 +151,11 @@ class ShotgunAuthenticator(object):
         http_proxy = http_proxy or self._defaults_manager.get_http_proxy()
 
         # @FIXME: if imported at file scope, we get a ImportError
-        from .shotgun_shared import cookies_include_sso_infos
+        from .shotgun_shared import has_sso_info_in_cookies
 
         # Create a session user
         impl = user_impl.SessionUser(host, login, session_token, http_proxy, password=password, cookies=cookies)
-        if cookies_include_sso_infos(cookies):
+        if has_sso_info_in_cookies(cookies):
             return user.ShotgunSamlUser(impl)
         else:
             return user.ShotgunUser(impl)

--- a/python/tank/authentication/shotgun_shared/__init__.py
+++ b/python/tank/authentication/shotgun_shared/__init__.py
@@ -15,4 +15,4 @@ This module contains files which are shared between RV and Toolkit.
 from .saml2_sso import Saml2SssoError, Saml2SssoMultiSessionNotSupportedError, Saml2Sso # noqa
 
 # Functions
-from .saml2_sso import is_sso_enabled, get_saml_claims_expiration, get_saml_user_name, get_session_id, get_csrf_token, get_csrf_key # noqa
+from .saml2_sso import is_sso_enabled_on_site, cookies_include_sso_infos, get_saml_claims_expiration, get_saml_user_name, get_session_id, get_csrf_token, get_csrf_key # noqa

--- a/python/tank/authentication/shotgun_shared/__init__.py
+++ b/python/tank/authentication/shotgun_shared/__init__.py
@@ -15,4 +15,4 @@ This module contains files which are shared between RV and Toolkit.
 from .saml2_sso import Saml2SssoError, Saml2SssoMultiSessionNotSupportedError, Saml2Sso # noqa
 
 # Functions
-from .saml2_sso import is_sso_enabled_on_site, cookies_include_sso_infos, get_saml_claims_expiration, get_saml_user_name, get_session_id, get_csrf_token, get_csrf_key # noqa
+from .saml2_sso import is_sso_enabled_on_site, has_sso_info_in_cookies, get_saml_claims_expiration, get_saml_user_name, get_session_id, get_csrf_token, get_csrf_key # noqa

--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -746,7 +746,7 @@ def is_sso_enabled_on_site(url):
     return False
 
 
-def cookies_include_sso_infos(encoded_cookies):
+def has_sso_info_in_cookies(encoded_cookies):
     """
     Indicate if SSO is being used from the Shotgun cookies.
 


### PR DESCRIPTION
…tion when the url points to a SSO-enabled Shotgun site.

It made little sense for the user to enter the url, username and password in the console only to be denied since the site was using SSO. We now detect if SSO is enabled as soon as the site url is entered.

Also took this opportunity to:
- Move the SSO check code within the shotgun_shared module,
- Created a new exception for the condition,
- Modified the name of the method checkin for SSO on the cookies,