### PR TITLE
[minor] Baked configs do not write out source descriptor

### DIFF
--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -133,20 +133,28 @@ class BakedConfiguration(Configuration):
                           non-plugin based toolkit projects, this value is None.
         :param config_descriptor: Descriptor object describing the configuration.
         """
-        config_writer = ConfigurationWriter(ShotgunPath.from_current_os_path(path), sg_connection)
+        # Write out a baked configuration - this is just like one of the
+        # configurations that are written out at runtime for cached configs,
+        # but with the difference that this will be bundled with an installation
+        # and therefore needs to be completely location agnostic.
+        config_writer = ConfigurationWriter(
+            ShotgunPath.from_current_os_path(path),
+            sg_connection
+        )
 
         config_writer.ensure_project_scaffold()
-
         config_descriptor.copy(os.path.join(path, "config"))
-
         config_writer.install_core(config_descriptor, bundle_cache_fallback_paths=[])
 
+        # write the pipeline_config.yml file but do not include the
+        # source_descriptor - setting this to None indicates
+        # that this should be looked up at runtime.
         config_writer.write_pipeline_config_file(
             pipeline_config_id=None,
             project_id=None,
             plugin_id=plugin_id,
             bundle_cache_fallback_paths=[],
-            source_descriptor=config_descriptor
+            source_descriptor=None
         )
 
     @property

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -432,8 +432,11 @@ class ConfigurationWriter(object):
 
     def write_pipeline_config_file(
         self,
-        pipeline_config_id, project_id, plugin_id,
-        bundle_cache_fallback_paths, source_descriptor
+        pipeline_config_id,
+        project_id,
+        plugin_id,
+        bundle_cache_fallback_paths,
+        source_descriptor
     ):
         """
         Writes out the the pipeline configuration file config/core/pipeline_config.yml
@@ -448,6 +451,10 @@ class ConfigurationWriter(object):
                           see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
                           non-plugin based toolkit projects, this value is None.
         :param bundle_cache_fallback_paths: List of bundle cache fallback paths.
+        :param source_descriptor: Descriptor object used to identify
+            which descriptor the pipeline configuration originated from.
+            For configurations where this source may not be directly accessible,
+            (e.g. baked configurations), this can be set to ``None``.
 
         :returns: Path to the configuration file that was written out.
         """
@@ -502,8 +509,10 @@ class ConfigurationWriter(object):
             "use_bundle_cache": True,
             "bundle_cache_fallback_roots": bundle_cache_fallback_paths,
             "use_shotgun_path_cache": True,
-            "source_descriptor": source_descriptor.get_dict()
         }
+
+        if source_descriptor:
+            pipeline_config_content["source_descriptor"] = source_descriptor.get_dict()
 
         # write pipeline_configuration.yml
         pipeline_config_path = os.path.join(

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -130,7 +130,7 @@ class PipelineConfiguration(object):
         else:
             self._bundle_cache_fallback_paths = []
 
-        # There are four ways this initializer can be invoked.
+        # There are five ways this initializer can be invoked.
         #
         # 1) Classic: We're instantiated from sgtk_from_path with a single path.
         # 2) Bootstrap: path is set, descriptor is unset and no descriptor inside
@@ -139,6 +139,8 @@ class PipelineConfiguration(object):
         #    pipeline_configuration.yml
         # 4) Bootstrap, path is set, descriptor is set and descriptor inside
         #    pipeline_configuration.yml
+        # 5) Baked configs via bootstrap, path is set, the rest is None. A baked
+        #    config has got the same layout as a classic installation.
         #
         # The correct way to handle all of this is to go from a descriptor string or dictionary and
         # instantiate the correct descriptor type.
@@ -156,6 +158,7 @@ class PipelineConfiguration(object):
             # The bootstrapper wrote the descriptor in the pipeline_configuration.yml file, nothing
             # more needs to be done.
             pass
+
         # If there's nothing in the file, but we're being passed down something by the bootstrapper,
         # we should use it! (3)
         elif descriptor:
@@ -171,7 +174,8 @@ class PipelineConfiguration(object):
                 is_installed = True
 
             descriptor_dict = descriptor.get_dict()
-        # Now we only have a path set. (1&2). We can't assume anything, but since all pipeline
+
+        # Now we only have a path set. (1, 2, 5). We can't assume anything, but since all pipeline
         # configurations, cached or installed, have the same layout on disk, we'll assume that we're
         # in an installed one. Also, since installed configurations are a bit more lenient about
         # things like info.yml, its a great fit since there are definitely installed configurations


### PR DESCRIPTION
Fixes an issue with baked configs where the build-time path descriptor was written into the plugin, causing it to work on the machine where it was built but nowhere else.