### PR TITLE
For #30005, copy the file in the right storage based on the config setting

### DIFF
--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -481,13 +481,13 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
                 "The path '%s' is associated with config root '%s'." % (path, storage_name)
             )
 
-            # check if the shotgun server supports the storage and relative_path parameters
-            # which allows us to specify exactly which storage to bind a publish to rather
-            # than relying on Shotgun to compute this
+            # check if the shotgun server supports the storage and relative_path parameters which
+            # allows us to specify exactly which storage to bind a publish to rather than relying on
+            # Shotgun to compute this.
             supports_specific_storage_syntax = (
                 hasattr(tk.shotgun, "server_caps") and
                 tk.shotgun.server_caps.version and
-                tk.shotgun.server_caps.version >= (6, 3, 17)
+                tk.shotgun.server_caps.version >= (7, 0, 1)
             )
 
             if supports_specific_storage_syntax:

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -476,54 +476,45 @@ def _create_published_file(tk, context, path, name, version_number, task, commen
         storage_name, path_cache = _calc_path_cache(tk, path)
 
         if path_cache:
-
             # there is a toolkit storage mapping defined for this storage
             log.debug(
                 "The path '%s' is associated with config root '%s'." % (path, storage_name)
             )
-            # specify the full path in shotgun
-            data["path"] = {"local_path": path}
 
-            # note - #30005 - there appears to be an issue on the serverside
-            # related to the explicit storage format and paths containing
-            # sequence tokens such as %04d. Commenting out the logic to handle
-            # the new explicit storage format for the time being while this is
-            # being investigated.
+            # check if the shotgun server supports the storage and relative_path parameters
+            # which allows us to specify exactly which storage to bind a publish to rather
+            # than relying on Shotgun to compute this
+            supports_specific_storage_syntax = (
+                hasattr(tk.shotgun, "server_caps") and
+                tk.shotgun.server_caps.version and
+                tk.shotgun.server_caps.version >= (6, 3, 17)
+            )
 
-            # # check if the shotgun server supports the storage and relative_path parameters
-            # # which allows us to specify exactly which storage to bind a publish to rather
-            # # than relying on Shotgun to compute this
-            # supports_specific_storage_syntax = (
-            #     hasattr(tk.shotgun, "server_caps") and
-            #     tk.shotgun.server_caps.version and
-            #     tk.shotgun.server_caps.version >= (6, 3, 17)
-            # )
-            #
-            # if supports_specific_storage_syntax:
-            #     # explicitly pass relative path and storage to shotgun
-            #     storage = tk.shotgun.find_one("LocalStorage", [["code", "is", storage_name]])
-            #
-            #     if storage is None:
-            #         # there is no storage in Shotgun that matches the one toolkit expects.
-            #         # this *may* be ok because there may be another storage in Shotgun that
-            #         # magically picks up the publishes and associates with them. In this case,
-            #         # issue a warning and fall back on the server-side functionality
-            #         log.warning(
-            #             "Could not find the expected storage '%s' in Shotgun to associate "
-            #             "publish '%s' with - falling back to Shotgun's built-in storage "
-            #             "resolution logic. It is recommended that you add the '%s' storage "
-            #             "to Shotgun" % (storage_name, path, storage_name))
-            #         data["path"] = {"local_path": path}
-            #
-            #     else:
-            #         data["path"] = {"relative_path": path_cache, "local_storage": storage}
-            #
-            # else:
-            #     # use previous syntax where we pass the whole path to Shotgun
-            #     # and shotgun will do the storage/relative path split server side.
-            #     # This operation may do unexpected things if you have multiple
-            #     # storages that are identical or overlapping
-            #     data["path"] = {"local_path": path}
+            if supports_specific_storage_syntax:
+                # explicitly pass relative path and storage to shotgun
+                storage = tk.shotgun.find_one("LocalStorage", [["code", "is", storage_name]])
+
+                if storage is None:
+                    # there is no storage in Shotgun that matches the one toolkit expects.
+                    # this *may* be ok because there may be another storage in Shotgun that
+                    # magically picks up the publishes and associates with them. In this case,
+                    # issue a warning and fall back on the server-side functionality
+                    log.warning(
+                        "Could not find the expected storage '%s' in Shotgun to associate "
+                        "publish '%s' with - falling back to Shotgun's built-in storage "
+                        "resolution logic. It is recommended that you add the '%s' storage "
+                        "to Shotgun" % (storage_name, path, storage_name))
+                    data["path"] = {"local_path": path}
+
+                else:
+                    data["path"] = {"relative_path": path_cache, "local_storage": storage}
+
+            else:
+                # use previous syntax where we pass the whole path to Shotgun
+                # and shotgun will do the storage/relative path split server side.
+                # This operation may do unexpected things if you have multiple
+                # storages that are identical or overlapping
+                data["path"] = {"local_path": path}
 
             # fill in the path cache field which is used for filtering in Shotgun
             # (because SG does not support


### PR DESCRIPTION
This ensures that a publish ends up associated with a storage that is define inside roots.yml.