### PR TITLE
Add templates_from_path function to return multiple templates

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -353,6 +353,25 @@ class Sgtk(object):
         from . import commands
         return commands.get_command(command_name, self)
         
+    def templates_from_path(self, path):
+        """
+        Finds templates that matches the given path::
+
+            >>> import sgtk
+            >>> tk = sgtk.sgtk_from_path("/studio/project_root")
+            >>> tk.templates_from_path("/studio/my_proj/assets/Car/Anim/work")
+            <Sgtk Template maya_asset_project: assets/%(Asset)s/%(Step)s/work>
+
+
+        :param path: Path to match against a template
+        :returns: list of :class:`TemplatePath` or [] if no match could be found.
+        """
+        matched_templates = []
+        for key, template in self.templates.items():
+            if template.validate(path):
+                matched_templates.append(template)
+        return matched_templates
+            
     def template_from_path(self, path):
         """
         Finds a template that matches the given path::
@@ -366,11 +385,8 @@ class Sgtk(object):
         :param path: Path to match against a template
         :returns: :class:`TemplatePath` or None if no match could be found.
         """
-        matched_templates = []
-        for key, template in self.templates.items():
-            if template.validate(path):
-                matched_templates.append(template)
-
+        matched_templates = self.templates_from_path(path)
+        
         if len(matched_templates) == 0:
             return None
         elif len(matched_templates) == 1:


### PR DESCRIPTION
Use cases : 
In cases where you have clashing templates, specifically string templates, you may wish to collect all the matching templates to then further filter by template name (eg if 'shot' in template_name, or if 'asset' in template_name). 
This would open up context-specific template searches, or the ability to identify the context of a file simply from a filename, rather than a full path. 

Description:
This update simply abstracts the template search part of template_from_path(path) to allow users to obtain all matching templates from a path, not just one, and more importantly, it does not raise an error if multple paths are found.