### PR TITLE
#35379 Adds localization of config during project setup if `core_api.yml` exists 

### DIFF
--- a/python/tank/commands/constants.py
+++ b/python/tank/commands/constants.py
@@ -39,7 +39,7 @@ PIPELINE_CONFIGURATION_ENTITY = "PipelineConfiguration"
 PRIMARY_PIPELINE_CONFIG_NAME = "Primary"
 
 # The name of the default config
-DEFAULT_CFG = "tk-config-default"
+DEFAULT_CFG = "tk-config-default2"
 
 # the name of the shell engine
 SHELL_ENGINE = "tk-shell"

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -86,18 +86,15 @@ class CoreLocalizeAction(Action):
         )
 
 
-def do_localize(log, sg_connection, pc_root_path, suppress_prompts):
+def do_localize(log, sg_connection, target_config_path, suppress_prompts):
     """
     Perform the actual localize command.
 
     :param log: logging object
     :param sg_connection: An open shotgun connection
-    :param str pc_root_path: Path to the config that should be localized.
+    :param str target_config_path: Path to the config that should be localized.
     :param bool suppress_prompts: Indicates if prompts should be suppressed.
     """
-
-    # leaving func signature the same, but renaming here for clarity
-    target_config_path = pc_root_path
 
     # the configuration to localize
     target_pipeline_config = pipelineconfig_factory.from_path(
@@ -115,8 +112,8 @@ def do_localize(log, sg_connection, pc_root_path, suppress_prompts):
             "local install of the core!"
         )
 
