### PR TITLE
#41067 [minor] Adds error check for installed configs.

### DIFF
--- a/python/tank/bootstrap/errors.py
+++ b/python/tank/bootstrap/errors.py
@@ -14,6 +14,7 @@ All custom exceptions that this module emits are defined here.
 
 from ..errors import TankError
 
+
 class TankBootstrapError(TankError):
     """
     Base class for all bootstrap related errors

--- a/python/tank/bootstrap/installed_configuration.py
+++ b/python/tank/bootstrap/installed_configuration.py
@@ -8,8 +8,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .configuration import Configuration
+import os
 
+from .errors import TankBootstrapError
+from .configuration import Configuration
 from .. import LogManager
 
 log = LogManager.get_logger(__name__)
@@ -47,7 +49,32 @@ class InstalledConfiguration(Configuration):
 
         :returns: LOCAL_CFG_UP_TO_DATE
         """
-        log.debug("%s is always up to date:" % self)
+        log.debug("Checking that classic config has got all the required files.")
+        # check that the path we have been given actually points at
+        # a classic configuration.
+        config_path = self._path.current_os
+        pipe_cfg_path = os.path.join(config_path, "core", "pipeline_configuration.yml")
+        if not os.path.exists(pipe_cfg_path):
+
+            log.warning(
+                "Your classic/installed pipeline configuration is missing the file %s. "
+                "Pipeline configurations using the fields windows_path, mac_path "
+                "or linux_path need to be created via the Toolkit "
+                "project setup process." % pipe_cfg_path
+            )
+
+            log.warning(
+                "Note: If you want to bootstrap toolkit directly from a "
+                "configuration that is stored locally, use the "
+                "PipelineConfiguration.descriptor field together with a path descriptor."
+            )
+
+            raise TankBootstrapError(
+                "Cannot find required system file 'core/pipeline_configuration.yml' "
+                "in configuration %s." % config_path
+            )
+
+        log.debug("Checking status of %s: Installed configs are always up to date:" % self)
 
         return self.LOCAL_CFG_UP_TO_DATE
 

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -880,6 +880,8 @@ class TestResolvedConfiguration(TankTestBase):
         """
         Makes sure an installed configuration is resolved.
         """
+        # note: this is using the classic config that is part of the
+        #       std test fixtures.
         config = self._resolver.resolve_shotgun_configuration(
             self.tk.pipeline_configuration.get_shotgun_id(),
             "sgtk:descriptor:not?a=descriptor",


### PR DESCRIPTION
Improves the error message you get in case you manually populate the `windows|mac|linux_path` fields on the pipeline configuration with a path, say to a configuration which was downloaded from github:

![image](https://user-images.githubusercontent.com/337710/33986082-66f5bb32-e0b4-11e7-9a8c-9d82d453b0f4.png)

The error message and log warnings:

<img width="1440" alt="screen shot 2017-12-14 at 09 49 44" src="https://user-images.githubusercontent.com/337710/33986126-8f232e82-e0b4-11e7-96b0-49e5ebde3c6c.png">


