### PR TITLE
#45876 Safe copy fallback for bundle cache I/O transactions

### DIFF
--- a/python/tank/descriptor/errors.py
+++ b/python/tank/descriptor/errors.py
@@ -23,6 +23,13 @@ class TankDescriptorError(TankError):
     pass
 
 
+class TankDescriptorIOError(TankDescriptorError):
+    """
+    Base class for all descriptor I/O related errors.
+    """
+    pass
+
+
 class TankAppStoreError(TankDescriptorError):
     """
     Errors relating to the Toolkit App Store app store.

--- a/python/tank/descriptor/io_descriptor/downloadable.py
+++ b/python/tank/descriptor/io_descriptor/downloadable.py
@@ -12,7 +12,7 @@ import os
 import uuid
 
 from .base import IODescriptorBase
-from ..errors import TankDescriptorError, TankError, TankDescriptorIOError
+from ..errors import TankDescriptorIOError
 from ...util import filesystem
 
 from ... import LogManager

--- a/python/tank/descriptor/io_descriptor/downloadable.py
+++ b/python/tank/descriptor/io_descriptor/downloadable.py
@@ -142,6 +142,14 @@ class IODescriptorDownloadable(IODescriptorBase):
                             target
                         )
                     )
+
+                    # first write out our metadata folder where we store the transaction marker.
+                    # this marks the beginning of the 'copy transaction' and will make sure that
+                    # the logic in _exists_local() will not think the folder is a legacy format
+                    # which doesn't implement transaction handling.
+                    metadata_folder = self._get_metadata_folder(target)
+                    filesystem.ensure_folder_exists(metadata_folder)
+
                     filesystem.move_folder(temporary_path, target)
                     # write end receipt
                     filesystem.touch_file(

--- a/python/tank/descriptor/io_descriptor/downloadable.py
+++ b/python/tank/descriptor/io_descriptor/downloadable.py
@@ -106,7 +106,10 @@ class IODescriptorDownloadable(IODescriptorBase):
             os.rename(temporary_path, target)
             # write end receipt
             filesystem.touch_file(
-                os.path.join(metadata_folder, self._DOWNLOAD_TRANSACTION_COMPLETE_FILE)
+                os.path.join(
+                    self._get_metadata_folder(target),
+                    self._DOWNLOAD_TRANSACTION_COMPLETE_FILE
+                )
             )
             move_succeeded = True
             log.debug("Successfully moved the downloaded descriptor to target path: %s." % target)
@@ -115,7 +118,7 @@ class IODescriptorDownloadable(IODescriptorBase):
 
             # if the target path already exists, this means someone else is either
             # moving things right now or have moved it already, so we are ok.
-            if not os.path.exists(target):
+            if not self._exists_local(target):
                 # the target path does not exist. so the rename failed for other reasons.
 
                 # if the rename did not work, it may be because the files are locked and
@@ -142,7 +145,10 @@ class IODescriptorDownloadable(IODescriptorBase):
                     filesystem.move_folder(temporary_path, target)
                     # write end receipt
                     filesystem.touch_file(
-                        os.path.join(metadata_folder, self._DOWNLOAD_TRANSACTION_COMPLETE_FILE)
+                        os.path.join(
+                            self._get_metadata_folder(target),
+                            self._DOWNLOAD_TRANSACTION_COMPLETE_FILE
+                        )
                     )
                     # move_folder leaves all folders in the filesystem
                     # clean out these as well in a graceful way.
@@ -156,8 +162,8 @@ class IODescriptorDownloadable(IODescriptorBase):
                         log.debug("Move failed. Attempting to clear out target path '%s'" % target)
                         filesystem.safe_delete_folder(target)
 
-                    # and raise an error.
-                    log.error(
+                    # ...and raise an error. Include callstack so we get full visibility here.
+                    log.exception(
                         "Failed to copy descriptor %s from the temporary path %s "
                         "to the bundle cache %s. Error: %s" % (self, temporary_path, target, e)
                     )

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -103,8 +103,14 @@ class IODescriptorGit(IODescriptorDownloadable):
 
         # Note: git doesn't like paths in single quotes when running on
         # windows - it also prefers to use forward slashes
+        #
+        # Also note - we are adding a --no-hardlinks flag here to ensure that
+        # when a github repo resides locally on a drive, git isn't trying
+        # to be clever and utilize hard links to save space - this can cause
+        # complications in cleanup scenarios and with file copying. We want
+        # each repo that we clone to be completely independent on a filesystem level.
         log.debug("Git Cloning %r into %s" % (self, target_path))
-        cmd = "git clone -q \"%s\" \"%s\"" % (self._path, target_path)
+        cmd = "git clone --no-hardlinks -q \"%s\" \"%s\"" % (self._path, target_path)
 
         # Note that we use os.system here to allow for git to pop up (in a terminal
         # if necessary) authentication prompting. This DOES NOT seem to be possible

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -276,7 +276,12 @@ def move_folder(src, dst, folder_permissions=0o775):
         log.debug("Moving directory: %s -> %s" % (src, dst))
 
         # first copy the content in the core folder
-        src_files = copy_folder(src, dst, folder_permissions)
+        src_files = copy_folder(
+            src,
+            dst,
+            folder_permissions,
+            skip_list=[]  # copy all files
+        )
 
         # now clear out the install location
         log.debug("Clearing out source location...")
@@ -285,12 +290,12 @@ def move_folder(src, dst, folder_permissions=0o775):
                 # on windows, ensure all files are writable
                 if sys.platform == "win32":
                     attr = os.stat(f)[0]
-                    if (not attr & stat.S_IWRITE):
+                    if not attr & stat.S_IWRITE:
                         # file is readonly! - turn off this attribute
                         os.chmod(f, stat.S_IWRITE)
                 os.remove(f)
             except Exception as e:
-                log.error("Could not delete file %s: %s" % (f, e))
+                log.warning("Could not delete file %s: %s" % (f, e))
 
 
 @with_cleared_umask

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import time
 import uuid
+import shutil
 import zipfile
 
 from tank_test.tank_test_base import TankTestBase, skip_if_git_missing, temp_env_var
@@ -23,6 +24,17 @@ from tank_test.tank_test_base import setUpModule # noqa
 
 import sgtk
 import tank
+
+
+def _raise_exception(placeholder_a="default_a", placeholder_b="default_b"):
+    """
+    Generic mock function to raise an OSError.
+
+    :param placeholder_a: Placeholder first argument
+    :param placeholder_b: Placeholder second argument
+    :raises: OSError
+    """
+    raise OSError("An unknown OSError occurred")
 
 
 class TestDownloadableIODescriptors(TankTestBase):
@@ -295,15 +307,6 @@ class TestDownloadableIODescriptors(TankTestBase):
             "Failed to write concurrently to shared bundle cache: %s" % ",".join(errors)
         )
 
-    def _raise_exception(self, placeholder_a="default_a", placeholder_b="default_b"):
-        """
-        Generic mock function to raise an OSError.
-
-        :param placeholder_a: Placeholder first argument
-        :param placeholder_b: Placeholder second argument
-        :raises: OSError
-        """
-        raise OSError("An unknown OSError occurred")
 
     ###############################################################################################
 
@@ -382,15 +385,24 @@ class TestDownloadableIODescriptors(TankTestBase):
         """
         Tests git branch descriptor downloads to the bundle cache.
         """
+        # make sure there is nothing in the bundle cache
+        git_location = os.path.join(self.tank_temp, "bundle_cache", "gitbranch", "tk-config-default.git", "e1c03fa")
+        if os.path.exists(git_location):
+            os.rename(git_location, "%s.%s" % (git_location, uuid.uuid4().hex))
+
+        # make sure nothing exists
+        self.assertFalse(os.path.exists(git_location))
+
         # setup git test data
         self._setup_git_data()
 
         self._download_git_branch_bundle()
 
         # make sure the expected local path exists.
-        self.assertTrue(os.path.exists(
-            os.path.join(self.tank_temp, "bundle_cache", "gitbranch", "tk-config-default.git", "e1c03fa")
-        ), "Failed to find the default bundle cache directory for the app store descriptor on disk.")
+        self.assertTrue(
+            os.path.exists(git_location),
+            "Failed to find the default bundle cache directory for the app store descriptor on disk."
+        )
 
         # now test concurrent downloads to a shared bundle cache
         self._test_multiprocess_download_to_shared_bundle_cache(
@@ -410,17 +422,84 @@ class TestDownloadableIODescriptors(TankTestBase):
         # ensure that an exception raised while downloading the descriptor to a
         # temporary folder will raise a TankDescriptorError
         with patch(
-                "tank.descriptor.io_descriptor.git_branch.IODescriptorGitBranch._download_local",
-                side_effect=self._raise_exception
+            "tank.descriptor.io_descriptor.git_branch.IODescriptorGitBranch._download_local",
+            side_effect=_raise_exception
         ):
-            with self.assertRaises(tank.descriptor.errors.TankDescriptorError):
+            with self.assertRaises(tank.descriptor.errors.TankDescriptorIOError):
                 self._download_git_branch_bundle()
 
-        # ensure that an exception raised while renaming the temporary folder
-        # to the target path will raise a TankError if the target does not exist.
-        with patch(
-                "os.rename",
-                side_effect=self._raise_exception
-        ):
-            with self.assertRaises(tank.errors.TankError):
-                self._download_git_branch_bundle()
+    @patch("os.rename", side_effect=_raise_exception)
+    def test_descriptor_rename_error_fallbacks(self, *_):
+        """
+        Tests that an error during the rename operation kicks in various fallbacks.
+        """
+        # make sure there is nothing in the bundle cache
+        git_location = os.path.join(self.tank_temp, "bundle_cache", "gitbranch", "tk-config-default.git", "e1c03fa")
+        if os.path.exists(git_location):
+            shutil.move(git_location, "%s.%s" % (git_location, uuid.uuid4().hex))
+
+        # make sure nothing exists
+        self.assertFalse(os.path.exists(git_location))
+
+        # make sure we cleaned up the temp location
+        tmp_location = os.path.join(self.tank_temp, "bundle_cache", "tmp")
+        tmp_files_before = os.listdir(tmp_location)
+
+        # setup shotgun test data
+        self._setup_git_data()
+
+        self._download_git_branch_bundle()
+
+        # make sure the expected local path exists despite the rename failing
+        self.assertTrue(
+            os.path.exists(git_location),
+            "Failed to find the default bundle cache directory for the app store descriptor on disk."
+        )
+
+        # make sure we cleaned up the temp location
+        tmp_files_after = os.listdir(tmp_location)
+        self.assertEqual(tmp_files_after, tmp_files_before)
+
+    @patch("tank.util.filesystem.move_folder")
+    @patch("os.rename", side_effect=_raise_exception)
+    def test_descriptor_rename_fallback_failure(self, rename_mock, move_mock):
+        """
+        Tests the expected behaviour when a rename fails and then 'plan B' fallback also fails.
+        """
+
+        def our_move_mock(src, dst):
+            """
+            Mock of tank.util.filesystem.move_folder which will write one dummy
+            file and then raise an OSError
+            """
+            os.mkdir(dst)
+            with open(os.path.join(dst, "some_file.foo"), "wt") as fh:
+                fh.write("file contents")
+            raise OSError("Something went wrong half way")
+        move_mock.side_effect = our_move_mock
+
+        # make sure there is nothing in the bundle cache
+        git_location = os.path.join(self.tank_temp, "bundle_cache", "gitbranch", "tk-config-default.git", "e1c03fa")
+        if os.path.exists(git_location):
+            shutil.move(git_location, "%s.%s" % (git_location, uuid.uuid4().hex))
+
+        # make sure nothing exists
+        self.assertFalse(os.path.exists(git_location))
+
+        # make sure we clean up the temp location as part of the code
+        tmp_location = os.path.join(self.tank_temp, "bundle_cache", "tmp")
+        tmp_files_before = os.listdir(tmp_location)
+
+        # setup shotgun test data
+        self._setup_git_data()
+
+        # check that it raises when the fallback copy fails
+        with self.assertRaises(tank.descriptor.errors.TankDescriptorIOError):
+            self._download_git_branch_bundle()
+
+        # make sure the bundle cache path is clean afterwards - no half way stuff stored.
+        self.assertFalse(os.path.exists(git_location))
+
+        # make sure we did not cleanup the temp location - it's left for support forensics
+        tmp_files_after = os.listdir(tmp_location)
+        self.assertNotEqual(tmp_files_after, tmp_files_before)

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -537,4 +537,3 @@ class TestDownloadableIODescriptors(TankTestBase):
         self.assertTrue(os.path.exists(os.path.join(git_location, "tk-metadata", "install_complete")))
         self.assertTrue(desc.exists_local())
         self.assertTrue(desc2.exists_local())
-

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -163,17 +163,18 @@ def _finalize_coverage(cov):
         print("Note: Full html coverage report can be found in the coverage_html_report folder.")
 
 
-def _initialize_logging(log_to_console):
+def _initialize_logging():
     """
     Sets up a log file for the unit tests and optionally logs everything to the console.
