### PR TITLE
#44757: Updated descriptor docs

### DIFF
--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -81,8 +81,13 @@ Several different descriptor types are supported by Toolkit:
 - A **manual** descriptor gives raw access to the bundle caching structure
 
 The descriptor API knows how to access and locally cache each of the types above.
+Descriptors that are downloaded (cached) to the local disk are called **downloadable** descriptors.
 You can control the location where the API caches items and supply additional lookup
 locations if you want to pre-bake your own collection of caches.
+
+Alternatively, you can set the ``SHOTGUN_BUNDLE_CACHE_PATH`` environment variable to
+a cache path on disk. This override could help facilitate workflows that require a
+centralized disk location to which the descriptors are cached.
 
 App store
 ============

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -66,6 +66,10 @@ pre-cache an environment for your studio or distribute a set of app and engine
 versions as an installable package that require no further retrieval in order
 to function.
 
+Alternatively, you can set the ``SHOTGUN_BUNDLE_CACHE_PATH`` environment variable to
+a cache path on disk. This override helps facilitate workflows that require a
+centralized disk location to which the descriptors are cached.
+
 Descriptor types
 ----------------------------------------
 
@@ -81,13 +85,11 @@ Several different descriptor types are supported by Toolkit:
 - A **manual** descriptor gives raw access to the bundle caching structure
 
 The descriptor API knows how to access and locally cache each of the types above.
-Descriptors that are downloaded (cached) to the local disk are called **downloadable** descriptors.
 You can control the location where the API caches items and supply additional lookup
 locations if you want to pre-bake your own collection of caches.
-
-Alternatively, you can set the ``SHOTGUN_BUNDLE_CACHE_PATH`` environment variable to
-a cache path on disk. This override could help facilitate workflows that require a
-centralized disk location to which the descriptors are cached.
+Descriptors that are downloaded (cached) to the local disk are called **downloadable** descriptors.
+The **app_store**, **shotgun**, **git** and **git_branch** descriptors are downloadable descriptors,
+while the **path**, **dev** and **manual** descriptors are accessed directly from the specified path.
 
 App store
 ============


### PR DESCRIPTION
Updated the docs to include information about the SHOTGUN_BUNDLE_CACHE_PATH environment variable and downloadable descriptors.
