### PR TITLE
#46177 Multi-path folders, expressions and project root bug fixes.

### DIFF
--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -87,7 +87,11 @@ class Entity(Folder):
         
         self._tk = tk
         self._entity_type = entity_type
-        self._entity_expression = shotgun_entity.EntityExpression(self._tk, self._entity_type, field_name_expression)
+        self._entity_expression = shotgun_entity.EntityExpression(
+            self._tk,
+            self._entity_type,
+            field_name_expression
+        )
         self._filters = filters
         self._create_with_parent = create_with_parent    
 
@@ -190,14 +194,16 @@ class Entity(Folder):
             # we have a constraint!
             entity_id = sg_data[my_sg_data_key]["id"]
             # add the id constraint to the filters
-            resolved_filters["conditions"].append({ "path": "id", "relation": "is", "values": [entity_id] })
+            resolved_filters["conditions"].append(
+                {"path": "id", "relation": "is", "values": [entity_id]}
+            )
             # get data - can be None depending on external filters
 
         # figure out which fields to retrieve
         fields = self._entity_expression.get_shotgun_fields()
         
         # add any shotgun link fields used in the expression
-        fields.update( self._entity_expression.get_shotgun_link_fields() )
+        fields.update(self._entity_expression.get_shotgun_link_fields())
         
         # always retrieve the name field for the entity
         fields.add(shotgun_entity.get_sg_entity_name_field(self._entity_type))

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -542,6 +542,10 @@ class PipelineConfiguration(object):
     def get_project_disk_name(self):
         """
         Returns the project name for the project associated with this PC.
+
+        .. note:: If the project name spans over multiple folder levels,
+                  it will contain a forward slash regardless of the current
+                  operating system platform.
         """
         return self._project_name
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -1246,7 +1246,6 @@ def _resolve_default_hook_value(value, engine_name=None):
     :param value: The unresolved default value for the hook
     :param engine_name: The name of the engine for engine-specific hook values
     :return: The resolved hook default value.
-
     """
 
     if not value:

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -237,7 +237,7 @@ class EntityExpression(object):
         field_defs = self._variations[longest_expr]
         link_names = [
             field["link_field_name"] for field in field_defs if field["link_field_name"] is not None
-            ]
+        ]
         return set(link_names)
 
     def generate_name(self, values):

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -299,8 +299,6 @@ class EntityExpression(object):
         # convert Shotgun values to string values
         str_data = {}
 
-        print field_defs
-        
         # get the Shotgun id from the Shotgun entity dict
         sg_id = values.get("id")
         

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -9,10 +9,9 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Utilities relating to shotgun entities 
+Utilities relating to Shotgun entities
 """
 
-import copy
 import re
 
 from . import constants
@@ -34,15 +33,16 @@ def get_sg_entity_name_field(entity_type):
     """
     Return the Shotgun name field to use for the specified entity type.
 
-    :param entity_type: The entity type to get the name field for.
+    :param str entity_type: The entity type to get the name field for.
     :returns: The name field for the specified entity type.
     """
     # Deal with some known special cases and assume "code" for anything else.
     return SG_ENTITY_SPECIAL_NAME_FIELDS.get(entity_type, "code")
 
