### PR TITLE
For #44568: refactor the login dialog to automatically detect a SSO site

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -143,7 +143,6 @@ class LoginDialog(QtGui.QDialog):
     def _update_ui_according_to_sso(self):
         """
         Updates the GUI if SSO is supported or not, hiding or showing the username/password fields.
-
         """
         url_to_test = self.ui.site.text().encode("utf-8").strip()
         sso_enabled = is_sso_enabled_on_site(url_to_test)

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -66,6 +66,13 @@ class LoginDialog(QtGui.QDialog):
         self._cookies = cookies
         self._use_sso = False
 
+        # Timer to update the GUI according to the URL, if SSO is supported or not.
+        # This is to make the UX smoother, as we do not check after each character
+        # typed, but instead wait for a period of inactivity from the user.
+        self._url_changed_timer = QtCore.QTimer(self)
+        self._url_changed_timer.setSingleShot(True)
+        self._url_changed_timer.timeout.connect(self._update_ui_accorging_to_sso)
+
         # setup the gui
         self.ui = login_dialog.Ui_LoginDialog()
         self.ui.setupUi(self)
@@ -95,10 +102,8 @@ class LoginDialog(QtGui.QDialog):
                 "You are renewing your session: you can't change your login."
             )
             self._set_login_message("Your session has expired. Please enter your password.")
-            self.ui.use_sso_link.setVisible(False)
         else:
             self._set_login_message("Please enter your credentials.")
-            self.ui.use_sso_link.linkActivated.connect(self._toggle_sso)
 
         # Set the focus appropriately on the topmost line edit that is empty.
         if self.ui.site.text():
@@ -123,13 +128,29 @@ class LoginDialog(QtGui.QDialog):
         self.ui.forgot_password_link.linkActivated.connect(self._link_activated)
 
         self.ui.site.editingFinished.connect(self._strip_whitespaces)
+        self.ui.site.textEdited.connect(self._site_url_changed)
         self.ui.login.editingFinished.connect(self._strip_whitespaces)
         self.ui._2fa_code.editingFinished.connect(self._strip_whitespaces)
         self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
 
-        url = self.ui.site.text().encode("utf-8")
-        if is_sso_enabled_on_site(url):
+        self._url_to_test = self.ui.site.text().encode("utf-8").strip()
+        self._update_ui_accorging_to_sso()
+
+    def _update_ui_accorging_to_sso(self):
+        """
+        Updates the GUI if SSO is supported or not, hiding or showing the username/password fields.
+
+        """
+        sso_enabled = is_sso_enabled_on_site(self._url_to_test)
+        if self._use_sso != sso_enabled:
             self._toggle_sso()
+
+    def _site_url_changed(self, text):
+        """
+        Starts a timer to wait until the user stops entering the URL .
+        """
+        self._url_to_test = text.strip()
+        self._url_changed_timer.start(200)
 
     def _strip_whitespaces(self):
         """
@@ -163,10 +184,8 @@ class LoginDialog(QtGui.QDialog):
         self._use_sso = not self._use_sso
         if self._use_sso:
             self.ui.message.setText("Sign in using your Single Sign-On (SSO) Account.")
-            self.ui.use_sso_link.setText("<a href=\"about:blank\"><span style=\" text-decoration: underline; color:#c0c1c3;\">Use Shotgun Account</span></a>")
         else:
             self.ui.message.setText("Please enter your credentials.")
-            self.ui.use_sso_link.setText("<a href=\"about:blank\"><span style=\" text-decoration: underline; color:#c0c1c3;\">Use Single Sign-On (SSO)</span></a>")
         self.ui.login.setVisible(not self._use_sso)
         self.ui.password.setVisible(not self._use_sso)
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -33,6 +33,11 @@ logger = LogManager.get_logger(__name__)
 # Name used to identify the client application when connecting via SSO to Shotugn.
 PRODUCT_IDENTIFIER = "toolkit"
 
+# Checking for SSO support on a site takes a few moments. When the user enters
+# a Shotgun site URL, we check for SSO support (and update the GUI) only after
+# the user has stopped for longer than the delay (in ms).
+USER_INPUT_DELAY_BEFORE_SSO_CHECK = 300
+
 
 class LoginDialog(QtGui.QDialog):
     """
@@ -71,7 +76,7 @@ class LoginDialog(QtGui.QDialog):
         # typed, but instead wait for a period of inactivity from the user.
         self._url_changed_timer = QtCore.QTimer(self)
         self._url_changed_timer.setSingleShot(True)
-        self._url_changed_timer.timeout.connect(self._update_ui_accorging_to_sso)
+        self._url_changed_timer.timeout.connect(self._update_ui_according_to_sso)
 
         # setup the gui
         self.ui = login_dialog.Ui_LoginDialog()
@@ -134,9 +139,9 @@ class LoginDialog(QtGui.QDialog):
         self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
 
         self._url_to_test = self.ui.site.text().encode("utf-8").strip()
-        self._update_ui_accorging_to_sso()
+        self._update_ui_according_to_sso()
 
-    def _update_ui_accorging_to_sso(self):
+    def _update_ui_according_to_sso(self):
         """
         Updates the GUI if SSO is supported or not, hiding or showing the username/password fields.
 
@@ -150,7 +155,7 @@ class LoginDialog(QtGui.QDialog):
         Starts a timer to wait until the user stops entering the URL .
         """
         self._url_to_test = text.strip()
