### PR TITLE
#45998 Adds new hook interface to support custom hook base classes

### DIFF
--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -563,6 +563,7 @@ def execute_hook(hook_path, parent, **kwargs):
     """
     return execute_hook_method([hook_path], parent, None, **kwargs)
 
+
 def execute_hook_method(hook_paths, parent, method_name, base_class=None, **kwargs):
     """
     New style hook execution, with method arguments and support for inheritance.
@@ -670,7 +671,7 @@ def get_hook_class(hook_paths, base_class=None):
 
     if base_class:
         # ensure the supplied base class is a subclass of Hook
-        if not isinstance(base_class, Hook):
+        if not issubclass(base_class, Hook):
             raise TankError(
                 "Error retrieving hook class. The supplied base class does not "
                 "inherit from `sgtk.Hook`. Hook paths supplied: %s" %

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -598,7 +598,8 @@ def execute_hook_method(hook_paths, parent, method_name, base_class=None, **kwar
                    app, engine or core object.
     :param method_name: method to execute. If None, the default method will be executed.
     :param base_class: A python class to use as the base class for the hook
-        class. This will override the default hook base class, ``Hook``.
+        class. This will override the default hook base class, ``Hook``. The
+        class should derive from ``Hook``.
     :returns: Whatever the hook returns.
     """
     hook = create_hook_instance(hook_paths, parent, base_class=base_class)
@@ -648,7 +649,8 @@ def get_hook_class(hook_paths, base_class=None):
         Example: ["/tmp/a.py", "/tmp/b.py", "/tmp/c.py"]
 
         1. The code in a.py is loaded in. get_hook_baseclass() will return Hook
-           at this point. class HookA is returned from our plugin loader.
+           at this point (or a custom base class, if supplied, that derives from
+           Hook). class HookA is returned from our plugin loader.
 
         2. /tmp/b.py is loaded in. get_hook_baseclass() now returns HookA, so
            if the hook code in B utilises get_hook_baseclass, this will will
@@ -673,9 +675,8 @@ def get_hook_class(hook_paths, base_class=None):
         # ensure the supplied base class is a subclass of Hook
         if not issubclass(base_class, Hook):
             raise TankError(
-                "Error retrieving hook class. The supplied base class does not "
-                "inherit from `sgtk.Hook`. Hook paths supplied: %s" %
-                (hook_paths,)
+                "Invalid custom hook base class. The supplied class '%s' does "
+                "not inherit from Hook." % (Hook,)
             )
     else:
         base_class = Hook

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -622,29 +622,12 @@ def execute_hook_method(hook_paths, parent, method_name, base_class=None, **kwar
 
 def create_hook_instance(hook_paths, parent, base_class=None):
     """
-    This method calls `get_hook_class` to retrieve the class for the supplied
-    hook paths. An instance of the hook class is returned.
-
-    :param hook_paths: List of full paths to hooks, in inheritance order.
-    :param parent: Parent object. This will be accessible inside
-                   the hook as self.parent, and is typically an
-                   app, engine or core object.
-    :param base_class: A python class to use as the base class for the created
-        hook. This will override the default hook base class, ``Hook``.
-    :returns: Instance of the hook.
-    """
-    cls = get_hook_class(hook_paths, base_class=base_class)
-    return cls(parent)
-
-
-def get_hook_class(hook_paths, base_class=None):
-    """
     New style hook execution, with method arguments and support for inheritance.
 
     This method takes a list of hook paths and will load each of the classes
     in, while maintaining the correct state of the class returned via
     get_hook_baseclass(). Once all classes have been successfully loaded,
-    the last class in the list is returned.
+    an instance of the last class in the list is returned.
 
         Example: ["/tmp/a.py", "/tmp/b.py", "/tmp/c.py"]
 
@@ -658,7 +641,7 @@ def get_hook_class(hook_paths, base_class=None):
 
         3. /tmp/c.py is finally loaded in, get_hook_baseclass() now returns HookB.
 
-        4. HookC class is returned.
+        4. An instance of the HookC class is returned.
 
     An optional `base_class` can be provided to override the default ``Hook``
     base class. This is useful for bundles that create hook instances at
@@ -723,11 +706,10 @@ def get_hook_class(hook_paths, base_class=None):
         # keep track of the current base class:
         _current_hook_baseclass.value = found_hook_class
 
-    # all class construction done. _current_hook_baseclass contains
-    # the last class we iterated over. This is the one we want to return
+    # all class construction done. _current_hook_baseclass contains the last
+    # class we iterated over. An instance of this is what we want to return
+    return _current_hook_baseclass.value(parent)
 
-    # return the class
-    return _current_hook_baseclass.value
 
 def get_hook_baseclass():
     """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -642,7 +642,7 @@ class TankBundle(object):
         hook_path = os.path.join(hook_folder, "%s.py" % hook_name)
         return hook.execute_hook(hook_path, self, **kwargs)
 
-    def create_hook_instance(self, hook_expression):
+    def create_hook_instance(self, hook_expression, base_class=None):
         """
         Returns the instance of a hook object given an expression.
 
@@ -663,11 +663,49 @@ class TankBundle(object):
 
         .. note:: For more information about hook syntax, see :class:`~sgtk.Hook`
 
+        An optional `base_class` can be provided to override the default ``Hook``
+        base class. This is useful for bundles that create hook instances at
+        execution time and wish to provide default implementation without the need
+        to configure the base hook.
+
         :param hook_expression: Path to hook to execute. See above for syntax details.
+        :param base_class: A python class to use as the base class for the created
+            hook. This will override the default hook base class, ``Hook``.
         :returns: :class:`Hook` instance.
         """
         resolved_hook_paths = self.__resolve_hook_expression(None, hook_expression)
-        return hook.create_hook_instance(resolved_hook_paths, self)
+        return hook.create_hook_instance(
+            resolved_hook_paths,
+            self,
+            base_class=base_class
+        )
+
+    def get_hook_class(self, hook_expression, base_class=None):
+        """
+        Returns the class for the hook resolved for the given expression.
+
+        The hook expression is the raw value that is specified in the configuration file.
+        If you want to access a configuration setting instead (like how for example
+        :meth:`execute_hook_method` works), simply call :meth:`get_setting()` to retrieve
+        the value and then pass the settings value to this method.
+
+        .. note:: For more information about hook syntax, see :class:`~sgtk.Hook`
+
+        An optional `base_class` can be provided to override the default ``Hook``
+        base class. This is useful for bundles that create hook instances at
+        execution time and wish to provide default implementation without the need
+        to configure the base hook.
+
+        :param hook_expression: Path to hook to execute. See above for syntax details.
+        :param base_class: A python class to use as the base class for the created
+            hook. This will override the default hook base class, ``Hook``.
+        :returns: :class:`Hook` instance.
+        """
+        resolved_hook_paths = self.__resolve_hook_expression(None, hook_expression)
+        return hook.get_hook_class(
+            resolved_hook_paths,
+            base_class=base_class
+        )
 
     def ensure_folder_exists(self, path):
         """

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -666,7 +666,7 @@ class TankBundle(object):
         An optional `base_class` can be provided to override the default ``Hook``
         base class. This is useful for bundles that create hook instances at
         execution time and wish to provide default implementation without the need
-        to configure the base hook.
+        to configure the base hook. The supplied class must inherit from Hook.
 
         :param hook_expression: Path to hook to execute. See above for syntax details.
         :param base_class: A python class to use as the base class for the created
@@ -683,6 +683,14 @@ class TankBundle(object):
     def get_hook_class(self, hook_expression, base_class=None):
         """
         Returns the class for the hook resolved for the given expression.
+
+        This method is useful for bundles that wish to provide a default class
+        implementation of a hook. The bundle can use this method to retrieve
+        a class from a hook expression and then supply the class as the
+        `base_class` argument to `create_hook_instance` for a configured hook.
+        This provides flexibility for bundles that wish to provide default
+        logic in a Hook subclass that does not have to be configured by the
+        user.
 
         The hook expression is the raw value that is specified in the configuration file.
         If you want to access a configuration setting instead (like how for example

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -680,41 +680,6 @@ class TankBundle(object):
             base_class=base_class
         )
 
-    def get_hook_class(self, hook_expression, base_class=None):
-        """
-        Returns the class for the hook resolved for the given expression.
-
-        This method is useful for bundles that wish to provide a default class
-        implementation of a hook. The bundle can use this method to retrieve
-        a class from a hook expression and then supply the class as the
-        `base_class` argument to `create_hook_instance` for a configured hook.
-        This provides flexibility for bundles that wish to provide default
-        logic in a Hook subclass that does not have to be configured by the
-        user.
-
-        The hook expression is the raw value that is specified in the configuration file.
-        If you want to access a configuration setting instead (like how for example
-        :meth:`execute_hook_method` works), simply call :meth:`get_setting()` to retrieve
-        the value and then pass the settings value to this method.
-
-        .. note:: For more information about hook syntax, see :class:`~sgtk.Hook`
-
-        An optional `base_class` can be provided to override the default ``Hook``
-        base class. This is useful for bundles that create hook instances at
-        execution time and wish to provide default implementation without the need
-        to configure the base hook.
-
-        :param hook_expression: Path to hook to execute. See above for syntax details.
-        :param base_class: A python class to use as the base class for the created
-            hook. This will override the default hook base class, ``Hook``.
-        :returns: :class:`Hook` instance.
-        """
-        resolved_hook_paths = self.__resolve_hook_expression(None, hook_expression)
-        return hook.get_hook_class(
-            resolved_hook_paths,
-            base_class=base_class
-        )
-
     def ensure_folder_exists(self, path):
         """
         Make sure that the given folder exists on disk.


### PR DESCRIPTION
This change adds a new, optional `base_class` argument to the `hook.create_hook_instance` method in core. This argument allows the calling code to override the hook base class used when loading the supplied hook paths. Having the ability to set the base class means bundles can define default hook implementations that do not require configuration. 

Additionally, the bulk of the previous logic for `create_hook_instance` has been moved to a new method called `get_hook_class` which simply returns the class without creating an instance. `create_hook_instance` simply calls `get_hook_class` with the required arguments and then returns the instantiated hook. 

The changes to these methods are reflected in the `bundle` convenience methods that wrap them. 

**NOTE**: I have not written tests for these methods yet. If you guys feel comfortable with this approach, I'll crank out the tests.