### PR TITLE
#45817 Removes settings validation from `SoftwareLauncher`

### DIFF
--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -156,21 +156,10 @@ class SoftwareLauncher(object):
         # make sure the current operating system platform is supported
         validation.validate_platform(descriptor)
 
-        # Get the settings for the engine and then validate them
-        engine_schema = descriptor.configuration_schema
-        validation.validate_settings(
-            engine_name,
-            tk,
-            context,
-            engine_schema,
-            settings
-        )
-
-        # Once the engine settings and descriptor have been validated,
-        # initialize members of this class. Since this code only runs
-        # during the pre-launch phase of an engine, there are no
-        # opportunities to change the Context or environment. Safe
-        # to cache these values.
+        # Once validated, initialize members of this class. Since this code only
+        # runs during the pre-launch phase of an engine, there are no
+        # opportunities to change the Context or environment. Safe to cache
+        # these values.
         self.__tk = tk
         self.__context = context
         self.__environment = env


### PR DESCRIPTION
We have an issue with `tk-maya` when creating `SoftwareLauncher` instances if there is no filesystem structure on disk for the context. The engine's `template_project` setting will not validate preventing the launcher from being created. 

This is a blunt solution that removes settings validation from the SW launcher. I will try to come up with a cleaner solution before end of day today. I'm out the rest of the week, so this is really just to get in front of @manneohrstrom for review. @mathurf will coordinate from here out. If this is good, it can be merged and tested. If not, we should discuss with @robblau how this affects defcon2 release.