-        self._url_changed_timer.start(200)
+        self._url_changed_timer.start(USER_INPUT_DELAY_BEFORE_SSO_CHECK)
 
     def _strip_whitespaces(self):
         """

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -138,7 +138,6 @@ class LoginDialog(QtGui.QDialog):
         self.ui._2fa_code.editingFinished.connect(self._strip_whitespaces)
         self.ui.backup_code.editingFinished.connect(self._strip_whitespaces)
 
-        self._url_to_test = self.ui.site.text().encode("utf-8").strip()
         self._update_ui_according_to_sso()
 
     def _update_ui_according_to_sso(self):
@@ -146,7 +145,8 @@ class LoginDialog(QtGui.QDialog):
         Updates the GUI if SSO is supported or not, hiding or showing the username/password fields.
 
         """
-        sso_enabled = is_sso_enabled_on_site(self._url_to_test)
+        url_to_test = self.ui.site.text().encode("utf-8").strip()
+        sso_enabled = is_sso_enabled_on_site(url_to_test)
         if self._use_sso != sso_enabled:
             self._toggle_sso()
 
@@ -154,7 +154,6 @@ class LoginDialog(QtGui.QDialog):
         """
         Starts a timer to wait until the user stops entering the URL .
         """
-        self._url_to_test = text.strip()
         self._url_changed_timer.start(USER_INPUT_DELAY_BEFORE_SSO_CHECK)
 
     def _strip_whitespaces(self):

--- a/python/tank/authentication/resources/login_dialog.ui
+++ b/python/tank/authentication/resources/login_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>364</width>
-    <height>321</height>
+    <height>304</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -221,19 +221,6 @@ QLineEdit:Disabled {
          </property>
          <item>
           <layout class="QVBoxLayout" name="links">
-           <item>
-            <widget class="QLabel" name="use_sso_link">
-             <property name="text">
-              <string>&lt;a href=&quot;about:blank&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0c1c3;&quot;&gt;Use Single Sign-On (SSO)&lt;/span&gt;&lt;/a&gt;</string>
-             </property>
-             <property name="textFormat">
-              <enum>Qt::RichText</enum>
-             </property>
-             <property name="margin">
-              <number>4</number>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QLabel" name="forgot_password_link">
              <property name="cursor">

--- a/python/tank/authentication/ui/login_dialog.py
+++ b/python/tank/authentication/ui/login_dialog.py
@@ -12,7 +12,7 @@ class Ui_LoginDialog(object):
     def setupUi(self, LoginDialog):
         LoginDialog.setObjectName("LoginDialog")
         LoginDialog.setWindowModality(QtCore.Qt.NonModal)
-        LoginDialog.resize(364, 321)
+        LoginDialog.resize(364, 304)
         LoginDialog.setMinimumSize(QtCore.QSize(364, 296))
         LoginDialog.setStyleSheet("QWidget\n"
 "{\n"
@@ -121,11 +121,6 @@ class Ui_LoginDialog(object):
         self.button_layout.setObjectName("button_layout")
         self.links = QtGui.QVBoxLayout()
         self.links.setObjectName("links")
-        self.use_sso_link = QtGui.QLabel(self.login_page)
-        self.use_sso_link.setTextFormat(QtCore.Qt.RichText)
-        self.use_sso_link.setMargin(4)
-        self.use_sso_link.setObjectName("use_sso_link")
-        self.links.addWidget(self.use_sso_link)
         self.forgot_password_link = QtGui.QLabel(self.login_page)
         self.forgot_password_link.setCursor(QtCore.Qt.PointingHandCursor)
         self.forgot_password_link.setStyleSheet("QWidget\n"
@@ -328,7 +323,6 @@ class Ui_LoginDialog(object):
         self.login.setPlaceholderText(QtGui.QApplication.translate("LoginDialog", "login", None, QtGui.QApplication.UnicodeUTF8))
         self.password.setPlaceholderText(QtGui.QApplication.translate("LoginDialog", "password", None, QtGui.QApplication.UnicodeUTF8))
         self.message.setText(QtGui.QApplication.translate("LoginDialog", "Please enter your credentials.", None, QtGui.QApplication.UnicodeUTF8))
-        self.use_sso_link.setText(QtGui.QApplication.translate("LoginDialog", "<a href=\"about:blank\"><span style=\" text-decoration: underline; color:#c0c1c3;\">Use Single Sign-On (SSO)</span></a>", None, QtGui.QApplication.UnicodeUTF8))
         self.forgot_password_link.setText(QtGui.QApplication.translate("LoginDialog", "<html><head/><body><p><a href=\"http://mystudio.shotgunstudio.com/user/forgot_password\"><span style=\" text-decoration: underline; color:#c0c1c3;\">Forgot your password?</span></a></p></body></html>", None, QtGui.QApplication.UnicodeUTF8))
         self.cancel.setText(QtGui.QApplication.translate("LoginDialog", "Cancel", None, QtGui.QApplication.UnicodeUTF8))
         self.sign_in.setText(QtGui.QApplication.translate("LoginDialog", "Sign In", None, QtGui.QApplication.UnicodeUTF8))


### PR DESCRIPTION
- Removed the 'Use Single Sign-On (SSO)'/ 'Use Shotgun Account' link, that would toggle the login dialog GUI,
- Instead added auto-detection of SSO support (or not) to update the GUI accordingly,
- A QTimer is used to do a SSO support check on the URL only after the user is done typing,
- The dialog height has been reduced back to its original pre-SSO-support size