### PR TITLE
For #46128, multiple endpoints for toolkit.ini

### DIFF
--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -97,6 +97,19 @@ class UserSettings(Singleton):
         """
         return self.get_setting(self._LOGIN, "default_login")
 
+    def get_section_settings(self, section):
+        """
+        Retrieves the name of the settings in a given section.
+
+        :param str section: Name of the section of the settings to retrieve.
+
+        :returns: A list of setting's name. If the section is missing, returns
+            ``None``.
+        """
+        if not self._user_config.has_section(section):
+            return None
+        return self._user_config.options(section)
+
     def get_setting(self, section, name):
         """
         Provides access to any setting, including ones in user defined sections.

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -11,7 +11,6 @@
 from __future__ import with_statement
 
 import os
-import uuid
 
 from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule # noqa
@@ -36,35 +35,6 @@ class UserSettingsTests(ShotgunTestBase):
         UserSettings.clear_singleton()
         self.addCleanup(UserSettings.clear_singleton)
 
-    def _mock_ini_file(self, login_section={}, custom_section={}):
-        """
-        Creates an ini file in a unique location with te user settings.
-
-        :param login_section: Dictionary of settings that will be stored in the [Login] section.
-        :param custom_section: Dictionary of settings that will be stored in the [Custom] section.
-        """
-        # Create a unique folder for this test.
-        folder = os.path.join(self.tank_temp, str(uuid.uuid4()))
-        os.makedirs(folder)
-
-        # Manually write the file as this is the format we're expecting the UserSettings
-        # to parse.
-
-        ini_file_location = os.path.join(folder, "toolkit.ini")
-        with open(ini_file_location, "w") as f:
-            f.writelines(["[Login]\n"])
-            for key, value in login_section.iteritems():
-                f.writelines(["%s=%s\n" % (key, value)])
-
-            f.writelines(["[Custom]\n"])
-            for key, value in custom_section.iteritems():
-                f.writelines(["%s=%s\n" % (key, value)])
-
-        # The setUp phase cleared the singleton. So set the preferences environment variable and
-        # instantiate the singleton, which will read the env var and open that location.
-        with patch.dict(os.environ, {"SGTK_PREFERENCES_LOCATION": ini_file_location}):
-            UserSettings()
-
     def test_empty_file(self):
         """
         Tests a complete yaml file.
@@ -79,7 +49,7 @@ class UserSettingsTests(ShotgunTestBase):
         """
         Tests a complete yaml file.
         """
-        self._mock_ini_file({
+        self.write_toolkit_ini_file({
             "default_site": "site",
             "default_login": "login",
             "http_proxy": "http_proxy",
@@ -96,7 +66,7 @@ class UserSettingsTests(ShotgunTestBase):
         """
         Tests a yaml file with the settings present but empty.
         """
-        self._mock_ini_file({
+        self.write_toolkit_ini_file({
             "default_site": "",
             "default_login": "",
             "http_proxy": "",
@@ -114,8 +84,8 @@ class UserSettingsTests(ShotgunTestBase):
         Tests that we can read settings in any section of the file.
         """
 
-        self._mock_ini_file(
-            custom_section={
+        self.write_toolkit_ini_file(
+            Custom={
                 "custom_key": "custom_value"
             }
         )
@@ -129,8 +99,8 @@ class UserSettingsTests(ShotgunTestBase):
         """
         Tests that we can read a setting into a boolean.
         """
-        self._mock_ini_file(
-            custom_section={
+        self.write_toolkit_ini_file(
+            Custom={
                 "valid": "ON",
                 "invalid": "L"
             }
@@ -145,13 +115,37 @@ class UserSettingsTests(ShotgunTestBase):
         ):
             UserSettings().get_boolean_setting("Custom", "invalid")
 
+    def test_settings_enumeration(self):
+        """
+        Tests that we can enumerate settings from a section.
+        """
+        self.write_toolkit_ini_file(
+            {
+                "this": "is",
+                "my": "boomstick"
+            },
+            Custom={}
+        )
+
+        self.assertEqual(
+            UserSettings().get_section_settings("missing section"), []
+        )
+
+        self.assertEqual(
+            UserSettings().get_section_settings("Custom"), []
+        )
+
+        self.assertEqual(
+            UserSettings().get_section_settings("Login"), ["this", "my"]
+        )
+
     def test_integer_setting(self):
         """
         Tests that we can read a setting into an integer
         """
 
-        self._mock_ini_file(
-            custom_section={
+        self.write_toolkit_ini_file(
+            Custom={
                 "valid": "1",
                 "also_valid": "-1",
                 "invalid": "L"
@@ -174,7 +168,7 @@ class UserSettingsTests(ShotgunTestBase):
         """
         Tests that setting an environment variable will be resolved.
         """
-        self._mock_ini_file({
+        self.write_toolkit_ini_file({
             # Config parser represent empty settings as empty strings
             "default_site": "https://${SGTK_TEST_SHOTGUN_SITE}.shotgunstudio.com"
         })

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -128,7 +128,7 @@ class UserSettingsTests(ShotgunTestBase):
         )
 
         self.assertEqual(
-            UserSettings().get_section_settings("missing section"), []
+            UserSettings().get_section_settings("missing section"), None
         )
 
         self.assertEqual(


### PR DESCRIPTION
Allows to enumerate the settings inside a section of the user settings. This is used by the browser integration to enumerate the settings from the `HostAliases` section when present. We only enumerate the names and not the values so users of the API can then use the name with the associated `get_boolean_setting`, `get_integer_setting`, `get_setting`, which will cast the string from the settings into the right type.

I've also moved some code to create `toolkit.ini` to `TankTestBase` so it can be reused in other tests, including tests from other repos, which the desktop server will use.