### PR TITLE
SPLAT-83: Stubs for get_session_path() and get_session_dependencies()

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1414,26 +1414,32 @@ class Engine(TankBundle):
             self.__qt_debug_info[widget.__repr__()] = weakref.ref(widget)
 
     ##########################################################################################
-    # scene management methods
+    # session management methods
 
     def get_session_path(self, session=None):
         """
-        Returns the path to the file associated with the currently open session
-        if it resides on disk. If unsaved, it returns None.
+        Returns an absolute path to the file associated with the active session
+        if it resides on disk, else returns an empty string.
 
-        :param session: An object representing the active document.
+        :param session: An object representing the active document
                         (for MDI applications).
-        :return: A path to the current file if it resides on disk, else None.
+        :returns: A path to the current file if it resides on disk, else an empty
+                  string.
+        :raises NotImplementedError: If not overridden in the derived class,
+                                     this method will raise a NotImplementedError.
         """
         raise NotImplementedError
 
     def get_session_dependencies(self, session=None):
         """
-        Returns a list of file or folder paths constituting the session's dependencies.
+        Returns a list of file or folder paths constituting the active
+        session's dependencies.
 
-        :param session: An object representing the active document.
+        :param session: An object representing the active document
                         (for MDI applications).
-        :return: A list of file or folder paths constituting the session's dependencies.
+        :returns: A list of file or folder paths constituting the session's dependencies.
+        :raises NotImplementedError: If not overridden in the derived class,
+                                     this method will raise a NotImplementedError.
         """
         raise NotImplementedError
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1400,7 +1400,7 @@ class Engine(TankBundle):
     def get_debug_tracked_qt_widgets(self):
         """
         Returns a dictionary of debug info about created Qt dialogs and widgets.
-        
+
         The keys of the dictionary are the string representation of a widget and the 
         corresponding value is a reference to that widget.
         """
@@ -1412,7 +1412,29 @@ class Engine(TankBundle):
         """
         if widget:
             self.__qt_debug_info[widget.__repr__()] = weakref.ref(widget)
-        
+
+    ##########################################################################################
+    # scene management methods
+
+    def get_session_path(self, session=None):
+        """
+        Returns the path to the file associated with the currently open session
+        if it resides on disk. If unsaved, it returns None.
+
+        :param session: An object to the active document (for MDI applications).
+        :return: A path to the current file if it resides on disk, else None.
+        """
+        raise NotImplementedError
+
+    def get_session_dependencies(self, session=None):
+        """
+        Returns a list of file or folder paths constituting the session's dependencies.
+
+        :param session: An object to the active document (for MDI applications).
+        :return: A list of file or folder paths constituting the session's dependencies.
+        """
+        raise NotImplementedError
+
     ##########################################################################################
     # private and protected methods
 
@@ -1646,7 +1668,7 @@ class Engine(TankBundle):
         :param bundle: The app, engine or framework object that is associated with this window
         :param widget_class: The class of the UI to be constructed. This must derive from QWidget.
         :type widget_class: :class:`PySide.QtGui.QWidget`
-            
+
         Additional parameters specified will be passed through to the widget_class constructor.
         """
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1435,44 +1435,40 @@ class Engine(TankBundle):
     ##########################################################################################
     # session management methods
 
-    def get_session_path(self, session=None):
+    def get_session_path(self):
         """
-        Returns the absolute path of the current file if it resides
+        Returns the absolute path of the current session if it resides
         on disk. If the session has never been saved and isn't
         associated with a file on disk yet, an empty string is returned.
 
-        :param session: An object representing the active document
-                        (for MDI applications).
-        :returns: The absolute path to the current file if it resides on
-                  disk, else returns an empty string.
+        :returns: The absolute path to the current session if it resides on
+                  disk, else returns None.
         :raises TankError: If the session being referred to is invalid or
                            cannot be determined, this method will raise a
                            TankError.
         :raises NotImplementedError: If not overridden in the derived class,
-                             this method will raise a NotImplementedError.
+                                     this method raises a NotImplementedError.
         """
         raise NotImplementedError
 