+
 def sg_entity_to_string(tk, sg_entity_type, sg_id, sg_field_name, data):
     """
-    Generates a string value given a shotgun value.
+    Generates a string value given a Shotgun value.
     This logic is in a hook but it typically does conversions such as:
     
     * "foo" ==> "foo"
@@ -53,10 +53,10 @@ def sg_entity_to_string(tk, sg_entity_type, sg_id, sg_field_name, data):
     This method may also raise exceptions in the case the string value is not valid.
     
     :param tk: Sgtk api instance
-    :param sg_entity_type: the shotgun entity type e.g. 'Shot'
-    :param sg_id: The shotgun id for the record, e.g 1234
+    :param sg_entity_type: the Shotgun entity type e.g. 'Shot'
+    :param sg_id: The Shotgun id for the record, e.g 1234
     :param sg_field_name: The field to generate value for, e.g. 'sg_sequence'
-    :param data: The shotgun entity data chunk that should be converted to a string.
+    :param data: The Shotgun entity data chunk that should be converted to a string.
     """
     # call out to core hook
     return tk.execute_core_hook(constants.PROCESS_FOLDER_NAME_HOOK_NAME, 
@@ -68,31 +68,33 @@ def sg_entity_to_string(tk, sg_entity_type, sg_id, sg_field_name, data):
 
 class EntityExpression(object):
     """
-    Represents a name expression for a shotgun entity.
-    A name expression converts a pattern and a set of shotgun data into a string:
+    Represents a name expression for a Shotgun entity.
+    A name expression converts a pattern and a set of Shotgun data into a string:
       
     Expression                 Shotgun Entity Data                          String Result
     ----------------------------------------------------------------------------------------
     * "code"                 + {"code": "foo_bar"}                      ==> "foo_bar"
-    * "{code}_{asset_type}"  + {"code": "foo_bar", "asset_type": "car"} ==> "foo_bar_car" 
+    * "{code}_{asset_type}"  + {"code": "foo_bar", "asset_type": "car"} ==> "foo_bar_car"
+    * "{code}/{asset_type}"  + {"code": "foo_bar", "asset_type": "car"} ==> "foo_bar/car"
     
     Optional fields are [bracketed]:
     
     * "{code}[_{asset_type}]" + {"code": "foo_bar", "asset_type": "car"} ==> "foo_bar_car"
     * "{code}[_{asset_type}]" + {"code": "foo_bar", "asset_type": None} ==> "foo_bar"
-    
-    It it is always connected to a specific shotgun entity type and 
-    the fields need to be shotgun fields that exists for that entity type.
+
+    Regular expressions can be used to evaluate substrings:
+
+    * "{code:^([^_]+)}/{code:^[^_]+(.+)}" + {"code": "foo_bar"} ==> "foo/bar"
+
+    It it is always connected to a specific Shotgun entity type and
+    the fields need to be Shotgun fields that exists for that entity type.
     """
     
     def __init__(self, tk, entity_type, field_name_expr):
         """
-        Constructor.
-        
-        :param entity_type: the shotgun entity type this is connected to
-        :param field_name_expr: string representing the expression
+        :param str entity_type: Associated Shotgun entity type.
+        :param str field_name_expr: Expression, e.g. '{code}/foo'
         """
-        
         self._tk = tk
         self._entity_type = entity_type
         self._field_name_expr = field_name_expr
@@ -108,86 +110,135 @@ class EntityExpression(object):
         # We want them most inclusive(longest) version first
         self._sorted_exprs = sorted(expr_variations, key=lambda x: len(x), reverse=True)
 
-        # now extract and store a bunch of data for each variation.
+        # Extract and store a bunch of data for each variation.
         self._variations = {}
         for v in expr_variations:
             
             try:            
-                # find all field names ["xx", "yy", "zz.xx"] from "{xx}_{yy}_{zz.xx}"
-                fields = set(re.findall('{([^}^{]*)}', v))
+                # find all field names: "{code:^([^_]+)}_{yy}_{zz.xx}"
+                fields = set(re.findall('{([^}]*)}', v))
             except Exception as error:
-                raise TankError("Could not parse the configuration field '%s' - Error: %s" % (field_name_expr, error) )
+                raise TankError(
+                    "Could not parse the configuration field '%s' - "
+                    "Error: %s" % (field_name_expr, error)
+                )
 
-            # now look for any field which contains a dot - these are all deep links.
-            # for example: sg_sequence.Sequence.code
-            # extract the actual link field from each one and put in entity_links set
-            # (in the above case, that would be sg_sequence)
-            entity_links = set()
-            for field in fields:
-                if "." in field:
-                    entity_links.add( field.split(".")[0] )
-                
+            # Go over fields strings and resolve tokens
+
+            # parsing 'sg_sequence.Sequence.code:^([^_]+)' resolves into
+            # {
+            #   'full_field_name': 'sg_sequence.Sequence.code',
+            #   'link_field_name': 'sg_sequence',
+            #   'regex_obj': <regex obj>
+            # }
+
+            # parsing 'code' resolves into
+            # {
+            #   'full_field_name': 'code',
+            #   'link_field_name': None,
+            #   'regex_obj': None
+            # }
+
+            resolved_fields = []
+            for field_token_expression in fields:
+
+                full_field_name = None
+                link_field_name = None
+                regex_obj = None
+
+                if ":" in field_token_expression:
+                    (full_field_name, regex) = field_token_expression.split(":", 1)
+
+                    try:
+                        regex_obj = re.compile(regex, re.UNICODE)
+                    except Exception as e:
+                        raise TankError(
+                            "Could not parse regex in configuration "
+                            "field '%s': %s" % (field_name_expr, e)
+                        )
+                else:
+                    full_field_name = field_token_expression
+
+                # extract the link for deep query fields
+                if "." in full_field_name:
+                    link_field_name = full_field_name.split(".")[0]
+
+                resolved_fields.append(
+                    {
+                        "full_field_name": full_field_name,
+                        "link_field_name": link_field_name,
+                        "regex_obj": regex_obj
+                    }
+                )
+
             # add this to our variations dict
-            self._variations[v] = {"entity_links": entity_links, "fields": fields}
-                
-    
+            self._variations[v] = resolved_fields
+
     def _get_expression_variations(self, definition):
         """
         Returns all possible optional variations for an expression.
         
-        "{manne}"               ==> ['{manne}']
-        "{manne}_{ludde}"       ==> ['{manne}_{ludde}']
-        "{manne}[_{ludde}]"     ==> ['{manne}', '{manne}_{ludde}']
-        "{manne}_[{foo}_{bar}]" ==> ['{manne}_', '{manne}_{foo}_{bar}']
-        
+        "{foo}"               ==> ['{foo}']
+        "{foo:[xxx]}_{bar}"   ==> ['{foo:[xxx]}_{bar}']
+        "{foo}[_{bar}]"       ==> ['{foo}', '{foo}_{bar}']
+        "{foo}_[{bar}_{baz}]" ==> ['{foo}_', '{foo}_{bar}_{baz}']
+
+        :param str definition: Expression to process.
+        :returns: List of variations. See example above.
         """
-        # split definition by optional sections
-        tokens = re.split("(\[[^]]*\])", definition)
+        # Split definition by optional sections
+        # Look for square brackets that contains at least one
+        # {expression} and ignore any square bracket inside
+        # expressions:
+        tokens = re.split("(\[[^\]]*\{.*\}[^\]]*\])", definition)
         # seed with empty string
-        definitions = ['']
+        definitions = [""]
         for token in tokens:
             temp_definitions = []
-            # regex return some blank strings, skip them
-            if token == '':
+            if token == "":
+                # regex return some blank strings, skip them
                 continue
-            if token.startswith('['):
-                # check that optional contains a key
-                if not re.search("{*[a-zA-Z_ 0-9]+}", token): 
-                    raise TankError("Optional sections must include a key definition.")
+            if token.startswith("["):
                 # Add definitions skipping this optional value
                 temp_definitions = definitions[:]
                 # strip brackets from token
-                token = re.sub('[\[\]]', '', token)
-            # check non-optional contains no dangleing brackets
-            if re.search("[\[\]]", token): 
-                raise TankError("Square brackets are not allowed outside of optional section definitions.")
+                token = token[1:-1]
             # make defintions with token appended
             for definition in definitions:
                 temp_definitions.append(definition + token)
             definitions = temp_definitions
+
         return definitions
-    
-    
+
     def get_shotgun_fields(self):
         """
-        Returns the shotgun fields that are needed in order to 
+        Returns the Shotgun fields that are needed in order to
         build this name expression. Returns all fields, including optional.
         
-        :returns: set of shotgun field names
+        :returns: Set of Shotgun field names, e.g. ('code', 'sg_sequence.Sequence.code')
         """        
-        # use the longest exprssion - this contains the most fields
+        # use the longest expression - this contains the most fields
         longest_expr = self._sorted_exprs[0]
-        return copy.copy(self._variations[longest_expr]["fields"])
+        field_defs = self._variations[longest_expr]
+        field_names = [field["full_field_name"] for field in field_defs]
+        return set(field_names)
     
     def get_shotgun_link_fields(self):
         """
         Returns a list of all entity links that are used in the name expression, 
         including optional ones.
-        For example, if a name expression for a Shot is {code}_{sg_sequence.Sequence.code},
-        the link fields for this expression is sg_sequence. 
+        For example, if a name expression for a Shot is '{code}_{sg_sequence.Sequence.code}',
+        the link fields for this expression is ['sg_sequence'].
+
+        :returns: Set of link fields, e.g. ('sg_sequence', 'entity')
         """
+        # use the longest exprssion - this contains the most fields
         longest_expr = self._sorted_exprs[0]
-        return copy.copy(self._variations[longest_expr]["entity_links"])
+        field_defs = self._variations[longest_expr]
+        link_names = [
+            field["link_field_name"] for field in field_defs if field["link_field_name"] is not None
+            ]
+        return set(link_names)
 
     def generate_name(self, values):
         """
@@ -196,10 +247,9 @@ class EntityExpression(object):
         Assumes the name will be used as a folder name and validates
         that the evaluated expression is suitable for disk use.
         
-        :param values: dictionary of values to use 
-        :returns: fully resolved name string
+        :param dict values: Dictionary of values to use.
+        :returns: Fully resolved name string.
         """
-                
         # first make sure that each field is valid
         for field_name in self.get_shotgun_fields():
             if field_name not in values:
@@ -234,7 +284,6 @@ class EntityExpression(object):
         
         return val 
 
-    
     def _generate_name(self, expression, values):
         """
         Generates a name given some fields.
@@ -243,62 +292,80 @@ class EntityExpression(object):
         that the evaluated expression is suitable for disk use.
         
         :param values: dictionary of values to use 
-        :returns: fully resolved name string
+        :returns: fully resolved name string or None if it cannot be resolved.
         """
 
-        fields = self._variations[expression]["fields"]
-        
-        # convert shotgun values to string values
+        field_defs = self._variations[expression]
+        # convert Shotgun values to string values
         str_data = {}
+
+        print field_defs
         
-        # get the shotgun id from the shotgun entity dict
+        # get the Shotgun id from the Shotgun entity dict
         sg_id = values.get("id")
         
         # first make sure that each field is valid
-        for field_name in fields:
-            # get value from shotgun data dict
-            raw_val = values.get(field_name)
+        for field_def in field_defs:
+
+            full_sg_field_name = field_def["full_field_name"]
+
+            # get value from Shotgun data dict
+            raw_val = values.get(full_sg_field_name)
             if raw_val is None:
                 # cannot resolve this!
                 return None
-                
+
             # now cast the value to a string
-            str_data[field_name] = sg_entity_to_string(self._tk, self._entity_type, sg_id, field_name, raw_val)
-            
-        
+            str_value = sg_entity_to_string(
+                self._tk,
+                self._entity_type,
+                sg_id,
+                full_sg_field_name,
+                raw_val
+            )
+
+            # see if we need to transform it via regex
+            if field_def["regex_obj"]:
+                str_value = self._process_regex(
+                    str_value,
+                    field_def["regex_obj"],
+                )
+
+            str_data[full_sg_field_name] = str_value
+
         # change format from {xxx} to %(xxx)s for value substitution.
-        adjusted_expr = expression.replace("{", "%(").replace("}", ")s")
+        # make sure we remove any expression tokens from folder:
+        # {xxx} -> %(xxx)s
+        # {xxx:yyy} -> %(xxx)s
+        adjusted_expr = re.sub("\{([^:\}]+)[^\}]*\}", "%(\\1)s", expression)
 
         # just to be sure, make sure to catch any exceptions here
         # and produce a more sensible error message.
         try:
-            val = adjusted_expr % (str_data)
+            val = adjusted_expr % str_data
         except Exception as error:
-            raise TankError("Could not populate values for the expression '%s' - please "
-                            "contact support! Error message: %s. "
-                            "Data: %s" % (expression, error, str_data))
+            raise TankError(
+                "Could not populate values for the expression '%s' - please "
+                "contact support! Error message: %s. "
+                "Data: %s" % (expression, error, str_data)
+            )
             
         # now validate the entire value!
         if not self._validate_name(val):
-            # not valid!!!
-            msg = ("The format string '%s' used in the configuration "
-                   "does not generate a valid folder name ('%s')! Valid "
-                   "values are %s." % (expression, val, constants.VALID_SG_ENTITY_NAME_EXPLANATION))
-            raise TankError(msg)      
+            raise TankError(
+                "The format string '%s' used in the configuration "
+                "does not generate a valid folder name ('%s')! Valid "
+                "values are %s." % (expression, val, constants.VALID_SG_ENTITY_NAME_EXPLANATION)
+            )
             
         return val
 
     def _validate_name(self, name):
         """
         Check that the name meets basic file system naming standards.
-        """    
-        
-        if self._entity_type == "Project":
-            # allow slashes in project names
-            exp = re.compile(constants.VALID_SG_PROJECT_NAME_REGEX, re.UNICODE)
-        else:
-            exp = re.compile(constants.VALID_SG_ENTITY_NAME_REGEX, re.UNICODE)    
-        
+        """
+        exp = re.compile(constants.VALID_SG_PROJECT_NAME_REGEX, re.UNICODE)
+
         if isinstance(name, unicode):
             return bool(exp.match(name))
         else:
@@ -306,3 +373,39 @@ class EntityExpression(object):
             u_name = name.decode("utf-8")
             return bool(exp.match(u_name))
 
+    def _process_regex(self, value, regex_obj):
+        """
+        Processes the given string value with the given regex.
+
+        :param value: Value to process, either unicode or str.
+        :param regex_obj: Regex object.
+        :return: Processed value, same type as value input parameter.
+            If input is None, an empty string is returned.
+        """
+        if value is None:
+            return ""
+
+        # perform the regex calculation in unicode space
+        if not isinstance(value, unicode):
+            input_is_utf8 = True
+            value_to_convert = value.decode("utf-8")
+        else:
+            input_is_utf8 = False
+            value_to_convert = value
+
+        # now perform extraction
+        match = regex_obj.match(value_to_convert)
+        if match is None:
+            # no match. return empty string
+            resolved_value = u""
+        else:
+            # we have a match object. concatenate the groups
+            resolved_value = "".join(match.groups())
+
+        # resolved value is now unicode. Convert it
+        # so that it is consistent with input
+        if isinstance(resolved_value, unicode) and input_is_utf8:
+            # input was utf-8, regex result is unicode, cast it back
+            return resolved_value.encode("utf-8")
+        else:
+            return resolved_value

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -112,11 +112,13 @@ class EntityExpression(object):
 
         # Extract and store a bunch of data for each variation.
         self._variations = {}
-        for v in expr_variations:
+        for expr_variation in expr_variations:
             
-            try:            
-                # find all field names: "{code:^([^_]+)}_{yy}_{zz.xx}"
-                fields = set(re.findall('{([^}]*)}', v))
+            try:
+                # find all field names, for example:
+                # "{xx}_{yy}_{zz.xx}" ----> ["xx", "yy", "zz.xx"]
+                # "{code:([^_]+)}_{yy}" --> ["code:([^_]+)", "yy"]
+                fields = set(re.findall('{([^}]*)}', expr_variation))
             except Exception as error:
                 raise TankError(
                     "Could not parse the configuration field '%s' - "
@@ -172,7 +174,7 @@ class EntityExpression(object):
                 )
 
             # add this to our variations dict
-            self._variations[v] = resolved_fields
+            self._variations[expr_variation] = resolved_fields
 
     def _get_expression_variations(self, definition):
         """

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -273,9 +273,9 @@ class EntityExpression(object):
             
             # try to make a nice descriptive name if possible
             if "code" in values:
-                nice_name = "%s %s (id %s)" % (self._entity_type, values["code"], values["id"])
+                nice_name = "%s %s (id %s)" % (self._entity_type, values["code"], values.get("id"))
             else:
-                nice_name = "%s %s" % (self._entity_type, values["id"])
+                nice_name = "%s id %s" % (self._entity_type, values.get("id"))
             
             raise TankError("Folder Configuration Error. Could not create folders for %s! "
                             "The expression %s refers to one or more values that are blank "

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -413,15 +413,15 @@ class TestShotgunRegisterPublish(TankTestBase):
 
 class TestCalcPathCache(TankTestBase):
     
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_data_roots")
-    def test_case_difference(self, get_data_roots):
+    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    def test_case_difference(self, get_local_storage_roots):
         """
         Case that root case is different between input path and that in roots file.
         Bug Ticket #18116
         """
-        get_data_roots.return_value = {"primary" : self.project_root}
+        get_local_storage_roots.return_value = {"primary": self.tank_temp}
         
-        relative_path = os.path.join("Some","Path")
+        relative_path = os.path.join("Some", "Path")
         wrong_case_root = self.project_root.swapcase()
         expected = os.path.join(os.path.basename(wrong_case_root), relative_path).replace(os.sep, "/")
 

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -302,21 +302,3 @@ class TestShotgunDownloadUrl(ShotgunTestBase):
         self.assertEqual(self.download_destination, full_path)
 
 
-class TestShotgunUtils(unittest.TestCase):
-    """
-    Test various Shotgun utilities and helpers
-    """
-    def test_entity_name_field(self):
-        """
-        Test retrieving the right "name" field for various entity types.
-        """
-        # Test most standard entities, and check that custom entities use "code"
-        for entity_type in ["Sequence", "Shot", "Asset", "CustomXXXXEntity"]:
-            self.assertEqual(
-                get_sg_entity_name_field(entity_type), "code"
-            )
-        # Test most standard entities where the name is in a "name" field.
-        for entity_type in ["HumanUser", "Project"]:
-            self.assertEqual(
-                get_sg_entity_name_field(entity_type), "name"
-            )

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -102,7 +102,7 @@ class TestShotgunEntity(TankTestBase):
                 sg_entity_type="Shot",
                 sg_id=123,
                 sg_field_name="link_field",
-                data=[{"name":"foo"}, {"name":"bar"}]
+                data=[{"name": "foo"}, {"name": "bar"}]
             ),
             "foo_bar"
         )

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -10,13 +10,13 @@
 
 import sgtk
 import tank
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule
+from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule  # noqa
 from tank.util.shotgun_entity import get_sg_entity_name_field, sg_entity_to_string
 
 
