### PR TITLE
Fixes a deadly pattern on KDE

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -171,6 +171,13 @@ class LoginDialog(QtGui.QDialog):
         """
         Displays the window modally.
         """
+        # This fixes a weird bug on Qt where calling show() and exec_() might lead
+        # to having an invisible modal QDialog and this state freezes the host
+        # application. (Require a `pkill -9 applicationName`). The fix in our case
+        # is pretty simple, we just have to not call show() before the call to
+        # exec_() since it implicitly call exec_().
+        #
+        # This bug is described here: https://bugreports.qt.io/browse/QTBUG-48248
         if QtCore.__version__.startswith("4."):
             self.show()
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -171,6 +171,9 @@ class LoginDialog(QtGui.QDialog):
         """
         Displays the window modally.
         """
+        if QtCore.__version__.startswith("4."):
+            self.show()
+
         self.raise_()
         self.activateWindow()
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -171,7 +171,6 @@ class LoginDialog(QtGui.QDialog):
         """
         Displays the window modally.
         """
-        self.show()
         self.raise_()
         self.activateWindow()
 


### PR DESCRIPTION
JIRA: N/A

DESCRIPTION

This fixes a weird bug on Qt where calling show() and exec_() might lead
to having an invisible modal QDialog and this state freezes the host
application. (Require a `pkill -9 applicationName`). The fix in our case
is pretty simple, we just have to not call show() before the call to
exec_() since it implicitly call show().

This bug is described here: https://bugreports.qt.io/browse/QTBUG-48248

It's a KDE platform bug/limitation and otherwise, it works really well
on other DE ( I tried with Gnome and with XFCE4 ).

TESTS

This dialog might be called on multiple platforms and using multiple Qt
binding (PySide, PySide2, PyQt, PyQt5) and I didn't tested on each
platforms.

DOC

N/A