### PR TITLE
Path cache indices and page size tweaks

### DIFF
--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -113,7 +113,14 @@ class PathCache(object):
             
             if len(table_names) == 0:
                 # we have a brand new database. Create all tables and indices
+
+                # note that because some clients are writing to NFS storage, we
+                # up the default page size somewhat (from 4k -> 8k) to improve
+                # performance. See https://sqlite.org/pragma.html#pragma_page_size
+
                 c.executescript("""
+                    PRAGMA page_size=8192;
+
                     CREATE TABLE path_cache (entity_type text, entity_id integer, entity_name text, root text, path text, primary_entity integer);
                 
                     CREATE INDEX path_cache_entity ON path_cache(entity_type, entity_id);
@@ -127,6 +134,8 @@ class PathCache(object):
                     CREATE TABLE shotgun_status (path_cache_id integer, shotgun_id integer);
                     
                     CREATE UNIQUE INDEX shotgun_status_id ON shotgun_status(path_cache_id);
+
+                    CREATE INDEX shotgun_status_shotgun_id ON shotgun_status(shotgun_id);
                     """)
                 self._connection.commit()
                 


### PR DESCRIPTION
Path cache performance tweaks based on client feedback to better the handle the case when people have a large number (500k+) of path cache entries:

- This adds a new path cache index to improve lookups when deleting path cache records.
- Also cranks up the paging to 8k (see https://sqlite.org/pragma.html#pragma_page_size) in order to improve I/O when there is a large volume of queries to commit and the path cache is stored on networked storage.