### PR TITLE
#43063 The documentation_url property now defaults to toolkit's user guide URL.

### DIFF
--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -304,11 +304,13 @@ class Descriptor(object):
     @property
     def documentation_url(self):
         """
-        The documentation url for this item or None if not defined.
+        The documentation url for this item. If no documentation url has been defined,
+        a url to the toolkit user guide is returned.
         """
         meta = self._get_manifest()
         doc_url = meta.get("documentation_url")
-        # note - doc_url can be none which is fine.
+        if doc_url is None:
+            doc_url = "https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide"
         return doc_url
 
     @property

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -540,7 +540,7 @@ class TestProperties(TestApplication):
         test engine properties
         """
         app = self.engine.apps["test_app"]
-        expected_doc_url =  "https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide"
+        expected_doc_url = "https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide"
         self.assertEqual(app.name, "test_app")
         self.assertEqual(app.display_name, "Test App")
         self.assertEqual(app.version, "Undefined")

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -540,9 +540,10 @@ class TestProperties(TestApplication):
         test engine properties
         """
         app = self.engine.apps["test_app"]
+        expected_doc_url =  "https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide"
         self.assertEqual(app.name, "test_app")
         self.assertEqual(app.display_name, "Test App")
         self.assertEqual(app.version, "Undefined")
-        self.assertEqual(app.documentation_url, None)
+        self.assertEqual(app.documentation_url, expected_doc_url)
         
 

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -111,10 +111,11 @@ class TestStartEngine(TestEngineBase):
         Test engine properties
         """
         engine = tank.platform.start_engine("test_engine", self.tk, self.context)
+        expected_doc_url = "https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide"
         self.assertEqual(engine.name, "test_engine")
         self.assertEqual(engine.display_name, "test_engine")
         self.assertEqual(engine.version, "Undefined")
-        self.assertEqual(engine.documentation_url, None)
+        self.assertEqual(engine.documentation_url, expected_doc_url)
         self.assertEqual(engine.instance_name, "test_engine")
         self.assertEqual(engine.context, self.context)
 


### PR DESCRIPTION
Currently, if no 'documentation_url' entry is present in an app's info.yml, clicking the 'Documentation' button in the app's information sidebar does not result in any action.

![Sidebar panel](https://user-images.githubusercontent.com/7693347/29960783-e5a28046-8eb1-11e7-8311-811f12d21c41.png)

By having the 'documentation_url' property on the Descriptor default to [toolkit's user guide URL](https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-User-Guide) (instead of `None`), the user will be directed to this webpage if no specific entry is made in info.yml.