### PR TITLE
43890 unit tests leave lot of stuff behind

### DIFF
--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -36,6 +36,10 @@ class InteractiveTests(TankTestBase):
             self._app = QtGui.QApplication(sys.argv)
         super(InteractiveTests, self).setUp()
 
+    def tearDown(self):
+        # Allows deletion of context tmp folder created by TankTestBase.setUpModule (global scope)
+        super(TankTestBase.TestCase, self).tearDown()
+
     def test_site_and_user_disabled_on_session_renewal(self):
         """
         Make sure that the site and user fields are disabled when doing session renewal
@@ -302,3 +306,8 @@ class InteractiveTests(TankTestBase):
 
 # Class decorators don't exist on Python2.5
 InteractiveTests = skip_if_pyside_missing(InteractiveTests)
+
+def tearDownModule():
+    from tank_test.tank_test_base import tearDownModule as baseTearDownModule
+    # Forwards necessary cleanup to parent module to avoid directly dealing with base module resources
+    baseTearDownModule()

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -10,6 +10,7 @@
 
 import os
 import tempfile
+import shutil
 import uuid
 import sgtk
 import tank
@@ -144,6 +145,7 @@ class TestApi(TankTestBase):
         bundle_root = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
 
         os.makedirs(bundle_root)
+        self.addCleanup(shutil.rmtree, bundle_root)
 
         d = sgtk.descriptor.create_descriptor(
             sg,
@@ -161,6 +163,7 @@ class TestApi(TankTestBase):
             "app_store",
             "tk-testaltcacheroot2",
             "v0.4.3")
+        self.addCleanup(shutil.rmtree, app_root_path)
         self._touch_info_yaml(app_root_path)
         self.assertEqual(d.get_path(), app_root_path)
 

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -10,10 +10,10 @@
 
 import os
 import tempfile
-import shutil
 import uuid
 import sgtk
 import tank
+import shutil
 
 from tank_test.tank_test_base import TankTestBase
 from tank_test.tank_test_base import setUpModule # noqa
@@ -145,7 +145,6 @@ class TestApi(TankTestBase):
         bundle_root = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
 
         os.makedirs(bundle_root)
-        self.addCleanup(shutil.rmtree, bundle_root)
 
         d = sgtk.descriptor.create_descriptor(
             sg,
@@ -163,9 +162,11 @@ class TestApi(TankTestBase):
             "app_store",
             "tk-testaltcacheroot2",
             "v0.4.3")
-        self.addCleanup(shutil.rmtree, app_root_path)
         self._touch_info_yaml(app_root_path)
         self.assertEqual(d.get_path(), app_root_path)
+
+        # Cleanup the 'bundleroot' created above
+        shutil.rmtree(bundle_root)
 
     def _test_uri(self, uri, location_dict):
 

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -123,12 +123,15 @@ class TestDownloadableIODescriptors(TankTestBase):
         :return: The path of the zip file
         """
         text_file_path = os.path.join(tempfile.gettempdir(), "%s_tank_content" % uuid.uuid4().hex)
+        self.addCleanup(os.remove, text_file_path)
+
         # write 10 MB of data into the text file
         with open(text_file_path, "wb") as f:
             f.seek((1024 * 1024 * size) - 1)
             f.write("\0")
 
         zip_file_path = os.path.join(tempfile.gettempdir(), "%s_tank_source.zip" % uuid.uuid4().hex)
+        self.addCleanup(os.remove, zip_file_path)
         try:
             zf = zipfile.ZipFile(zip_file_path, "w")
             zf.write(text_file_path, arcname="large_binary_file")

