### PR TITLE
39289 culling old cached data

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -800,7 +800,7 @@ class TankBundle(object):
                         # Log the error for debug purpose
                         self.logger.debug(
                             "Warning: couldn't check %s for removal: %s" % (
-                            file_path, e
+                                file_path, e
                             ),
                             exc_info=True,
                         )

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -656,7 +656,6 @@ class TestBundleDataCache(TestApplication):
             one_day_in_seconds = (
                 one_day_delta.microseconds + (one_day_delta.seconds + one_day_delta.days * 24 * 3600) * 10**6
             ) / 10**6
-            one_day_in_seconds = datetime.timedelta(days=1).total_seconds()
             day_before_timestamp = time.time() - one_day_in_seconds
             os.utime(
                 dummy_file,

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -655,7 +655,7 @@ class TestBundleDataCache(TestApplication):
             # value ourself
             one_day_in_seconds = (
                 one_day_delta.microseconds + (one_day_delta.seconds + one_day_delta.days * 24 * 3600) * 10**6
-                ) / 10**6
+            ) / 10**6
             one_day_in_seconds = datetime.timedelta(days=1).total_seconds()
             day_before_timestamp = time.time() - one_day_in_seconds
             os.utime(

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -618,3 +618,17 @@ class TestBundleDataCache(TestApplication):
                     os.path.sep, os.path.sep, name,
                 ))
             )
+
+    def test_cleaning_cached_data(self):
+        app = self.engine.apps["test_app"]
+        # Create dummy cached data
+        cache_folder = app.site_cache_location
+        os.mkdir(os.path.join(cache_folder, "test"))
+        self.create_file(os.path.join(cache_folder, "foo.txt"))
+        self.create_file(os.path.join(cache_folder, "blah.txt"))
+        self.create_file(os.path.join(cache_folder, "test", "foo.txt"))
+        self.create_file(os.path.join(cache_folder, "test", "blah.txt"))
+        app.remove_old_cached_data(-1)
+        # Test frameworks
+        for name, fw in app.frameworks.iteritems():
+            fw.remove_old_cached_data(-1)

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -650,6 +650,12 @@ class TestBundleDataCache(TestApplication):
                 self.assertTrue(os.path.exists(os.path.join(cache_folder, dummy_file)))
             # Change the modification time for a file and clean it up
             dummy_file = os.path.join(cache_folder, dummy_files.pop())
+            one_day_delta = datetime.timedelta(days=1)
+            # Datetime total_seconds was introduced in Python 2.7, so compute the
+            # value ourself
+            one_day_in_seconds = (
+                one_day_delta.microseconds + (one_day_delta.seconds + one_day_delta.days * 24 * 3600) * 10**6
+                ) / 10**6
             one_day_in_seconds = datetime.timedelta(days=1).total_seconds()
             day_before_timestamp = time.time() - one_day_in_seconds
             os.utime(

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -651,7 +651,7 @@ class TestBundleDataCache(TestApplication):
             # Change the modification time for a file and clean it up
             dummy_file = os.path.join(cache_folder, dummy_files.pop())
             one_day_in_seconds = datetime.timedelta(days=1).total_seconds()
-            day_before_timestamp = time.time() - one_day_in_seconds -1
+            day_before_timestamp = time.time() - one_day_in_seconds
             os.utime(
                 dummy_file,
                 (day_before_timestamp, day_before_timestamp)


### PR DESCRIPTION
Added `Bundle. _remove_old_cached_data` method which removes cached data which has not been modified recently and added some unit tests for the new method.

This new method is used in `tk-framework-shotgunutils`: https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/76, but could be used for other bundles if needed.

It is the bundle implementation responsibility to ensure a cached file modification time is updated if it does not want it be removed when calling `_remove_old_cached_data`. Please let me know if that sounds right.

The _grace period_ must be at least `1` (one day) to prevent all files in a cache to be accidentally deleted.
