### PR TITLE
For 43890: Fix unittest leaking fairly large amount of data

### DIFF
--- a/tests/bootstrap_tests/test_backups.py
+++ b/tests/bootstrap_tests/test_backups.py
@@ -178,5 +178,15 @@ class TestBackups(TankTestBase):
             config._cleanup_backup_folders(config_backup_folder_path, core_backup_folder_path)
 
             # Verify that backup folders were cleaned up
+            # Only the 'placeholder' file should remain
             self.assertEqual(os.listdir(core_install_backup_path), ['placeholder'])
             self.assertEqual(os.listdir(config_install_backup_path), ['placeholder'])
+
+            # Try deleting the 'config_install_backup_path' parent folder
+            # which was deliberately set to READ_ONLY on Windows
+            # and verify it no longer exists afterward.
+            parent_folder = os.path.join(config_install_backup_path, os.pardir)
+            sgtk.util.filesystem.safe_delete_folder(parent_folder)
+            self.assertFalse(os.path.exists(parent_folder))
+
+

--- a/tests/bootstrap_tests/test_backups.py
+++ b/tests/bootstrap_tests/test_backups.py
@@ -188,5 +188,3 @@ class TestBackups(TankTestBase):
             parent_folder = os.path.join(config_install_backup_path, os.pardir)
             sgtk.util.filesystem.safe_delete_folder(parent_folder)
             self.assertFalse(os.path.exists(parent_folder))
-
-

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -21,7 +21,6 @@ import shutil
 import pprint
 import threading
 import tempfile
-import uuid
 import contextlib
 
 from tank_vendor.shotgun_api3.lib import mockgun
@@ -128,17 +127,12 @@ def setUpModule():
     """
     global TANK_TEMP
 
-    # determine tests root location
-    temp_dir = tempfile.gettempdir()
-    # make a unique test dir for each file
-    temp_dir_name = "tankTemporaryTestData"
-    # Append a random string to the temp directory name to make it unique. time.time
-    # doesn't have enough resolution!!!
-    temp_dir_name += "_%s" % (uuid.uuid4(),)
+    # determine tests root location, the mkdtemp() method does handle uniqueness
+    TANK_TEMP = tempfile.mkdtemp(prefix="TestData_")
 
-    TANK_TEMP = os.path.join(temp_dir, temp_dir_name)
     # print out the temp data location
     msg = "Toolkit test data location: %s" % TANK_TEMP
+    # prints a visual text divider
     print("\n" + "=" * len(msg))
     print(msg)
     print("=" * len(msg) + "\n")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -202,11 +202,6 @@ def _parse_command_line():
     :returns: The options and the name of the unit test specified on the command line, if any.
     """
     parser = OptionParser()
-    # TODO: ask aout the 'action' params below
-    parser.add_option("--clean-temp-data",
-                      action="store_true",
-                      dest="clean_temp_data",
-                      help="delete all temporary test data on test run completion")
     parser.add_option("--with-coverage",
                       action="store_true",
                       dest="coverage",
@@ -282,9 +277,8 @@ if __name__ == "__main__":
     if ret_val.errors or ret_val.failures:
         exit_val = 1
 
-    if options.clean_temp_data:
-        # Note: relying on own value rather than tempfile.tempdir
-        print("\nCleaning up '%s'" % (new_base_tempdir))
-        shutil.rmtree(new_base_tempdir)
+    # Note: relying on own value rather than tempfile.tempdir
+    print("\nCleaning up '%s'" % (new_base_tempdir))
+    shutil.rmtree(new_base_tempdir)
 
     sys.exit(exit_val)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -13,9 +13,7 @@ from __future__ import print_function
 import sys
 import os
 import glob
-import datetime
 import tempfile
-import uuid
 import shutil
 from optparse import OptionParser
 
@@ -239,10 +237,7 @@ if __name__ == "__main__":
     # will be created. Having a single top-level folder will make
     # complete deletion very easy.
     #
-    timestamp_str = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-    current_test_run_subdir = "tk-core-tests-%s-%s" % (timestamp_str, uuid.uuid4())
-    new_base_tempdir = os.path.join(tempfile.gettempdir(), current_test_run_subdir)
-    os.makedirs(new_base_tempdir)
+    new_base_tempdir = tempfile.mkdtemp(prefix="tankTemporary_")
 
     #
     # Now that we have our global test run subdir created, let's

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -235,17 +235,16 @@ def _parse_command_line():
 if __name__ == "__main__":
 
     #
-    # Figure out and create our own base temporary storage into which
-    # everything else will be created. It will be easy then to cleanup
-    # everything we create.
+    # Create our own temporary base storage into which everything
+    # will be created. Having a single top-level folder will make
+    # complete deletion very easy.
     #
-    current_base_tmpdir = tempfile.gettempdir()
     timestamp_str = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-    hex128bit_str = uuid.uuid4()
-    current_test_run_subdir = "tk-core-tests-%s-%s" % (timestamp_str,hex128bit_str)
-    new_base_tempdir = os.path.join(current_base_tmpdir, current_test_run_subdir)
+    current_test_run_subdir = "tk-core-tests-%s-%s" % (timestamp_str, uuid.uuid4())
+    new_base_tempdir = os.path.join(tempfile.gettempdir(), current_test_run_subdir)
     os.makedirs(new_base_tempdir)
 
+    #
     # Now that we have our global test run subdir created, let's
     # re-assign tempfile.temdir() value to be used a new base directory
     #
@@ -253,6 +252,7 @@ if __name__ == "__main__":
     #       for later restoring. This is not changing value of default
     #       temporary directory for anything else than this instance of
     #       the 'tempfile' module. Overall system is not affected.
+    #
     tempfile.tempdir = new_base_tempdir
 
     options, test_names = _parse_command_line()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -14,7 +14,6 @@ import sys
 import os
 import glob
 import tempfile
-import shutil
 from optparse import OptionParser
 
 
@@ -285,10 +284,12 @@ if __name__ == "__main__":
         exit_val = 1
 
     finally:
+        from tank.util.filesystem import safe_delete_folder
+
         # Note: Relying on own value rather than tempfile.tempdir
         #       being global it MIGHT be changed by anyone test
         if new_base_tempdir and os.path.isdir(new_base_tempdir):
             print("\nCleaning up '%s'" % (new_base_tempdir))
-            shutil.rmtree(new_base_tempdir)
+            safe_delete_folder(new_base_tempdir)
 
     sys.exit(exit_val)


### PR DESCRIPTION
Alternate & simpler solution to previously submitted PR: https://github.com/shotgunsoftware/tk-core/pull/550

The solution is just about wrapping everything the tests are creating into another temporary directory level that can be easily deleted afterwards.

Point to discuss:
- Whether or not to actually include work from the original PR
- Current default is NOT to clean anything unless the --clean-temp-data switch is used.
- What should be the value to the 'action' parameter (see below)?

Also, to address concerns by JF, I'm attaching a crude summary of running multiple test runs on OSX. The summary simply shows that cleaning up files only takes a tiny bit more time, about 0.42% more. I expect that results on Windows would be larger but still small.

[crude_instrumentation_delete_all_vs_no_delete_all.ods.zip](https://github.com/shotgunsoftware/tk-core/files/1482383/crude_instrumentation_delete_all_vs_no_delete_all.ods.zip)

