### PR TITLE
45379 update metrics api to track os info

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -120,19 +120,19 @@ class PlatformInfo(object):
     @classmethod
     def get_platform_info(cls):
         """
-        Returns a simple OS and OS version information of the underlying host.
-        The information is cached to to saves on subsequent calls.
+        Returns a simple OS and OS version information about the underlying host.
+        The information is cached to saves on subsequent calls.
 
-        :return: A dict of basic platform information such as:
-            {'OS Version': 'Debian 7', 'OS': 'Linux'}
-            {'OS Version': 'Ubuntu 12', 'OS': 'Linux'}
-            {'OS Version': '10.7', 'OS': 'Mac'}
-            {'OS Version': '10.13', 'OS': 'Mac'}
-            {'OS Version': '2000', 'OS': 'Windows'}
-            {'OS Version': 'XP', 'OS': 'Windows'}
-            {'OS Version': '7', 'OS': 'Windows'}
-            {'OS Version': '8', 'OS': 'Windows'}
-            {'OS Version': '10', 'OS': 'Windows'}
+        Below are a some different output value examples:
+        - {'OS Version': 'Debian 8', 'OS': 'Linux'}
+        - {'OS Version': 'Ubuntu 14', 'OS': 'Linux'}
+        - {'OS Version': '10.7', 'OS': 'Mac'}
+        - {'OS Version': '10.13', 'OS': 'Mac'}
+        - {'OS Version': '7', 'OS': 'Windows'}
+        - {'OS Version': '10', 'OS': 'Windows'}
+
+        :return: A dict of basic OS and OS version.
+
         """
 
         if cls.__cached_platform_info:
@@ -696,6 +696,9 @@ class EventMetric(object):
                             additional, non-standard properties that should be logged.
         """
 
+        if not properties:
+            properties = {}
+
         if not bundle:
             # No bundle specified, try guessing one
             try:
@@ -716,20 +719,12 @@ class EventMetric(object):
                 pass
 
         if bundle:
-            base_properties = bundle.get_metrics_properties()
-
             # Add base properties to specified properties (if any)
-            if properties:
-                properties.update(base_properties)
-            else:
-                properties = base_properties
+            properties.update(bundle.get_metrics_properties())
         # else we won't get base properties
 
         # Now add basic platform information to the metric properties
-        if properties:
-            properties.update(PlatformInfo.get_platform_info())
-        else:
-            properties = PlatformInfo.get_platform_info()
+        properties.update(PlatformInfo.get_platform_info())
 
         MetricsQueueSingleton().log(
             cls(group, name, properties),

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -119,6 +119,21 @@ class PlatformInfo(object):
 
     @classmethod
     def get_platform_info(cls):
+        """
+        Returns a simple OS and OS version information of the underlying host.
+        The information is cached to to saves on subsequent calls.
+
+        :return: A dict of basic platform information such as:
+            {'OS Version': 'Debian 7', 'OS': 'Linux'}
+            {'OS Version': 'Ubuntu 12', 'OS': 'Linux'}
+            {'OS Version': '10.7', 'OS': 'Mac'}
+            {'OS Version': '10.13', 'OS': 'Mac'}
+            {'OS Version': '2000', 'OS': 'Windows'}
+            {'OS Version': 'XP', 'OS': 'Windows'}
+            {'OS Version': '7', 'OS': 'Windows'}
+            {'OS Version': '8', 'OS': 'Windows'}
+            {'OS Version': '10', 'OS': 'Windows'}
+        """
 
         if cls.__cached_platform_info:
             return cls.__cached_platform_info
@@ -143,10 +158,10 @@ class PlatformInfo(object):
                 os_info["OS"] = "Unsupported system: (%s)" % (system)
 
         except:
-            # On any exception we fallback to defaukt value
+            # On any exception we fallback to default value
             pass
 
-        # Saved as cached version
+        # Cache information to save on subsequent calls
         cls.__cached_platform_info = os_info
         return os_info
 

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -52,7 +52,7 @@ class PlatformInfo(object):
         Returns a macOS / OSX friendly version string such as:
             10.7, 10.11, 10.12, etc
 
-        :return: A simply os version identification string.
+        :return: A str of a simple OS version string.
         """
 
         os_version = "Unknown"
@@ -79,7 +79,7 @@ class PlatformInfo(object):
         Returns a Linux friendly version string such as:
             "Ubuntu 12", "Fedora 24", "Red Hat 7", "Debian 8" etc
 
-        :return: A simply os version identification string.
+        :return: A str of a simple OS version string.
         """
         os_version = "Unknown"
 
@@ -103,7 +103,7 @@ class PlatformInfo(object):
         Returns a Windows friendly version string such as:
             2000, XP, 7, 10 etc.
 
-        :return: A simply os version identification string.
+        :return: A str of a simple OS version string.
         """
         os_version = "Unknown"
 

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -1073,7 +1073,6 @@ class TestBundleMetrics(TankTestBase):
             self.assertTrue(hook_called)
 
 
-
 from tank.util.metrics import PlatformInfo
 
 
