### PR TITLE
#39910 windows using git -C for operations, linux uses just git

### DIFF
--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -152,7 +152,6 @@ class IODescriptorGit(IODescriptorDownloadable):
                     # and solves an issue with UNC paths on windows.
                     full_command = "git -C \"%s\" %s" % (target_path, command)
                 else:
-                    os.chdir(target_path)
                     full_command = "git %s" % command
 
                 log.debug("Executing '%s'" % full_command)

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
+import sys
 import uuid
 import shutil
 import tempfile
@@ -127,27 +128,52 @@ class IODescriptorGit(IODescriptorDownloadable):
         log.debug("Git clone into '%s' successful." % target_path)
 
         # clone worked ok! Now execute git commands on this repo
+
         output = None
-        for command in commands:
 
-            # we use git -C to specify the working directory where to execute the command
-            full_command = "git -C \"%s\" %s" % (target_path, command)
-            log.debug("Executing '%s'" % full_command)
+        # note: for windows, we use git -C to point git to the right current
+        # working directory. This requires git 1.9+. This is to ensure that
+        # the solution handles UNC paths, which do not support os.getcwd() operations.
+        #
+        # for other platforms, we omit -C to ensure compatibility with older versions
+        # of git. Centos 7 still ships with 1.8.
 
-            try:
-                output = subprocess_check_output(
-                    full_command,
-                    shell=True
-                )
+        cwd = os.getcwd()
+        try:
+            if sys.platform != "win32":
+                log.debug("Setting cwd to '%s'" % target_path)
+                os.chdir(target_path)
 
-                # note: it seems on windows, the result is sometimes wrapped in single quotes.
-                output = output.strip().strip("'")
+            for command in commands:
 
-            except SubprocessCalledProcessError as e:
-                raise TankGitError(
-                    "Error executing git operation '%s': %s (Return code %s)" % (full_command, e.output, e.returncode)
-                )
-            log.debug("Execution successful. stderr/stdout: '%s'" % output)
+                if sys.platform == "win32":
+                    # we use git -C to specify the working directory where to execute the command
+                    # this option was added in as part of git 1.9
+                    # and solves an issue with UNC paths on windows.
+                    full_command = "git -C \"%s\" %s" % (target_path, command)
+                else:
+                    os.chdir(target_path)
+                    full_command = "git %s" % command
+
+                log.debug("Executing '%s'" % full_command)
+                try:
+                    output = subprocess_check_output(
+                        full_command,
+                        shell=True
+                    )
+
+                    # note: it seems on windows, the result is sometimes wrapped in single quotes.
+                    output = output.strip().strip("'")
+
+                except SubprocessCalledProcessError as e:
+                    raise TankGitError(
+                        "Error executing git operation '%s': %s (Return code %s)" % (full_command, e.output, e.returncode)
+                    )
+                log.debug("Execution successful. stderr/stdout: '%s'" % output)
+        finally:
+            if sys.platform != "win32":
+                log.debug("Restoring cwd (to '%s')" % cwd)
+                os.chdir(cwd)
 
         # return the last returned stdout/stderr
         return output


### PR DESCRIPTION
Addendum. The -C flag was introduced in 1.9 of git. Centos 7 still defaults to 1.8 (released 2013) so for linux this reverts to the old tk approach of setting the current work dir before and after operations.