### PR TITLE
Git improvements

### DIFF
--- a/python/tank/commands/clone_configuration.py
+++ b/python/tank/commands/clone_configuration.py
@@ -159,7 +159,11 @@ def _do_clone(log, tk, source_pc_id, user_id, new_name, target_linux, target_mac
                                     ["code", "project", "linux_path", "windows_path", "mac_path"])
     source_folder = source_pc.get(curr_os)
     
-    target_folder = {"linux2":target_linux, "win32":target_win, "darwin":target_mac }[sys.platform] 
+    target_folder = {
+        "linux2": target_linux,
+        "win32": target_win,
+        "darwin": target_mac
+    }[sys.platform]
     
     log.debug("Cloning %s -> %s" % (source_folder, target_folder))
     
@@ -175,7 +179,8 @@ def _do_clone(log, tk, source_pc_id, user_id, new_name, target_linux, target_mac
         os.mkdir(os.path.join(target_folder, "cache"), 0o777)
         filesystem.copy_folder(
             os.path.join(source_folder, "config"),
-            os.path.join(target_folder, "config")
+            os.path.join(target_folder, "config"),
+            skip_list=[]
         )
         filesystem.copy_folder(
             os.path.join(source_folder, "install"),

--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -284,7 +284,7 @@ class PushPCAction(Action):
             try:
                 # copy everything!
                 log.debug("Copying %s -> %s" % (source_path, target_tmp_path))
-                filesystem.copy_folder(source_path, target_tmp_path)
+                filesystem.copy_folder(source_path, target_tmp_path, skip_list=[])
                 
                 # If the source and target configurations are both localized, then also copy the
                 # core-related api files to the target config. Otherwise, skip them.

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -1009,7 +1009,7 @@ class TemplateConfiguration(object):
                 Descriptor.CONFIG,
                 {"type": "app_store", "name": config_uri},
                 resolve_latest=True,
-                local_fallback_when_disconnected = False
+                local_fallback_when_disconnected=False
             )
             descriptor.ensure_local()
 

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -941,7 +941,7 @@ class TemplateConfiguration(object):
         # unzip into temp location
         self._log.debug("Unzipping configuration and inspecting it...")
         zip_unpack_tmp = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
-        unzip_file(zip_path, zip_unpack_tmp)
+        unzip_file(zip_path, zip_unpack_tmp, auto_detect_bundle=True)
         template_items = os.listdir(zip_unpack_tmp)
         for item in ["core", "env", "hooks"]:
             if item not in template_items:

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -884,7 +884,8 @@ class TemplateConfiguration(object):
             self._sg,
             Descriptor.CONFIG,
             {"type": "git_branch", "path": git_uri, "branch": "master"},
-            resolve_latest=True
+            resolve_latest=True,
+            local_fallback_when_disconnected=False,
         )
 
     def _read_roots_file(self):
@@ -1007,7 +1008,8 @@ class TemplateConfiguration(object):
                 self._sg,
                 Descriptor.CONFIG,
                 {"type": "app_store", "name": config_uri},
-                resolve_latest=True
+                resolve_latest=True,
+                local_fallback_when_disconnected = False
             )
             descriptor.ensure_local()
 

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -25,7 +25,8 @@ def create_descriptor(
         bundle_cache_root_override=None,
         fallback_roots=None,
         resolve_latest=False,
-        constraint_pattern=None):
+        constraint_pattern=None,
+        local_fallback_when_disconnected=True):
     """
     Factory method. Use this when creating descriptor objects.
 
@@ -59,8 +60,15 @@ def create_descriptor(
                                 - ``v0.1.2``, ``v0.12.3.2``, ``v0.1.3beta`` - a specific version
                                 - ``v0.12.x`` - get the highest v0.12 version
                                 - ``v1.x.x`` - get the highest v1 version
+    :param local_fallback_when_disconnected: If resolve_latest is set to True, specify the behaviour
+                            in the case when no connection to a remote descriptor can be established,
+                            for example because and internet connection isn't available. If True, the
+                            descriptor factory will attempt to fall back on any existing locally cached
+                            bundles and return the latest one available. If False, a
+                            :class:`TankDescriptorError` is returned instead.
 
     :returns: :class:`Descriptor` object
+    :raises: :class:`TankDescriptorError`
     """
     from .descriptor_bundle import AppDescriptor, EngineDescriptor, FrameworkDescriptor
     from .descriptor_cached_config import CachedConfigDescriptor