@@ -1165,7 +1164,7 @@ class TestPlatformInfo(unittest2.TestCase):
 
     @patch("platform.system", return_value="Windows")
     @patch("platform.release", side_effect=Exception)
-    def test_as_mac_without_mac_version(self, mocked_release, mocked_system):
+    def test_as_mac_without_release(self, mocked_release, mocked_system):
         """
         Tests handling of an exception caused by the 'release' method.
         """
@@ -1188,7 +1187,3 @@ class TestPlatformInfo(unittest2.TestCase):
         self.assertEquals("Unknown", platform_info["OS Version"])
         self.assertTrue(mocked_system.called)
         self.assertFalse(mocked_release.called)
-
-
-
-

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -34,6 +34,7 @@ import time
 import threading
 import urllib2
 import time
+import unittest2
 
 
 class TestEventMetric(TankTestBase):
@@ -1070,3 +1071,124 @@ class TestBundleMetrics(TankTestBase):
                         hook_called = True
                         break
             self.assertTrue(hook_called)
+
+
+
+from tank.util.metrics import PlatformInfo
+
+
+class TestPlatformInfo(unittest2.TestCase):
+
+    def setUp(self):
+        super(TestPlatformInfo, self).setUp()
+        # reset un-cache PlatformInfo cached value
+        PlatformInfo._PlatformInfo__cached_platform_info = None
+
+    @patch("platform.system", return_value="Windows")
+    @patch("platform.release", return_value="XP")
+    def test_as_windows(self, mocked_release, mocked_system):
+        """
+        Tests as a Windows XP system
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Windows", platform_info["OS"])
+        self.assertEquals("XP", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_release.called)
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.mac_ver", return_value=("10.7.5", ("", "", ""), "i386"))
+    def test_as_osx(self, mocked_mac_ver, mocked_system):
+        """
+        Tests as some OSX Lion system
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Mac", platform_info["OS"])
+        self.assertEquals("10.7", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_mac_ver.called)
+
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.linux_distribution", return_value=("debian", "7.7", ""))
+    def test_as_linux(self, mocked_system, mocked_linux_distribution):
+        """
+        Tests as a Linux Debian system
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Linux", platform_info["OS"])
+        self.assertEquals("Debian 7", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_linux_distribution.called)
+
+    @patch("platform.system", return_value="BSD")
+    @patch("platform.linux_distribution", side_effect=Exception)
+    def test_as_unsupported_system(self, mocked_linux_distribution, mocked_system):
+        """
+        Tests a fake unsupported system
+        """
+        mocked_linux_distribution.reset_mock()
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Unsupported system: (BSD)", platform_info["OS"])
+        self.assertEquals("Unknown", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertFalse(mocked_linux_distribution.called)
+
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.linux_distribution", side_effect=Exception)
+    def test_as_linux_without_distribution(self, mocked_linux_distribution, mocked_system):
+        """
+        Tests handling of an exception caused by the 'linux_distribution' method.
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Linux", platform_info["OS"])
+        self.assertEquals("Unknown", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_linux_distribution.called)
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.mac_ver", side_effect=Exception)
+    def test_as_mac_without_mac_version(self, mocked_mac_ver, mocked_system):
+        """
+        Tests handling of an exception caused by the 'mac_ver' method.
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Mac", platform_info["OS"])
+        self.assertEquals("Unknown", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_mac_ver.called)
+
+    @patch("platform.system", return_value="Windows")
+    @patch("platform.release", side_effect=Exception)
+    def test_as_mac_without_mac_version(self, mocked_release, mocked_system):
+        """
+        Tests handling of an exception caused by the 'release' method.
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Windows", platform_info["OS"])
+        self.assertEquals("Unknown", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertTrue(mocked_release.called)
+
+    @patch("platform.system", side_effect=Exception)
+    @patch("platform.release", side_effect=Exception)
+    def test_system(self, mocked_release, mocked_system):
+        """
+        Tests handling of an exception caused by the 'system' method.
+        """
+        platform_info = PlatformInfo.get_platform_info()
+        self.assertIsNotNone(platform_info)
+        self.assertEquals("Unknown", platform_info["OS"])
+        self.assertEquals("Unknown", platform_info["OS Version"])
+        self.assertTrue(mocked_system.called)
+        self.assertFalse(mocked_release.called)
+
+
+
+


### PR DESCRIPTION
This pull request is about adding very basic platform information to emitted metrics. To simplying Amplitude query I was asked to limit version string to minimum. Here are a few sample outputs:

{'OS Version': 'Debian 7', 'OS': 'Linux'}
{'OS Version': 'Ubuntu 12', 'OS': 'Linux'}
{'OS Version': '10.7', 'OS': 'Mac'}
{'OS Version': '10.13', 'OS': 'Mac'}
{'OS Version': '2000', 'OS': 'Windows'}
{'OS Version': 'XP', 'OS': 'Windows'}
{'OS Version': '7', 'OS': 'Windows'}
{'OS Version': '8', 'OS': 'Windows'}
{'OS Version': '10', 'OS': 'Windows'}
