### PR TITLE
Allow updating arbitrary env dictionaries

### DIFF
--- a/python/tank/util/environment.py
+++ b/python/tank/util/environment.py
@@ -15,7 +15,7 @@ Helper methods that do environment management
 import os, sys
 
 
-def append_path_to_env_var(env_var_name, path):
+def append_path_to_env_var(env_var_name, path, environ=None):
     """
     Append the path to the given environment variable.
     Creates the env var if it doesn't exist already.
@@ -25,7 +25,7 @@ def append_path_to_env_var(env_var_name, path):
     return _add_path_to_env_var(env_var_name, path, prepend=False)
 
 
-def prepend_path_to_env_var(env_var_name, path):
+def prepend_path_to_env_var(env_var_name, path, environ=None):
     """
     Prepend the path to the given environment variable.
     Creates the env var if it doesn't exist already.
@@ -35,19 +35,22 @@ def prepend_path_to_env_var(env_var_name, path):
     return _add_path_to_env_var(env_var_name, path, prepend=True)
 
 
-def _add_path_to_env_var(env_var_name, path, prepend=False):
+def _add_path_to_env_var(env_var_name, path, prepend=False, environ=None):
     """
     Append or prepend the path to the given environment variable.
     Creates the env var if it doesn't exist already.
     will concatenate paths using : on linux and ; on windows
     """
     
+    if environ is None:
+        environ = os.environ
+    
     if sys.platform == "win32":
         env_var_sep = ";"
     else:
         env_var_sep = ":"        
     
-    paths = os.environ.get(env_var_name, "").split(env_var_sep)
+    paths = environ.get(env_var_name, "").split(env_var_sep)
     # clean up empty entries
     paths = [x for x in paths if x != ""]
     # Do not add path if it already exists in the list
@@ -57,4 +60,6 @@ def _add_path_to_env_var(env_var_name, path, prepend=False):
         else:
             paths.append(path)
     # and put it back
-    os.environ[env_var_name] = env_var_sep.join(paths)
+    environ[env_var_name] = env_var_sep.join(paths)
+    
+    return environ

--- a/python/tank/util/environment.py
+++ b/python/tank/util/environment.py
@@ -22,7 +22,7 @@ def append_path_to_env_var(env_var_name, path, environ=None):
     will concatenate paths using : on linux and ; on windows
     """
     
-    return _add_path_to_env_var(env_var_name, path, prepend=False)
+    return _add_path_to_env_var(env_var_name, path, prepend=False, environ)
 
 
 def prepend_path_to_env_var(env_var_name, path, environ=None):
@@ -32,7 +32,7 @@ def prepend_path_to_env_var(env_var_name, path, environ=None):
     will concatenate paths using : on linux and ; on windows
     """
     
-    return _add_path_to_env_var(env_var_name, path, prepend=True)
+    return _add_path_to_env_var(env_var_name, path, prepend=True, environ)
 
 
 def _add_path_to_env_var(env_var_name, path, prepend=False, environ=None):


### PR DESCRIPTION
Allows the user to provide an alternate dictionary to update instead of just using os.environ. The enables users to create or modify environment dictionaries other than the active one. So a user could, for example, copy the current environment, modify the copy, and then provide then supply that copy to any potential consumer without modifying the current runtime.