### PR TITLE
For #43941: Removed unsightly stack trace when a user was attempting …

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -57,6 +57,13 @@ class ConsoleAuthenticationHandlerBase(object):
                 # Insert a \n on the current line so the print is displayed on a new time.
                 print
                 raise AuthenticationCancelled()
+            except ConsoleLoginWithSSONotSupportedError, e:
+                # SSO login requires a Web-like environment at this time.
+                # Should the user attempts to connect to a site that uses SSO,
+                # we simply prompt them again for another URL.
+                print "%s" % e
+                print
+                continue
 
             try:
                 try:

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -52,7 +52,7 @@ class ConsoleLoginWithSSONotSupportedError(ShotgunAuthenticationError):
         :param str url: Url of the site where login was attempted.
         """
         ShotgunAuthenticationError.__init__(
-            self, "Authentication using username/password is not allowed on the console for a SSO-enabled Shotgun site: %s" % url
+            self, "Authentication using username/password is not allowed on the console for a SSO-enabled (%s)" % url
         )
 
 


### PR DESCRIPTION
…to connect to a SSO-enabled site

Using a tank command on a SSO site would spit out an ugly stack trace.

Now we behave the same way as when the credentials are incorrect: we loop asking for a site url, username and password.