### PR TITLE
Adds {test_root}/python to the PYTHONPATH when running tests.

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -238,6 +238,13 @@ if __name__ == "__main__":
 
     _initialize_logging(options.log_to_console)
 
+    # If we have a custom test root, add its python folder, if it exists, so the user doesn't need
+    # to set it up themselves.
+    if options.test_root:
+        python_test_root = os.path.join(options.test_root, "python")
+        if os.path.exists(python_test_root):
+            sys.path.insert(0, python_test_root)
+
     ret_val = _run_tests(options.test_root, test_names)
 
     if options.coverage:


### PR DESCRIPTION
When writing tests from repos outside of tk-core, we constantly need to follow this pattern of

```
test_python_path = os.path.abspath(os.path.join( os.path.dirname(__file__), "..", "python"))
sys.path.append(test_python_path)
from base_test import MyCustomTestBase
```

or edit the `PYTHONPATH` in a shell script before invoking the tests.

Since the pattern of having `tests/python` is becoming common, the testing framework will acknowledge the fact and automate the process of adding to the `PYTHONPATH`.