### PR TITLE
For #43297: Adds support for env vars for python interpreter paths on Windows.

### DIFF
--- a/scripts/tank_cmd.bat
+++ b/scripts/tank_cmd.bat
@@ -32,6 +32,9 @@ rem -- now get path to python interpreter by reading config file
 rem -- 'usebackq' is used to allow quoting of the path which could potentially contain spaces
 rem -- 'tokens=*' is used to ensure each line of the file doesn't get split on whitespace
 for /f "usebackq tokens=*" %%G in ("%INTERPRETER_CONFIG_FILE%") do (SET PYTHON_INTERPRETER=%%G)
+rem -- flatten any environment variables that might be contained within the path.
+rem -- https://stackoverflow.com/questions/28115337/how-to-expand-environment-variable-inside-string-read-from-file
+call set "PYTHON_INTERPRETER=%PYTHON_INTERPRETER%"
 IF NOT EXIST "%PYTHON_INTERPRETER%" GOTO NO_INTERPRETER
 
 rem -- execute the python script which does the actual work.


### PR DESCRIPTION
If an environment variable is used in an interpreter_windows.cfg file in a config, they will now be flattened out by tank_cmd.bat.