### PR TITLE
44140 add toolkit ability to prevent internet connection

### DIFF
--- a/python/tank/descriptor/constants.py
+++ b/python/tank/descriptor/constants.py
@@ -81,3 +81,6 @@ APP_STORE_HTTP_PROXY = "app_store_http_proxy"
 
 # environment variable used to indicate the primary bundle cache path to be used.
 BUNDLE_CACHE_PATH_ENV_VAR = "SHOTGUN_BUNDLE_CACHE_PATH"
+
+# environment variable used to disable connection to the app store
+DISABLE_APPSTORE_ACCESS_ENV_VAR = "SHOTGUN_DISABLE_APPSTORE_ACCESS"

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -853,6 +853,10 @@ class IODescriptorAppStore(IODescriptorDownloadable):
 
         :return: True if a remote is accessible, false if not.
         """
+        # check whether we're asked to bypass app store connection
+        if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
+            return False
+
         # check if we can connect to Shotgun
         can_connect = True
         try:

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -726,7 +726,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
                 else:
                     raise
 
-            log.debug("Connecting to %s..." % constants.SGTK_APP_STORE)
+            log.info("NICOLAS: Connecting to %s..." % constants.SGTK_APP_STORE)
             # Connect to the app store and resolve the script user id we are connecting with.
             # Set the timeout explicitly so we ensure the connection won't hang in cases where
             # a response is not returned in a reasonable amount of time.
@@ -855,6 +855,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         """
         # check whether we're asked to bypass app store connection
         if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
