### PR TITLE
For #43140: Makes SystemSettings a singleton.

### DIFF
--- a/python/tank/util/system_settings.py
+++ b/python/tank/util/system_settings.py
@@ -15,11 +15,22 @@ System settings management.
 
 import urllib
 
+from .singleton import Singleton
+from .. import LogManager
 
-class SystemSettings(object):
+logger = LogManager.get_logger(__name__)
+
+
+class SystemSettings(Singleton):
     """
     Handles loading the system settings.
     """
+
+    def _init_singleton(self):
+        """
+        Singleton initialization.
+        """
+        logger.debug("OS http proxy: %s", self.http_proxy)
 
     @property
     def http_proxy(self):


### PR DESCRIPTION
This class should be a singleton, and it also gives us a convenient location to log the OS http proxy from.

`DEBUG [15:45:44 802.000045776]: OS http proxy: None`

```
>>> sgtk.util.system_settings.SystemSettings() is sgtk.util.system_settings.SystemSettings()
True
>>>
```