-    # if a core descriptor is supplied, ensure it is local and use it as the
-    # core to localize.
+    # if a core descriptor is supplied, ensure it is cached locally and use it
+    # as the core to localize.
     if pipelineconfig_utils.has_core_descriptor(target_config_path):
         core_descriptor = pipelineconfig_utils.get_core_descriptor(
             target_config_path,
@@ -126,6 +123,7 @@ def do_localize(log, sg_connection, pc_root_path, suppress_prompts):
         source_core_path = core_descriptor.get_path()
         source_core_version = core_descriptor.get_version()
     else:
+        # fall back to using the core that exists in the source config
         source_core_path = os.path.join(
             source_config_path,
             "install",
@@ -246,7 +244,7 @@ def do_localize(log, sg_connection, pc_root_path, suppress_prompts):
         target_core_backup_folder_name = datetime.datetime.now().strftime(
             "%Y%m%d_%H%M%S")
 
-        # full path tot he core backup folder (including timestamped folder)
+        # full path to the core backup folder (including timestamped folder)
         target_core_backup_folder_path = os.path.join(
             target_core_backup_path, target_core_backup_folder_name)
 

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -11,10 +11,8 @@
 # make sure that py25 has access to with statement
 from __future__ import with_statement
 
-
 import os
 import sys
-import stat
 import shutil
 import datetime
 
@@ -25,7 +23,6 @@ from .action_base import Action
 from . import console_utils
 from .. import pipelineconfig_utils
 from .. import pipelineconfig_factory
-
 
 # these are the items that need to be copied across
 # when a configuration is upgraded to contain a core API
@@ -52,7 +49,6 @@ class CoreLocalizeAction(Action):
         # this method can be executed via the API
         self.supports_api = True
 
-
     def run_noninteractive(self, log, parameters):
         """
         Tank command API accessor.
@@ -63,7 +59,12 @@ class CoreLocalizeAction(Action):
         """
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
-        return do_localize(log, pc_root, suppress_prompts=True)
+        return do_localize(
+            log,
+            self.tk.shotgun,
+            pc_root,
+            suppress_prompts=True
+        )
 
     def run_interactive(self, log, args):
         """
@@ -77,26 +78,70 @@ class CoreLocalizeAction(Action):
 
         pc_root = self.tk.pipeline_configuration.get_path()
         log.debug("Executing the localize command for %r" % self.tk)
-        return do_localize(log, pc_root, suppress_prompts=False)
+        return do_localize(
+            log,
+            self.tk.shotgun,
+            pc_root,
+            suppress_prompts=False
+        )
 
 
-def do_localize(log, pc_root_path, suppress_prompts):
+def do_localize(log, sg_connection, pc_root_path, suppress_prompts):
     """
     Perform the actual localize command.
 
     :param log: logging object
-    :param pc_root_path: Path to the config that should be localized.
-    :param suppress_prompts: Boolean to indicate if no questions should be asked.
+    :param sg_connection: An open shotgun connection
+    :param str pc_root_path: Path to the config that should be localized.
+    :param bool suppress_prompts: Indicates if prompts should be suppressed.
     """
-    pipeline_config = pipelineconfig_factory.from_path(pc_root_path)
+
+    # leaving func signature the same, but renaming here for clarity
+    target_config_path = pc_root_path
+
+    # the configuration to localize
+    target_pipeline_config = pipelineconfig_factory.from_path(
+        target_config_path)
+
+    # the core install location for the current config. this will be resolved to
+    # a linked config or the config where the running core lives
+    source_config_path = target_pipeline_config.get_install_location()
 
     log.info("")
-    if pipeline_config.is_localized():
-        raise TankError("Looks like your current pipeline configuration already has a local install of the core!")
+    if target_pipeline_config.is_localized():
+        # if we're here, there's already a core in the config's install folder
+        raise TankError(
+            "Looks like your current pipeline configuration already has a "
+            "local install of the core!"
+        )
 
-    core_api_root = pipeline_config.get_install_location()
+    # if a core descriptor is supplied, ensure it is local and use it as the
+    # core to localize.
+    if pipelineconfig_utils.has_core_descriptor(target_config_path):
+        core_descriptor = pipelineconfig_utils.get_core_descriptor(
+            target_config_path,
+            sg_connection
+        )
+        core_descriptor.ensure_local()
+        source_core_path = core_descriptor.get_path()
+        source_core_version = core_descriptor.get_version()
+    else:
+        source_core_path = os.path.join(
+            source_config_path,
+            "install",
+            "core"
+        )
 
-    log.info("This will copy the Core API in %s \ninto the Pipeline configuration %s." % (core_api_root, pc_root_path))
+        # resolve the version of core
+        source_core_version = \
+            target_pipeline_config.get_associated_core_version()
+
+    log.info(
+        "This will copy the Core API in %s \n"
+        "into the Pipeline configuration %s." %
+        (source_core_path, target_config_path)
+    )
+
     log.info("")
     if not suppress_prompts:
         # check with user if they wanna continue
@@ -105,37 +150,44 @@ def do_localize(log, pc_root_path, suppress_prompts):
             log.info("Operation cancelled.")
             return
 
-    # see what version of core is bundled with this config
-    core_version = pipeline_config.get_associated_core_version()
-
-    log.debug("About to localize '%s'" % pc_root_path)
-    log.debug("Associated core is '%s', version %s" % (core_api_root, core_version))
-    log.debug("The version of core running this code is %s" % pipelineconfig_utils.get_currently_running_api_version())
+    log.debug("About to localize '%s'" % target_config_path)
+    log.debug(
+        "Associated core is '%s', version %s" %
+        (source_core_path, source_core_version)
+    )
+    log.debug(
+        "The version of core running this code is %s" %
+        pipelineconfig_utils.get_currently_running_api_version()
+    )
 
     # proceed with setup
     log.info("")
 
+    # define the install paths for the source and target configs
+    source_install_path = os.path.join(source_config_path, "install")
+    target_install_path = os.path.join(target_config_path, "install")
+
     try:
 
-        # step one - localize all bundles
+        # ---- Step 1: Localize all bundles...
 
-        if is_version_older(core_version, "v0.18.0"):
-            # now if we are localizing a pre-0.18 core, it means we are using modern
-            # (post 0.18) core code to copy a 0.17 core across into the configuration
-            # in this case, the old storage logic for descriptors applies. We handle this
-            # by brute forcing it and copying all items across in the install folder.
+        if is_version_older(source_core_version, "v0.18.0"):
+            # now if we are localizing a pre-0.18 core, it means we are using
+            # modern (post 0.18) core code to copy a 0.17 core across into the
+            # configuration in this case, the old storage logic for descriptors
+            # applies. We handle this by brute forcing it and copying all items
+            # across in the install folder.
 
-            log.debug("Using a 0.18 core to localize a 0.17 core. Falling back on blanket copy of install.")
+            log.debug(
+                "Using a 0.18 core to localize a 0.17 core. Falling back on "
+                "blanket copy of install."
+            )
 
-            # copy all the contents of the install location across except
-            # for the contents in the core and core.backup folders - these are handled
-            # explicitly later on
+            # copy all the contents of the install location across except for
+            # the contents in the core and core.backup folders - these are
+            # handled explicitly later on
 
-            source_install_path = os.path.join(core_api_root, "install")
-            target_install_path = os.path.join(pc_root_path, "install")
-
-            names = os.listdir(source_install_path)
-            for name in names:
+            for name in os.listdir(source_install_path):
 
                 if name in ["core", "core.backup"]:
                     # skip now and handle separately
@@ -156,9 +208,9 @@ def do_localize(log, pc_root_path, suppress_prompts):
             # First get a list of all bundle descriptors.
             # Key by descriptor uri, which ensures no repetition.
             descriptors = {}
-            for env_name in pipeline_config.get_environments():
+            for env_name in target_pipeline_config.get_environments():
 
-                env_obj = pipeline_config.get_environment(env_name)
+                env_obj = target_pipeline_config.get_environment(env_name)
 
                 for engine in env_obj.get_engines():
                     descriptor = env_obj.get_engine_descriptor(engine)
@@ -172,44 +224,63 @@ def do_localize(log, pc_root_path, suppress_prompts):
                     descriptor = env_obj.get_framework_descriptor(framework)
                     descriptors[descriptor.get_uri()] = descriptor
 
-            # Now re-cache all the relevant apps into the new install location.
-            target_bundle_cache_root = os.path.join(pc_root_path, "install")
-
             for idx, descriptor in enumerate(descriptors.itervalues()):
                 # print one based indices for more human friendly output
-                log.info("%s/%s: Copying %s..." % (idx + 1, len(descriptors), descriptor))
-                descriptor.clone_cache(target_bundle_cache_root)
+                log.info(
+                    "%s/%s: Copying %s..." %
+                    (idx + 1, len(descriptors), descriptor)
+                )
+                descriptor.clone_cache(target_install_path)
 
+        # ---- Step 2: Backup the target core and copy the new core across...
 
-        # Step 2: Backup the target core and copy the new core across.
-        source_core = os.path.join(core_api_root, "install", "core")
-        target_core = os.path.join(pc_root_path, "install", "core")
-        backup_location = os.path.join(pc_root_path, "install", "core.backup")
+        # construct paths to the installed "core" and "core.backup" folders in
+        # the target config
+        target_core_path = os.path.join(target_install_path, "core")
+        target_core_backup_path = os.path.join(
+            target_install_path, "core.backup")
 
         log.info("Backing up existing Core API...")
-        backup_folder_name = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        backup_path = os.path.join(backup_location, backup_folder_name)
-        src_files = filesystem.copy_folder(target_core, backup_path)
 
+        # timestamped folder name in "core.backup"
+        target_core_backup_folder_name = datetime.datetime.now().strftime(
+            "%Y%m%d_%H%M%S")
+
+        # full path tot he core backup folder (including timestamped folder)
+        target_core_backup_folder_path = os.path.join(
+            target_core_backup_path, target_core_backup_folder_name)
+
+        # do the actual copy of whatever's currently in "install/core" to the
+        # timestampted backup folder
+        src_files = filesystem.copy_folder(
+            target_core_path, target_core_backup_folder_path)
+
+        # clean out the "core" folder
         log.debug("Clearing out core target location...")
         for f in src_files:
             filesystem.safe_delete_file(f)
 
-        log.info("Copying Core %s \nto %s" % (source_core, target_core))
-        filesystem.copy_folder(source_core, target_core)
+        log.info(
+            "Copying Core %s \nto %s" %
+            (source_core_path, target_core_path)
+        )
+        filesystem.copy_folder(source_core_path, target_core_path)
 
         # Step 3: Copy some core config files across.
         log.info("Copying Core configuration files...")
         for fn in CORE_FILES_FOR_LOCALIZE:
-            src = os.path.join(core_api_root, "config", "core", fn)
-            tgt = os.path.join(pc_root_path, "config", "core", fn)
+            src = os.path.join(source_config_path, "config", "core", fn)
+            tgt = os.path.join(target_config_path, "config", "core", fn)
             log.debug("Copy %s -> %s" % (src, tgt))
-            # If we're copying any other file than app_store.yml, it is mandatory. If we're copying
-            # app_store.yml, only copy it if it exists This is because when you are localizing a
-            # core, app_store.yml might be present or not depending if you are migrating a core
-            # configured with a pre Shotgun 6 or post Shotgun 6 site. In the later, AppStore
-            # credentials can be retrieved using a session token and therefore we don't need the
-            # AppStore credentials to be saved on disk.
+
+            # If we're copying any other file than app_store.yml, it is
+            # mandatory. If we're copying app_store.yml, only copy it if it
+            # exists. This is because when you are localizing a core,
+            # app_store.yml might be present or not depending if you are
+            # migrating a core configured with a pre Shotgun 6 or post Shotgun 6
+            # site. In the latter, AppStore credentials can be retrieved using a
+            # session token and therefore we don't need the AppStore credentials
+            # to be saved on disk.
             if fn != "app_store.yml" or os.path.exists(src):
                 filesystem.copy_file(src, tgt, permissions=0o666)
 
@@ -220,12 +291,12 @@ def do_localize(log, pc_root_path, suppress_prompts):
     log.info("The Core API was successfully localized.")
 
     log.info("")
-    log.info("Localize complete! This pipeline configuration now has an independent API.")
+    log.info(
+        "Localize complete! "
+        "This pipeline configuration now has an independent API."
+    )
     log.info("")
     log.info("")
-
-
-
 
 
 class ShareCoreAction(Action):

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -122,6 +122,12 @@ def do_localize(log, sg_connection, target_config_path, suppress_prompts):
         core_descriptor.ensure_local()
         source_core_path = core_descriptor.get_path()
         source_core_version = core_descriptor.get_version()
+
+        log.info(
+            "Core descriptor %s, specified in core/core_api.yml, "
+            "will be installed." % (core_descriptor.get_uri())
+        )
+
     else:
         # fall back to using the core that exists in the source config
         source_core_path = os.path.join(
@@ -134,11 +140,11 @@ def do_localize(log, sg_connection, target_config_path, suppress_prompts):
         source_core_version = \
             target_pipeline_config.get_associated_core_version()
 
-    log.info(
-        "This will copy the Core API in %s \n"
-        "into the Pipeline configuration %s." %
-        (source_core_path, target_config_path)
-    )
+        log.info(
+            "This will copy the Core API in %s \n"
+            "into the Pipeline configuration %s." %
+            (source_core_path, target_config_path)
+        )
 
     log.info("")
     if not suppress_prompts:

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -75,9 +75,9 @@ class SetupProjectAction(Action):
         self.parameters["config_uri"] = { "description": ("The configuration to use when setting up this project. "
                                                           "This can be a path on disk to a directory containing a "
                                                           "config, a path to a git bare repo (e.g. a git repo path "
-                                                          "which ends with .git) or 'tk-config-default' "
+                                                          "which ends with .git) or 'tk-config-default2' "
                                                           "to fetch the default config from the toolkit app store."),
-                                          "default": "tk-config-default",
+                                          "default": "tk-config-default2",
                                           "type": "str" }
 
         # note how the current platform's default value is None in order to make that required
@@ -689,8 +689,6 @@ class SetupProjectAction(Action):
 
         return location
 
-
-
     def _ask_location(self, log, default, os_nice_name):
         """
         Helper method - asks the user where to put a pipeline config.
@@ -742,6 +740,10 @@ class SetupProjectAction(Action):
         log.info("  - on Linux:   '%s'" % params.get_associated_core_path("linux2"))
         log.info("  - on Windows: '%s'" % params.get_associated_core_path("win32"))            
         log.info("")
+        log.info("NOTE: If the installed configuration contains a ")
+        log.info("      core_api.yml file, the version of core specified in ")
+        log.info("      that file will be localized after project setup is ")
+        log.info("      complete.")
         log.info("")
 
 

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -72,13 +72,15 @@ class SetupProjectAction(Action):
                                                    "default": None,
                                                    "type": "str" }
 
-        self.parameters["config_uri"] = { "description": ("The configuration to use when setting up this project. "
-                                                          "This can be a path on disk to a directory containing a "
-                                                          "config, a path to a git bare repo (e.g. a git repo path "
-                                                          "which ends with .git) or 'tk-config-default2' "
-                                                          "to fetch the default config from the toolkit app store."),
-                                          "default": "tk-config-default2",
-                                          "type": "str" }
+        self.parameters["config_uri"] = {
+            "description": "The configuration to use when setting up this "
+                "project. This can be a path on disk to a directory containing "
+                "a config, a path to a git bare repo (e.g. a git repo path "
+                "which ends with .git) or '%s' to fetch the default config "
+                "from the toolkit app store." % (constants.DEFAULT_CFG,),
+            "default": constants.DEFAULT_CFG,
+            "type": "str"
+        }
 
         # note how the current platform's default value is None in order to make that required
         self.parameters["config_path_mac"] = { "description": ("The path on disk where the configuration should be "

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -157,16 +157,22 @@ class SetupProjectAction(Action):
         
         # and finally carry out the setup
         run_project_setup(log, sg, params)
-        
-        # check if we should run the localization afterwards
-        # if we are running a localized pc, the root path of the core
-        # api is the same as the root path for the associated pc
-        if pipelineconfig_utils.is_localized(curr_core_path):
-            log.info("Localizing Core...")
-            core_localize.do_localize(log, 
-                                      params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True)
 
+        config_path = params.get_configuration_location(sys.platform)
+
+        # if the new project's config has a core descriptor, then we should
+        # localize it to use that version of core. alternatively, if the current
+        # core being used is localized, then localize the new config with it.
+        if (pipelineconfig_utils.has_core_descriptor(config_path) or
+            pipelineconfig_utils.is_localized(curr_core_path)):
+
+            log.info("Localizing Core...")
+            core_localize.do_localize(
+                log,
+                self.tk.shotgun,
+                config_path,
+                suppress_prompts=True
+            )
 
     def run_interactive(self, log, args):
         """
@@ -237,16 +243,23 @@ class SetupProjectAction(Action):
         
         # and finally carry out the setup
         run_project_setup(log, sg, params)
-        
-        # check if we should run the localization afterwards
-        # if we are running a localized pc, the root path of the core
-        # api is the same as the root path for the associated pc
-        if pipelineconfig_utils.is_localized(curr_core_path):
+
+        config_path = params.get_configuration_location(sys.platform)
+
+        # if the new project's config has a core descriptor, then we should
+        # localize it to use that version of core. alternatively, if the current
+        # core being used is localized, then localize the new core with it.
+        if (pipelineconfig_utils.has_core_descriptor(config_path) or
+            pipelineconfig_utils.is_localized(curr_core_path)):
+
             log.info("Localizing Core...")
-            core_localize.do_localize(log, 
-                                      params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True)
-        
+            core_localize.do_localize(
+                log,
+                self.tk.shotgun,
+                config_path,
+                suppress_prompts=True
+            )
+
         # display readme etc.
         readme_content = params.get_configuration_readme()
         if len(readme_content) > 0:

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -609,16 +609,28 @@ class SetupProjectWizard(object):
         # and finally carry out the setup
         run_project_setup(self._log, self._sg, self._params)
 
-        # check if we should run the localization afterwards
-        # note - when running via the wizard, toolkit script credentials are stripped
-        # out as the core is copied across as part of a localization if the site we are configuring
-        # supports the authentication module, ie, Shotgun 6.0.2 and greater.
+        # ---- check if we should run the localization afterwards
+
+        # note - when running via the wizard, toolkit script credentials are
+        # stripped out as the core is copied across as part of a localization if
+        # the site we are configuring supports the authentication module, ie,
+        # Shotgun 6.0.2 and greater.
         #
-        # this is primarily targeting the Shotgun desktop, meaning that even if the 
-        # shotgun desktop's site configuration contains script credentials, these are
-        # not propagated into newly created toolkit projects.
-        #
-        if core_settings["localize"]:
-            core_localize.do_localize(self._log, 
-                                      self._params.get_configuration_location(sys.platform), 
-                                      suppress_prompts=True)
+        # this is primarily targeting the Shotgun desktop, meaning that even if
+        # the shotgun desktop's site configuration contains script credentials,
+        # these are not propagated into newly created toolkit projects.
+
+        config_path = self._params.get_configuration_location(sys.platform)
+
+        # if the new project's config has a core descriptor, then we should
+        # localize it to use that version of core. alternatively, if the current
+        # core being used is localized (as returned via `get_core_settings`),
+        # then localize the new core with it.
+        if (pipelineconfig_utils.has_core_descriptor(config_path) or
+            core_settings["localize"]):
+            core_localize.do_localize(
+                self._log,
+                self._sg,
+                config_path,
+                suppress_prompts=True
+            )

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -615,7 +615,7 @@ class SetupProjectWizard(object):
         # stripped out as the core is copied across as part of a localization if
         # the site we are configuring supports the authentication module, ie,
         # Shotgun 6.0.2 and greater.
-        #
+
         # this is primarily targeting the Shotgun desktop, meaning that even if
         # the shotgun desktop's site configuration contains script credentials,
         # these are not propagated into newly created toolkit projects.

--- a/python/tank/constants.py
+++ b/python/tank/constants.py
@@ -39,6 +39,9 @@ PIPELINE_CONFIG_DEV_DESCRIPTOR_TOKEN = "{PIPELINE_CONFIG}"
 # the name of the file that holds the templates.yml config
 CONTENT_TEMPLATES_FILE = "templates.yml"
 
+# config file with information about which core to use
+CONFIG_CORE_DESCRIPTOR_FILE = "core_api.yml"
+
 # the name of the primary pipeline configuration
 PRIMARY_PIPELINE_CONFIG_NAME = "Primary"
 

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -157,8 +157,7 @@ def get_roots_metadata(pipeline_config_path):
 ####################################################################################################################
 # Core API resolve utils
 
-def get_core_descriptor(pipeline_config_path, shotgun_connection,
-    bundle_cache_fallback_paths=None):
+def get_core_descriptor(pipeline_config_path, shotgun_connection, bundle_cache_fallback_paths=None):
     """
     Returns a descriptor object for the uri/dict defined in the config's
     ``core_api.yml`` file (if it exists).
@@ -201,8 +200,8 @@ def get_core_descriptor(pipeline_config_path, shotgun_connection,
         core_descriptor_dict = data["location"]
     except Exception as e:
         raise TankError(
-            "Cannot read invalid core descriptor file '%s': %s" % (
-            descriptor_file_path, e)
+            "Cannot read invalid core descriptor file '%s': %s" %
+            (descriptor_file_path, e)
         )
     finally:
         fh.close()

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -17,8 +17,16 @@ from __future__ import with_statement
 
 import os
 
+from tank_vendor import yaml
+
 from . import constants
 from . import LogManager
+
+from .descriptor import (
+    Descriptor,
+    create_descriptor,
+    is_descriptor_version_missing
+)
 
 from .util import yaml_cache
 from .util import ShotgunPath
@@ -27,6 +35,18 @@ from .util.shotgun import get_deferred_sg_connection
 from .errors import TankError
 
 logger = LogManager.get_logger(__name__)
+
+
+def has_core_descriptor(pipeline_config_path):
+    """
+    Returns ``True`` if the pipeline configuration contains a core descriptor
+    file.
+
+    :param pipeline_config_path: path to a pipeline configuration root folder
+    :return: ``True`` if the core descriptor file exists, ``False`` otherwise
+    """
+    # probe by looking for the existence of a core api descriptor file
+    return os.path.exists(_get_core_descriptor_file(pipeline_config_path))
 
 
 def is_localized(pipeline_config_path):
@@ -142,6 +162,67 @@ def get_roots_metadata(pipeline_config_path):
 
 ####################################################################################################################
 # Core API resolve utils
+
+def get_core_descriptor(pipeline_config_path, shotgun_connection,
+    bundle_cache_fallback_paths=None):
+    """
+    Returns a descriptor object for the uri/dict defined in the config's
+    ``core_api.yml`` file (if it exists).
+
+    If the config does not define a core descriptor file, then ``None`` will be
+    returned.
+
+    :param str pipeline_config_path: The path to the pipeline configuration
+    :param shotgun_connection: An open connection to shotgun
+    :param bundle_cache_fallback_paths: bundle cache search path
+
+    :return: A core descriptor object
+    """
+
+    descriptor_file_path = _get_core_descriptor_file(pipeline_config_path)
+
+    if not os.path.exists(descriptor_file_path):
+        return None
+
+    # the core_api.yml contains info about the core:
+    #
+    # location:
+    #    name: tk-core
+    #    type: app_store
+    #    version: v0.16.34
+
+    logger.debug("Found core descriptor file '%s'" % descriptor_file_path)
+
+    # read the file first
+    fh = open(descriptor_file_path, "rt")
+    try:
+        data = yaml.load(fh)
+        core_descriptor_dict = data["location"]
+    except Exception as e:
+        raise TankError(
+            "Cannot read invalid core descriptor file '%s': %s" % (
+            descriptor_file_path, e)
+        )
+    finally:
+        fh.close()
+
+    # we have a core descriptor specification. Get a descriptor object for it
+    logger.debug(
+        "Config has a specific core defined in core/core_api.yml: %s" %
+        core_descriptor_dict,
+    )
+
+    # when core is specified, check if it defines a specific version or not
+    use_latest = is_descriptor_version_missing(core_descriptor_dict)
+
+    return create_descriptor(
+        shotgun_connection,
+        Descriptor.CORE,
+        core_descriptor_dict,
+        fallback_roots=bundle_cache_fallback_paths or [],
+        resolve_latest=use_latest
+    )
+
 
 def get_path_to_current_core():
     """
@@ -425,3 +506,17 @@ def _get_version_from_manifest(info_yml_path):
     return data
 
 
+def _get_core_descriptor_file(pipeline_config_path):
+    """
+    Helper method. Returns the path to the config's core_api.yml file.
+    (May not exist)
+
+    :param pipeline_config_path: path to the pipeline configuration on disk
+    :return: A string path to the core_api.yml file within the config.
+    """
+    return os.path.join(
+        pipeline_config_path,
+        "config",
+        "core",
+        constants.CONFIG_CORE_DESCRIPTOR_FILE
+    )

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -22,12 +22,6 @@ from tank_vendor import yaml
 from . import constants
 from . import LogManager
 
-from .descriptor import (
-    Descriptor,
-    create_descriptor,
-    is_descriptor_version_missing
-)
-
 from .util import yaml_cache
 from .util import ShotgunPath
 from .util.shotgun import get_deferred_sg_connection
@@ -178,6 +172,13 @@ def get_core_descriptor(pipeline_config_path, shotgun_connection,
 
     :return: A core descriptor object
     """
+
+    # avoid circular dependencies
+    from .descriptor import (
+        Descriptor,
+        create_descriptor,
+        is_descriptor_version_missing
+    )
 
     descriptor_file_path = _get_core_descriptor_file(pipeline_config_path)
 

--- a/tests/commands_tests/test_setupproject.py
+++ b/tests/commands_tests/test_setupproject.py
@@ -11,7 +11,6 @@
 """
 Unit tests tank setup_project.
 """
-
 from __future__ import with_statement
 
 import os
@@ -44,88 +43,6 @@ class TestSetupProject(TankTestBase):
         patcher = patch_app_store()
         self._mock_store = patcher.start()
         self.addCleanup(patcher.stop)
-        self.second_project = {
-            "type": "Project",
-            "id": 7777,
-            "code": "another_project",
-        }
-        self.add_to_sg_mock_db(self.second_project)
-        project_root = os.path.join(self.tank_temp, "test_setup_project")
-        os.makedirs(project_root)
-
-        # Make sure we have a version in the app store for all bundles.
-        self._mock_store.add_engine("tk-engine", "v1.0.0")
-        self._mock_store.add_engine("tk-test", "v1.0.0")
-        self._mock_store.add_application("tk-multi-app", "v1.0.0")
-        self._mock_store.add_application("tk-multi-nodep", "v1.0.0")
-        self._mock_store.add_framework("tk-framework-test", "v1.0.0")
-        self._mock_store.add_framework("tk-framework-2nd-level-dep", "v1.0.0")
-
-    @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
-    def test_setup_project(self, mocked=None):
-        """
-        Test setting up a Project.
-        """
-        new_config_root = os.path.join(self.tank_temp, "test_setup_project_config")
-
-        def mocked_resolve_core_path(core_path):
-            return {
-                "linux2": core_path,
-                "darwin": core_path,
-                "win32": core_path,
-            }
-
-        mocked.side_effect = mocked_resolve_core_path
-        command = self.tk.get_command("setup_project")
-        command.set_logger(logging.getLogger("/dev/null"))
-        # Test we can setup a new project and it does not fail.
-        command.execute({
-            "project_id": self.second_project["id"],
-            "project_folder_name": "test_setup_project",
-            "config_uri": self.project_config,
-            "config_path_mac": new_config_root if sys.platform == "darwin" else None,
-            "config_path_win": new_config_root if sys.platform == "win32" else None,
-            "config_path_linux": new_config_root if sys.platform.startswith("linux") else None,
-        })
-        new_pc = tank.pipelineconfig_factory.from_path(new_config_root)
-        # Check we get back our custom primary root name
-        self.assertEqual(new_pc.get_data_roots().keys(), ["setup_project_root"])
-
-
-
-class TestSetupProjectWithSpecificCore(TankTestBase):
-    """
-    Testing that core_api.yml in the config is supported.
-    """
-
-    def setUp(self):
-        """
-        Prepare unit test.
-        """
-        TankTestBase.setUp(
-            self,
-            # Use a custom primary root name
-            parameters={"primary_root_name": "test_setup_project_with_core"}
-        )
-        self.setup_fixtures("app_store_tests")
-
-        patcher = patch_app_store()
-        self._mock_store = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.second_project = {
-            "type": "Project",
-            "id": 6666,
-            "code": "another_project",
-        }
-        self.add_to_sg_mock_db(self.second_project)
-        project_root = os.path.join(self.tank_temp, "test_setup_project_with_core")
-        os.makedirs(project_root)
-
-        # add a core_api.yml
-        with open(os.path.join(self.project_config, "core", "core_api.yml"), "wt") as fp:
-            fp.write("location:\n")
-            fp.write("   type: dev\n")
-            fp.write("   path: %s\n" % self.tank_source_path)
 
         # Make sure we have a version in the app store for all bundles.
         self._mock_store.add_engine("tk-engine", "v1.0.0")
@@ -138,58 +55,136 @@ class TestSetupProjectWithSpecificCore(TankTestBase):
         # the std fixtures do not have a full core installation so ensure
         # that we mock one that localize can pick up
         self._fake_core_install = os.path.join(self.tank_temp, "fake_core_install")
-        os.makedirs(os.path.join(self._fake_core_install, "install"))
-        os.makedirs(os.path.join(self._fake_core_install, "install", "core"))
-        os.makedirs(os.path.join(self._fake_core_install, "install", "core", "bad_path"))
-        os.makedirs(os.path.join(self._fake_core_install, "config"))
-        cfg_core = os.path.join(self._fake_core_install, "config", "core")
-        os.makedirs(cfg_core)
-        self.create_file(os.path.join(cfg_core, "shotgun.yml"), "{host: http://unit_test_mock_sg}")
-        self.create_file(os.path.join(cfg_core, "interpreter_Darwin.cfg"), "")
-        self.create_file(os.path.join(cfg_core, "interpreter_Linux.cfg"), "")
-        self.create_file(os.path.join(cfg_core, "interpreter_Windows.cfg"), "")
+        if not os.path.exists(self._fake_core_install):
+            os.makedirs(os.path.join(self._fake_core_install, "install"))
+            os.makedirs(os.path.join(self._fake_core_install, "install", "core"))
+            os.makedirs(os.path.join(self._fake_core_install, "install", "core", "fake_core"))
+            os.makedirs(os.path.join(self._fake_core_install, "config"))
+            cfg_core = os.path.join(self._fake_core_install, "config", "core")
+            os.makedirs(cfg_core)
+            self.create_file(os.path.join(cfg_core, "shotgun.yml"), "{host: http://unit_test_mock_sg}")
+            self.create_file(os.path.join(cfg_core, "interpreter_Darwin.cfg"), "")
+            self.create_file(os.path.join(cfg_core, "interpreter_Linux.cfg"), "")
+            self.create_file(os.path.join(cfg_core, "interpreter_Windows.cfg"), "")
 
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_install_location")
+
     @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
-    def test_setup_project(self, resolve_all_os_paths_to_core_mock, get_install_location_mock):
+    def test_setup_project(self, mocked=None):
         """
         Test setting up a Project.
         """
-        new_config_root = os.path.join(self.tank_temp, "test_setup_project_core_api")
-
         def mocked_resolve_core_path(core_path):
             return {
                 "linux2": core_path,
                 "darwin": core_path,
                 "win32": core_path,
             }
+        mocked.side_effect = mocked_resolve_core_path
 
-        resolve_all_os_paths_to_core_mock.side_effect = mocked_resolve_core_path
-
-        def mocked_get_install_location():
-            return self._fake_core_install
-
-        get_install_location_mock.side_effect = mocked_get_install_location
+        # create new project
+        new_project = {
+            "type": "Project",
+            "id": 1234,
+            "code": "new_project_1234",
+        }
+        self.add_to_sg_mock_db(new_project)
+        # location where the config will be installed
+        new_config_root = os.path.join(self.tank_temp, "new_project_1234_config")
+        # location where the data will be installed
+        os.makedirs(os.path.join(self.tank_temp, "new_project_1234"))
 
         command = self.tk.get_command("setup_project")
         command.set_logger(logging.getLogger("/dev/null"))
-
         # Test we can setup a new project and it does not fail.
         command.execute({
-            "project_id": self.second_project["id"],
-            "project_folder_name": "test_setup_project_with_core",
+            "project_id": new_project["id"],
+            "project_folder_name": "new_project_1234",
             "config_uri": self.project_config,
             "config_path_mac": new_config_root if sys.platform == "darwin" else None,
             "config_path_win": new_config_root if sys.platform == "win32" else None,
             "config_path_linux": new_config_root if sys.platform.startswith("linux") else None,
         })
 
-        new_pc = tank.pipelineconfig_factory.from_path(new_config_root)
-
         # Check we get back our custom primary root name
-        self.assertEqual(new_pc.get_data_roots().keys(), ["test_setup_project_with_core"])
+        new_pc = tank.pipelineconfig_factory.from_path(new_config_root)
+        self.assertEqual(new_pc.get_data_roots().keys(), ["setup_project_root"])
 
-        # the 'fake' core that we mocked earlier has a 'bad_path' folder
-        self.assertFalse(os.path.exists(os.path.join(new_config_root, "install", "core", "bad_path")))
-        # instead we expect a full installl
-        self.assertTrue(os.path.exists(os.path.join(new_config_root, "install", "core", "python", "tank", "errors.py")))
+        # make sure the fake core didn't get copied across, e.g. that
+        # we didn't localize the setup
+        self.assertFalse(os.path.exists(
+            os.path.join(new_config_root, "install", "core", "bad_path")
+        ))
+
+        # make sure we have the core location files for this unlocalized setup
+        self.assertTrue(os.path.exists(
+            os.path.join(new_config_root, "install", "core", "core_Darwin.cfg")
+        ))
+
+    @patch("tank.pipelineconfig.PipelineConfiguration.get_install_location")
+    @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
+    def test_setup_project_with_external_core(self, resolve_all_os_paths_to_core_mock, get_install_location_mock):
+        """
+        Test setting up a Project config that has a core/core_api.yml file included.
+        """
+        def mocked_resolve_core_path(core_path):
+            return {
+                "linux2": core_path,
+                "darwin": core_path,
+                "win32": core_path,
+            }
+        resolve_all_os_paths_to_core_mock.side_effect = mocked_resolve_core_path
+
+        def mocked_get_install_location():
+            return self._fake_core_install
+        get_install_location_mock.side_effect = mocked_get_install_location
+
+        # add a core_api.yml to our config that we are installing from, telling the
+        # setup project command to use this when running the localize portion of the setup.
+        core_api_path = os.path.join(self.project_config, "core", "core_api.yml")
+        with open(core_api_path, "wt") as fp:
+            fp.write("location:\n")
+            fp.write("   type: dev\n")
+            fp.write("   path: %s\n" % self.tank_source_path)
+
+        try:
+            # create new project
+            new_project = {
+                "type": "Project",
+                "id": 1235,
+                "code": "new_project_1235",
+            }
+            self.add_to_sg_mock_db(new_project)
+            new_config_root = os.path.join(self.tank_temp, "new_project_1235_config")
+            # location where the data will be installed
+            os.makedirs(os.path.join(self.tank_temp, "new_project_1235"))
+
+            command = self.tk.get_command("setup_project")
+            command.set_logger(logging.getLogger("/dev/null"))
+            # Test we can setup a new project and it does not fail.
+            command.execute({
+                "project_id": new_project["id"],
+                "project_folder_name": "new_project_1235",
+                "config_uri": self.project_config,
+                "config_path_mac": new_config_root if sys.platform == "darwin" else None,
+                "config_path_win": new_config_root if sys.platform == "win32" else None,
+                "config_path_linux": new_config_root if sys.platform.startswith("linux") else None,
+            })
+
+            # Check we get back our custom primary root name
+            new_pc = tank.pipelineconfig_factory.from_path(new_config_root)
+            self.assertEqual(new_pc.get_data_roots().keys(), ["setup_project_root"])
+
+            # the 'fake' core that we mocked earlier has a 'bad_path' folder
+            self.assertFalse(os.path.exists(
+                os.path.join(new_config_root, "install", "core", "bad_path")
+            ))
+
+            # instead we expect a full installl
+            self.assertTrue(os.path.exists(
+                os.path.join(new_config_root, "install", "core", "python", "tank", "errors.py")
+            ))
+
+        finally:
+            os.remove(core_api_path)
+
+

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -320,6 +320,17 @@ class TankMockStoreDescriptor(IODescriptorBase):
         """
         return True
 
+    def clone_cache(self, cache_root):
+        """
+        The descriptor system maintains an internal cache where it downloads
+        the payload that is associated with the descriptor. Toolkit supports
+        complex cache setups, where you can specify a series of path where toolkit
+        should go and look for cached items.
+
+        :param cache_root: Root point of the cache location to copy to.
+        :returns: True if the cache was copied, false if not
+        """
+        return True
 
 class _Patcher(object):
     """


### PR DESCRIPTION
This change modifies the `core_localize` command logic, and by proxy the `setup_project` and `setup_project_wizard` commands. Previously, during project setup, the config would be localized if the source config had a local core. This change adds an additional check to `setup_project` to localize using the core specified in `core_api.yml` of the target project (if it exists). If no `core_api.yml` file exists, the previous logic will be used to determine if a localization is required.

In addition, the `setup_project` command's default config has been updated from `tk-config-default` to `tk-config-default2`. 

Adds 2 new methods to `pipelineconfig_utils`: 

- `has_core_descriptor`: Returns `True` if the pipeline configuration contains a core descriptor file
- `get_core_descriptor`: Returns a descriptor object for the uri/dict defined in the config's `core_api.yml` file (if it exists)

This is a fairly old portion of the core code and it is likely that I may have left out something important or missed something entirely. Please have a look and let me know.

I did look into adding tests for this, but it is unclear to me how much work it would be to mock some of the descriptor methods to simulate all the work that is done during localization. Let me know if you want to discuss that as well.