### PR TITLE
For #43294, site level caching.

### DIFF
--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -129,8 +129,11 @@ class CacheLocation(HookBaseClass):
         folder inside the bundle cache location).
 
         It is possible to omit some components of the path by explicitly passing
-        a `None` value for them, only the bundle name is required. For example, with
-        `project_id=None`, a site level cache path will be returned.
+        a `None` value for them, only the bundle name is required. For example,
+        with `project_id=None`, a site level cache path will be returned.
+        Ommitting the `project_id` can be used to cache data for the site
+        configuration, or to share data accross all projects belonging to a
+        common site.
 
         :param project_id: The shotgun id of the project to store caches for, or None.
         :param plugin_id: Unique string to identify the scope for a particular plugin

--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -128,12 +128,16 @@ class CacheLocation(HookBaseClass):
         which needs to cache things per-instance can implement this using a sub
         folder inside the bundle cache location).
 
-        :param project_id: The shotgun id of the project to store caches for
+        It is possible to omit some components of the path by explicitly passing
+        a `None` value for them, only the bundle name is required. For example, with
+        `project_id=None`, a site level cache path will be returned.
+
+        :param project_id: The shotgun id of the project to store caches for, or None.
         :param plugin_id: Unique string to identify the scope for a particular plugin
-                          or integration. For more information,
+                          or integration, or None. For more information,
                           see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
                           non-plugin based toolkit projects, this value is None.
-        :param pipeline_configuration_id: The shotgun pipeline config id to store caches for
+        :param pipeline_configuration_id: The shotgun pipeline config id to store caches for, or None.
         :param bundle: The app, engine or framework object which is requesting the cache folder.
         :returns: The path to a folder which should exist on disk.
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -257,8 +257,6 @@ class TankBundle(object):
         sessions::
 
             stored_query_data_path = os.path.join(self.cache_location, "query.dat")
-
-        :returns: A string, full path to a cache location.
         """
         project_id = self.__tk.pipeline_configuration.get_project_id()
         return self.get_project_cache_location(project_id)
@@ -278,10 +276,20 @@ class TankBundle(object):
         sessions and can be shared across a site::
 
             stored_query_data_path = os.path.join(self.site_cache_location, "query.dat")
-
-        :returns: A string, full path to a cache location.
         """
-        return self.get_site_cache_location()
+        # this method is memoized for performance since it is being called a lot!
+        if self.__cache_location.get("site") is None:
+
+            self.__cache_location["site"] = self.__tk.execute_core_hook_method(
+                constants.CACHE_LOCATION_HOOK_NAME,
+                "get_bundle_data_cache_path",
+                project_id=None,
+                plugin_id=None,
+                pipeline_configuration_id=None,
+                bundle=self
+            )
+
+        return self.__cache_location["site"]
 
     @property
     def context(self):
@@ -480,27 +488,6 @@ class TankBundle(object):
             )
 
         return self.__cache_location[project_id]
-
-    def get_site_cache_location(self):
-        """
-        Gets the bundle's site cache-location path.
-
-        :returns: Cache location directory path.
-        :rtype str:
-        """
-        # this method is memoized for performance since it is being called a lot!
-        if self.__cache_location.get("site") is None:
-
-            self.__cache_location["site"] = self.__tk.execute_core_hook_method(
-                constants.CACHE_LOCATION_HOOK_NAME,
-                "get_bundle_data_cache_path",
-                project_id=None,
-                plugin_id=None,
-                pipeline_configuration_id=None,
-                bundle=self
-            )
-
-        return self.__cache_location["site"]
 
     def get_setting(self, key, default=None):
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -259,9 +259,31 @@ class TankBundle(object):
 
             stored_query_data_path = os.path.join(self.cache_location, "query.dat")
 
+        :returns: A string, full path to a cache location.
         """
         project_id = self.__tk.pipeline_configuration.get_project_id()
         return self.get_project_cache_location(project_id)
+
+    @property
+    def site_cache_location(self):
+        """
+        A site location on disk where the app or engine can store
+        random cache data. This location is guaranteed to exist on disk.
+
+        This location is configurable via the ``cache_location`` hook.
+        It is typically points at a path in the local filesystem, e.g
+        on for example on the mac::
+
+            ~/Library/Caches/Shotgun/SITENAME/BUNDLE_NAME
+
+        This can be used to store cache data that the app wants to reuse across
+        sessions and can be shared across a site::
+
+            stored_query_data_path = os.path.join(self.cache_location, "query.dat")
+
+        :returns: A string, full path to a cache location.
+        """
+        return self.get_site_cache_location()
 
     @property
     def context(self):
@@ -460,6 +482,27 @@ class TankBundle(object):
             )
 
         return self.__cache_location[project_id]
+
+    def get_site_cache_location(self):
+        """
+        Gets the bundle's site cache-location path.
+
+        :returns: Cache location directory path.
+        :rtype str:
+        """
+        # this method is memoized for performance since it is being called a lot!
+        if self.__cache_location.get("site") is None:
+
+            self.__cache_location["site"] = self.__tk.execute_core_hook_method(
+                constants.CACHE_LOCATION_HOOK_NAME,
+                "get_bundle_data_cache_path",
+                project_id=None,
+                plugin_id=None,
+                pipeline_configuration_id=None,
+                bundle=self
+            )
+
+        return self.__cache_location["site"]
 
     def get_setting(self, key, default=None):
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -249,8 +249,7 @@ class TankBundle(object):
         random cache data. This location is guaranteed to exist on disk.
 
         This location is configurable via the ``cache_location`` hook.
-        It is typically points at a path in the local filesystem, e.g
-        on for example on the mac::
+        It typically points at a path in the local filesystem, e.g on a mac::
 
             ~/Library/Caches/Shotgun/SITENAME/PROJECT_ID/BUNDLE_NAME
 
@@ -271,15 +270,14 @@ class TankBundle(object):
         random cache data. This location is guaranteed to exist on disk.
 
         This location is configurable via the ``cache_location`` hook.
-        It is typically points at a path in the local filesystem, e.g
-        on for example on the mac::
+        It typically points at a path in the local filesystem, e.g on a mac::
 
             ~/Library/Caches/Shotgun/SITENAME/BUNDLE_NAME
 
         This can be used to store cache data that the app wants to reuse across
         sessions and can be shared across a site::
 
-            stored_query_data_path = os.path.join(self.cache_location, "query.dat")
+            stored_query_data_path = os.path.join(self.site_cache_location, "query.dat")
 
         :returns: A string, full path to a cache location.
         """

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -304,7 +304,7 @@ class LocalFileStorageManager(object):
             # new paths are on the form
             # project 123, config 33:       root/mysite/p123c33
             # project 123 with plugin id:   root/mysite/p123.review.rv
