### PR TITLE
Feature/sso

### DIFF
--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -18,8 +18,19 @@ credentials are reused. If a Toolkit-enabled process is launched a second time, 
 credentials are reused if available.
 """
 
-from .errors import ShotgunAuthenticationError, AuthenticationError, IncompleteCredentials, AuthenticationCancelled
+from .errors import (  # noqa
+    AuthenticationCancelled,
+    AuthenticationError,
+    ConsoleLoginWithSSONotSupportedError,
+    IncompleteCredentials,
+    ShotgunAuthenticationError,
+)
 from .shotgun_authenticator import ShotgunAuthenticator
 from .defaults_manager import DefaultsManager
 from .core_defaults_manager import CoreDefaultsManager
-from .user import ShotgunUser, deserialize_user, serialize_user
+from .user import (  # noqa
+    deserialize_user,
+    serialize_user,
+    ShotgunSamlUser,
+    ShotgunUser,
+)

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -47,6 +47,30 @@ class AuthenticationCancelled(ShotgunAuthenticationError):
     """
 
     def __init__(self):
+        """
+        Constructor.
+        """
         ShotgunAuthenticationError.__init__(
             self, "Authentication was cancelled by the user."
+        )
+
+
+class AuthenticationSSOError(ShotgunAuthenticationError):
+    """
+    Base class for all SSO-related exceptions coming out from this module.
+    """
+
+
+class ConsoleLoginWithSSONotSupportedError(AuthenticationSSOError):
+    """
+    Thrown when attempting to use Username/Password pair to login onto
+    a SSO-enabled site.
+    """
+
+    def __init__(self, url):
+        """
+        :param str url: Url of the site where login was attempted.
+        """
+        ShotgunAuthenticationError.__init__(
+            self, "Authentication using username/password is not allowed on the console for %s, an SSO-enabled site." % url
         )

