### PR TITLE
For #44951, login dropdown fix

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -220,7 +220,7 @@ class LoginDialog(QtGui.QDialog):
         # show or hide the login and password fields.
         self.ui.site.lineEdit().textEdited.connect(self._site_url_changing)
         # If a site has been selected, we need to update the login field.
-        self.ui.site.activated.connect(lambda x: self._on_site_changed())
+        self.ui.site.activated.connect(self._on_site_changed)
         self.ui.site.lineEdit().editingFinished.connect(self._on_site_changed)
 
         self._query_task = QuerySiteAndUpdateUITask(self)
@@ -422,9 +422,11 @@ class LoginDialog(QtGui.QDialog):
         """
         # Wait for any ongoing SSO check thread.
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
-        if not self._query_task.wait(THREAD_WAIT_TIMEOUT_MS):
-            logger.warning("Timed out awaiting check for SSO support on the site: %s" % self._get_current_site())
-        QtGui.QApplication.restoreOverrideCursor()
+        try:
+            if not self._query_task.wait(THREAD_WAIT_TIMEOUT_MS):
+                logger.warning("Timed out awaiting check for SSO support on the site: %s" % self._get_current_site())
+        finally:
+            QtGui.QApplication.restoreOverrideCursor()
 
         # pull values from the gui
         site = self._get_current_site()

--- a/python/tank/authentication/resources/login_dialog.ui
+++ b/python/tank/authentication/resources/login_dialog.ui
@@ -71,6 +71,20 @@ QComboBox:down-arrow {
 QLineEdit:Disabled {
     background-color: rgb(60, 60, 60);
     color: rgb(160, 160, 160);
+}
+
+QComboBox::drop-down:disabled {
+    border-width: 0px;
+
+}
+
+QComboBox::down-arrow:disabled {
+    image: url(noimg); border-width: 0px;
+}
+
+QComboBox::disabled {
+    background-color: rgb(60, 60, 60);
+    color: rgb(160, 160, 160);
 }</string>
   </property>
   <property name="modal">

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -205,6 +205,11 @@ def _try_load_site_authentication_file(file_path):
     :returns: site authentication style dictionary
     """
     content = _try_load_yaml_file(file_path)
+
+    # No not attempt to filter out content that is not understood. This allows
+    # the file to be backwards and forward compatible with different versions
+    # of core.
+
     # Make sure any mandatory entry is present.
     content.setdefault(_USERS, [])
     content.setdefault(_CURRENT_USER, None)
@@ -228,6 +233,11 @@ def _try_load_global_authentication_file(file_path):
     :returns: global authentication style dictionary
     """
     content = _try_load_yaml_file(file_path)
+
+    # No not attempt to filter out content that is not understood. This allows
+    # the file to be backwards and forward compatible with different versions
+    # of core.
+
     # Make sure any mandatody entry is present.
     content.setdefault(_CURRENT_HOST, None)
     content.setdefault(_RECENT_HOSTS, [])
@@ -462,6 +472,31 @@ def get_current_host():
     return host
 
 
+def _get_recent_items(document, recent_field, current_field, type_name):
+    """
+    Extract the list of recent items from the document.
+
+    If the recent_field is not set, then we'll simply return the current_field's
+    value. The recent_field will be empty when upgrading from an older core
+    that didn't support the recent users/hosts list.
+
+    :param object document: Document to extract information from
+    :param recent_field: Field from which we need to retrieve
+    """
+    # Extract the list of recent items.
+    items = document[recent_field]
+
+    # Then check if the current is part of the list. It's not? This is because
+    # an older core updated the file, but didn't know about the recent list and
+    # didn't update it. This is possible because since day one the authentication.yml
+    # has been treated as document with certain fields set and when the document
+    # is rewritten it is rewritten as is, except for the bits that were updated.
+    if document[current_field] and document[current_field] not in items:
+        items.insert(0, document[current_field])
+    logger.debug("Recent %s are: %s", type_name, items)
+    return items
+
+
 def get_recent_hosts():
     """
     Retrieves the list of recently visited hosts.
@@ -470,8 +505,7 @@ def get_recent_hosts():
     """
     info_path = _get_global_authentication_file_location()
     document = _try_load_global_authentication_file(info_path)
-    logger.debug("Recent hosts are: %s", document[_RECENT_HOSTS])
-    return document[_RECENT_HOSTS]
+    return _get_recent_items(document, _RECENT_HOSTS, _CURRENT_HOST, "hosts")
 
 
 def get_recent_users(site):
@@ -483,7 +517,7 @@ def get_recent_users(site):
     info_path = _get_site_authentication_file_location(site)
     document = _try_load_site_authentication_file(info_path)
     logger.debug("Recent users are: %s", document[_RECENT_USERS])
-    return document[_RECENT_USERS]
+    return _get_recent_items(document, _RECENT_USERS, _CURRENT_USER, "users")
 
 
 @LogManager.log_timing

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -206,7 +206,7 @@ def _try_load_site_authentication_file(file_path):
     """
     content = _try_load_yaml_file(file_path)
 
-    # No not attempt to filter out content that is not understood. This allows
+    # Do not attempt to filter out content that is not understood. This allows
     # the file to be backwards and forward compatible with different versions
     # of core.
 
