### PR TITLE
For #44135: Properly handles multi-tiered include structures in configs.

### DIFF
--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -953,7 +953,7 @@ class WritableEnvironment(InstalledEnvironment):
         if new_location_data and constants.ENVIRONMENT_LOCATION_KEY in data:
             data[constants.ENVIRONMENT_LOCATION_KEY] = new_location_data
         elif new_location_data:
-            data = new_location_data
+            data.update(new_location_data)
 
         return data
         

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -930,10 +930,10 @@ class WritableEnvironment(InstalledEnvironment):
         # In the former, the new location information is replaced at
         # the top level of the data dictionary. For the latter, the
         # location key's contents is replaced.
-        if new_location and constants.ENVIRONMENT_LOCATION_KEY in data:
-            data[constants.ENVIRONMENT_LOCATION_KEY] = new_location
-        elif new_location:
-            data = new_location
+        if new_location_data and constants.ENVIRONMENT_LOCATION_KEY in data:
+            data[constants.ENVIRONMENT_LOCATION_KEY] = new_location_data
+        elif new_location_data:
+            data = new_location_data
 
         return data
         

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -570,6 +570,8 @@ class Environment(object):
                     absolute_location,
                 )
                 bundle_tokens = [bundle_token]
+            else:
+                bundle_tokens.append(bundle_name)
         else:
             # bundle is defined in the current file
             bundle_tokens.append(bundle_name)
@@ -847,7 +849,6 @@ class WritableEnvironment(InstalledEnvironment):
             engine_data[constants.ENVIRONMENT_LOCATION_KEY] = new_location
         elif new_location:
             engine_data = new_location
-
 
         self._update_settings_recursive(engine_data, new_data)
         self.__write_data(yml_file, yml_data)

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -883,7 +883,7 @@ class WritableEnvironment(InstalledEnvironment):
         else:
             self._use_ruamel_yaml_parser = val
 
-    def _update_location_data(data, new_location_data):
+    def _update_location_data(self, data, new_location_data):
         """
         Updates the location contents of the given data dictionary
         with that contained in the given new_location_data. If the

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -391,7 +391,7 @@ class Environment(object):
             raise TankError("Failed to find the location of the '%s' engine in the '%s' environment!"
                             % (engine_name, self._env_path))
 
-        logger.debug("Engine %s found: %s", (tokens, path))
+        logger.debug("Engine %s found: %s", tokens, path)
         return tokens, path
 
     def find_framework_instances_from(self, yml_file):
@@ -490,7 +490,7 @@ class Environment(object):
             raise TankError("Failed to find the location of the '%s' framework in the '%s' environment!"
                             % (framework_name, self._env_path))
 
-        logger.debug("Framework %s found: %s", (tokens, path))
+        logger.debug("Framework %s found: %s", tokens, path)
         return tokens, path
 
     def find_location_for_app(self, engine_name, app_name):
@@ -553,7 +553,7 @@ class Environment(object):
             raise TankError("Failed to find the location of the '%s' app under the '%s' engine in the '%s' environment!"
                             % (engine_name, app_name, self._env_path))
 
-        logger.debug("App %s found: %s", (tokens, path))
+        logger.debug("App %s found: %s", tokens, path)
         return tokens, path
 
     def __find_location_for_bundle(

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -371,6 +371,12 @@ class Environment(object):
         """
         # get the raw data:
         root_yml_data = self.__load_environment_data()
