### PR TITLE
#44931 path cache deletions are now batched

### DIFF
--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -1150,7 +1150,6 @@ class TestPathCacheBatchDeletion(TankTestBase):
         # # now make sure it doesn't fail
         # path_cache.SQLITE_MAX_ITEMS_FOR_IN_STATEMENT = paging_limit
 
-
         record_count = list(cursor.execute("select count(*) from shotgun_status"))[0][0]
         self.assertEqual(record_count, 3148)
 

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -1095,7 +1095,7 @@ class TestPathCacheBatchDeletion(TankTestBase):
         # insert dummy data so we can delete it
         folder_ids = []
         entity_type = "Shot"
-        for idx in xrange(3000):
+        for idx in xrange(3147):
             entity_id = idx
             entity_name = "name_%s" % idx
 


### PR DESCRIPTION
if your sqlite `in` statements are too large, the query engine will fail:

```
# File "/s/apps/packages/mikrosAnim/tank/masterTkConfig/release/tkconfig/config/core/hooks/engine_init.py", line 102, in execute 
# tk.synchronize_filesystem_structure() 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/api.py", line 737, in synchronize_filesystem_structure 
# return folder.synchronize_folders(self, full_sync) 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/folder/operations.py", line 102, in synchronize_folders 
# return FolderIOReceiver.sync_path_cache(tk, full_sync) 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/folder/folder_io.py", line 71, in sync_path_cache 
# rd = path_cache.synchronize(full_sync) 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/path_cache.py", line 395, in synchronize 
# return self._do_incremental_sync(c, response[1:]) 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/path_cache.py", line 694, in _do_incremental_sync 
# self._remove_filesystem_location_entities(cursor, sg_folder_ids) 
# File "/s/apps/packages/mikrosAnim/tkCore/0.18.73.mikros.1.5/studio/install/core/python/tank/path_cache.py", line 986, in _remove_filesystem_location_entities 
# folder_ids 
# OperationalError: too many SQL variables #
```

This fix batches them up into smaller chunks to avoid this limitation.