### PR TITLE
For # 45071: Fixes reference to self in a static function.

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -952,8 +952,8 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
                     value=x,
                     schema=value_schema,
                     bundle=bundle,
+                )
             )
-        )
 
     elif settings_type == "dict":
         items = schema.get("items", {})
@@ -999,6 +999,7 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
         processed_val = value
 
     return processed_val
+
 
 def resolve_setting_value(tk, engine_name, schema, settings, key, default, bundle=None):
     """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -898,7 +898,7 @@ class TankBundle(object):
         # config schema so we need to account for that.
         schema = self.__descriptor.configuration_schema.get(key, None)
         return resolve_setting_value(
-            self.__tk, self._get_engine_name(), schema, settings, key, default
+            self.__tk, self._get_engine_name(), schema, settings, key, default, self
         )
 
     def _get_engine_name(self):
@@ -921,7 +921,7 @@ class TankBundle(object):
         return engine_name
 
 
-def _post_process_settings_r(tk, key, value, schema):
+def _post_process_settings_r(tk, key, value, schema, bundle=None):
     """
     Recursive post-processing of settings values
 
@@ -929,22 +929,44 @@ def _post_process_settings_r(tk, key, value, schema):
     :param key: setting name
     :param value: Input value to resolve using specified schema
     :param schema: A schema defining types and defaults for settings.
+    :param bundle: The bundle object. This is only used in the case
+        the value argument is a string starting with "hook:", which
+        then requires the use of a core hook to resolve the setting.
+        If no bundle is given and this situation arises, then the
+        current bundle, as reported by sgtk.platform.current_bundle,
+        will be used.
+
     :returns: Processed value for key setting
     """
+    bundle = bundle or sgtk.platform.current_bundle()
     settings_type = schema.get("type")
 
     if settings_type == "list":
         processed_val = []
         value_schema = schema["values"]
         for x in value:
-            processed_val.append(_post_process_settings_r(tk, key, x, value_schema))
+            processed_val.append(
+                _post_process_settings_r(
+                    tk=tk,
+                    key=key,
+                    value=x,
+                    schema=value_schema,
+                    bundle=bundle,
+            )
+        )
 
     elif settings_type == "dict":
         items = schema.get("items", {})
         # note - we assign the original values here because we
         processed_val = value
         for (key, value_schema) in items.iteritems():
-            processed_val[key] = _post_process_settings_r(tk, key, value[key], value_schema)
+            processed_val[key] = _post_process_settings_r(
+                tk=tk,
+                key=key,
+                value=value[key],
+                schema=value_schema,
+                bundle=bundle,
+            )
 
     elif settings_type == "config_path":
         # this is a config path. Stored on the form
@@ -969,7 +991,7 @@ def _post_process_settings_r(tk, key, value, schema):
         hook_name = chunks[1]
         params = chunks[2:]
         processed_val = tk.execute_core_hook(
-            hook_name, setting=key, bundle_obj=self, extra_params=params
+            hook_name, setting=key, bundle_obj=bundle, extra_params=params
         )
 
     else:
@@ -978,7 +1000,7 @@ def _post_process_settings_r(tk, key, value, schema):
 
     return processed_val
 
-def resolve_setting_value(tk, engine_name, schema, settings, key, default):
+def resolve_setting_value(tk, engine_name, schema, settings, key, default, bundle=None):
     """
     Resolve a setting value.  Exposed to allow values to be resolved for
     settings derived outside of the app.
@@ -991,6 +1013,11 @@ def resolve_setting_value(tk, engine_name, schema, settings, key, default):
     :param dict settings: the settings dictionary source
     :param str key: setting name
     :param default: a default value to use for the setting
+    :param bundle: The bundle object. This is only used in situations where
+        a setting's value must be resolved via calling a hook. If None, the
+        current bundle, as provided by sgtk.platform.current_bundle, will
+        be used.
+
     :returns: Resolved value of input setting key
     """
     # Get the value for the supplied key
@@ -1011,7 +1038,7 @@ def resolve_setting_value(tk, engine_name, schema, settings, key, default):
     # We have a value of some kind and a schema. Allow the post
     # processing code to further resolve the value.
     if value and schema:
-        value = _post_process_settings_r(tk, key, value, schema)
+        value = _post_process_settings_r(tk, key, value, schema, bundle)
 
     return value
 

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -35,6 +35,10 @@ configuration:
     test_template:
         type: template
         required_fields: [name,version]
+
+    test_template_hook:
+        type: template
+        default_value: "hook:template_setting_resolution"
     
     test_hook_std:
         type: hook

--- a/tests/fixtures/config/core/hooks/template_setting_resolution.py
+++ b/tests/fixtures/config/core/hooks/template_setting_resolution.py
@@ -14,6 +14,7 @@ Test hook.
 
 from tank import Hook
 
+
 class TemplateSettingHook(Hook):
     def execute(self, **kwargs):
         return "12345"

--- a/tests/fixtures/config/core/hooks/template_setting_resolution.py
+++ b/tests/fixtures/config/core/hooks/template_setting_resolution.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Test hook.
+"""
+
+from tank import Hook
+
+class TemplateSettingHook(Hook):
+    def execute(self, **kwargs):
+        return "12345"

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -168,6 +168,9 @@ class TestGetSetting(TestApplication):
         tmpl = self.app.get_template("test_template")
         self.assertEqual("maya_publish_name", tmpl.name)
         self.assertIsInstance(tmpl, Template)
+
+        # Also ensure that we can define a template via core hook.
+        self.assertEqual("12345", self.app.get_setting("test_template_hook"))
         
         # test resource
         self.assertEqual(self.test_resource, self.app.get_setting("test_icon"))


### PR DESCRIPTION
In bundle.py, we have logic for resolving template-type settings for bundles that can have a hook defined as their value. In this situation, the referenced core hook is called, which will then return the value for the setting.

During the major refactoring work that came about as part of the zero config project, one of the bundle instance methods was converted to be a static function. The regression occurs as a result of a lingering reference to "self" in the now-static function. The fix is to default to the current bundle, but offer the option of passing in a bundle object explicitly.