+            log.info("NICOLAS: %s is set active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR)
             return False
 
         # check if we can connect to Shotgun

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -704,8 +704,8 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         # and shotgun sites.
 
         if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
-            message = "NICOLAS: %s is active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR
-            log.info(message)
+            message = "The '%s' environment variable is active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR
+            log.debug(message)
             raise TankAppStoreConnectionError(message)
 
         sg_url = self._sg_connection.base_url
@@ -732,7 +732,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
                 else:
                     raise
 
-            log.info("NICOLAS: Connecting to %s..." % constants.SGTK_APP_STORE)
+            log.debug("Connecting to %s..." % constants.SGTK_APP_STORE)
             # Connect to the app store and resolve the script user id we are connecting with.
             # Set the timeout explicitly so we ensure the connection won't hang in cases where
             # a response is not returned in a reasonable amount of time.
@@ -861,7 +861,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         """
         # check whether we're asked to bypass app store connection
         if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
-            log.info("NICOLAS: %s is set active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR)
+            log.info("The '%s' environment variable %s is set active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR)
             return False
 
         # check if we can connect to Shotgun

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -859,10 +859,6 @@ class IODescriptorAppStore(IODescriptorDownloadable):
 
         :return: True if a remote is accessible, false if not.
         """
-        # check whether we're asked to bypass app store connection
-        if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
-            log.info("The '%s' environment variable %s is set active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR)
-            return False
 
         # check if we can connect to Shotgun
         can_connect = True

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -702,6 +702,12 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         # this assumes that there is a strict
         # 1:1 relationship between app store accounts
         # and shotgun sites.
+
+        if os.environ.get(constants.DISABLE_APPSTORE_ACCESS_ENV_VAR, "0") == "1":
+            message = "NICOLAS: %s is active, preventing connection to app store." % constants.DISABLE_APPSTORE_ACCESS_ENV_VAR
+            log.info(message)
+            raise TankAppStoreConnectionError(message)
+
         sg_url = self._sg_connection.base_url
 
         if sg_url not in self._app_store_connections:

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -289,8 +289,8 @@ class TestAppStoreConnectivity(TankTestBase):
         self.assertEqual(mock.call_count, 0)
 
     #@patch("tank_vendor.shotgun_api3.Shotgun._http_request")
-    @patch("urllib2.urlopen")
     @patch("tank_vendor.shotgun_api3.Shotgun")
+    @patch("urllib2.urlopen")
     def test_disabling_access_to_app_store(self, urlopen_mock, shotgun_mock):
         """
         Tests that we can prevent connection to the app store based on usage

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -22,8 +22,6 @@ from mock import patch
 from tank_test.tank_test_base import TankTestBase, setUpModule
 
 import sgtk
-import tank
-import urllib2
 from sgtk.descriptor import Descriptor
 from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.descriptor.descriptor import create_descriptor
@@ -327,7 +325,6 @@ class TestAppStoreConnectivity(TankTestBase):
 
             return MockResponse(None, 404)
 
-
         def shotgun_mock_impl(*args, **kwargs):
             """
             Mocking up shotgun_api3.Shotgun() constructor.
@@ -362,7 +359,3 @@ class TestAppStoreConnectivity(TankTestBase):
         # Test present inactive (again)
         os.environ[env_var_name] = "0"
         self._helper_test_disabling_access_to_app_store(shotgun_mock, True)
-
-
-
-

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -288,7 +288,6 @@ class TestAppStoreConnectivity(TankTestBase):
         mock.reset_mock()
         self.assertEqual(mock.call_count, 0)
 
-    #@patch("tank_vendor.shotgun_api3.Shotgun._http_request")
     @patch("tank_vendor.shotgun_api3.Shotgun")
     @patch("urllib2.urlopen")
     def test_disabling_access_to_app_store(self, urlopen_mock, shotgun_mock):
@@ -299,7 +298,7 @@ class TestAppStoreConnectivity(TankTestBase):
         def urlopen_mock_impl(*args, **kwargs):
             """
             Necessary mock so we can pass beyond:
-            - appstore.IODescriptorAppStore.has_remote_access()`
+            - appstore.IODescriptorAppStore.has_remote_access()
                 - appstore.IODescriptorAppStore.__create_sg_app_store_connection()
                     - appstore.IODescriptorAppStore.__get_app_store_key_from_shotgun()
             """
@@ -336,6 +335,9 @@ class TestAppStoreConnectivity(TankTestBase):
         shotgun_mock.side_effect = shotgun_mock_impl
         urlopen_mock.side_effect = urlopen_mock_impl
 
+        # NOTE: We're not using the tank.descriptor.constants.DISABLE_APPSTORE_ACCESS_ENV_VAR
+        # constant so we can independently tests that the name of the used environment
+        # variable did not change.
         env_var_name = "SHOTGUN_DISABLE_APPSTORE_ACCESS"
 
         # Test without the environment variable being present

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -298,14 +298,19 @@ class TestAppStoreConnectivity(TankTestBase):
         def urlopen_mock_impl(*args, **kwargs):
             """
             Necessary mock so we can pass beyond:
-            - appstore.IODescriptorAppStore.has_remote_access()
-                - appstore.IODescriptorAppStore.__create_sg_app_store_connection()
-                    - appstore.IODescriptorAppStore.__get_app_store_key_from_shotgun()
+            - `
+                - `appstore.IODescriptorAppStore.__create_sg_app_store_connection()`
+                    - appstore.IODescriptorAppStore.__get_app_store_key_from_shotgun()`
+
+            Otherwise the code would always cause an exception that is caught by the
+            the `appstore.IODescriptorAppStore.has_remote_access()` except statement
+            which causes the method to return False all of the time which then
+            prevents execution of the code of interest.
             """
 
             class MockResponse:
                 """
-                Custom mocked reponse to allow successful execution of the
+                Custom mocked response to allow successful execution of the
                 `appstore.IODescriptorAppStore.__get_app_store_key_from_shotgun()` method.
                 """
                 def __init__(self, json_data, status_code):
@@ -326,9 +331,9 @@ class TestAppStoreConnectivity(TankTestBase):
         def shotgun_mock_impl(*args, **kwargs):
             """
             Mocking up shotgun_api3.Shotgun() constructor.
-            We're not really interrested in mocking what it does but really just verify
-            whether it gets called as an instance of the class is created in the process
-            of creating an app store connection in from the `has_remote_access` method.
+            We're not really interested in mocking what it does as much as
+            verifying whether or not an instance is created from calling the
+            `appstore.IODescriptorAppStore.has_remote_access()` method.
             """
             pass
 


### PR DESCRIPTION
From manual testing and usage of a packet capture utility I was NOT able to confirm that no additional Internet connections is made other than connections to the main SG site. Once I filtered out the obvious, what remained was at least connections to 2-3 remote machines. Although, usage of the new environment variable did prevent some connection to SG app store, I would still see some connections to some AWS machine which, I believe, relates to SG App Store.

I've tried setting up my own local SG server, I could then disconnect network adapters entirely but  whether or not I was using the new environment variable did not changed anything (beside maybe a few log file messages ) I suspected that my local installation of SG was not 100% complete and was missing at least some setup relating to AWS ( which seems to relate to SG App Store)

I let you decide whether or not this is sufficient.

 