-
-    :param log_to_console: If True, all Toolkit logging will go to the console.
     """
     import tank
     tank.LogManager().initialize_base_file_handler("run_tests")
 
     if options.log_to_console:
         tank.LogManager().initialize_custom_handler()
+
+    if options.debug:
+        tank.LogManager().global_debug = True
 
 
 def _run_tests(test_root, test_names):
@@ -213,9 +214,12 @@ def _parse_command_line():
                       action="store",
                       dest="test_root",
                       help="Specify a folder where to look for tests.")
+    parser.add_option("--debug", "-d",
+                      action="store_true",
+                      help="Enable debug logging.")
     parser.add_option("--log-to-console", "-l",
                       action="store_true",
-                      help="run tests and redirect logging output to the console.")
+                      help="Run tests and redirect logging output to the console.")
 
     (options, args) = parser.parse_args()
 
@@ -260,7 +264,7 @@ if __name__ == "__main__":
         if options.coverage:
             cov = _initialize_coverage(options.test_root)
 
-        _initialize_logging(options.log_to_console)
+        _initialize_logging()
 
         # If we have a custom test root, add its python folder, if it exists, so the user doesn't need
         # to set it up themselves.


### PR DESCRIPTION
This adds a fallback to the transaction system handling downloadble descriptor types.

Previously, the code would be downloaded into a temp space in the bundle cache, then upon completion the tmp folder would be renamed into its right bundle cache location. This is an atomic operation meaning its fast and transactional in nature, avoiding any potential file leftovers inside the bundle cache on failure.

In the wild, we have seen bugs on windows where this approach fails - possibly due to file locking because of AV scans kicking in after download - but we are not entirely sure yet.

This change implements a fallback, a plan B in case the rename fails. In this case, a slower and more elaborate process is initiated, whereby the temp content is copied into place and then the tmp space is cleaned up, done gracefully so that if a tmp file cannot be deleted, the system will log a warning and continue. In the case the plan B copy fails, an IO exception is raised and the bundle cache folder is cleaned out.

This also fixes a bug where our std move method wouldn't move certain hidden files.