-            # site project:                 root/mysite/p0
+            # site project:                 root/mysite/site
 
             pc_suffix = ""
             if pipeline_config_id and not plugin_id:

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -316,7 +316,8 @@ class LocalFileStorageManager(object):
             elif plugin_id and pipeline_config_id:
                 pc_suffix = "c%d.%s" % (pipeline_config_id, filesystem.create_valid_filename(plugin_id))
             else:
-                # this is a possible, however not recommended state
+                # No pipeline config id nor plugin id which is possible for caching
+                # at the site level.
                 pc_suffix = ""
 
             if project_id is None:

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -550,3 +550,46 @@ class TestProperties(TestApplication):
         self.assertEqual(app.documentation_url, expected_doc_url)
         
 
+
+class TestBundleDataCache(TestApplication):
+    """
+    Test bundle data cache paths
+    """
+
+    def test_project_data_path(self):
+        app = self.engine.apps["test_app"]
+        project_data_cache_path = app.cache_location
+        # We should have the project id in the path
+        self.assertTrue(
+            "%sp%d" % (os.path.sep, app.context.project["id"]) in project_data_cache_path
+        )
+        site_data_cache_path = app.site_cache_location
+        # We should not have the project id in the path
+        self.assertFalse(
+            "%sp%d" % (os.path.sep, app.context.project["id"]) in site_data_cache_path
+        )
+        # The path should end with "/site/<bundle name>"
+        self.assertTrue(
+            site_data_cache_path.endswith("%ssite%s%s" % (
+                os.path.sep, os.path.sep, app.name,
+            ))
+        )
+        # Test frameworks
+        for name, fw in app.frameworks.iteritems():
+            fw_data_cache_path = fw.cache_location
+            # We should have the project id in the path
+            self.assertTrue(
+                "%sp%d" % (os.path.sep, app.context.project["id"]) in fw_data_cache_path
+            )
+            fw_data_cache_path = fw.site_cache_location
+            # We should not have the project id in the path
+            self.assertFalse(
+                "%sp%d" % (os.path.sep, app.context.project["id"]) in fw_data_cache_path
+            )
+            # The path should end with "/site/<bundle name>"
+            self.assertTrue(
+                fw_data_cache_path.endswith("%ssite%s%s" % (
+                    os.path.sep, os.path.sep, name,
+                ))
+            )
+

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -548,7 +548,6 @@ class TestProperties(TestApplication):
         self.assertEqual(app.display_name, "Test App")
         self.assertEqual(app.version, "Undefined")
         self.assertEqual(app.documentation_url, expected_doc_url)
-        
 
 
 class TestBundleDataCache(TestApplication):
@@ -556,7 +555,10 @@ class TestBundleDataCache(TestApplication):
     Test bundle data cache paths
     """
 
-    def test_project_data_path(self):
+    def test_data_path(self):
+        """
+        Test project/site data paths.
+        """
         app = self.engine.apps["test_app"]
         project_data_cache_path = app.cache_location
         # We should have the project id in the path
@@ -592,4 +594,3 @@ class TestBundleDataCache(TestApplication):
                     os.path.sep, os.path.sep, name,
                 ))
             )
-


### PR DESCRIPTION
The goal of this work is to allow to cache data at the site level, rather than duplicating data per project / pipeline config / plugin id. Typical use of site caching would be thumbnails or SG queries issued from tk-framework-shotgunutils.

- Added `Bundle.site_cache_location` which allows to retrieve a cache location with just a `site` folder.
- Added unit tests for `cache_location` (project based) and `site_cache_location`.
- Mentioned in `CacheLocation.get_bundle_data_cache_path` that component params can be set to `None` to omit them.
- Changed internal comment to mention that not having a pc id nor a plugin id is a valid use case for site caches.