--- a/tests/python/tank_test/misc_test_utils.py
+++ b/tests/python/tank_test/misc_test_utils.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Miscellaneous utility methods
+"""
+
+import os
+import platform
+
+
+def format_value(num, suffix='B'):
+    """
+    Formats a possibly large value into a more readable
+    value. e.g.: 4.6GB instead of 4592672954
+
+    Reference: https://stackoverflow.com/a/1094933/710183
+
+    :param num: An integer representing a byte count
+    :param suffix: A string of a suffix to be appended to the returned value (e.g.: KB, KiB)
+    :return: A human readable string of a possible large value
+    """
+    for unit in ['','K','M','G','T','P','E','Z']:
+        if abs(num) < 1024.0:
+            return "%6.1f %s%s" % (num, unit, suffix)
+        num /= 1024.0
+
+    return "%6.1f %s%s" % (num, 'Yi', suffix)
+
+
+def get_size(start_path='.'):
+    """
+    Returns the size of the specified element, recursively calculating
+    its size if the specified element is a folder.
+
+    Reference: https://stackoverflow.com/a/16465439/710183
+
+    :param start_path:
+    :return: An integer size in bytes
+    """
+    if os.path.isdir(start_path):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(start_path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                # Skip if entry is a link
+                if not os.path.islink(fp):
+                    total_size += os.path.getsize(fp)
+    else:
+        total_size = os.path.getsize(start_path)
+
+    return total_size
+
+
+def creation_date(path_to_file):
+    """
+    Try to get the date that a file was created, falling back to when it was
+    last modified if that isn't possible.
+
+    Reference: https://stackoverflow.com/a/39501288/710183
+
+    :param path_to_file: A string of a path to a file or folder
+    :return: An integer size in bytes
+    """
+    if platform.system() == 'Windows':
+        return os.path.getctime(path_to_file)
+    else:
+        stat = os.stat(path_to_file)
+        try:
+            return stat.st_birthtime
+        except AttributeError:
+            # We're probably on Linux. No easy way to get creation dates here,
+            # so we'll settle for when its content was last modified.
+            return stat.st_mtime

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -138,6 +138,7 @@ def setUpModule():
 
     TANK_TEMP = os.path.join(temp_dir, temp_dir_name)
     # print out the temp data location
+
     msg = "Toolkit test data location: %s" % TANK_TEMP
     print("\n" + "=" * len(msg))
     print(msg)
@@ -157,6 +158,12 @@ def setUpModule():
     # copy tank engine code into place
     os.makedirs(os.path.join(install_dir, "engines"))
 
+def tearDownModule():
+    # Last chance to delete what was created in `TANK_TEMP`
+    if TANK_TEMP:
+        if os.path.exists(TANK_TEMP):
+            if os.path.isdir(TANK_TEMP):
+                shutil.rmtree(TANK_TEMP)
 
 class TankTestBase(unittest.TestCase):
     """
@@ -279,6 +286,7 @@ class TankTestBase(unittest.TestCase):
         mockgun.Shotgun.set_schema_paths(mockgun_schema_path, mockgun_schema_entity_path)
 
         self.tank_temp = TANK_TEMP
+        self.addCleanup(shutil.rmtree, self.tank_temp)
 
         self.cache_root = os.path.join(self.tank_temp, "cache_root")
 
@@ -395,6 +403,10 @@ class TankTestBase(unittest.TestCase):
 
         # back up the authenticated user in case a unit test doesn't clean up correctly.
         self._authenticated_user = sgtk.get_authenticated_user()
+
+    def tearDown(self):
+        # Add `TankTestBase` cleanup here
+        super(unittest.TestCase, self).tearDown()
 
     def _mock_return_value(self, to_mock, return_value):
         """

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -159,11 +159,14 @@ def setUpModule():
     os.makedirs(os.path.join(install_dir, "engines"))
 
 def tearDownModule():
-    # Last chance to delete what was created in `TANK_TEMP`
+    """
+    Cleanup what was created in 'setUpModule'
+    """
     if TANK_TEMP:
         if os.path.exists(TANK_TEMP):
             if os.path.isdir(TANK_TEMP):
                 shutil.rmtree(TANK_TEMP)
+
 
 class TankTestBase(unittest.TestCase):
     """
@@ -286,7 +289,6 @@ class TankTestBase(unittest.TestCase):
         mockgun.Shotgun.set_schema_paths(mockgun_schema_path, mockgun_schema_entity_path)
 
         self.tank_temp = TANK_TEMP
-        self.addCleanup(shutil.rmtree, self.tank_temp)
 
         self.cache_root = os.path.join(self.tank_temp, "cache_root")
 
@@ -404,10 +406,6 @@ class TankTestBase(unittest.TestCase):
         # back up the authenticated user in case a unit test doesn't clean up correctly.
         self._authenticated_user = sgtk.get_authenticated_user()
 
