### PR TITLE
#46590 Fixes a bug when a site contains configs linked to projects without tank_name defined

### DIFF
--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -539,13 +539,17 @@ def _get_pipeline_configs_for_path(path, data):
 
         for s in storages:
 
-            # all installed/classic pipeline configurations are associated
-            # with a project which has a tank_name set
+            # installed/classic pipeline configurations are associated with a
+            # project which has a tank_name set. this key will always exist, but
+            # the value may be None for projects not using the templates/schema
+            # system
             project_name = pc["project.Project.tank_name"]
 
-            # if the project's tank_name is None, then this configuration is not
-            # a classic/installed configuration. We know it can't be associated
-            # with a path, so there's no need to process it.
+            # this method is used to look up the appropriate configuration given
+            # a path on disk. Configurations that don't have a file system
+            # presence (not using the templates/schema system) can be safely
+            # ignored as the path can't be associated with that type of
+            # configuration
             if not project_name:
                 continue
 

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -538,9 +538,16 @@ def _get_pipeline_configs_for_path(path, data):
     for pc in data["pipeline_configurations"]:
 
         for s in storages:
-            # all pipeline configurations are associated
+
+            # all installed/classic pipeline configurations are associated
             # with a project which has a tank_name set
             project_name = pc["project.Project.tank_name"]
+
+            # if the project's tank_name is None, then this configuration is not
+            # a classic/installed configuration. We know it can't be associated
+            # with a path, so there's no need to process it.
+            if not project_name:
+                continue
 
             # for multi level projects, there may be slashes, e.g
             # project_name is "parent/child"

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -482,6 +482,48 @@ class TestTankFromPathOverlapStorage(TankTestBase):
         else:
             os.environ["TANK_CURRENT_PC"] = old_tank_current_pc
 
+class TestTankFromPathPCWithProjectWithoutTankName(TankTestBase):
+    """
+    Tests edge case where getting path for classic/installed project and another
+    project exists without a tank name.
+    """
 
+    def setUp(self):
 
+        super(TestTankFromPathPCWithProjectWithoutTankName, self).setUp()
 
+        # a separate project record without the tank name set
+        self.other_project = {
+            "type": "Project",
+            "name": "Project without tank_name set",
+            "id": 77777,
+            "archived": False,
+            "tank_name": None
+        }
+
+        # define an additional pipeline config linked to the other project
+        self.other_pc = {
+            "type": "PipelineConfiguration",
+            "code": "Other",
+            "id": 123456,
+            "project": self.other_project,
+            "windows_path": "/foobar",
+            "mac_path": "/foobar",
+            "linux_path": "/foobar",
+        }
+
+        self.add_to_sg_mock_db(self.other_project)
+        self.add_to_sg_mock_db(self.other_pc)
+
+    def test_sgtk_from_path_project_no_tank_name(self):
+        """
+        Ensure no errors and valid Tank instance returned when a project exists
+        with no tank_name
+        """
+
+        path = os.path.join(self.project_root, "child_dir")
+
+        # this will raise if an exception occurs. prior to the associated fix
+        # (#46590), if there was a project defined for the site without a
+        # tank_name set, this code would fail.
+        config = sgtk.pipelineconfig_factory.from_path(path)


### PR DESCRIPTION
This issue cropped up when working on one project with a classic/installed config. There are scenarios where bootstrap fails while trying to find a config for a given path because other configs are associated with projects that do not have a `tank_name` defined. This is a little fix to bypass trying to associate a path to a config if the config being compared is not classic/installed.