-class TestShotgunUtils(TankTestBase):
+class TestShotgunEntity(TankTestBase):
     """
-    Test various Shotgun utilities and helpers
+    Test shotgun entity parsing classes and methods.
     """
 
     def setUp(self):
@@ -24,7 +24,7 @@ class TestShotgunUtils(TankTestBase):
         to pass in as callbacks to Schema.create_folders. The mock objects are
         then queried to see what paths the code attempted to create.
         """
-        super(TestShotgunUtils, self).setUp()
+        super(TestShotgunEntity, self).setUp()
         self.setup_fixtures()
 
     def test_entity_name_field(self):
@@ -53,35 +53,56 @@ class TestShotgunUtils(TankTestBase):
         # project fields are allowed to have slashes for folder creation purposes.
         self.assertEqual(
             sg_entity_to_string(
-                self.tk, sg_entity_type="Project", sg_id=123, sg_field_name="tank_name", data="foo/bar&"
+                self.tk,
+                sg_entity_type="Project",
+                sg_id=123,
+                sg_field_name="tank_name",
+                data="foo/bar&"
             ),
             "foo/bar-"
         )
         # other ETs are not.
         self.assertEqual(
             sg_entity_to_string(
-                self.tk, sg_entity_type="Shot", sg_id=123, sg_field_name="code", data="foo/bar&"
+                self.tk,
+                sg_entity_type="Shot",
+                sg_id=123,
+                sg_field_name="code",
+                data="foo/bar&"
             ),
             "foo-bar-"
         )
 
         # basic conversion of other types
         self.assertEqual(
-            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123, sg_field_name="int_field", data=123
+            sg_entity_to_string(
+                self.tk,
+                sg_entity_type="Shot",
+                sg_id=123,
+                sg_field_name="int_field",
+                data=123
             ),
             "123"
         )
 
         self.assertEqual(
-            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123,
-                sg_field_name="link_field", data={"type": "Shot", "id": 123, "name": "foo"}
+            sg_entity_to_string(
+                self.tk,
+                sg_entity_type="Shot",
+                sg_id=123,
+                sg_field_name="link_field",
+                data={"type": "Shot", "id": 123, "name": "foo"}
             ),
             "foo"
         )
 
         self.assertEqual(
-            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123,
-                sg_field_name="link_field", data=[{"name":"foo"}, {"name":"bar"}]
+            sg_entity_to_string(
+                self.tk,
+                sg_entity_type="Shot",
+                sg_id=123,
+                sg_field_name="link_field",
+                data=[{"name":"foo"}, {"name":"bar"}]
             ),
             "foo_bar"
         )
@@ -100,7 +121,8 @@ class TestShotgunUtils(TankTestBase):
         self.assertEqual(ee.get_shotgun_link_fields(), set())
         self.assertEqual(
             ee.generate_name({"code": "foo", "entity": {"type:": "Asset", "id": 123, "name": "NAB"}}),
-            "foo_NAB")
+            "foo_NAB"
+        )
 
         ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}_{sg_sequence.Sequence.code}")
         self.assertEqual(ee.get_shotgun_fields(), set(["code", "sg_sequence.Sequence.code"]))
@@ -109,8 +131,10 @@ class TestShotgunUtils(TankTestBase):
             ee.generate_name(
                 {"code": "foo",
                  "sg_sequence.Sequence.code": "NAB",
-                 "sg_sequence": {"type:": "Sequence", "id": 123, "name": "NAB"}}),
-            "foo_NAB")
+                 "sg_sequence": {"type:": "Sequence", "id": 123, "name": "NAB"}}
+            ),
+            "foo_NAB"
+        )
 
         # raise exception when fields are not supplied
         ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}")
@@ -129,7 +153,8 @@ class TestShotgunUtils(TankTestBase):
         self.assertEqual(ee.get_shotgun_link_fields(), set())
         self.assertEqual(
             ee.generate_name({"code": "foo", "entity": {"type:": "Asset", "id": 123, "name": "NAB"}}),
-            "foo_NAB")
+            "foo_NAB"
+        )
 
         # setting entity to none omits the optional field
         self.assertEqual(ee.generate_name({"code": "foo", "entity": None}), "foo")

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -207,3 +207,4 @@ class TestShotgunEntity(TankTestBase):
         ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^([^_]+)}[XXX{status:^([^_]+)}]")
         self.assertEqual(ee.generate_name({"code": "foo_bar", "status": "baz_boo"}), "fooXXXbaz")
         self.assertEqual(ee.generate_name({"code": "foo_bar", "status": None}), "foo")
+

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -144,6 +144,13 @@ class TestShotgunEntity(TankTestBase):
             {"extra": "data"}
         )
 
+    def test_entity_expression_multi_folder(self):
+        """
+        Tests that expressions can contain slashes
+        """
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}/{code2}")
+        self.assertEqual(ee.generate_name({"code": "foo", "code2": "bar"}), "foo/bar")
+
     def test_entity_expression_optional(self):
         """
         Tests basic expressions for entity objects with optional tokens

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+import tank
+from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule
+from tank.util.shotgun_entity import get_sg_entity_name_field, sg_entity_to_string
+
+
+class TestShotgunUtils(TankTestBase):
+    """
+    Test various Shotgun utilities and helpers
+    """
+
+    def setUp(self):
+        """Sets up entities in mocked shotgun database and creates Mock objects
+        to pass in as callbacks to Schema.create_folders. The mock objects are
+        then queried to see what paths the code attempted to create.
+        """
+        super(TestShotgunUtils, self).setUp()
+        self.setup_fixtures()
+
+    def test_entity_name_field(self):
+        """
+        Test retrieving the right "name" field for various entity types.
+        """
+        # Test most standard entities, and check that custom entities use "code"
+        for entity_type in ["Sequence", "Shot", "Asset", "CustomXXXXEntity"]:
+            self.assertEqual(
+                get_sg_entity_name_field(entity_type), "code"
+            )
+        # Test most standard entities where the name is in a "name" field.
+        for entity_type in ["HumanUser", "Project", "Department"]:
+            self.assertEqual(
+                get_sg_entity_name_field(entity_type), "name"
+            )
+
+        self.assertEqual(get_sg_entity_name_field("Task"), "content")
+        self.assertEqual(get_sg_entity_name_field("Note"), "subject")
+        self.assertEqual(get_sg_entity_name_field("Delivery"), "title")
+
+    def test_entity_to_string(self):
+        """
+        Tests converting sg data into string format
+        """
+        # project fields are allowed to have slashes for folder creation purposes.
+        self.assertEqual(
+            sg_entity_to_string(
+                self.tk, sg_entity_type="Project", sg_id=123, sg_field_name="tank_name", data="foo/bar&"
+            ),
+            "foo/bar-"
+        )
+        # other ETs are not.
+        self.assertEqual(
+            sg_entity_to_string(
+                self.tk, sg_entity_type="Shot", sg_id=123, sg_field_name="code", data="foo/bar&"
+            ),
+            "foo-bar-"
+        )
+
+        # basic conversion of other types
+        self.assertEqual(
+            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123, sg_field_name="int_field", data=123
+            ),
+            "123"
+        )
+
+        self.assertEqual(
+            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123,
+                sg_field_name="link_field", data={"type": "Shot", "id": 123, "name": "foo"}
+            ),
+            "foo"
+        )
+
+        self.assertEqual(
+            sg_entity_to_string(self.tk, sg_entity_type="Shot", sg_id=123,
+                sg_field_name="link_field", data=[{"name":"foo"}, {"name":"bar"}]
+            ),
+            "foo_bar"
+        )
+
+    def test_entity_expression_simple(self):
+        """
+        Tests basic expressions for entity objects
+        """
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set())
+        self.assertEqual(ee.generate_name({"code": "foo", "extra": "data"}), "foo")
+
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}_{entity}")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code", "entity"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set())
+        self.assertEqual(
+            ee.generate_name({"code": "foo", "entity": {"type:": "Asset", "id": 123, "name": "NAB"}}),
+            "foo_NAB")
+
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}_{sg_sequence.Sequence.code}")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code", "sg_sequence.Sequence.code"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set(["sg_sequence"]))
+        self.assertEqual(
+            ee.generate_name(
+                {"code": "foo",
+                 "sg_sequence.Sequence.code": "NAB",
+                 "sg_sequence": {"type:": "Sequence", "id": 123, "name": "NAB"}}),
+            "foo_NAB")
+
+        # raise exception when fields are not supplied
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}")
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"extra": "data"}
+        )
+
+    def test_entity_expression_optional(self):
+        """
+        Tests basic expressions for entity objects with optional tokens
+        """
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}[_{entity}]")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code", "entity"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set())
+        self.assertEqual(
+            ee.generate_name({"code": "foo", "entity": {"type:": "Asset", "id": 123, "name": "NAB"}}),
+            "foo_NAB")
+
+        # setting entity to none omits the optional field
+        self.assertEqual(ee.generate_name({"code": "foo", "entity": None}), "foo")
+
+        # omitting the field raises an exception
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"code": "foo"}
+        )
+
+        # setting the required field raises an exception
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"code": None, "entity": {"type:": "Asset", "id": 123, "name": "NAB"}, }
+        )
+
+        # verify that deep links work with optional expressions
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}[_{sg_sequence.Sequence.code}]")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code", "sg_sequence.Sequence.code"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set(["sg_sequence"]))
+        self.assertEqual(
+            ee.generate_name({"code": "foo", "sg_sequence.Sequence.code": "NAB"}),
+            "foo_NAB"
+        )
+
+    def test_entity_expression_regex(self):
+        """
+        Tests regex entity expressions
+        """
+        # test simple
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^([^_]+)}")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set())
+        self.assertEqual(ee.generate_name({"code": "foo_bar"}), "foo")
+
+        # test that multiple regex expressions get concatenated
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^([^_]+)_(.+)$}")
+        self.assertEqual(ee.generate_name({"code": "foo_the_rest"}), "foothe_rest")
+
+        # test that this works with optional expressions
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^([^_]+)}[XXX{status:^([^_]+)}]")
+        self.assertEqual(ee.generate_name({"code": "foo_bar", "status": "baz_boo"}), "fooXXXbaz")
+        self.assertEqual(ee.generate_name({"code": "foo_bar", "status": None}), "foo")


### PR DESCRIPTION
Improvements to folder creation:
- Fixes a bug where projects with a multi-folder tank name didn't publish files correctly
- Adds support for regex patterns and multiple folders for a single schema yaml file. For example:

```
type: "shotgun_entity"
name: "{code:^([^_]+)}/code" # <----- here
entity_type: "Asset"
filters:
    - { "path": "project", "relation": "is", "values": [ "$project" ] }
    - { "path": "sg_asset_type", "relation": "is", "values": [ "$asset_type"] }
```

This new `{field_name:regex}` syntax is consistent with template regex syntax and allows
for the extraction of subsets from shotgun data and using that in folder creation tokens. 
Also note how the slash in `{code:^([^_]+)}/code` will result in multiple folder levels will be created for this one single schema entry.