### PR TITLE
Addendum for #43390, extra slash filtering fix

### DIFF
--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -207,6 +207,24 @@ def _parse_config_data(file_data, user, shotgun_cfg_path):
     return config_data
 
 
+def _sanitize_url(server_url):
+
+    # Then break up the url into chunks
+    tokens_parsed = urlparse.urlparse(server_url)
+
+    # Then extract the good parts from the url
+    clean_url_tokens = urlparse.ParseResult(
+        # We want https when there is no specified scheme.
+        scheme=tokens_parsed.scheme or "https",
+        # If only a host has been provided, path will be set.
+        # If a scheme was set, then use the netloc
+        netloc=tokens_parsed.netloc or tokens_parsed.path,
+        path="", params="", query="", fragment=""
+    )
+
+    return urlparse.urlunparse(clean_url_tokens)
+
+
 def sanitize_url(server_url):
     """
     Cleans up a url to that only scheme, host and optional port number remains.
@@ -222,12 +240,6 @@ def sanitize_url(server_url):
     :returns: The cleaned up URL.
     """
 
-    # First clean up any extra spaces.
-    server_url = server_url.strip()
-
-    # Then break up the url into chunks
-    parsed_url = urlparse.urlparse(server_url)
-
     # FIXME: Python 2.6.x has difficulty parsing a URL that doesn't start with a scheme when there
     # is already a port number. Python 2.7 doesn't have this issue. Ignore this bug for now since it
     # is very unlikely Shotgun will be running off a custom port.
@@ -241,17 +253,15 @@ def sanitize_url(server_url):
     # As such, when sanitizing a url, we want to keep only the scheme and
     # network location
 
-    # Then extract the good parts from the url
-    clean_url = urlparse.ParseResult(
-        # We want https when there is no specified scheme.
-        scheme=parsed_url.scheme or "https",
-        # If only a host has been provided, path will be set.
-        # If a scheme was set, then use the netloc
-        netloc=parsed_url.netloc or parsed_url.path,
-        path="", params="", query="", fragment=""
-    )
-
-    return urlparse.urlunparse(clean_url)
+    first_pass = _sanitize_url(server_url.strip())
+    # We have to do two passes here. The reason is that if you use a slash in your URL but provide
+    # no scheme, the urlparse/unparse calls will recreate the URL as is. Fortunately, when the
+    # scheme is missing we're adding in https://. At that point the url is not ambiguous anymore for
+    # urlparse/urlparse and it can split the url correctly into 
+    # - https (scheme)
+    # - test.shogunstudio.com (network location)
+    # - /... (path)
+    return _sanitize_url(first_pass)
 
 
 def get_associated_sg_base_url():

--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -207,7 +207,26 @@ def _parse_config_data(file_data, user, shotgun_cfg_path):
     return config_data
 
 
-def _sanitize_url(server_url):
+def __sanitize_url(server_url):
+    """
+    Parses a URL and makes sure it has a scheme and no extra / and path.
+
+    ..note:: Calling this method only once might yield incorrect result. Always call
+        the sanitize_url function instead.
+
+    :param str server_url: URL to clean up.
+
+    :returns: The cleaned up URL.
+    """
+
+    # The given url https://192.168.1.250:30/path?a=b is parsed such that
+    # scheme => https
+    # netloc => 192.168.1.250:30
+    # path = /path
+    # query = a=b
+
+    # As such, when sanitizing a url, we want to keep only the scheme and
+    # network location
 
     # Then break up the url into chunks
     tokens_parsed = urlparse.urlparse(server_url)
@@ -243,17 +262,7 @@ def sanitize_url(server_url):
     # FIXME: Python 2.6.x has difficulty parsing a URL that doesn't start with a scheme when there
     # is already a port number. Python 2.7 doesn't have this issue. Ignore this bug for now since it
     # is very unlikely Shotgun will be running off a custom port.
-
-    # The given url https://192.168.1.250:30/path?a=b is parsed such that
-    # scheme => https
-    # netloc => 192.168.1.250:30
-    # path = /path
-    # query = a=b
-
-    # As such, when sanitizing a url, we want to keep only the scheme and
-    # network location
-
-    first_pass = _sanitize_url(server_url.strip())
+    first_pass = __sanitize_url(server_url.strip())
     # We have to do two passes here. The reason is that if you use a slash in your URL but provide
     # no scheme, the urlparse/unparse calls will recreate the URL as is. Fortunately, when the
     # scheme is missing we're adding in https://. At that point the url is not ambiguous anymore for
@@ -261,7 +270,7 @@ def sanitize_url(server_url):
     # - https (scheme)
     # - test.shogunstudio.com (network location)
     # - /... (path)
-    return _sanitize_url(first_pass)
+    return __sanitize_url(first_pass)
 
 
 def get_associated_sg_base_url():

--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -257,7 +257,7 @@ def sanitize_url(server_url):
     # We have to do two passes here. The reason is that if you use a slash in your URL but provide
     # no scheme, the urlparse/unparse calls will recreate the URL as is. Fortunately, when the
     # scheme is missing we're adding in https://. At that point the url is not ambiguous anymore for
-    # urlparse/urlparse and it can split the url correctly into 
+    # urlparse/urlparse and it can split the url correctly into
     # - https (scheme)
     # - test.shogunstudio.com (network location)
     # - /... (path)

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -158,6 +158,16 @@ class TestGetSgConfigData(TankTestBase):
             sanitize_url("127.0.0.1")
         )
 
+        self.assertEquals(
+            "https://test.shotgunstudio.com",
+            sanitize_url("test.shotgunstudio.com/")
+        )
+
+        self.assertEquals(
+            "https://test.shotgunstudio.com",
+            sanitize_url("test.shotgunstudio.com/a")
+        )
+
         # WARNING!!!!!!
 
         # Python 2.6.x has difficulty parsing a URL that doesn't start with a scheme when there is


### PR DESCRIPTION
Fixes URL with an extra / and no scheme, like `test.shotgunstudio.com/`.