@@ -234,7 +234,7 @@ def _try_load_global_authentication_file(file_path):
     """
     content = _try_load_yaml_file(file_path)
 
-    # No not attempt to filter out content that is not understood. This allows
+    # Do not attempt to filter out content that is not understood. This allows
     # the file to be backwards and forward compatible with different versions
     # of core.
 

--- a/python/tank/authentication/ui/login_dialog.py
+++ b/python/tank/authentication/ui/login_dialog.py
@@ -65,6 +65,20 @@ class Ui_LoginDialog(object):
 "QLineEdit:Disabled {\n"
 "    background-color: rgb(60, 60, 60);\n"
 "    color: rgb(160, 160, 160);\n"
+"}\n"
+"\n"
+"QComboBox::drop-down:disabled {\n"
+"    border-width: 0px;\n"
+"\n"
+"}\n"
+"\n"
+"QComboBox::down-arrow:disabled {\n"
+"    image: url(noimg); border-width: 0px;\n"
+"}\n"
+"\n"
+"QComboBox::disabled {\n"
+"    background-color: rgb(60, 60, 60);\n"
+"    color: rgb(160, 160, 160);\n"
 "}")
         LoginDialog.setModal(True)
         self.verticalLayout_2 = QtGui.QVBoxLayout(LoginDialog)

--- a/python/tank/authentication/ui/recent_box.py
+++ b/python/tank/authentication/ui/recent_box.py
@@ -46,7 +46,7 @@ class RecentBox(QtGui.QComboBox):
 
         # We'll use a completer that shows all results and we'll do the matching ourselves, as the completion
         # engine can only work from the beginning of a string...
-        self._completer = QtGui.QCompleter()
+        self._completer = QtGui.QCompleter(self)
         self._completer.setCompletionMode(QtGui.QCompleter.UnfilteredPopupCompletion)
 
         # We'll do our own filtering.

--- a/tests/authentication_tests/test_session_cache.py
+++ b/tests/authentication_tests/test_session_cache.py
@@ -26,15 +26,99 @@ class SessionCacheTests(ShotgunTestBase):
     def setUp(self):
         super(SessionCacheTests, self).setUp()
         # Wipe the global session file that has been edited by previous tests.
+        self._write_global_yml({})
+
+    def _write_global_yml(self, content):
+        """
+        Writes the global authentication file.
+        """
         session_cache._write_yaml_file(
             session_cache._get_global_authentication_file_location(),
-            {}
+            content
+        )
+
+    def _write_site_yml(self, site, content):
+        """
+        Writes the site authentication file.
+        """
+        session_cache._write_yaml_file(
+            session_cache._get_site_authentication_file_location(site),
+            content
         )
 
     def _clear_site_yml(self, site):
-        session_cache._write_yaml_file(
-            session_cache._get_site_authentication_file_location(site),
-            {}
+        """
+        Clears the site authentication file.
+        """
+        self._write_site_yml(site, {})
+
+    def test_recent_users_upgrade(self):
+        """
+        Ensures that if we've just upgraded to the latest core that the current
+        user is part of the recent users.
+        """
+        HOST = "https://host.shotgunstudio.com"
+
+        # The recent_users array is not present in the authentication.yml
+        # file, so make sure that the session cache reports the user as the
+        # most recent.
+        self._write_site_yml(
+            HOST, {"current_user": "current.user", "users": []}
+        )
+
+        self.assertEqual(
+            session_cache.get_recent_users(HOST),
+            ["current.user"]
+        )
+
+    def test_recent_hosts_upgrade(self):
+        """
+        Ensures that if we've just upgraded to the latest core that the current
+        host is part of the recent hosts.
+        """
+        # The recent_users array is not present in the authentication.yml
+        # file, so make sure that the session cache reports the user as the
+        # most recent.
+        self._write_global_yml(
+            {"current_host": "https://host.shotgunstudio.com"}
+        )
+
+        self.assertEqual(
+            session_cache.get_recent_hosts(),
+            ["https://host.shotgunstudio.com"]
+        )
+
+    def test_recent_users_downgrade(self):
+        """
+        Ensures that if an older core updated the authentication file, which means
+        recent_users has not been kept up to date, that the recent users list
+        has the current_user at the front.
+        """
+        HOST = "https://host.shotgunstudio.com"
+        self._write_site_yml(
+            HOST,
+            {"current_user": "current.user", "recent_users": ["older.user"]}
+        )
+
+        self.assertEqual(
+            session_cache.get_recent_users(HOST), ["current.user", "older.user"]
+        )
+
+    def test_recent_hosts_downgrade(self):
+        """
+        Ensures that if an older core updated the authentication file, which means
+        recent_hosts has not been kept up to date, that the recent hosts list
+        has the current_host at the front.
+        """
+        self._write_global_yml(
+            {"current_host": "https://current.shotgunstudio.com", "recent_hosts": ["https://older.shotgunstudio.com"]}
+        )
+
+        self.assertEqual(
+            session_cache.get_recent_hosts(), [
+                "https://current.shotgunstudio.com",
+                "https://older.shotgunstudio.com"
+            ]
         )
 
     def test_recent_hosts(self):


### PR DESCRIPTION
Fixes 3 small issues Francis found during QA.
- The new combo box widgets weren't grayed out when renewing session
- Constant crash on exit on Windows 7 (not 10!) in the Desktop
- When switching back and forth between version of core the UI wasn't consistent.