### PR TITLE
For splat24, create fields script

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -22,6 +22,7 @@ from . import session_cache
 from .. import LogManager
 from .errors import AuthenticationError, AuthenticationCancelled
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
+from ..util.shotgun.connection import sanitize_url
 
 from getpass import getpass
 
@@ -190,4 +191,4 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
             hostname = self._get_keyboard_input("Host", hostname)
         login = self._get_keyboard_input("Login", login)
         password = self._get_password()
-        return hostname, login, password
+        return sanitize_url(hostname), login, password

--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -30,6 +30,9 @@ class DefaultsManager(object):
     If, however, you want to implement a custom behavior around how defaults
     are managed, simply derive from this class and pass your custom instance
     to the :class:`ShotgunAuthenticator` object when you construct it.
+
+    :param str fixed_host: Allows to specify the host that will be used for authentication.
+        Defaults to ``None``.
     """
 
     def __init__(self, fixed_host=None):

--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -32,16 +32,19 @@ class DefaultsManager(object):
     to the :class:`ShotgunAuthenticator` object when you construct it.
     """
 
-    def __init__(self):
+    def __init__(self, fixed_host=None):
         self._user_settings = UserSettings()
         self._system_settings = SystemSettings()
+        self._fixed_host = fixed_host
 
     def is_host_fixed(self):
         """
         When doing an interactive login, this indicates if the user can decide
         the host to connect to. In its default implementation, the :class:`DefaultsManager`
         will indicate that the host is not fixed, meaning that the user will be
-        presented with an option to pick a site at login time.
+        presented with an option to pick a site at login time, unless a default
+        host was provided during initialization. If that is the case, then this
+        method will return ``True``.
 
         With something like Toolkit, where each project already have a specific
         site association, you typically want to override this to return True,
@@ -52,7 +55,7 @@ class DefaultsManager(object):
                   to log in to, True if the host is already predetermined and cannot
                   be changed by the user.
         """
-        return False
+        return self._fixed_host is not None
 
     def get_host(self):
         """
@@ -62,16 +65,17 @@ class DefaultsManager(object):
         used to implement single sign-on between all Toolkit desktop
         applications (at the moment, tank and Shotgun Desktop).
 
-        The default implementation maintains a concept of a "current host"
-        which will be presented as a default to users when they are
-        logging in.
+        The default implementation will return the fixed host if one was provided
+        during the initialization. If fixed host was provided, the default
+        implementation maintains a concept of a "current host" which will be
+        presented as a default to users when they are logging in.
 
         When the host is fixed, this must return a value and this value will
         be used as an absolute rather than a default suggested to the user.
 
         :returns: A string containing the default host name.
         """
-        return session_cache.get_current_host() or self._user_settings.default_site
+        return self._fixed_host or session_cache.get_current_host() or self._user_settings.default_site
 
     def set_host(self, host):
         """

--- a/tests/authentication_tests/test_auth_settings.py
+++ b/tests/authentication_tests/test_auth_settings.py
@@ -199,3 +199,13 @@ class DefaultsManagerTest(TankTestBase):
             sgtk.authentication.CoreDefaultsManager,
             sgtk.util.CoreDefaultsManager
         )
+
+    @patch(
+        "tank.authentication.session_cache.get_current_host",
+        return_value=_SESSION_CACHE_HOST
+    )
+    def test_fixed_host_on_init_overrides_everything(self, _):
+        fixed_host = "https://my-custom-host.shotgunstudio.com"
+        dm = DefaultsManager(fixed_host)
+        self.assertEqual(dm.is_host_fixed(), True)
+        self.assertEqual(dm.get_host(), fixed_host)


### PR DESCRIPTION
This change was required so that a standalone script that took a site name on the command line could auto-login to the site if there is a current session.

Currently, ShotgunAuthenticator.get_user() will look for the current site and then the current user for that site. If there is a current session, it will automatically log you in.

However, in a custom script, the user will want to provide the host name on the command line and run the script. The script should be able to reuse the current credentials for that site if there are any.

By allowing to specify the default host, the implementation of ShotgunAuthenticator.get_user() can look into into any site and auto-sign in the user if there is a current session.
