### PR TITLE
#46697 Fix for PyQt4 with authentication dialog.

### DIFF
--- a/python/tank/authentication/shotgun_shared/saml2_sso.py
+++ b/python/tank/authentication/shotgun_shared/saml2_sso.py
@@ -192,7 +192,8 @@ class Saml2Sso(object):
         # Worst case scenario : should Shotgun modify how the warning is displayed
         # it would show up in the page.
         css_style = base64.b64encode("div.browser_not_approved { display: none !important; }")
-        self._view.settings().setUserStyleSheetUrl("data:text/css;charset=utf-8;base64," + css_style)
+        url = QtCore.QUrl("data:text/css;charset=utf-8;base64," + css_style)
+        self._view.settings().setUserStyleSheetUrl(url)
 
         # Threshold percentage of the SSO session duration, at which
         # time the pre-emptive renewal operation should be started.


### PR DESCRIPTION
This is to fix an issue where the login screen would error when being created in an environment running PyQt4.

The fix is to just explicitly state that we want to create a QtCore.QUrl when passing the url through to the `setUserStyleSheetUrl` method. Without this, on PyQt4 it would complain that it got the wrong argument type.