+
+        logger.debug(
+            "Finding %s, absolute_location=%s...",
+            engine_name,
+            absolute_location,
+        )
         
         # find the location for the engine:
         tokens, path = self.__find_location_for_bundle(
@@ -385,6 +391,7 @@ class Environment(object):
             raise TankError("Failed to find the location of the '%s' engine in the '%s' environment!"
                             % (engine_name, self._env_path))
 
+        logger.debug("Engine %s found: %s", (tokens, path))
         return tokens, path
 
     def find_framework_instances_from(self, yml_file):
@@ -466,6 +473,11 @@ class Environment(object):
         root_yml_data = self.__load_data(fw_location)
 
         # find the location for the framework:
+        logger.debug(
+            "Finding %s, absolute_location=%s...",
+            framework_name,
+            absolute_location,
+        )
         tokens, path = self.__find_location_for_bundle(
             fw_location,
             root_yml_data,
@@ -478,6 +490,7 @@ class Environment(object):
             raise TankError("Failed to find the location of the '%s' framework in the '%s' environment!"
                             % (framework_name, self._env_path))
 
+        logger.debug("Framework %s found: %s", (tokens, path))
         return tokens, path
 
     def find_location_for_app(self, engine_name, app_name):
@@ -508,6 +521,12 @@ class Environment(object):
         :returns: (list of tokens, file path)
         :rtype: tuple
         """
+        logger.debug(
+            "Finding %s, engine_name=%s, absolute_location=%s...",
+            app_name,
+            engine_name,
+            absolute_location,
+        )
         # first, find the location of the engine:
         (engine_tokens, engine_yml_file) = self.find_location_for_engine(engine_name)
 
@@ -533,7 +552,8 @@ class Environment(object):
         if not path:
             raise TankError("Failed to find the location of the '%s' app under the '%s' engine in the '%s' environment!"
                             % (engine_name, app_name, self._env_path))
-        
+
+        logger.debug("App %s found: %s", (tokens, path))
         return tokens, path
 
     def __find_location_for_bundle(

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -267,6 +267,7 @@ def find_framework_location(file_name, framework_name, context):
     
     # return the location of the framework if we can
     return root_fw_lookup.get(framework_name) or None
+
     
 def find_reference(file_name, context, token, absolute_location=False):
     """
@@ -347,10 +348,3 @@ def find_reference(file_name, context, token, absolute_location=False):
                 found_file = include_file
 
     return (found_file, found_token)
-    
-
-
-
-
-
-

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -268,28 +268,89 @@ def find_framework_location(file_name, framework_name, context):
     # return the location of the framework if we can
     return root_fw_lookup.get(framework_name) or None
     
-def find_reference(file_name, context, token):
+def find_reference(file_name, context, token, absolute_location=False):
     """
-    Non-recursive. Looks at all include files and searches
-    for @token. Returns the file in which it is found.
+    Non-recursive unless the absolute_location argument is True. Looks at all
+    include files and searches for @token. Returns the file in which
+    it is found when absolute_location is False, and returns a tuple containing
+    the file path and the token where the data can be found.
+
+    :param str file_name: The yml file to find the reference in.
+    :param context: The context object to use when resolving includes.
+    :param str token: The token to search for.
+    :param bool absolute_location: Whether to recurse up the environment stack
+        until absolute data is found. If this is True, a tuple containing
+        the file path and token where the absolute can be found.
+
+    :returns: Tuple containing the file path where the data was found
+        and the token within the file where the data resides.
+    :rtype: tuple
     """
-    
     # load the data in 
     data = g_yaml_cache.get(file_name) or {}
     
     # first build our big fat lookup dict
     include_files = _resolve_includes(file_name, data, context)
-    
     found_file = None
-    
+    found_token = token
+
     for include_file in include_files:
-                
         # path exists, so try to read it
         included_data = g_yaml_cache.get(include_file) or {}
         
         if token in included_data:
-            found_file = include_file
-        
-    return found_file
+            # If we've been asked to ensure an absolute location, we need
+            # to do some extra work, which might involve recursing up the
+            # config stack until we get to a location descriptor dictionary.
+            if absolute_location:
+                token_data = included_data[token]
+                include_token = None
+
+                # If the value of the token is an include, then we can
+                # recurse up, directly referencing the include name as
+                # the new token.
+                if isinstance(token_data, basestring) and token_data.startswith("@"):
+                    include_token = token_data
+                else:
+                    # In the case where the data isn't itself an include,
+                    # we also need to make sure that the location descriptor
+                    # is itself not an include. If it is, then we still have
+                    # to recurse up the stack until we find the absolute
+                    # location descriptor. In that case, the location value
+                    # becomes the token we're looking for.
+                    if constants.ENVIRONMENT_LOCATION_KEY in included_data[token]:
+                        # Check to see if there's a location descriptor. If there
+                        # is then we need to check to see if that's an include.
+                        location = included_data[token][constants.ENVIRONMENT_LOCATION_KEY]
+                        if location and isinstance(location, basestring) and location.startswith("@"):
+                            include_token = location
+
+                # If we have an include we need to resolve, we take the current
+                # file where we found the include, and the included name becomes
+                # the new token we're looking for.
+                if include_token is not None:
+                    found_file, found_token = find_reference(
+                        include_file,
+                        context,
+                        include_token[1:],
+                        absolute_location=True,
+                    )
+                else:
+                    # We're at the top and we have the concrete location
+                    # descriptor. We can return the include file and token
+                    # where the data was found.
+                    found_file = include_file
+                    found_token = token
+            else:
+                # We've not been asked to resolve the absolute location, so we
+                # don't do any additional work.
+                found_file = include_file
+
+    return (found_file, found_token)
     
+
+
+
+
+
 

--- a/tests/fixtures/config/env/engine_location.yml
+++ b/tests/fixtures/config/env/engine_location.yml
@@ -1,0 +1,4 @@
+
+engine.location:
+  type: dev
+  path: '{PIPELINE_CONFIG}/config/bundles/test_app'

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -1,5 +1,7 @@
 # this is a comment at the top of the file
-include: ./empty_config.yml
+includes:
+- ./empty_config.yml
+- ./engine_location.yml
 
 frameworks:
     test_framework_v1.x.x:
@@ -10,6 +12,10 @@ frameworks:
 
 engines:
   # this is a comment after the engines section
+    test_included_engine:
+        apps: 
+        location: '@engine.location'
+
     test_engine:
         location: {'type': 'dev', 'path': '{PIPELINE_CONFIG}/config/bundles/test_engine'}
         debug_logging: false

--- a/tests/fixtures/config/env/test_post_update_new_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_new_parser.yml
@@ -1,5 +1,7 @@
 # this is a comment at the top of the file
-include: ./empty_config.yml
+includes:
+- ./empty_config.yml
+- ./engine_location.yml
 
 frameworks:
   test_framework_v1.x.x:
@@ -10,6 +12,9 @@ frameworks:
 
 engines:
   # this is a comment after the engines section
+  test_included_engine:
+    apps:
+    location: '@engine.location'
   test_engine:
     location: {type: dev, path: '{PIPELINE_CONFIG}/config/bundles/test_engine'}
     debug_logging: false

--- a/tests/fixtures/config/env/test_post_update_old_parser.yml
+++ b/tests/fixtures/config/env/test_post_update_old_parser.yml
@@ -70,8 +70,9 @@ engines:
           test_str: b
     debug_logging: false
     location: {path: '{PIPELINE_CONFIG}/config/bundles/test_engine', type: dev}
+  test_included_engine: {apps: null, location: '@engine.location'}
 frameworks:
   test_framework_v1.x.x:
     location: {path: '{PIPELINE_CONFIG}/config/bundles/test_framework', type: dev,
       version: v1.0.0}
-include: ./empty_config.yml
+includes: [./empty_config.yml, ./engine_location.yml]

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -253,7 +253,6 @@ class TestUpdateEnvironment(TankTestBase):
         cfg_after = self.env.get_app_settings("test_engine", "new_app")
         self.assertEqual(cfg_after, {})
 
-
     def test_find_included_engine_location(self):
         # In the case where we use the protected method to access the
         # absolute location of the engine's descriptor, we'll end up

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -43,7 +43,7 @@ class TestEnvironment(TankTestBase):
     def test_basic_properties(self):
         self.assertEqual(self.env.name, "test")
         # disabled engine should be skipped
-        self.assertEqual(self.env.get_engines(), ["test_engine"])
+        self.assertEqual(self.env.get_engines(), ["test_included_engine", "test_engine"])
         # disabled app should be skipped
         self.assertEqual(self.env.get_apps("test_engine"), ["test_app"])
         
@@ -252,6 +252,25 @@ class TestUpdateEnvironment(TankTestBase):
         # ensure memory was updated
         cfg_after = self.env.get_app_settings("test_engine", "new_app")
         self.assertEqual(cfg_after, {})
+
+
+    def test_find_included_engine_location(self):
+        # In the case where we use the protected method to access the
+        # absolute location of the engine's descriptor, we'll end up
+        # with the path to the engine_location.yml file, which is being
+        # included into test.yml.
+        tokens, yml_file = self.env._find_location_for_engine(
+            "test_included_engine",
+            absolute_location=True,
+        )
+        self.assertEqual(os.path.basename(yml_file), "engine_location.yml")
+
+        # In the default case, we end up with test.yml, which is where
+        # the test_included_engine instance is defined.
+        tokens, yml_file = self.env.find_location_for_engine(
+            "test_included_engine"
+        )
+        self.assertEqual(os.path.basename(yml_file), "test.yml")
     
         
     def test_update_engine_settings(self):
@@ -413,7 +432,6 @@ class TestRuamelParser(TankTestBase):
         # python, replace the FLOAT_VALUE keyword in the expected fixture
         # with whatever the current version of python is expecting
         expected_env = [l.replace("FLOAT_VALUE", repr(1.1)) for l in expected_env]
-
         self.assertEqual(updated_env, expected_env)
 
 
@@ -451,5 +469,4 @@ class TestPyYamlParser(TankTestBase):
         # python, replace the FLOAT_VALUE keyword in the expected fixture
         # with whatever the current version of python is expecting
         expected_env = [l.replace("FLOAT_VALUE", repr(1.1)) for l in expected_env]
-
         self.assertEqual(updated_env, expected_env)


### PR DESCRIPTION
The structure of the basic and default2 configs has highlighted some limitations of the `tank updates` command and how it deals with includes. In situations where multiple levels of references are used, we see the update logic replacing includes with baked-out data. This does not break the config, but it does destroy its include structure.

This attempts to do everything properly and in a backwards compatible way. There is a fair amount of inflexibility in the environment API that means this is pretty challenging. It's likely that this code is difficult to follow, but I would argue that it was before, as well, and only a significant refactor would correct that.