### PR TITLE
For #43941: prevent authentication when in console mode

### DIFF
--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -52,7 +52,7 @@ class ConsoleLoginWithSSONotSupportedError(ShotgunAuthenticationError):
         :param str url: Url of the site where login was attempted.
         """
         ShotgunAuthenticationError.__init__(
-            self, "Authentication using username/password is not allowed on the console for an SSO-enabled site."
+            self, "Authentication using username/password is not allowed on the console for %s, an SSO-enabled site." % url
         )
 
 


### PR DESCRIPTION
We prevent console-based authentication/re-authentication.

Should the saved session still be valid, a console-based application will be able to run.