### PR TITLE
#46693 Fix for producedural hook evaluation for complex data types

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -1062,7 +1062,25 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
     """
     settings_type = schema.get("type")
 
-    if settings_type == "list":
+    if isinstance(value, basestring) and value.startswith("hook:"):
+        # handle the special form where the value is computed in a hook.
+        #
+        # if the template parameter is on the form
+        # a) hook:foo_bar
+        # b) hook:foo_bar:testing1:testing2
+        #
+        # The following hook will be called
+        # a) core hook 'foo_bar' with parameters []
+        # b) core hook 'foo_bar' with parameters ['testing1', 'testing2']
+        #
+        chunks = value.split(":")
+        hook_name = chunks[1]
+        params = chunks[2:]
+        processed_val = tk.execute_core_hook(
+            hook_name, setting=key, bundle_obj=bundle, extra_params=params
+        )
+
+    elif settings_type == "list":
         processed_val = []
         value_schema = schema["values"]
         for x in value:
@@ -1096,24 +1114,6 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
         config_folder = tk.pipeline_configuration.get_config_location()
         adjusted_value = value.replace("/", os.path.sep)
         processed_val = os.path.join(config_folder, adjusted_value)
-
-    elif isinstance(value, basestring) and value.startswith("hook:"):
-        # handle the special form where the value is computed in a hook.
-        #
-        # if the template parameter is on the form
-        # a) hook:foo_bar
-        # b) hook:foo_bar:testing:testing
-        #
-        # The following hook will be called
-        # a) foo_bar with parameters []
-        # b) foo_bar with parameters [testing, testing]
-        #
-        chunks = value.split(":")
-        hook_name = chunks[1]
-        params = chunks[2:]
-        processed_val = tk.execute_core_hook(
-            hook_name, setting=key, bundle_obj=bundle, extra_params=params
-        )
 
     else:
         # pass-through

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -1062,6 +1062,9 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
     """
     settings_type = schema.get("type")
 
+    # first check for procedural overrides where instead of getting a value,
+    # directly from the config, we call a hook to evaluate a config value
+    # at runtime:
     if isinstance(value, basestring) and value.startswith("hook:"):
         # handle the special form where the value is computed in a hook.
         #
@@ -1079,8 +1082,10 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
         processed_val = tk.execute_core_hook(
             hook_name, setting=key, bundle_obj=bundle, extra_params=params
         )
+        return processed_val
 
-    elif settings_type == "list":
+    # No procedural overrides in place - instead handle the value based on type
+    if settings_type == "list":
         processed_val = []
         value_schema = schema["values"]
         for x in value:

--- a/tests/fixtures/config/bundles/test_app/info.yml
+++ b/tests/fixtures/config/bundles/test_app/info.yml
@@ -282,6 +282,23 @@ configuration:
         type: str
         default_value_tk-maya: "foobar"
 
+    # hook evaluator tests
+    test_str_evaluator:
+        type: str
+
+    test_int_evaluator:
+        type: int
+
+    test_simple_dictionary_evaluator:
+        type: dict
+        items:
+            test_str:
+                type: str
+            test_int:
+                type: int
+
+
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/tests/fixtures/config/core/hooks/test_evaluator.py
+++ b/tests/fixtures/config/core/hooks/test_evaluator.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank import Hook
+
+
+class TestEvaluator(Hook):
+    
+    def execute(self, setting, bundle_obj, extra_params, **kwargs):
+        """
+        Procedural settings evaluator.
+
+        If applied to an env setting like this:
+
+        > app_setting: hook:test_evaluator:foo:bar
+
+        This hook will get called with the following syntax:
+
+        setting='app_setting', bundle_obj=<the app>, extra_params=['foo', 'bar']
+
+        :param str setting: The name of the setting for which we are evaluating.
+        :param bundle_obj: The associated app, engine or framework object.
+        :param extra_params: List of options passed from the setting. If the settings
+            string is "hook:hook_name:foo:bar", extra_params would
+            be ['foo', 'bar']
+
+        returns: a value expected by the overridden setting.
+        """
+
+        # we expect the following setup in our test environment:
+        #
+        # test_str_evaluator: hook:test_evaluator
+        # test_int_evaluator: hook:test_evaluator
+        # test_simple_dictionary_evaluator: hook:test_evaluator:param
+        # test_complex_dictionary_evaluator:
+        # test_str: a
+        # test_list: hook:test_evaluator
+
+        if setting == "test_str_evaluator":
+            return "string_value"
+        if setting == "test_int_evaluator":
+            return 1
+        if setting == "test_simple_dictionary_evaluator":
+            # test_str: 'param'
+            return {"test_str": extra_params[0], "test_int": 1}