--- a/python/tank/authentication/resources/login_dialog.ui
+++ b/python/tank/authentication/resources/login_dialog.ui
@@ -220,29 +220,33 @@ QLineEdit:Disabled {
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="forgot_password_link">
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">QWidget
+          <layout class="QVBoxLayout" name="links">
+           <item>
+            <widget class="QLabel" name="forgot_password_link">
+             <property name="cursor">
+              <cursorShape>PointingHandCursor</cursorShape>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">QWidget
 {
     color: rgb(192, 193, 195);
 }</string>
-           </property>
-           <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://mystudio.shotgunstudio.com/user/forgot_password&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0c1c3;&quot;&gt;Forgot your password?&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::RichText</enum>
-           </property>
-           <property name="margin">
-            <number>4</number>
-           </property>
-           <property name="openExternalLinks">
-            <bool>false</bool>
-           </property>
-          </widget>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://mystudio.shotgunstudio.com/user/forgot_password&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0c1c3;&quot;&gt;Forgot your password?&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::RichText</enum>
+             </property>
+             <property name="margin">
+              <number>4</number>
+             </property>
+             <property name="openExternalLinks">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <spacer name="sign_in_hspacer">

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -37,6 +37,7 @@ _CURRENT_HOST = "current_host"
 _CURRENT_USER = "current_user"
 _USERS = "users"
 _LOGIN = "login"
+_SESSION_METADATA = "session_metadata"
 _SESSION_TOKEN = "session_token"
 _SESSION_CACHE_FILE_NAME = "authentication.yml"
 
@@ -65,7 +66,6 @@ def _get_global_authentication_file_location():
 
     :returns: Path to the login information.
     """
-
     # try current generation path first
     path = os.path.join(
         LocalFileStorageManager.get_global_root(LocalFileStorageManager.CACHE),
@@ -223,7 +223,7 @@ def _try_load_global_authentication_file(file_path):
     return content
 
 
-def _insert_or_update_user(users_file, login, session_token):
+def _insert_or_update_user(users_file, login, session_token, session_metadata):
     """
     Finds or updates an entry in the users file with the given login and
     session token.
@@ -231,6 +231,7 @@ def _insert_or_update_user(users_file, login, session_token):
     :param users_file: Users dictionary to update.
     :param login: Login of the user to update.
     :param session_token: Session token of the user to update.
+    :param session_metadata: Information needed for when SSO is used. This is an obscure blob of data.
 
     :returns: True is the users dictionary has been updated, False otherwise.
     """
@@ -238,14 +239,25 @@ def _insert_or_update_user(users_file, login, session_token):
     for user in users_file[_USERS]:
         # If we've matched what we are looking for.
         if _is_same_user(user, login):
+            result = False
             # Update and return True only if something changed.
             if user[_SESSION_TOKEN] != session_token:
                 user[_SESSION_TOKEN] = session_token
-                return True
-            else:
-                return False
+                result = True
+            if user.get(_SESSION_METADATA) and user[_SESSION_METADATA] != session_metadata:
+                user[_SESSION_METADATA] = session_metadata
+                result = True
+            return result
     # This is a new user, add it to the list.
-    users_file[_USERS].append({_LOGIN: login, _SESSION_TOKEN: session_token})
+    user = {
+        _LOGIN: login,
+        _SESSION_TOKEN: session_token
+    }
+    # We purposely do not save unset session_metadata to avoid de-serialization issues
+    # when the data is read by older versions of the tk-core.
+    if session_metadata is not None:
+        user[_SESSION_METADATA] = session_metadata
+    users_file[_USERS].append(user)
     return True
 
 
@@ -306,25 +318,32 @@ def get_session_data(base_url, login):
         for user in users_file[_USERS]:
             # Search for the user in the users dictionary.
             if _is_same_user(user, login):
-                return {
+                session_data = {
                     # There used to be a time where we didn't strip whitepsaces
                     # before writing the file, so do it now just in case.
                     _LOGIN: user[_LOGIN].strip(),
                     _SESSION_TOKEN: user[_SESSION_TOKEN]
                 }
+                # We want to keep session_metadata out of the session data if there
+                # is none. This is to ensure backward compatibility for older
+                # version of tk-core reading the authentication.yml
+                if user.get(_SESSION_METADATA):
+                    session_data[_SESSION_METADATA] = user[_SESSION_METADATA]
+                return session_data
         logger.debug("No cached user found for %s" % login)
     except Exception:
         logger.exception("Exception thrown while loading cached session info.")
         return None
 
 
-def cache_session_data(host, login, session_token):
+def cache_session_data(host, login, session_token, session_metadata=None):
     """
     Caches the session data for a site and a user.
 
     :param host: Site we want to cache a session for.
     :param login: User we want to cache a session for.
     :param session_token: Session token we want to cache.
+    :param session_metadata: Session meta data.
     """
     # Retrieve the cached info file location from the host
     file_path = _get_site_authentication_file_location(host)
@@ -335,7 +354,7 @@ def cache_session_data(host, login, session_token):
 
     document = _try_load_site_authentication_file(file_path)
 
-    if _insert_or_update_user(document, login, session_token):
+    if _insert_or_update_user(document, login, session_token, session_metadata):
         # Write back the file only it a new user was added.
         _write_yaml_file(file_path, document)
         logger.debug("Updated session cache data.")

--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+"""Shotgun Authenticator."""
+
 from . import interactive_authentication
 from . import user
 from . import user_impl
@@ -15,6 +17,7 @@ from . import session_cache
 from .errors import IncompleteCredentials
 from .defaults_manager import DefaultsManager
 from .. import LogManager
+from .shotgun_shared import has_sso_info_in_cookies
 
 logger = LogManager.get_logger(__name__)
 
@@ -114,20 +117,50 @@ class ShotgunAuthenticator(object):
 
         :returns: The SessionUser based on the login information provided.
         """
-        host, login, session_token = interactive_authentication.authenticate(
+        host, login, session_token, session_metadata = interactive_authentication.authenticate(
             self._defaults_manager.get_host(),
             self._defaults_manager.get_login(),
             self._defaults_manager.get_http_proxy(),
             self._defaults_manager.is_host_fixed()
         )
-        return self.create_session_user(
+        return self._create_session_user(
             login=login, session_token=session_token,
-            host=host, http_proxy=self._defaults_manager.get_http_proxy()
+            host=host, http_proxy=self._defaults_manager.get_http_proxy(),
+            session_metadata=session_metadata
         )
+
+    def _create_session_user(self, login, session_token=None, password=None, host=None, http_proxy=None, session_metadata=None):
+        """
+        Create a :class:`ShotgunUser` given a set of human user credentials.
+        Either a password or session token must be supplied. If a password is supplied,
+        a session token will be generated for security reasons.
+
+        This is an internal version of the method, which makes reference to the
+        session_metadata. This is an implementation details which we want to hide from the public interface.
+
+        :param login: Shotgun user login
+        :param session_token: Shotgun session token
+        :param password: Shotgun password
+        :param host: Shotgun host to log in to. If None, the default host will be used.
+        :param http_proxy: Shotgun proxy to use. If None, the default http proxy will be used.
+        :param session_metadata: Information needed when SSO is used. This is an obscure blob of data.
+
+        :returns: A :class:`ShotgunUser` instance.
+        """
+        # Get the defaults is arguments were None.
+        host = host or self._defaults_manager.get_host()
+        http_proxy = http_proxy or self._defaults_manager.get_http_proxy()
+
+        # Create a session user
+        impl = user_impl.SessionUser(host, login, session_token, http_proxy, password=password, session_metadata=session_metadata)
+        if has_sso_info_in_cookies(session_metadata):
+            return user.ShotgunSamlUser(impl)
+        else:
+            return user.ShotgunUser(impl)
 
     def create_session_user(self, login, session_token=None, password=None, host=None, http_proxy=None):
         """
-        Create an AuthenticatedUser given a set of human user credentials.
+        Create a :class:`ShotgunUser` given a set of human user credentials.
         Either a password or session token must be supplied. If a password is supplied,
         a session token will be generated for security reasons.
 
@@ -139,14 +172,8 @@ class ShotgunAuthenticator(object):
 
         :returns: A :class:`ShotgunUser` instance.
         """
-        # Get the defaults is arguments were None.
-        host = host or self._defaults_manager.get_host()
-        http_proxy = http_proxy or self._defaults_manager.get_http_proxy()
-
-        # Create a session user
-        return user.ShotgunUser(
-            user_impl.SessionUser(host, login, session_token, http_proxy, password=password)
-        )
+        # Leverage the private implementation.
+        return self._create_session_user(login, session_token, password, host, http_proxy)
 
     def create_script_user(self, api_script, api_key, host=None, http_proxy=None):
         """
@@ -214,12 +241,13 @@ class ShotgunAuthenticator(object):
         # If some of the arguments are missing, don't worry, create_session_user
         # will take care of it.
         elif "login" in credentials or "password" in credentials or "session_token" in credentials:
-            return self.create_session_user(
+            return self._create_session_user(
                 login=credentials.get("login"),
                 password=credentials.get("password"),
                 session_token=credentials.get("session_token"),
                 host=credentials.get("host"),
-                http_proxy=credentials.get("http_proxy")
+                http_proxy=credentials.get("http_proxy"),
+                session_metadata=credentials.get("session_metadata")
             )
         # We don't know what this is, abort!
         else:

--- a/python/tank/authentication/shotgun_shared/__init__.py
+++ b/python/tank/authentication/shotgun_shared/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+"""
+This module contains files which are shared between RV and Toolkit.
+"""
+
+# Classes
+from .saml2_sso import (  # noqa
+    Saml2Sso,
+    Saml2SsoError,
+    Saml2SsoMissingQtModuleError,
+    Saml2SsoMultiSessionNotSupportedError,
+)
+
+# Functions
+from .saml2_sso import (  # noqa
+    get_csrf_key,
+    get_csrf_token,
+    get_logger,
+    get_saml_claims_expiration,
+    get_saml_user_name,
+    get_session_id,
+    has_sso_info_in_cookies,
+    is_sso_enabled_on_site,
+    set_logger_parent,
+)

--- a/python/tank/authentication/shotgun_shared/authentication_session_data.py
+++ b/python/tank/authentication/shotgun_shared/authentication_session_data.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2017 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+"""
+Authentication Session abstraction.
+"""
+
+
+class AuthenticationSessionData(object):
+    """
+    Holds session information.
+
+    A session object holds information coming from both the toolkit current session
+    and from the QWebView used to login/renew session from our SSO enabled site.
+
+    Attributes:
+        cookies:            A string of the base64 encoded json string of raw
+                            cookies.
+        crsf_value:         A string for the crsf value.
+        csrf_key:           A string for the crsf key.
+        error:              A string which describe the error encountered.
+        host:               A string for the hostname.
+        product:            A string for the product (used at login).
+        session_expitation: An int in seconds for the UTC time of expiration.
+        session_id:         A string for the session id.
+        user_id:            A string for the user id.
+    """
+
+    def __init__(self, settings={}):
+        """
+        Constructor.
+
+        Args:
+            settings (dict):    Dictionary of element to add to the settings.
+                                Non-used key/value pairs will be discarded
+                                silently.
+        """
+        self._cookies = None
+        self._csrf_key = None
+        self._csrf_value = None
+        self._error = None
+        self._host = None
+        self._product = None
+        self._session_expiration = None
+        self._session_id = None
+        self._user_id = None
+        self.merge_settings(settings)
+
+    def __repr__(self):
+        """
+        Returns a string reprensentation of the session.
+
+        :returns: A string containing all of the session data.
+        """
+        params = {}
+        for key, value in vars(self).iteritems():
+            if value is not None:
+                params[key] = value
+
+        return "<Session %s>" % params
+
+    def merge_settings(self, settings):
+        """
+        Merge new settings with existing ones.
+
+        Args:
+            settings (dict):    Dictionary of element to merge to the settings.
+                                Non-used key/value pairs will be discarded
+                                silently.
+        """
+        for key, value in settings.iteritems():
+            _key = "_%s" % key
+            if _key in vars(self):
+                setattr(self, _key, value)
+
+    @property
+    def cookies(self):
+        """String R/W property."""
+        return str(self._cookies or "")
+
+    @cookies.setter
+    def cookies(self, value):
+        self._cookies = value
+
+    @property
+    def csrf_key(self):
+        """
+        String R/W property.
+
+        This is the key name of the CRSF token, which will include a unique ID.
+        The ID corresponds to the Shogun user ID.
+        """
+        return str(self._csrf_key or "")
+
+    @csrf_key.setter
+    def csrf_key(self, value):
+        self._csrf_key = value
+
+    @property
+    def csrf_value(self):
+        """
+        String R/W property.
+
+        This is the value of the Cross-Site Request Forgery token.
+        """
+        return str(self._csrf_value or "")
+
+    @csrf_value.setter
+    def csrf_value(self, value):
+        self._csrf_value = value
+
+    @property
+    def error(self):
+        """String R/W property."""
+        return str(self._error or "")
+
+    @error.setter
+    def error(self, value):
+        self._error = value
+
+    @property
+    def host(self):
+        """String R/W property."""
+        return str(self._host or "")
+
+    @host.setter
+    def host(self, value):
+        self._host = value
+
+    @property
+    def product(self):
+        """String R/W property."""
+        return str(self._product or "undefined")
+
+    @product.setter
+    def product(self, value):
+        self._product = value
+
+    @property
+    def session_expiration(self):
+        """Int R/W property."""
+        return int(self._session_expiration or 0)
+
+    @session_expiration.setter
+    def session_expiration(self, value):
+        self._session_expiration = int(value)
+
+    @property
+    def session_id(self):
+        """String R/W property."""
+        return str(self._session_id or "")
+
+    @session_id.setter
+    def session_id(self, value):
+        self._session_id = value
+
+    @property
+    def user_id(self):
+        """String R/W property."""
+        return str(self._user_id or "")
+
+    @user_id.setter
+    def user_id(self, value):
+        self._user_id = value

--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -1,0 +1,874 @@
+# Copyright (c) 2017 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+"""
+Module to support SSO login via a web browser and automated session renewal.
+
+This module, in conjunction with the slmodule, handles authentication on
+SSO enabled Shotgun websites. When we are in a session connected via SSO, we
+also handle automatic (and headless) renewal of the session.
+"""
+
+import base64
+from Cookie import SimpleCookie
+import json
+import logging
+import os
+import time
+import urllib
+
+from tank_vendor.shotgun_api3 import Shotgun
+
+from .authentication_session_data import AuthenticationSessionData
+
+
+# Error messages for events.
+HTTP_CANT_CONNECT_TO_SHOTGUN = "Cannot Connect To Shotgun site."
+HTTP_AUTHENTICATE_REQUIRED = "Valid credentials are required."
+HTTP_AUTHENTICATE_SSO_NOT_UPPORTED = "SSO not supported or enabled on that site."
+HTTP_CANT_AUTHENTICATE_SSO_TIMEOUT = "Time out attempting to authenticate to SSO service."
+HTTP_CANT_AUTHENTICATE_SSO_NO_ACCESS = "You have not been granted access to the Shotgun site."
+
+# Paths for bootstrap the login/renewal process.
+URL_SAML_RENEW_PATH = "/saml/saml_renew"
+URL_SAML_RENEW_LANDING_PATH = "/saml/saml_renew_landing"
+
+# Old login path, which is not used for SSO.
+URL_LOGIN_PATH = "/user/login"
+
+# Timer related values.
+# @TODO: parametrize these and add environment variable overload.
+WATCHDOG_TIMEOUT_MS = 5000
+PREEMPTIVE_RENEWAL_THRESHOLD = 0.9
+SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
+
+
+def get_logger():
+    """
+    Return the logger for this module.
+    """
+    return logging.getLogger(__name__)
+
+
+def set_logger_parent(logger_parent):
+    """
+    Set the logger parent to this module's logger.
+    """
+    logger = get_logger()
+    logger.parent = logger_parent
+
+
+class Saml2SsoError(Exception):
+    """
+    Top level exception for all saml2_sso level runtime errors
+    """
+
+
+class Saml2SsoMultiSessionNotSupportedError(Saml2SsoError):
+    """
+    Exception that indicates the cookies contains sets of tokens from mutliple users.
+    """
+
+
+class Saml2SsoMissingQtModuleError(Saml2SsoError):
+    """
+    Exception that indicates that a required Qt component is missing.
+    """
+
+
+class Saml2SsoMissingQtCore(Saml2SsoMissingQtModuleError):
+    """
+    Exception that indicates that the QtCore component is missing.
+    """
+
+
+class Saml2SsoMissingQtGui(Saml2SsoMissingQtModuleError):
+    """
+    Exception that indicates that the QtGui component is missing.
+    """
+
+
+class Saml2SsoMissingQtNetwork(Saml2SsoMissingQtModuleError):
+    """
+    Exception that indicates that the QtNetwork component is missing.
+    """
+
+
+class Saml2SsoMissingQtWebKit(Saml2SsoMissingQtModuleError):
+    """
+    Exception that indicates that the QtWebKit component is missing.
+    """
+
+
+class Saml2Sso(object):
+    """Performs Shotgun SSO login and pre-emptive renewal."""
+
+    def __init__(self, window_title="SSO", qt_modules={}):
+        """
+        Create a SSO login dialog, using a Web-browser like environment.
+
+        :param window_title: Title to use for the window.
+        :param qt_modules: a dictionnary of required Qt modules.
+                           For Qt4/PySide, we require modules QtCore, QtGui, QtNetwork and QtWebKit
+
+        :returns: The Saml2Sso oject.
+        """
+        self._logger = get_logger()
+        self._logger.debug("Constructing SSO dialog: %s" % window_title)
+
+        QtCore = self._QtCore = qt_modules.get('QtCore')  # noqa
+        QtGui = self._QtGui = qt_modules.get('QtGui')  # noqa
+        QtNetwork = self._QtNetwork = qt_modules.get('QtNetwork')  # noqa
+        QtWebKit = self._QtWebKit = qt_modules.get('QtWebKit')  # noqa
+
+        if QtCore is None:
+            raise Saml2SsoMissingQtCore("The QtCore module is unavailable")
+
+        if QtGui is None:
+            raise Saml2SsoMissingQtGui("The QtGui module is unavailable")
+
+        if QtNetwork is None:
+            raise Saml2SsoMissingQtNetwork("The QtNetwork module is unavailable")
+
+        if QtWebKit is None:
+            raise Saml2SsoMissingQtWebKit("The QtWebKit module is unavailable")
+
+        self._event_data = None
+        self._sessions_stack = []
+        self._session_renewal_active = False
+
+        self._dialog = QtGui.QDialog()
+        self._dialog.setWindowTitle(window_title)
+        self._dialog.finished.connect(self.on_dialog_closed)
+
+        self._view = QtWebKit.QWebView(self._dialog)
+        self._view.page().networkAccessManager().finished.connect(self.on_http_response_finished)
+        self._view.page().networkAccessManager().authenticationRequired.connect(self._on_authentication_required)
+        self._view.loadFinished.connect(self.on_load_finished)
+
+        # Purposely disable the 'Reload' contextual menu, as it should not be
+        # used for SSO. Reloading the page confuses the server.
+        self._view.page().action(QtWebKit.QWebPage.Reload).setVisible(False)
+
+        # Ensure that the background color is not controlled by the login page.
+        # We want to be able to display any login dialog page without having
+        # the night theme of the SG Desktop impacting it. White is the safest
+        # background color.
+        self._view.setStyleSheet("background-color:white;")
+
+        # The context : in some special cases, Shotgun will take you into an alternate
+        # login flow. E.g. when you need to change your password, enter a 2FA value,
+        # link your SSO account with an existing account on the site, etc.
+        #
+        # The issue : when using a non-approved browser, Shotgun will display a
+        # warning stating that your browser is not supported. This is fine should
+        # you be interacting with the whole site. But in our case, we only
+        # navigate the login flow; presenting relatively simple pages. The warning
+        # is not warranted. The browser used is dependent on the version of Qt/PySide
+        # being used and we have little or no control over it.
+        #
+        # The solution : hide the warning by overriding the CSS of the page.
+        # Fixing Shotgun to recognize the user-agent used by the different version
+        # of Qt so that the warning is not displayed would be a tedious task. The
+        # present solution is simpler, with the only drawback being the dependency
+        # on the name of the div for the warning. No error is generated
+        # if that div.browser_not_approved is not present in the page.
+        #
+        # Worst case scenario : should Shotgun modify how the warning is displayed
+        # it would show up in the page.
+        css_style = base64.b64encode("div.browser_not_approved { display: none !important; }")
+        self._view.settings().setUserStyleSheetUrl("data:text/css;charset=utf-8;base64," + css_style)
+
+        # Threshold percentage of the SSO session duration, at which
+        # time the pre-emptive renewal operation should be started.
+        # @TODO: Make threshold parameter configurable.
+        self._sso_preemptive_renewal_threshold = PREEMPTIVE_RENEWAL_THRESHOLD
+
+        # We use the _sso_countdown_timer so that it fires once. Its purpose
+        # is to start the other _sso_renew_timer. It fires once at an interval
+        # of '0', which means 'whenever there are no event waiting in the
+        # queue'. The intent is that it will execute the actual (and costly)
+        # renewal at a time when the main event loop is readily available.
+        #
+        # The _sso_countdown_timer will be re-started in on_renew_sso_session.
+        # Thus re-starting the chain of reneal events.
+        self._sso_countdown_timer = QtCore.QTimer(self._dialog)
+        self._sso_countdown_timer.setSingleShot(True)
+        self._sso_countdown_timer.timeout.connect(self.on_schedule_sso_session_renewal)
+
+        self._sso_renew_timer = QtCore.QTimer(self._dialog)
+        self._sso_renew_timer.setInterval(0)
+        self._sso_renew_timer.setSingleShot(True)
+        self._sso_renew_timer.timeout.connect(self.on_renew_sso_session)
+
+        # Watchdog timer to detect abnormal conditions during SSO
+        # session renewal.
+        # If timeout occurs, then the renewal is considered to have
+        # failed, therefore the operation is aborted and recovery
+        # by interactive authentication is initiated.
+        # @TODO: Make watchdog timer duration configurable.
+        self._sso_renew_watchdog_timeout_ms = WATCHDOG_TIMEOUT_MS
+        self._sso_renew_watchdog_timer = QtCore.QTimer(self._dialog)
+        self._sso_renew_watchdog_timer.setInterval(self._sso_renew_watchdog_timeout_ms)
+        self._sso_renew_watchdog_timer.setSingleShot(True)
+        self._sso_renew_watchdog_timer.timeout.connect(self.on_renew_sso_session_timeout)
+
+        # We need a way to trace the current status of our login process.
+        self._login_status = 0
+
+        # For debugging purposes
+        # @TODO: Find a better way than to use the log level
+        if self._logger.level == logging.DEBUG or "SHOTGUN_SSO_DEVELOPER_ENABLED" in os.environ:
+            self._logger.debug("Using developer mode. Disabling strict SSL mode, enabling developer tools and local storage.")
+            # Disable SSL validation, useful when using a VM or a test site.
+            config = QtNetwork.QSslConfiguration.defaultConfiguration()
+            config.setPeerVerifyMode(QtNetwork.QSslSocket.VerifyNone)
+            QtNetwork.QSslConfiguration.setDefaultConfiguration(config)
+
+            # Adds the Developer Tools option when right-clicking
+            QtWebKit.QWebSettings.globalSettings().setAttribute(
+                QtWebKit.QWebSettings.WebAttribute.DeveloperExtrasEnabled,
+                True
+            )
+            QtWebKit.QWebSettings.globalSettings().setAttribute(
+                QtWebKit.QWebSettings.WebAttribute.LocalStorageEnabled,
+                True
+            )
+
+    def __del__(self):
+        """Destructor."""
+        self._logger.debug("Destroying SSO dialog")
+
+    @property
+    def _session(self):
+        """
+        String RO property.
+
+        Returns the current session, if any. The session provides information
+        on the current context (host, user ID, etc.)
+        """
+        return self._sessions_stack[-1] if len(self._sessions_stack) > 0 else None
+
+    def start_new_session(self, session_data):
+        """
+        Create a new session, based on the data provided.
+        """
+        self._logger.debug("Starting a new session")
+        self._sessions_stack.append(AuthenticationSessionData(session_data))
+        self.update_browser_from_session()
+
+    def end_current_session(self):
+        """
+        Destroy the current session, and resume the previous one, if any.
+        """
+        self._logger.debug("Ending current session")
+        if len(self._sessions_stack) > 0:
+            self._sessions_stack.pop()
+        self.update_browser_from_session()
+
+    def update_session_from_browser(self):
+        """
+        Updtate our session from the browser cookies.
+
+        We want to limit access to the actual session cookies, as their name
+        in the browser may differ from how the value is named on our session
+        representation, which is loosely based on that of RV itself.
+        """
+        self._logger.debug("Updating session cookies from browser")
+
+        cookie_jar = self._view.page().networkAccessManager().cookieJar()
+
+        # Here, the cookie jar is a dictionary of key/values
+        cookies = SimpleCookie()
+
+        for cookie in cookie_jar.allCookies():
+            cookies.load(str(cookie.toRawForm()))
+
+        encoded_cookies = _encode_cookies(cookies)
+        content = {
+            "session_expiration": get_saml_claims_expiration(encoded_cookies),
+            "session_id": get_session_id(encoded_cookies),
+            "user_id": get_saml_user_name(encoded_cookies),
+            "csrf_key": get_csrf_key(encoded_cookies),
+            "csrf_value": get_csrf_token(encoded_cookies),
+        }
+
+        # To minimize handling, we also keep a snapshot of the browser cookies.
+        # We do so for all of them, as some are used by the IdP and we do not
+        # want to manage those. Their names may change from IdP version and
+        # providers. We figure it is simpler to keep everything.
+
+        # Here, we have a list of cookies in raw text form
+        content["cookies"] = encoded_cookies
+
+        self._session.merge_settings(content)
+
+    def update_browser_from_session(self):
+        """
+        Update/reset the browser cookies with what we have.
+
+        We keep in the session a snapshot of the cookies used in the login and
+        renewal. These are persisted in the RV session. This function will
+        be used when originally setting the browser for login using a saved
+        session or when opening a connection to a new server.
+        """
+        self._logger.debug("Updating browser cookies from session")
+        QtNetwork = self._QtNetwork  # noqa
+
+        qt_cookies = []
+        if self._session is not None:
+            cookies = _decode_cookies(self._session.cookies)
+            qt_cookies = QtNetwork.QNetworkCookie.parseCookies(cookies.output(header=""))
+
+        self._view.page().networkAccessManager().cookieJar().setAllCookies(qt_cookies)
+
+    def stop_session_renewal(self):
+        """
+        Stop automatic session renewal.
+
+        This will be needed before opening a connection to a different server.
+        We want to avoid confusion as to where the session is created and
+        renewed.
+        """
+        self._logger.debug("Stopping automatic session renewal")
+
+        self._session_renewal_active = False
+        self._sso_renew_watchdog_timer.stop()
+        self._sso_countdown_timer.stop()
+        self._sso_renew_timer.stop()
+
+    def start_sso_renewal(self):
+        """
+        Start the automated SSO session renewal.
+
+        This will be done in the background, hopefully not impacting any
+        ongoing process such as playback.
+        """
+        self._logger.debug("Starting automatic session renewal")
+
+        self._sso_renew_watchdog_timer.stop()
+
+        # We will need to cause an immediate renewal in order to get an
+        # accurate knowledge of the session expiration. 0 is a special value
+        # for QTimer intervals, so we use 1ms.
+        interval = 1
+        if self._session.session_expiration > time.time():
+            interval = (self._session.session_expiration - time.time()) * self._sso_preemptive_renewal_threshold * 1000
+
+            # For debugging purposes
+            # @TODO: Find a better way than to use this EV
+            if "SHOTGUN_SSO_DEVELOPER_ENABLED" in os.environ:
+                interval = SHOTGUN_SSO_RENEWAL_INTERVAL
+        self._logger.debug("Setting session renewal interval to: %s seconds" % interval)
+
+        self._sso_countdown_timer.setInterval(interval)
+        self._sso_countdown_timer.start()
+        self._session_renewal_active = True
+
+    def on_http_response_finished(self, reply):
+        """
+        This callbaback is triggered after every page load in the QWebView.
+        """
+        error = reply.error()
+        url = reply.url().toString().encode("utf-8")
+        session = AuthenticationSessionData() if self._session is None else self._session
+        QtNetwork = self._QtNetwork  # noqa
+
+        if (
+            error is not QtNetwork.QNetworkReply.NetworkError.NoError and
+            error is not QtNetwork.QNetworkReply.NetworkError.OperationCanceledError
+        ):
+            if error is QtNetwork.QNetworkReply.NetworkError.HostNotFoundError:
+                session.error = HTTP_CANT_CONNECT_TO_SHOTGUN
+            elif error is QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError:
+                if url.startswith(session.host + URL_SAML_RENEW_PATH):
+                    # This is likely because the subdomain is not valid.
+                    # e.g. https://foobar.shotgunstudio.com
+                    # Here the domain (shotgunstudio.com) is valid, but not
+                    # foobar.
+                    session.error = HTTP_CANT_CONNECT_TO_SHOTGUN
+                else:
+                    # We silently ignore content not found otherwise.
+                    pass
+            elif error is QtNetwork.QNetworkReply.NetworkError.UnknownContentError:
+                # This means that the site does not support SSO or that
+                # it is not enabled.
+                session.error = HTTP_AUTHENTICATE_SSO_NOT_UPPORTED
+            elif error is QtNetwork.QNetworkReply.NetworkError.ContentOperationNotPermittedError:
+                # This means that the SSO login worked, but that the user does
+                # have access to the site.
+                session.error = HTTP_CANT_AUTHENTICATE_SSO_NO_ACCESS
+            elif error is QtNetwork.QNetworkReply.NetworkError.AuthenticationRequiredError:
+                # This means that the user entered incorrect credentials.
+                if url.startswith(session.host):
+                    session.error = HTTP_AUTHENTICATE_REQUIRED
+                else:
+                    # If we are not on our site, we are on the Identity Provider (IdP) portal site.
+                    # We let it deal with the error.
+                    # Reset the error to None to disregard the error.
+                    session.error = None
+            else:
+                session.error = reply.attribute(QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute)
+        elif url.startswith(session.host + URL_LOGIN_PATH):
+            # If we are being redirected to the login page, then SSO is not
+            # enabled on that site.
+            session.error = HTTP_AUTHENTICATE_SSO_NOT_UPPORTED
+
+        if session.error:
+            # If there are any errors, we exit by force-closing the dialog.
+            self._logger.error("Closing SSO dialog on Error (%s - %s) from loading page: %s" % (error, session.error, url))
+            self._dialog.reject()
+
+    def _on_authentication_required(self, reply, authenticator):
+        """
+        Called when authentication is required to get to a web page.
+
+        This method is required to support NTLM/Kerberos on a Windows machine,
+        of if there is a SSO Desktop integration plugin.
+        """
+        # Setting the user to an empty string tells the QAuthenticator to
+        # negociate the authentication with the user's credentials.
+        authenticator.setUser('')
+
+    def is_handling_event(self):
+        """
+        Called to know if an event is currently being handled.
+        """
+        return self._event_data is not None
+
+    def handle_event(self, event_data):
+        """
+        Called to start the handling of an event.
+        """
+        if not self.is_handling_event():
+            self._event_data = event_data
+
+            # At this point, we want to stop any background session renewal, as
+            # it may impede with our new sesion login.
+            self.stop_session_renewal()
+
+            self.start_new_session(event_data)
+        else:
+            self._logger.error("Calling handle_event while event %s is currently being handled" % self._event_data["event"])
+
+    def resolve_event(self, end_session=False):
+        """
+        Called to return the results of the event.
+        """
+        if self.is_handling_event():
+            if end_session:
+                self.end_current_session()
+            self._event_data = None
+        else:
+            self._logger.warn("Called resolve_event when no event is being handled.")
+
+    def get_session_data(self):
+        """Returns the relevant session data for the toolkit."""
+        return (
+            self._session.host,
+            self._session.user_id,
+            self._session.session_id,
+            self._session.cookies
+        )
+
+    def get_session_error(self):
+        """Returns the the error string of the last failed operation."""
+        res = None
+        if self._session and len(self._session.error) > 0:
+            res = self._session.error
+        return res
+
+    ############################################################################
+    #
+    # QTimer callbacks
+    #
+    ############################################################################
+
+    def on_schedule_sso_session_renewal(self):
+        """
+        Called to trigger the session renewal.
+
+        The session renewal, via the off-screen QWebView, will be done at the
+        next time the application event loop does not have any pending events.
+        """
+        self._logger.debug("Schedule SSO session renewal")
+        self._sso_renew_timer.start()
+
+    def on_renew_sso_session(self):
+        """
+        Called to renew the current SSO session.
+
+        The renewal will be done via an off-screen QWebView. The intent is to
+        benefit from the saved session cookies to automatically trigger the
+        renewal without having the user having to enter any inputs.
+        """
+        self._logger.debug("Renew SSO session")
+        self._sso_renew_watchdog_timer.start()
+
+        # We do not update the page cookies, assuming that they have already
+        # have been cleared/updated before.
+        self._view.page().mainFrame().load(self._session.host + URL_SAML_RENEW_PATH)
+
+    def on_renew_sso_session_timeout(self):
+        """
+        Called when the SSO session renewal is taking too long to complete.
+
+        The purpose of this callback is to stop the page loading.
+        """
+        self._logger.debug("Timeout awaiting session renewal")
+        self._dialog.reject()
+
+    ############################################################################
+    #
+    # Qt event handlers
+    #
+    ############################################################################
+
+    def on_load_finished(self, succeeded):
+        """
+        Called by Qt when the Web Page has finished loading.
+
+        The renewal process goes thru a number of redirects. We detect the
+        end of the process by checking the page loaded, as we know where we
+        expect to land in the end.
+
+        At that point, we stop the process by sending the 'accept' event to
+        the dialog. If the process is taking too long, we have a timer
+        (_sso_renew_watchdog_timer) which will trigger and attempt to cleanup
+        the process.
+        """
+        url = self._view.page().mainFrame().url().toString().encode("utf-8")
+        if (
+                self._session is not None and
+                url.startswith(self._session.host + URL_SAML_RENEW_LANDING_PATH)
+        ):
+            self.update_session_from_browser()
+            if self._session_renewal_active:
+                self.start_sso_renewal()
+
+            self._dialog.accept()
+
+        if not succeeded and url != "":
+            self._logger.error("Loading of page \"%s\" generated an error." % url)
+            # @FIXME: Figure out proper way of handling error.
+
+    ############################################################################
+    #
+    # Mu events handlers
+    #
+    ############################################################################
+
+    def on_sso_login_attempt(self, event_data=None, use_watchdog=False):
+        """
+        Called to attempt a login process with user interaction.
+
+        The user will be presented with the appropriate web pages from their
+        IdP in order to log on to Shotgun.
+        """
+        self._logger.debug("SSO login attempt")
+        QtCore = self._QtCore  # noqa
+
+        if event_data is not None:
+            self.handle_event(event_data)
+
+        if use_watchdog:
+            self._logger.debug("Starting watchdog")
+            self._sso_renew_watchdog_timer.start()
+
+        # If we do have session cookies, let's attempt a session renewal
+        # without presenting any GUI.
+        if self._session.cookies:
+            self._logger.debug("Attempting a GUI-less renewal")
+            loop = QtCore.QEventLoop(self._dialog)
+            self._dialog.finished.connect(loop.exit)
+            self.on_renew_sso_session()
+            status = loop.exec_()
+            self._login_status = self._login_status or status
+            return self._login_status
+
+        else:
+            self._view.show()
+            self._view.raise_()
+
+            # We append the product code to the GET request.
+            self._view.page().mainFrame().load(
+                self._session.host + URL_SAML_RENEW_PATH + "?product=%s" % self._session.product
+            )
+
+            self._dialog.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
+            status = self._dialog.exec_()
+            self._login_status = self._login_status or status
+            return self._login_status
+
+    def on_sso_login_cancel(self, event):
+        """
+        Called to cancel an ongoing login attempt.
+        """
+        self._logger.debug("Cancel SSO login attempt")
+
+        # We only need to cancel if there is login attempt currently being made.
+        if self.is_handling_event():
+            self.stop_session_renewal()
+            self.resolve_event(end_session=True)
+        self._dialog.accept()
+
+    def on_dialog_closed(self, result):
+        """
+        Called whenever the dialog is dismissed.
+
+        This can be the result of a callback, a timeout or user interaction.
+        """
+        self._logger.debug("SSO dialog closed")
+        QtGui = self._QtGui  # noqa
+
+        if self.is_handling_event():
+            if result == QtGui.QDialog.Rejected and self._session.cookies != "":
+                # We got here because of a timeout attempting a GUI-less login.
+                # Let's clear the cookies, and force the use of the GUI.
+                self._session.cookies = ""
+                # Let's have another go, without any cookies this time !
+                # This will force the GUI to be shown to the user.
+                self._logger.debug("Unable to login/renew claims automaticall, presenting GUI to user")
+                status = self.on_sso_login_attempt()
+                self._login_status = self._login_status or status
+            else:
+                self.resolve_event()
+        else:
+            # Should we get a rejected dialog, then we have had a timeout.
+            if result == QtGui.QDialog.Rejected:
+                # @FIXME: Figure out exactly what to do when we have a timeout.
+                self._logger.warn("Our QDialog got canceled outside of an event handling")
+
+        # Clear the web page
+        self._view.page().mainFrame().load("about:blank")
+
+    def on_sso_enable_renewal(self, event):
+        """
+        Called when enabling automatic SSO session renewal.
+
+        A new session will be created if there is not already a current one.
+        This will be in the case of the automatic (and successful)
+        authentication at the startup of the application.
+
+        """
+        self._logger.debug("SSO automatic renewal enabled")
+
+        contents = json.loads(event.contents())
+
+        if self._session is None:
+            self.start_new_session({
+                "host": contents["params"]["site_url"],
+                "cookies": contents["params"]["cookies"]
+            })
+        self.start_sso_renewal()
+
+    def on_sso_disable_renewal(self, event):
+        """
+        Called to disable automatic session renewal.
+
+        This will be required when switching to a new connection (where the new
+        site may not using SSO) or at the close of the application.
+        """
+        self._logger.debug("SSO automatic renewal disabled")
+        self.stop_session_renewal()
+
+################################################################################
+#
+# functions
+#
+################################################################################
+
+
+def _decode_cookies(encoded_cookies):
+    """
+    Extract the cookies from a base64 encoded string.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: A SimpleCookie containing all the cookies.
+    """
+    cookies = SimpleCookie()
+    if encoded_cookies:
+        try:
+            decoded_cookies = base64.b64decode(encoded_cookies)
+            cookies.load(decoded_cookies)
+        except TypeError as e:
+            get_logger().error("Unable to decode the cookies: %s" % e.message)
+    return cookies
+
+
+def _encode_cookies(cookies):
+    """
+    Extract the cookies from a base64 encoded string.
+
+    :param cookies: A Cookie.SimpleCookie instance representing the cookie jar.
+
+    :returns: An encoded string representing the cookie jar.
+    """
+    encoded_cookies = base64.b64encode(cookies.output())
+    return encoded_cookies
+
+
+def _get_shotgun_user_id(cookies):
+    """
+    Returns the id of the user in the shotgun instance, based on the cookies.
+
+    :param cookies: A Cookie.SimpleCookie instance representing the cookie jar.
+
+    :returns: A string user id value, or None.
+    """
+    user_id = None
+    user_domain = None
+    for cookie in cookies:
+        # Shotgun appends the unique numerical ID of the user to the cookie name:
+        # ex: shotgun_sso_session_userid_u78
+        if cookie.startswith("shotgun_sso_session_userid_u"):
+            if user_id is not None:
+                # Should we find multiple cookies with the same prefix, it means
+                # that we are using cookies from a multi-session environment. We
+                # have no way to identify the proper user id in the lot.
+                message = "The cookies for this user seem to come from two different shotgun sites: '%s' and '%s'"
+                raise Saml2SsoMultiSessionNotSupportedError(message % (user_domain, cookies[cookie]['domain']))
+            user_id = cookie[28:]
+            user_domain = cookies[cookie]['domain']
+    return user_id
+
+
+def _get_cookie_from_prefix(encoded_cookies, cookie_prefix):
+    """
+    Returns a cookie value based on a prefix to which we will append the user id.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+    :param cookie_prefix: The prefix of the cookie name.
+
+    :returns: A string of the cookie value, or None.
+    """
+    value = None
+    cookies = _decode_cookies(encoded_cookies)
+    key = "%s%s" % (cookie_prefix, _get_shotgun_user_id(cookies))
+    if key in cookies:
+        value = cookies[key].value
+    return value
+
+
+def is_sso_enabled_on_site(url):
+    """
+    Check to see if the web site uses sso.
+
+    We want this method to fail as quickly as possible if there are any
+    issues. Failure is not considered critical, thus known exceptions are
+    silently ignored. At the moment this method is only used to make the
+    GUI show/hide some of the input fields.
+
+    :returns: a boolean indicating if SSO has been enabled or not.
+    """
+    try:
+        # Temporary shotgun instance, used only for the purpose of checking
+        # the site infos.
+        #
+        # The constructor of Shotgun requires either a username/login or
+        # key/scriptname pair or a session_token. The token is only used in
+        # calls which need to be authenticated. The 'info' call does not
+        # require authentication.
+        info = Shotgun(url, session_token="dummy", connect=False).info()
+        get_logger().debug("User authentication method for %s: %s" % (url, info["user_authentication_method"]))
+        if "user_authentication_method" in info:
+            return info["user_authentication_method"] == "saml2"
+    except Exception as e:
+        # Silently ignore exceptions
+        get_logger().debug("Unable to connect with %s, got exception '%s' assuming SSO is not enabled" % (url, e))
+
+    return False
+
+
+def has_sso_info_in_cookies(encoded_cookies):
+    """
+    Indicate if SSO is being used from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: True or False
+    """
+    cookies = _decode_cookies(encoded_cookies)
+    return _get_shotgun_user_id(cookies) is not None
+
+
+def get_saml_claims_expiration(encoded_cookies):
+    """
+    Obtain the expiration time of the saml claims from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: An int with the time in seconds since January 1st 1970 UTC, or None
+    """
+    # Shotgun appends the unique numerical ID of the user to the cookie name:
+    # ex: shotgun_sso_session_expiration_u78
+    saml_claims_expiration = _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_expiration_u")
+    if saml_claims_expiration is not None:
+        saml_claims_expiration = int(saml_claims_expiration)
+    return saml_claims_expiration
+
+
+def get_saml_user_name(encoded_cookies):
+    """
+    Obtain the saml user name from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: A string with the user name, or None
+    """
+    # Shotgun appends the unique numerical ID of the user to the cookie name:
+    # ex: shotgun_sso_session_userid_u78
+    user_name = _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_userid_u")
+    if user_name is not None:
+        user_name = urllib.unquote(user_name)
+    return user_name
+
+
+def get_session_id(encoded_cookies):
+    """
+    Obtain the session id from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: A string with the session id, or None
+    """
+    session_id = None
+    cookies = _decode_cookies(encoded_cookies)
+    key = "_session_id"
+    if key in cookies:
+        session_id = cookies[key].value
+    return session_id
+
+
+def get_csrf_token(encoded_cookies):
+    """
+    Obtain the csrf token from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: A string with the csrf token, or None
+    """
+    # Shotgun appends the unique numerical ID of the user to the cookie name:
+    # ex: csrf_token_u78
+    return _get_cookie_from_prefix(encoded_cookies, "csrf_token_u")
+
+
+def get_csrf_key(encoded_cookies):
+    """
+    Obtain the csrf token name from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: A string with the csrf token name
+    """
+    cookies = _decode_cookies(encoded_cookies)
+    # Shotgun appends the unique numerical ID of the user to the cookie name:
+    # ex: csrf_token_u78
+    return "csrf_token_u%s" % _get_shotgun_user_id(cookies)

--- a/python/tank/authentication/shotgun_wrapper.py
+++ b/python/tank/authentication/shotgun_wrapper.py
@@ -15,12 +15,15 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
+import httplib
 
 from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault
+from tank_vendor.shotgun_api3.lib.xmlrpclib import ProtocolError
 from . import interactive_authentication, session_cache
 from .. import LogManager
 
 logger = LogManager.get_logger(__name__)
+
 
 class ShotgunWrapper(Shotgun):
     """
@@ -31,6 +34,7 @@ class ShotgunWrapper(Shotgun):
     password to renew the session. Once the session is renewed, the call will be
     executed again.
     """
+
     def __init__(self, *args, **kwargs):
         """
         Constructor. This has the same parameters as the Shotgun class, but it
@@ -60,6 +64,21 @@ class ShotgunWrapper(Shotgun):
         except AuthenticationFault:
             logger.debug("Authentication failure.")
             pass
+        except ProtocolError as e:
+            # One potential source of the error is that our SAML claims have
+            # expired. We check if we were given a 302 and the
+            # saml_login_request URL. In that case we will proceed to renew
+            # the session.
+            if (
+                e.errcode == httplib.FOUND and
+                "location" in e.headers and
+                e.headers["location"].endswith("/saml/saml_login_request")
+            ):
+                # Silently ignoring the exception, as we will trigger the
+                # renew_session() call later on.
+                logger.debug("The SAML claims have expired. We need to renew the session")
+            else:
+                raise e
 
         # Before renewing the session token, let's see if there is another
         # one in the session_cache.

--- a/python/tank/authentication/ui/login_dialog.py
+++ b/python/tank/authentication/ui/login_dialog.py
@@ -119,6 +119,8 @@ class Ui_LoginDialog(object):
         self.button_layout.setSpacing(10)
         self.button_layout.setContentsMargins(0, -1, -1, -1)
         self.button_layout.setObjectName("button_layout")
+        self.links = QtGui.QVBoxLayout()
+        self.links.setObjectName("links")
         self.forgot_password_link = QtGui.QLabel(self.login_page)
         self.forgot_password_link.setCursor(QtCore.Qt.PointingHandCursor)
         self.forgot_password_link.setStyleSheet("QWidget\n"
@@ -129,7 +131,8 @@ class Ui_LoginDialog(object):
         self.forgot_password_link.setMargin(4)
         self.forgot_password_link.setOpenExternalLinks(False)
         self.forgot_password_link.setObjectName("forgot_password_link")
-        self.button_layout.addWidget(self.forgot_password_link)
+        self.links.addWidget(self.forgot_password_link)
+        self.button_layout.addLayout(self.links)
         spacerItem1 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
         self.button_layout.addItem(spacerItem1)
         self.cancel = QtGui.QPushButton(self.login_page)

--- a/python/tank/authentication/ui/qt_abstraction.py
+++ b/python/tank/authentication/ui/qt_abstraction.py
@@ -17,5 +17,7 @@ from ...util.qt_importer import QtImporter
 _importer = QtImporter()
 QtCore = _importer.QtCore
 QtGui = _importer.QtGui
+QtWebKit = _importer.QtWebKit
+QtNetwork = _importer.QtNetwork
 qt_version_tuple = _importer.qt_version_tuple
 del _importer

--- a/python/tank/authentication/ui_authentication.py
+++ b/python/tank/authentication/ui_authentication.py
@@ -17,7 +17,6 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
-import logging
 
 from .errors import AuthenticationCancelled
 from . import invoker
@@ -32,14 +31,17 @@ class UiAuthenticationHandler(object):
     directly and be used through the authenticate and renew_session methods.
     """
 
-    def __init__(self, is_session_renewal, fixed_host=False):
+    def __init__(self, is_session_renewal, fixed_host=False, session_metadata=None):
         """
         Creates the UiAuthenticationHandler object.
         :param is_session_renewal: Boolean indicating if we are renewing a session. True if we are, False otherwise.
+        :param fixed_host: Indicate if the user can select a different host for connecting to.
+        :param session_metadata: Data required when SSO is used. This is an obscure blob of data.
         """
         self._is_session_renewal = is_session_renewal
         self._gui_launcher = invoker.create()
         self._fixed_host = fixed_host
+        self._session_metadata = session_metadata
 
     def authenticate(self, hostname, login, http_proxy):
         """
@@ -50,7 +52,6 @@ class UiAuthenticationHandler(object):
         :param http_proxy: Proxy server to use when validating credentials. Can be None.
         :returns: A tuple of (hostname, login, session_token)
         """
-        
         # deferred import because the login dialog contains QT references.
         from . import login_dialog
 
@@ -65,7 +66,8 @@ class UiAuthenticationHandler(object):
                 hostname=hostname,
                 login=login,
                 http_proxy=http_proxy,
-                fixed_host=self._fixed_host
+                fixed_host=self._fixed_host,
+                session_metadata=self._session_metadata
             )
             return dlg.result()
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -19,6 +19,7 @@ import sys
 import imp
 import uuid
 
+import sgtk
 from .. import hook
 from ..util.metrics import EventMetric
 from ..errors import TankError, TankNoDefaultValueError

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -19,7 +19,6 @@ import sys
 import imp
 import uuid
 
-import sgtk
 from .. import hook
 from ..util.metrics import EventMetric
 from ..errors import TankError, TankNoDefaultValueError

--- a/tests/authentication_tests/test_session_cache.py
+++ b/tests/authentication_tests/test_session_cache.py
@@ -97,25 +97,36 @@ class SessionCacheTests(TankTestBase):
         session_cache.cache_session_data(
             host,
             "bob",
-            "bob_session_token"
+            "bob_session_token",
+            "bob_session_metadata"
         )
         self.assertEqual(
             session_cache.get_session_data(host, "bob")["session_token"], "bob_session_token"
+        )
+        self.assertEqual(
+            session_cache.get_session_data(host, "bob")["session_metadata"], "bob_session_metadata"
         )
 
         # Make sure we can store a second one.
         session_cache.cache_session_data(
             host,
             "alice",
-            "alice_session_token"
+            "alice_session_token",
+            "alice_session_metadata"
         )
         # We can see the old one
         self.assertEqual(
             session_cache.get_session_data(host, "bob")["session_token"], "bob_session_token"
         )
+        self.assertEqual(
+            session_cache.get_session_data(host, "bob")["session_metadata"], "bob_session_metadata"
+        )
         # check for the new one
         self.assertEqual(
             session_cache.get_session_data(host, "alice")["session_token"], "alice_session_token"
+        )
+        self.assertEqual(
+            session_cache.get_session_data(host, "alice")["session_metadata"], "alice_session_metadata"
         )
 
         session_cache.delete_session_data(host, "bob")
@@ -123,6 +134,9 @@ class SessionCacheTests(TankTestBase):
         self.assertEqual(session_cache.get_session_data(host, "bob"), None)
         self.assertEqual(
             session_cache.get_session_data(host, "alice")["session_token"], "alice_session_token"
+        )
+        self.assertEqual(
+            session_cache.get_session_data(host, "alice")["session_metadata"], "alice_session_metadata"
         )
 
     def test_login_case_insensitivity(self):


### PR DESCRIPTION
I was planning on refactoring the authenticate method (returning a dictionary instead of a tuple). But I found the resulting code to be a bit bloated and not adding any readability... So I have decided to forgo this for the time being. This can always be done after the SSO code has been merged into master.

Background info: SSO authentication needs to be done via a web browser like environment (in this case, Qt's QtWebKit)

So, with this PR, we have:
- added the shotgun_shared module, which is meant to encapsulate the SSO login logic. It is meant to be shared between RV, Toolkit and Shotgun API3 python applications,
- support for SSO on the GUI login widget. The login dialog will detect an SSO-enabled site, and allow/remove the username/password fields,
- support for SSO credential renewal loop,
- proper handling of missing Qt components (we fallback on the non-SSO GUI should QtWebKit and QtNetwork not be available),
- session_cache support for cookies (which is one of the important aspect of SSO: the need of cookies to save the browser state),
- addition of a ShotgunSamlUser class, for SSO users (SAML is the underlying protocol),
- new SSO-specific tests (unfortunately, no interactive tests yet),
- some import statements have been re-written to use a tuple, allowing multi-line imports and alphabetical sorting,
- some changes to make the python linter happy (added function/method comments, inserted/remove empty lines in some places, # noqa directives, etc.)
- as an added bonus : trailing spaces removal !

IMPORTANT: Qt5's QWebEngine is not yet supported, but is coming. But some DCCs that use PySide2 also support the old QtWebKit modules (e.g. Maya 2017 at least)