### PR TITLE
For #43813: Toggling the global debug state sets TK_DEBUG in the environment.

### DIFF
--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -525,7 +525,7 @@ class LogManager(object):
             #
             # We don't want subprocesses of this process to spawn with
             # logging on. An example of where this is useful is in the
-            # comment above, where the case of tk-desktop is outlined.
+            # comment below, where the case of tk-desktop is outlined.
             if constants.DEBUG_LOGGING_ENV_VAR in os.environ:
                 log.debug(
                     "Removing %s from the environment for this session. This "

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -519,6 +519,22 @@ class LogManager(object):
         """
         Sets the state of the global debug in toolkit.
         """
+        if not state:
+            # This needs to be logged before we turn off the global
+            # debug logging.
+            #
+            # We don't want subprocesses of this process to spawn with
+            # logging on. An example of where this is useful is in the
+            # comment above, where the case of tk-desktop is outlined.
+            if constants.DEBUG_LOGGING_ENV_VAR in os.environ:
+                log.debug(
+                    "Removing %s from the environment for this session. This "
+                    "ensures that subprocesses spawned from this process will "
+                    "inherit the global debug logging setting from this process.",
+                    constants.DEBUG_LOGGING_ENV_VAR
+                )
+                del os.environ[constants.DEBUG_LOGGING_ENV_VAR]
+
         self._global_debug = state
         if self._global_debug:
             new_log_level = logging.DEBUG
@@ -542,6 +558,9 @@ class LogManager(object):
                 "Debug logging enabled. To permanently enable it, "
                 "set the %s environment variable." % constants.DEBUG_LOGGING_ENV_VAR
             )
+            # This needs to be logged after the global debug has been
+            # turned on, which is why it is happening last.
+            #
             # Setting the environment variable for this session will
             # mean that any subprocesses spawned will inherit debug
             # logging from this process. A good example of where this
@@ -557,18 +576,6 @@ class LogManager(object):
                 constants.DEBUG_LOGGING_ENV_VAR
             )
             os.environ[constants.DEBUG_LOGGING_ENV_VAR] = "1"
-        else:
-            # We don't want subprocesses of this process to spawn with
-            # logging on. An example of where this is useful is in the
-            # comment above, where the case of tk-desktop is outlined.
-            if constants.DEBUG_LOGGING_ENV_VAR in os.environ:
-                log.debug(
-                    "Removing %s from the environment for this session. This "
-                    "ensures that subprocesses spawned from this process will "
-                    "inherit the global debug logging setting from this process.",
-                    constants.DEBUG_LOGGING_ENV_VAR
-                )
-                del os.environ[constants.DEBUG_LOGGING_ENV_VAR]
 
     def _get_global_debug(self):
         """

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -542,6 +542,33 @@ class LogManager(object):
                 "Debug logging enabled. To permanently enable it, "
                 "set the %s environment variable." % constants.DEBUG_LOGGING_ENV_VAR
             )
+            # Setting the environment variable for this session will
+            # mean that any subprocesses spawned will inherit debug
+            # logging from this process. A good example of where this
+            # is advantageous is in tk-desktop, where we provide a
+            # menu action to toggle debug logging. When it is toggled
+            # on, we set the env var here, which then means that when
+            # a user navigates to a project in SG Desktop, the Python
+            # subprocess spawned will also have debug logging active.
+            log.debug(
+                "Setting %s in the environment for this session. This "
+                "ensures that subprocesses spawned from this process will "
+                "inherit the global debug logging setting from this process.",
+                constants.DEBUG_LOGGING_ENV_VAR
+            )
+            os.environ[constants.DEBUG_LOGGING_ENV_VAR] = "1"
+        else:
+            # We don't want subprocesses of this process to spawn with
+            # logging on. An example of where this is useful is in the
+            # comment above, where the case of tk-desktop is outlined.
+            if constants.DEBUG_LOGGING_ENV_VAR in os.environ:
+                log.debug(
+                    "Removing %s from the environment for this session. This "
+                    "ensures that subprocesses spawned from this process will "
+                    "inherit the global debug logging setting from this process.",
+                    constants.DEBUG_LOGGING_ENV_VAR
+                )
+                del os.environ[constants.DEBUG_LOGGING_ENV_VAR]
 
     def _get_global_debug(self):
         """

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -133,9 +133,6 @@ UNMANAGED_PIPELINE_CONFIG_NAME = "Unmanaged"
 # the shotgun engine always has this name
 SHOTGUN_ENGINE_NAME = "tk-shotgun"
 