--- a/tests/fixtures/config/core/hooks/test_evaluator.py
+++ b/tests/fixtures/config/core/hooks/test_evaluator.py
@@ -45,5 +45,13 @@ class TestEvaluator(Hook):
         if setting == "test_int_evaluator":
             return 1
         if setting == "test_simple_dictionary_evaluator":
-            # test_str: 'param'
+            #
+            # we are grabbing the value passed from the configuration
+            # and passing it back. In this particular case, tests
+            # are calling it with the following env config syntax:
+            #
+            # test_simple_dictionary_evaluator: hook:test_evaluator:param
+            #
+            # ...which will result in extra_params[0]=='param'
+            #
             return {"test_str": extra_params[0], "test_int": 1}

--- a/tests/fixtures/config/core/hooks/test_evaluator.py
+++ b/tests/fixtures/config/core/hooks/test_evaluator.py
@@ -39,9 +39,6 @@ class TestEvaluator(Hook):
         # test_str_evaluator: hook:test_evaluator
         # test_int_evaluator: hook:test_evaluator
         # test_simple_dictionary_evaluator: hook:test_evaluator:param
-        # test_complex_dictionary_evaluator:
-        # test_str: a
-        # test_list: hook:test_evaluator
 
         if setting == "test_str_evaluator":
             return "string_value"

--- a/tests/fixtures/config/env/post_update/test_post_update_new_parser.yml
+++ b/tests/fixtures/config/env/post_update/test_post_update_new_parser.yml
@@ -102,6 +102,10 @@ engines:
           - test_str: ba
           - test_str: bb                  
 
+        test_str_evaluator: hook:test_evaluator
+        test_int_evaluator: hook:test_evaluator
+        test_simple_dictionary_evaluator: hook:test_evaluator:param
+
       disabled_app:
         location: {type: dev, path: DISABLED_APP_LOCATION, disabled: true}
   disabled_engine:

--- a/tests/fixtures/config/env/post_update/test_post_update_old_parser.yml
+++ b/tests/fixtures/config/env/post_update/test_post_update_old_parser.yml
@@ -52,11 +52,14 @@ engines:
         test_hook_std: config_test_hook
         test_icon: foo/bar.png
         test_int: 1
+        test_int_evaluator: hook:test_evaluator
         test_no_schema: 1234.5678
         test_publish_type: Render Scene
         test_simple_dictionary: {test_int: 1, test_str: a}
+        test_simple_dictionary_evaluator: hook:test_evaluator:param
         test_simple_list: [a, b, c, d]
         test_str: a
+        test_str_evaluator: hook:test_evaluator
         test_tank_type: Render Scene Tank
         test_template: maya_publish_name
         test_very_complex_list:

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -113,6 +113,10 @@ engines:
                             -   test_str: ba
                             -   test_str: bb
 
+                test_str_evaluator: hook:test_evaluator
+                test_int_evaluator: hook:test_evaluator
+                test_simple_dictionary_evaluator: hook:test_evaluator:param
+
             disabled_app:
                 location: {'type': 'dev', 'path': 'DISABLED_APP_LOCATION', 'disabled': True}
     disabled_engine:

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -207,6 +207,14 @@ class TestGetSetting(TestApplication):
         # test legacy case where a setting has no schema
         self.assertEqual(1234.5678, self.app.get_setting("test_no_schema"))
 
+        # procudural hook based evaluation of settings
+        self.assertEqual("string_value", self.app.get_setting("test_str_evaluator"))
+        self.assertEqual(1, self.app.get_setting("test_int_evaluator"))
+        self.assertEqual(
+            {"test_str": "param", "test_int": 1},
+            self.app.get_setting("test_simple_dictionary_evaluator")
+        )
+
         # test allow empty types with no default
         self.assertEqual([], self.app.get_setting("test_allow_empty_list"))
         self.assertEqual({}, self.app.get_setting("test_allow_empty_dict"))


### PR DESCRIPTION
Fixes a bug which previously prevented the use of procedural hook based evaluation of complex environment properties such as list and strings. Also adds tests for procedural hook based evaluation.