### PR TITLE
For #46079, renew session fix

### DIFF
--- a/python/tank/authentication/invoker.py
+++ b/python/tank/authentication/invoker.py
@@ -22,22 +22,33 @@ from .. import LogManager
 logger = LogManager.get_logger(__name__)
 
 
+# When importing qt_abstraction, a lot of code is executed to detects which
+# version of Qt is being used. Running business logic at import time is not
+# something usually done by the Toolkit. The worry is that the import may fail
+# in the context of a DCC, but occur too early for the Toolkit logging to be
+# fully in place to record it.
+try:
+    from .ui.qt_abstraction import QtCore, QtGui
+except Exception:
+    QtCore, QtGui = None, None
+
+
 def create():
     """
     Create the object used to invoke function calls on the main thread when
     called from a different thread.
 
     You typically use this method like this:
-    
+
         def show_ui():
             # show QT dialog
             dlg = MyQtDialog()
             result = dlg.exec_()
             return result
-        
-        # create invoker object 
+
+        # create invoker object
         my_invoker = invoker.create()
-    
+
         # launch dialog - invoker ensures that the UI
         # gets launched in the main thread
         result = my_invoker(show_ui)
@@ -46,8 +57,6 @@ def create():
               simple pass through method will execute the code in the same
               thread will be produced.
     """
-    from .ui.qt_abstraction import QtCore, QtGui
-
     # If we are already in the main thread, no need for an invoker, invoke directly in this thread.
     if QtCore.QThread.currentThread() == QtGui.QApplication.instance().thread():
         return lambda fn, *args, **kwargs: fn(*args, **kwargs)


### PR DESCRIPTION
When swapping the Toolkit core, a new version of the Toolkit library gets loaded, whose internal APIs may have different signatures. Since the SSO code modified the signature of certain internal APIs, it is very important that Toolkit always uses the correct version of the internal APIs of the authentication module, even after a core swap.

To ensure this, we need to make sure the authentication module always pulls any dependencies at import time and not execution time, which means no local imports.

Note that this doesn't solve all the use cases, but it solves the important one.

Here are the scenarios where you might run into this bug.

1. Use the latest core to bootstrap and swaps to an older core.
This is the case which this branch solves. It ensures the originally imported core always uses the original internal APIs.
2. Use the older core to bootstrap and swap to the newer core.
The older core will be broken because the internal APIs will have been changed. There's no way around this bug. Hopefully, any client who uses an older core to bootstrap can also update the older core so they run a fixed version of the authentication module. After all, if they were able to upgrade to the most recent core for a project, they upgrade the desktop startup or the desktop's config.
3. Older to older and newer to newer shouldn't cause an issue.

In the wild, this situation should fix itself naturally.

Here's the startup sequence for the Desktop.

1. User launches the Shotgun Desktop with an outdated version of the Desktop Startup.
2. User authenticates with the version of core that has local imports.
3. User downloads the latest version of Desktop Startup and restarts.
4. User authenticates with the version of core that uses global imports.
5. Desktop swaps the core to an older or newer one. Doesn't matter. The authenticated user object it still running the original code and the desktop works.

The edge case that breaks Toolkit has the following components:
1. a desktop config that uses the old core
2. a project that uses the newer core

In that case, the authentication will be done using the old core and we'll swap into the new one, which has a different internal API. If this happens, the client can simply upgrade their desktop's core to the latest version and all will be fine.

To fix that bug, we would need to merge  [this in](https://github.com/shotgunsoftware/tk-core/pull/500), which is a much riskier fix and requires more one more update to desktop startup so that we stop and restart the SSO loop.