-# the desktop engine always has this name
-DESKTOP_ENGINE_NAME = "tk-desktop"
-
 # Shotgun: The entity that represents Pipeline Configurations in Shotgun
 # (defined here for backwards compatibility with the admin-ui framework)
 PIPELINE_CONFIGURATION_ENTITY = "PipelineConfiguration"

--- a/python/tank/platform/constants.py
+++ b/python/tank/platform/constants.py
@@ -133,6 +133,9 @@ UNMANAGED_PIPELINE_CONFIG_NAME = "Unmanaged"
 # the shotgun engine always has this name
 SHOTGUN_ENGINE_NAME = "tk-shotgun"
 
+# the desktop engine always has this name
+DESKTOP_ENGINE_NAME = "tk-desktop"
+
 # Shotgun: The entity that represents Pipeline Configurations in Shotgun
 # (defined here for backwards compatibility with the admin-ui framework)
 PIPELINE_CONFIGURATION_ENTITY = "PipelineConfiguration"

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -207,9 +207,23 @@ class Engine(TankBundle):
         # point we want to try and have all app initialization complete.
         self.__run_post_engine_inits()
 
-        if self.name not in [constants.SHELL_ENGINE_NAME, constants.SHOTGUN_ENGINE_NAME] \
-                and self.__has_018_logging_support():
+        # The Desktop engine provides its own advanced menu toggle for
+        # debug logging. For the Shotgun engine, we don't want to provide
+        # a debug logging toggle for browser integration. Instead, that
+        # will follow the global debug state, or that managed by the Desktop
+        # engine. For the shell engine, it doesn't make sense to have an
+        # engine command registered for something like toggling debug
+        # logging. If the user wants to control that in the shell, they
+        # either do that with the TK_DEBUG environment variable, or by
+        # setting the state in the LogManager directly if they're running
+        # in tank shell.
+        no_debug_toggle_engines = [
+            constants.DESKTOP_ENGINE_NAME,
+            constants.SHELL_ENGINE_NAME,
+            constants.SHOTGUN_ENGINE_NAME,
+        ]
 
+        if self.name not in no_debug_toggle_engines and self.__has_018_logging_support():
             # if engine supports new logging implementation,
             #
             # we cannot add the 'toggle debug logging' for

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import copy
+
+import sgtk
+from tank_test.tank_test_base import *
+
+class TestLogManager(TankTestBase):
+    """Tests the LogManager interface."""
+    def test_global_debug_environment(self):
+        """
+        Ensures that the debug logging environment variable is set/unset when
+        the global debug logging property is toggled.
+        """
+        manager = sgtk.log.LogManager()
+        original_env = copy.copy(os.environ)
+        original_debug = manager.global_debug
+        debug_name = sgtk.constants.DEBUG_LOGGING_ENV_VAR
+
+        try:
+            if debug_name in os.environ:
+                del os.environ[debug_name]
+
+            manager.global_debug = True
+            self.assertTrue((debug_name in os.environ))
+
+            manager.global_debug = False
+            self.assertTrue((debug_name not in os.environ))
+        finally:
+            manager.global_debug = original_debug
+            os.environ = original_env

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -12,7 +12,9 @@ import os
 import copy
 
 import sgtk
-from tank_test.tank_test_base import *
+
+from tank_test.tank_test_base import setUpModule # noqa
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestLogManager(TankTestBase):

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -12,7 +12,8 @@ import os
 import copy
 
 import sgtk
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
+
 
 class TestLogManager(TankTestBase):
     """Tests the LogManager interface."""

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -12,7 +12,7 @@ import os
 import copy
 
 import sgtk
-from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import *
 
 
 class TestLogManager(TankTestBase):
@@ -32,10 +32,10 @@ class TestLogManager(TankTestBase):
                 del os.environ[debug_name]
 
             manager.global_debug = True
-            self.assertTrue((debug_name in os.environ))
+            self.assertIn(debug_name, os.environ)
 
             manager.global_debug = False
-            self.assertTrue((debug_name not in os.environ))
+            self.assertNotIn(debug_name, os.environ)
         finally:
             manager.global_debug = original_debug
             os.environ = original_env


### PR DESCRIPTION
* The intent is to ensure that any subprocesses spawned that make use of SGTK will inherit the global debug logging setting from the current process. A concrete use case is in tk-desktop, where we want toggling of the global debug state to cause any DCC launches to start with the same debug logging state.

* The tk-desktop engine no longer receives a debug toggle engine command. The engine itself provides this toggling capability from its advanced menu provided by desktop_window.py.