### PR TITLE
For #46680, bootstrap crash

### DIFF
--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -178,13 +178,12 @@ class Configuration(object):
         # module, so try to import.
         try:
             # Use backwards compatible imports.
-            from tank_vendor.shotgun_authentication import ShotgunAuthenticator
+            from tank_vendor.shotgun_authentication import ShotgunAuthenticator, deserialize_user
             from ..util import CoreDefaultsManager
         except ImportError:
             log.debug("Using pre-0.16 core, no authenticated user will be set.")
             return None
 
-        from ..authentication import deserialize_user
         from .. import api
 
         log.debug("The project's core supports the authentication module.")

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -22,6 +22,7 @@ from sgtk.bootstrap.configuration import Configuration
 from sgtk.authentication import ShotgunAuthenticator, ShotgunSamlUser
 from sgtk.authentication.user_impl import SessionUser
 import sgtk
+import tank_vendor
 
 
 REPO_ROOT = os.path.normpath(
@@ -105,8 +106,8 @@ class TestConfiguration(TestConfigurationBase):
         ):
             # Python 2.6 doesn't support multi-expression with statement, so nest the calls instead.
             with patch(
-                "tank.authentication.deserialize_user",
-                wraps=sgtk.authentication.user.deserialize_user
+                "tank_vendor.shotgun_authentication.deserialize_user",
+                wraps=tank_vendor.shotgun_authentication.deserialize_user
             ) as deserialize_wrapper:
                 current_user = self._create_session_user("current_user")
                 configuration._set_authenticated_user(current_user, current_user.login, "invalid")


### PR DESCRIPTION
When the core is swapped, we need to make sure we import authentication methods from backwards compatible location.

If we don't, we crash the bootstrap process with previous versions of Toolkit. Right now 0.16 and 0.17 core's can't be bootstrapped into. :(