-    def tearDown(self):
-        # Add `TankTestBase` cleanup here
-        super(unittest.TestCase, self).tearDown()
-
     def _mock_return_value(self, to_mock, return_value):
         """
         Mocks a method with to return a specified return value.
@@ -450,6 +448,10 @@ class TankTestBase(unittest.TestCase):
 
             # move project scaffold out of the way
             self._move_project_data()
+
+            # Force cleanup
+            tearDownModule()
+
             # important to delete this to free memory
             self.tk = None
         finally:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -278,7 +278,6 @@ def test_leaked_files_after_date(test_start_time):
     total_leaked_bytes = 0
     for f in leaking_resources:
         entry_size = utils.get_size(f)
-        #entry_size = get_total_size(f)
         total_leaked_bytes = total_leaked_bytes + entry_size
         print("ERROR: %s leaked, Test resource leak: %s" % (utils.format_value(entry_size), str(f)))
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 import sys
 import os
 import glob
-import platform
 import tempfile
 import time
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -13,6 +13,10 @@ from __future__ import print_function
 import sys
 import os
 import glob
+import platform
+import tempfile
+import time
+
 from optparse import OptionParser
 
 
@@ -40,6 +44,9 @@ print("Adding tests/python/third_party location to python_path: %s" % test_pytho
 sys.path = [test_python_path] + sys.path
 
 import unittest2 as unittest
+
+# Requires the extra sys paths added above
+import tank_test.misc_test_utils as utils
 
 
 class TankTestRunner(object):
@@ -223,9 +230,71 @@ def _parse_command_line():
     return options, test_names
 
 
+def test_leaked_files_after_date(test_start_time):
+    """
+    Heuristically try to determine whether any of the tests leaked some resource files
+    :param test_start_time: double unix timestamp
+    :return: integer 1 on failure else returns 0
+    """
+
+    know_tank_filemasks = [
+        "tankTemporaryTestData",
+        "_tank_source",
+        "_tank_content"
+    ]
+
+    temp_dir = tempfile.gettempdir()
+    all_files_and_folders = os.listdir(temp_dir)
+
+    possibly_leaking_resources = []
+    leaking_resources = []
+    for f in all_files_and_folders:
+        try:
+            full_path = os.path.join(temp_dir, f)
+            d = utils.creation_date(full_path)
+            if d >= test_start_time:
+                basename = os.path.basename(full_path)
+                if any(fm in basename for fm in know_tank_filemasks):
+                    leaking_resources.append(full_path)
+                else:
+                    possibly_leaking_resources.append(full_path)
+
+        except Exception as e:
+            print("Exception: %s" % (str(e)))
+
+    #
+    # Prints out 'possible' resource leaks
+    #
+    print("")
+    for f in possibly_leaking_resources:
+        print("WARNING: Possible resource leak: %s" % str(f))
+
+    #
+    # Prints out known resource leaks
+    #
+    if not leaking_resources:
+        return 0
+
+    print("")
+    total_leaked_bytes = 0
+    for f in leaking_resources:
+        entry_size = utils.get_size(f)
+        #entry_size = get_total_size(f)
+        total_leaked_bytes = total_leaked_bytes + entry_size
+        print("ERROR: %s leaked, Test resource leak: %s" % (utils.format_value(entry_size), str(f)))
+
+    if total_leaked_bytes:
+        print("ERROR: %s total leaked" % utils.format_value(total_leaked_bytes))
+
+    return 1
+
+
 if __name__ == "__main__":
 
     options, test_names = _parse_command_line()
+
+    # Create a time marker
+    test_start_time = time.time()
 
     # Do not import Toolkit before coverage or it will tank (pun intended) our coverage
     # score. We'll do this test even when we're not running code coverage to make sure
@@ -253,7 +322,8 @@ if __name__ == "__main__":
         _finalize_coverage(cov)
 
     # Exit value determined by failures and errors
-    exit_val = 0
+    exit_val = test_leaked_files_after_date(test_start_time)
+
     if ret_val.errors or ret_val.failures:
         exit_val = 1
     sys.exit(exit_val)

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -407,6 +407,10 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
     Tests proxy connection for site and appstore connections.
     """
 
+    def tearDown(self):
+        # Allows deletion of context tmp folder created by TankTestBase.setUpModule (global scope)
+        super(ConnectionSettingsTestCases.Impl, self).tearDown()
+
     def _run_test(
         self,
         site,
@@ -446,3 +450,8 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
                 source_store_proxy=source_store_proxy,
                 expected_store_proxy=expected_store_proxy
             )
+
+def tearDownModule():
+    from tank_test.tank_test_base import tearDownModule as baseTearDownModule
+    # Forwards necessary cleanup to parent module to avoid directly dealing with base module resources
+    baseTearDownModule()

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -407,10 +407,6 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
     Tests proxy connection for site and appstore connections.
     """
 
-    def tearDown(self):
-        # Allows deletion of context tmp folder created by TankTestBase.setUpModule (global scope)
-        super(ConnectionSettingsTestCases.Impl, self).tearDown()
-
     def _run_test(
         self,
         site,
@@ -450,8 +446,3 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
                 source_store_proxy=source_store_proxy,
                 expected_store_proxy=expected_store_proxy
             )
-
-def tearDownModule():
-    from tank_test.tank_test_base import tearDownModule as baseTearDownModule
-    # Forwards necessary cleanup to parent module to avoid directly dealing with base module resources
-    baseTearDownModule()


### PR DESCRIPTION
This should address most of the test resource leaks.
The fix prevents about 120MB of leaked resources per run.
Unfortunately I cannot run all tests and I feel there might be some leftover I cannot test.
On a random non-dev. Windows VM I have an  additional failing test (testGitIODescriptor) which does leak files but we agreed that leaked resources on failure was acceptable.

I also added post run `run_tests` test which lists known leaks and possible ones. As we cannot be `lsof` on all platforms it would be difficult to determine for sure what process owed at some point a given file. The additional test method does return a failure condition if it finds known resource leak and simply print warnings on possible leaks.