@@ -92,7 +100,8 @@ def create_descriptor(
         bundle_cache_root_override,
         fallback_roots,
         resolve_latest,
-        constraint_pattern
+        constraint_pattern,
+        local_fallback_when_disconnected
     )
 
     # now create a high level descriptor and bind that with the low level descriptor

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -65,7 +65,7 @@ def create_descriptor(
                             for example because and internet connection isn't available. If True, the
                             descriptor factory will attempt to fall back on any existing locally cached
                             bundles and return the latest one available. If False, a
-                            :class:`TankDescriptorError` is returned instead.
+                            :class:`TankDescriptorError` is raised instead.
 
     :returns: :class:`Descriptor` object
     :raises: :class:`TankDescriptorError`

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -23,7 +23,8 @@ def create_io_descriptor(
         bundle_cache_root,
         fallback_roots,
         resolve_latest,
-        constraint_pattern=None):
+        constraint_pattern=None,
+        local_fallback_when_disconnected=True):
     """
     Factory method. Use this method to construct all DescriptorIO instances.
 
@@ -57,7 +58,15 @@ def create_io_descriptor(
                                 - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
                                 - v0.12.x - get the highest v0.12 version
                                 - v1.x.x - get the highest v1 version
+    :param local_fallback_when_disconnected: If resolve_latest is set to True, specify the behaviour
+                            in the case when no connection to a remote descriptor can be established,
+                            for example because and internet connection isn't available. If True, the
+                            descriptor factory will attempt to fall back on any existing locally cached
+                            bundles and return the latest one available. If False, a
+                            :class:`TankDescriptorError` is returned instead.
+
     :returns: Descriptor object
+    :raises: :class:`TankDescriptorError`
     """
     from .base import IODescriptorBase
     from .appstore import IODescriptorAppStore