-    def get_session_dependencies(self, session=None):
+    def get_session_dependencies(self):
         """
         Returns a list of file dependencies for the current session.
 
-        :param session: An object representing the active document
-                        (for MDI applications).
         :returns: A list of file dependencies required to load
                   the session. The data returned is of the form:
                   [
-                    {"path": "/foo/bar/hello.%04d.jpeg",
-                     "engine": "tk-engine",
-                     "type": "type1"
+                    {"path": "/foo/bar/hello.jpeg",
+                     "engine": "tk-maya",
+                     "type": "reference"
                      },
                     {"path": "/foo/bar/hello.obj",
-                     "engine": "tk-engine",
-                     "type": "type2"
+                     "engine": "tk-maya",
+                     "type": "file"
                      },
                   ]
         :raises NotImplementedError: If not overridden in the derived class,
-                                     this method will raise a NotImplementedError.
+                                     this method raises a NotImplementedError.
         """
         raise NotImplementedError
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1421,7 +1421,8 @@ class Engine(TankBundle):
         Returns the path to the file associated with the currently open session
         if it resides on disk. If unsaved, it returns None.
 
-        :param session: An object to the active document (for MDI applications).
+        :param session: An object representing the active document.
+                        (for MDI applications).
         :return: A path to the current file if it resides on disk, else None.
         """
         raise NotImplementedError
@@ -1430,7 +1431,8 @@ class Engine(TankBundle):
         """
         Returns a list of file or folder paths constituting the session's dependencies.
 
-        :param session: An object to the active document (for MDI applications).
+        :param session: An object representing the active document.
+                        (for MDI applications).
         :return: A list of file or folder paths constituting the session's dependencies.
         """
         raise NotImplementedError

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1418,26 +1418,40 @@ class Engine(TankBundle):
 
     def get_session_path(self, session=None):
         """
-        Returns an absolute path to the file associated with the active session
-        if it resides on disk, else returns an empty string.
+        Returns the absolute path of the current file if it resides
+        on disk. If the session has never been saved and isn't
+        associated with a file on disk yet, an empty string is returned.
 
         :param session: An object representing the active document
                         (for MDI applications).
-        :returns: A path to the current file if it resides on disk, else an empty
-                  string.
+        :returns: The absolute path to the current file if it resides on
+                  disk, else returns an empty string.
+        :raises TankError: If the session being referred to is invalid or
+                           cannot be determined, this method will raise a
+                           TankError.
         :raises NotImplementedError: If not overridden in the derived class,
-                                     this method will raise a NotImplementedError.
+                             this method will raise a NotImplementedError.
         """
         raise NotImplementedError
 
     def get_session_dependencies(self, session=None):
         """
-        Returns a list of file or folder paths constituting the active
-        session's dependencies.
+        Returns a list of file dependencies for the current session.
 
         :param session: An object representing the active document
                         (for MDI applications).
-        :returns: A list of file or folder paths constituting the session's dependencies.
+        :returns: A list of file dependencies required to load
+                  the session. The data returned is of the form:
+                  [
+                    {"path": "/foo/bar/hello.%04d.jpeg",
+                     "engine": "tk-engine",
+                     "type": "type1"
+                     },
+                    {"path": "/foo/bar/hello.obj",
+                     "engine": "tk-engine",
+                     "type": "type2"
+                     },
+                  ]
         :raises NotImplementedError: If not overridden in the derived class,
                                      this method will raise a NotImplementedError.
         """

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1438,8 +1438,8 @@ class Engine(TankBundle):
     def get_session_path(self):
         """
         Returns the absolute path of the current session if it resides
-        on disk. If the session has never been saved and isn't
-        associated with a file on disk yet, an empty string is returned.
+        on disk. If the session has never been saved and isn't associated
+        with a file on disk yet, None is returned.
 
         :returns: The absolute path to the current session if it resides on
                   disk, else returns None.


### PR DESCRIPTION
Adds stubs for the following methods:
* get_session_path() - (Not implemented) Method that returns the path associated with the current session.
* get_session_dependencies() - (Not implemented) Method that returns the file path dependencies of the file.

Linked with: https://github.com/shotgunsoftware/tk-maya/pull/60