### PR TITLE
For 45519: cleanup SSO module.

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -24,7 +24,7 @@ from . import session_cache
 from ..util.shotgun import connection
 from .shotgun_shared import Saml2Sso, is_sso_enabled_on_site, Saml2SsoMissingQtModuleError
 from .errors import AuthenticationError
-from .ui.qt_abstraction import QtGui, QtCore
+from .ui.qt_abstraction import QtGui, QtCore, QtNetwork, QtWebKit
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
 from .. import LogManager
 
@@ -62,8 +62,6 @@ class LoginDialog(QtGui.QDialog):
         """
         QtGui.QDialog.__init__(self, parent)
 
-        from .ui.qt_abstraction import QtNetwork
-        from .ui.qt_abstraction import QtWebKit
         qt_modules = {
             "QtCore": QtCore,
             "QtGui": QtGui,

--- a/python/tank/authentication/shotgun_shared/__init__.py
+++ b/python/tank/authentication/shotgun_shared/__init__.py
@@ -15,8 +15,8 @@ This module contains files which are shared between RV and Toolkit.
 from .saml2_sso import (  # noqa
     Saml2Sso,
     Saml2SsoError,
-    Saml2SsoMultiSessionNotSupportedError,
     Saml2SsoMissingQtModuleError,
+    Saml2SsoMultiSessionNotSupportedError,
 )
 
 # Functions
@@ -29,4 +29,5 @@ from .saml2_sso import (  # noqa
     get_session_id,
     has_sso_info_in_cookies,
     is_sso_enabled_on_site,
+    set_logger_parent,
 )

--- a/python/tank/authentication/shotgun_shared/__init__.py
+++ b/python/tank/authentication/shotgun_shared/__init__.py
@@ -12,7 +12,21 @@ This module contains files which are shared between RV and Toolkit.
 """
 
 # Classes
-from .saml2_sso import Saml2SsoError, Saml2SsoMultiSessionNotSupportedError, Saml2Sso # noqa
+from .saml2_sso import (  # noqa
+    Saml2Sso,
+    Saml2SsoError,
+    Saml2SsoMultiSessionNotSupportedError,
+    Saml2SsoMissingQtModuleError,
+)
 
 # Functions
-from .saml2_sso import is_sso_enabled_on_site, has_sso_info_in_cookies, get_saml_claims_expiration, get_saml_user_name, get_session_id, get_csrf_token, get_csrf_key # noqa
+from .saml2_sso import (  # noqa
+    get_csrf_key,
+    get_csrf_token,
+    get_logger,
+    get_saml_claims_expiration,
+    get_saml_user_name,
+    get_session_id,
+    has_sso_info_in_cookies,
+    is_sso_enabled_on_site,
+)

--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -56,6 +56,14 @@ def get_logger():
     return logging.getLogger(__name__)
 
 
+def set_logger_parent(logger_parent):
+    """
+    Set the logger parent to this module's logger.
+    """
+    logger = get_logger()
+    logger.parent = logger_parent
+
+
 class Saml2SsoError(Exception):
     """
     Top level exception for all saml2_sso level runtime errors

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -14,12 +14,17 @@ import time
 
 from . import interactive_authentication
 from . import user_impl
+from . import shotgun_shared
 from .. import LogManager
 from .errors import AuthenticationCancelled
-from .shotgun_shared import get_saml_claims_expiration
 
 
 logger = LogManager.get_logger(__name__)
+
+# Import the logger from sso_shared, re-parent it and rename it.
+shotgun_shared_logger = shotgun_shared.get_logger()
+shotgun_shared_logger.parent = logger
+shotgun_shared_logger.name = shotgun_shared_logger.name.replace('tank.', 'sgtk.core.')
 
 
 class ShotgunUser(object):
@@ -163,7 +168,7 @@ class ShotgunSamlUser(ShotgunUser):
 
         :returns: The expiration in seconds since January 1st 1970 UTC.
         """
-        return get_saml_claims_expiration(self._impl.get_cookies())
+        return shotgun_shared.get_saml_claims_expiration(self._impl.get_cookies())
 
     def _do_automatic_claims_renewal(self, preemtive_renewal_threshold=0.9):
         """

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -21,10 +21,8 @@ from .errors import AuthenticationCancelled
 
 logger = LogManager.get_logger(__name__)
 
-# Import the logger from sso_shared, re-parent it and rename it.
-shotgun_shared_logger = shotgun_shared.get_logger()
-shotgun_shared_logger.parent = logger
-shotgun_shared_logger.name = shotgun_shared_logger.name.replace('tank.', 'sgtk.core.')
+# Ensure that the SSO-related logging will be merged in our loggin.
+shotgun_shared.set_logger_parent(logger)
 
 
 class ShotgunUser(object):


### PR DESCRIPTION
This commit addresses the following points:
- Properly handles a missing Qt module (e.g. we allow regular Qt login with Username/Password),
- Isolate shotgun_shared module so that Qt modules are passed as arguments,
- Remove dependency of shotgun_shared on Toolkit components (Qt libraries and Logger),
- Connected the shotgun_shared logger to the Toolkit logger.
- Cleaned up the log messages, made them a bit more palatable to human readers,
- Removed commented out code,