@@ -118,16 +127,34 @@ def create_io_descriptor(
         if descriptor.has_remote_access():
             log.debug("Remote connection is available - attempting to get latest version from remote...")
             descriptor = descriptor.get_latest_version(constraint_pattern)
+            log.debug("Resolved latest to be %r" % descriptor)
+
         else:
-            log.debug("Remote connection is not available - falling back on getting latest version from cache...")
-            latest_cached_descriptor = descriptor.get_latest_cached_version(constraint_pattern)
-            if latest_cached_descriptor is None:
-                raise TankDescriptorError("No cached versions of %r cached locally on disk." % descriptor)
+            if local_fallback_when_disconnected:
+                # get latest from bundle cache
+                log.warning(
+                    "Remote connection is not available - will try to get "
+                    "the latest locally cached version of %s..." % descriptor
+                )
+                latest_cached_descriptor = descriptor.get_latest_cached_version(constraint_pattern)
+                if latest_cached_descriptor is None:
+                    log.warning("No locally cached versions of %r available." % descriptor)
+                    raise TankDescriptorError(
+                        "Could not get latest version of %s. "
+                        "For more details, see the log." % descriptor
+                    )
+                log.debug("Latest locally cached descriptor is %r" % latest_cached_descriptor)
+                descriptor = latest_cached_descriptor
 
-            log.debug("Latest cached descriptor is %r" % latest_cached_descriptor)
-            descriptor = latest_cached_descriptor
+            else:
+                # do not attempt to get the latest locally cached version
+                log.warning("Remote connection not available to determine latest version.")
+                raise TankDescriptorError(
+                    "Could not get latest version of %s. "
+                    "For more details, see the log." % descriptor
+                )
 
-        log.debug("Resolved latest to be %r" % descriptor)
+
 
     return descriptor
 

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -63,7 +63,7 @@ def create_io_descriptor(
                             for example because and internet connection isn't available. If True, the
                             descriptor factory will attempt to fall back on any existing locally cached
                             bundles and return the latest one available. If False, a
-                            :class:`TankDescriptorError` is returned instead.
+                            :class:`TankDescriptorError` is raised instead.
 
     :returns: Descriptor object
     :raises: :class:`TankDescriptorError`

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -131,7 +131,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         for command in commands:
 
             # we use git -C to specify the working directory where to execute the command
-            full_command = "git -C \"%s\" %s" % (cwd, command)
+            full_command = "git -C \"%s\" %s" % (target_path, command)
             log.debug("Executing '%s'" % full_command)
 
             try:

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -115,7 +115,10 @@ class IODescriptorGit(IODescriptorDownloadable):
         # Note that we use os.system here to allow for git to pop up (in a terminal
         # if necessary) authentication prompting. This DOES NOT seem to be possible
         # with subprocess.
+        log.debug("Executing command '%s' using os.system()" % cmd)
+        log.debug("Note: in a terminal environment, this may prompt for authentication")
         status = os.system(cmd)
+        log.debug("Command returned exit code %s" % status)
         if status != 0:
             raise TankGitError(
                 "Error executing git operation. The git command '%s' "
@@ -124,34 +127,27 @@ class IODescriptorGit(IODescriptorDownloadable):
         log.debug("Git clone into '%s' successful." % target_path)
 
         # clone worked ok! Now execute git commands on this repo
-        cwd = os.getcwd()
         output = None
-        try:
-            log.debug("Setting cwd to '%s'" % target_path)
-            os.chdir(target_path)
-            for command in commands:
+        for command in commands:
 
-                full_command = "git %s" % command
-                log.debug("Executing '%s'" % full_command)
+            # we use git -C to specify the working directory where to execute the command
+            full_command = "git -C \"%s\" %s" % (cwd, command)
+            log.debug("Executing '%s'" % full_command)
 
-                try:
-                    output = subprocess_check_output(
-                        full_command,
-                        shell=True
-                    )
+            try:
+                output = subprocess_check_output(
+                    full_command,
+                    shell=True
+                )
 
-                    # note: it seems on windows, the result is sometimes wrapped in single quotes.
-                    output = output.strip().strip("'")
+                # note: it seems on windows, the result is sometimes wrapped in single quotes.
+                output = output.strip().strip("'")
 
-                except SubprocessCalledProcessError as e:
-                    raise TankGitError(
-                        "Error executing git operation '%s': %s (Return code %s)" % (full_command, e.output, e.returncode)
-                    )
-                log.debug("Execution successful. stderr/stdout: '%s'" % output)
-
-        finally:
-            log.debug("Restoring cwd (to '%s')" % cwd)
-            os.chdir(cwd)
+            except SubprocessCalledProcessError as e:
+                raise TankGitError(
+                    "Error executing git operation '%s': %s (Return code %s)" % (full_command, e.output, e.returncode)
+                )
+            log.debug("Execution successful. stderr/stdout: '%s'" % output)
 
         # return the last returned stdout/stderr
         return output

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -134,6 +134,17 @@ class TestApi(TankTestBase):
         )
         self.assertEqual(d.get_uri(), "sgtk:descriptor:app_store?name=tk-testbundlefactory&version=v0.2.3")
 
+        # test opting out of the local fallback
+        with self.assertRaisesRegexp(tank.descriptor.TankDescriptorError, "Could not get latest version of"):
+            sgtk.descriptor.create_descriptor(
+                self.tk.shotgun,
+                sgtk.descriptor.Descriptor.CONFIG,
+                {"type": "app_store", "name": "tk-testbundlefactory"},
+                resolve_latest=True,
+                local_fallback_when_disconnected=False
+            )
+
+
     def test_alt_cache_root(self):
         """
         Testing descriptor constructor in alternative cache location


### PR DESCRIPTION
Tickets #36070 #37578 #39910 #40633 #43066 #44576

A collection of improvements related to git descriptors:

## Zips from github
If you download a [zip](https://github.com/shotgunsoftware/tk-core/archive/master.zip) directly from github, this can be used by the advanced project setup:

![image](https://user-images.githubusercontent.com/337710/34039483-8cad15f4-e187-11e7-89b8-4f7c1f84f9cc.png)

(Note that this already works for the uploaded_config field in shotgun)

## clone and push copies .git
- The clone pipeline configuration method in shotgun (if you right click on a pc) now copies the `.git` folder as part of the cloning. This was not the case in recent versions of core, a regression introduced at some point in the 0.18 cycle.

- The push configuration tank command now also copies everything (including `.git` folders) when you perform the push

## issues with UNC paths
Previously, if your configuration was installed in a UNC path based location, git commands would not work. This is now fixed and things like `tank updates` should work correctly when using git descriptors.

## Non-helpful error messages
Previously, when trying to set up an authenticated git repo, you could get some really weird misleading error messages. These are now replaced with a 'could not get latest version' message:

![image](https://user-images.githubusercontent.com/337710/34044186-ec341d6a-e19b-11e7-8455-092b2531b8a9.png)

