### PR TITLE
For #44492: Replace usage of local SG connection handle with global s…

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -118,12 +118,21 @@ class IODescriptorAppStore(IODescriptorBase):
         "sg_deprecation_message"
     ]
 
+    @property
+    def _sg_connection(self):
+        """
+        Returns a thread-safe shotgun connection handle as maintained
+        by the `util.shotgun.get_sg_connection()` method.
+        :return: SG API handle
+        """
+        return shotgun.get_sg_connection()
+
     def __init__(self, descriptor_dict, sg_connection, bundle_type):
         """
         Constructor
 
         :param descriptor_dict: descriptor dictionary describing the bundle
-        :param sg_connection: Shotgun connection to associated site
+        :param sg_connection: (ignored, no longer used) Shotgun connection to associated site
         :param bundle_type: Either Descriptor.APP, CORE, ENGINE or FRAMEWORK or CONFIG
         :return: Descriptor instance
         """
@@ -135,7 +144,6 @@ class IODescriptorAppStore(IODescriptorBase):
             optional=["label"]
         )
 
-        self._sg_connection = sg_connection
         self._type = bundle_type
         self._name = descriptor_dict.get("name")
         self._version = descriptor_dict.get("version")

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -118,15 +118,6 @@ class IODescriptorAppStore(IODescriptorBase):
         "sg_deprecation_message"
     ]
 
-    @property
-    def _sg_connection(self):
-        """
-        Returns a thread-safe shotgun connection handle as maintained
-        by the `util.shotgun.get_sg_connection()` method.
-        :return: SG API handle
-        """
-        return shotgun.get_sg_connection()
-
     def __init__(self, descriptor_dict, sg_connection, bundle_type):
         """
         Constructor

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -16,7 +16,7 @@ import urlparse
 
 from .. import constants
 from ... import LogManager
-from ...util import filesystem
+from ...util import shotgun, filesystem
 from ...util.version import is_version_newer
 from ..errors import TankDescriptorError, TankMissingManifestError
 
@@ -38,6 +38,15 @@ class IODescriptorBase(object):
     systems: There may be an app descriptor which knows how to communicate with the
     Tank App store and one which knows how to handle the local file system.
     """
+
+    @property
+    def _sg_connection(self):
+        """
+        Returns a thread-safe shotgun connection handle as maintained
+        by the `util.shotgun.get_sg_connection()` method.
+        :return: SG API handle
+        """
+        return shotgun.get_sg_connection()
 
     def __init__(self, descriptor_dict):
         """

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -66,7 +66,6 @@ class IODescriptorShotgunEntity(IODescriptorBase):
             optional=["project_id"]
         )
 
-        self._sg_connection = sg_connection
         self._entity_type = descriptor_dict.get("entity_type")
         self._name = descriptor_dict.get("name")
         self._field = descriptor_dict.get("field")


### PR DESCRIPTION
To prevent possible multi-threading issues, the SG connections should be polled from the global scope util.shotgun.get_sg_connection() helper method. The later ensures that the connection is local to the thread using it.