### PR TITLE
For #46894, shortens the length of shotgun descriptors

### DIFF
--- a/.tkdeploy
+++ b/.tkdeploy
@@ -1,0 +1,11 @@
+[packaging]
+exclude=
+    # Remove CI files.
+    .travis.yml
+    appveyor.yml
+    .flake8
+    .hound.yml
+    .coveragerc
+    # Remove unneeded files.
+    tests
+    docs

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -225,12 +225,8 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
                   constraint_pattern argument will be ignored by this
                   method implementation.
 
-        :param constraint_pattern: If this is specified, the query will be constrained
-               by the given pattern. Version patterns are on the following forms:
-
-                - v0.1.2, v0.12.3.2, v0.1.3beta - a specific version
-                - v0.12.x - get the highest v0.12 version
-                - v1.x.x - get the highest v1 version
+        :param constraint_pattern: This parameter is unused and remains here to be compatible
+            with the expected signature for this method.
 
         :returns: IODescriptorShotgunEntity object
         """
@@ -240,11 +236,6 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
         log.debug("Finding latest version of %s..." % self)
 
         if self._mode == self._MODE_NAME_BASED:
-            spec_name_fields = {
-                "Project": "name",
-                "Task": "content",
-                "HumanUser": "name"
-            }
             name_field = get_sg_entity_name_field(self._entity_type)
 
             filters = [[name_field, "is", self._name]]
@@ -310,10 +301,19 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
         Returns a descriptor object that represents the latest version
         that is locally available in the bundle cache search path.
 
-        :param constraint_pattern: This parameter is unused.
+        .. note:: The concept of constraint patterns doesn't apply to
+                  shotgun attachment ids and any data passed via the
+                  constraint_pattern argument will be ignored by this
+                  method implementation.
+
+        :param constraint_pattern: This parameter is unused and remains here to be compatible
+            with the expected signature for this method.
 
         :returns: instance deriving from IODescriptorBase or None if not found
         """
+        if constraint_pattern:
+            log.warning("%s does not support version constraint patterns." % self)
+
         # not possible to determine what 'latest' means in this case
         # so check if the current descriptor exists on disk and in this
         # case return it

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -141,20 +141,9 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
         #
         # format for these paths will be
         #
-        # for the syntax when name and project is specified:
-        # bundle_cache/sg/SITE_NAME/EntityType.AttachmentField/[ProjectId_]NameField/AttachmentId
+        # bundle_cache/sg/SITE_NAME/AttachmentId
         #
-        # bundle_cache/sg/wintermute/PipelineConfiguration.sg_config/p509_Primary/v25283
-        #
-        #
-        # for the syntax when id is specified:
-        # bundle_cache/sg/SITE_NAME/EntityType.AttachmentField/entity_id/AttachmentId
-        #
-        # bundle_cache/sg/wintermute/PipelineConfiguration.sg_config/12345/v25283
-        #
-        # note: readability is promoted here - if in the future we discover issues with MAXPATH,
-        #       we turn the wintermute/PipelineConfiguration.sg_config/p509_Primary part into
-        #       a hash.
+        # bundle_cache/sg/wintermute/v25283
 
         # Firstly, because the bundle cache can be global, make sure we include the sg site name.
         # first, get site only; https://www.FOO.com:8080 -> www.foo.com

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -330,8 +330,7 @@ class TestDescriptorSupport(TankTestBase):
         }
 
         path = os.path.join(
-            self.install_root, "sg", "unit_test_mock_sg",
-            "PipelineConfiguration.sg_config", "p123_primary", "v456"
+            self.install_root, "sg", "unit_test_mock_sg", "v456"
         )
         self._create_info_yaml(path)
 

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -358,8 +358,7 @@ class TestDownloadableIODescriptors(ShotgunTestBase):
         self._test_multiprocess_download_to_shared_bundle_cache(
             self._download_shotgun_bundle,
             os.path.join(self.tank_temp, "shared_bundle_cache"),
-            os.path.join(self.tank_temp, "shared_bundle_cache", "sg", "unit_test_mock_sg",
-                         "PipelineConfiguration.sg_config", "p123_primary", "v456", "large_binary_file")
+            os.path.join(self.tank_temp, "shared_bundle_cache", "sg", "unit_test_mock_sg", "v456", "large_binary_file")
         )
 
     @skip_if_git_missing

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -314,7 +314,6 @@ class TestDownloadableIODescriptors(ShotgunTestBase):
             "Failed to write concurrently to shared bundle cache: %s" % ",".join(errors)
         )
 
-
     ###############################################################################################
 
     def test_appstore_downloads(self):
@@ -352,8 +351,7 @@ class TestDownloadableIODescriptors(ShotgunTestBase):
 
         # make sure the expected local path exists.
         self.assertTrue(os.path.exists(
-            os.path.join(self.tank_temp, "bundle_cache", "sg", "unit_test_mock_sg", "PipelineConfiguration.sg_config",
-                         "p123_primary", "v456", "large_binary_file")
+            os.path.join(self.tank_temp, "bundle_cache", "sg", "unit_test_mock_sg", "v456", "large_binary_file")
         ), "Failed to find the default bundle cache directory for the shotgun entity descriptor on disk.")
 
         # now test concurrent downloads to a shared bundle cache

--- a/tests/descriptor_tests/test_shotgun.py
+++ b/tests/descriptor_tests/test_shotgun.py
@@ -68,7 +68,10 @@ class TestShotgunIODescriptor(ShotgunTestBase):
 
         # test project id not int
         _test_raises_error(
-            {"type": "shotgun", "version": 123, "entity_type": "Shot", "field": "sg_field", "project_id": "foo", "name": "aaa123"}
+            {
+                "type": "shotgun", "version": 123, "entity_type": "Shot",
+                "field": "sg_field", "project_id": "foo", "name": "aaa123"
+            }
         )
 
     def test_construction_by_id(self):
@@ -121,7 +124,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         """
         Test downloading shotgun descriptor based on id
         """
-        expected_path = os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "Shot.sg_field", "1234", "v123")
+        expected_path = os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "v123")
 
         def fake_download_attachment(*args, **kwargs):
             # assert that the expected download target is requested
@@ -153,7 +156,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         Test downloading descriptor based on name
         """
         expected_path = os.path.join(
-            self.bundle_cache, "sg", "unit_test_mock_sg", "Shot.sg_field", "p123_bbb111", "v123"
+            self.bundle_cache, "sg", "unit_test_mock_sg", "v124"
         )
 
         def fake_download_attachment(*args, **kwargs):
@@ -168,7 +171,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             sgtk.descriptor.Descriptor.APP,
             {
                 "type": "shotgun",
-                "version": 123,
+                "version": 124,
                 "entity_type": "Shot",
                 "field": "sg_field",
                 "name": "bbb111",
@@ -394,18 +397,16 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         """
         Tests resolving locally cached items by name
         """
-        root_path = os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "Shot.sg_field", "p123_aaa111")
-        os.makedirs(os.path.join(root_path, "v123"))
-        os.makedirs(os.path.join(root_path, "v99"))
-        os.makedirs(os.path.join(root_path, "invalid_stuff"))
-        os.makedirs(os.path.join(root_path, "v2454"))
+        os.makedirs(
+            os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "v99")
+        )
 
         desc = sgtk.descriptor.create_descriptor(
             self.mockgun,
             sgtk.descriptor.Descriptor.APP,
             {
                 "type": "shotgun",
-                "version": 0,
+                "version": 99,
                 "entity_type": "Shot",
                 "field": "sg_field",
                 "name": "aaa111",
@@ -414,26 +415,42 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             bundle_cache_root_override=self.bundle_cache
         )
 
-        self.assertEquals(desc.version, "v0")
+        self.assertEquals(desc.version, "v99")
         latest_cached = desc.find_latest_cached_version()
-        self.assertEquals(latest_cached.version, "v2454")
-
-    def test_get_latest_cached_by_id(self):
-        """
-        Tests resolving locally cached items by id
-        """
-        root_path = os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "Shot.sg_field", "567")
-        os.makedirs(os.path.join(root_path, "v123"))
-        os.makedirs(os.path.join(root_path, "v99"))
-        os.makedirs(os.path.join(root_path, "invalid_stuff"))
-        os.makedirs(os.path.join(root_path, "v2454"))
+        self.assertEquals(latest_cached.version, "v99")
 
         desc = sgtk.descriptor.create_descriptor(
             self.mockgun,
             sgtk.descriptor.Descriptor.APP,
             {
                 "type": "shotgun",
-                "version": 0,
+                "version": 1,
+                "entity_type": "Shot",
+                "field": "sg_field",
+                "name": "aaa111",
+                "project_id": 123
+            },
+            bundle_cache_root_override=self.bundle_cache
+        )
+
+        self.assertEquals(desc.version, "v1")
+        latest_cached = desc.find_latest_cached_version()
+        self.assertEquals(latest_cached, None)
+
+    def test_get_latest_cached_by_id(self):
+        """
+        Tests resolving locally cached items by id
+        """
+        os.makedirs(
+            os.path.join(self.bundle_cache, "sg", "unit_test_mock_sg", "v98")
+        )
+
+        desc = sgtk.descriptor.create_descriptor(
+            self.mockgun,
+            sgtk.descriptor.Descriptor.APP,
+            {
+                "type": "shotgun",
+                "version": 98,
                 "entity_type": "Shot",
                 "field": "sg_field",
                 "id": 567
@@ -441,6 +458,23 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             bundle_cache_root_override=self.bundle_cache
         )
 
-        self.assertEquals(desc.version, "v0")
+        self.assertEquals(desc.version, "v98")
         latest_cached = desc.find_latest_cached_version()
-        self.assertEquals(latest_cached.version, "v2454")
+        self.assertEquals(latest_cached.version, "v98")
+
+        desc = sgtk.descriptor.create_descriptor(
+            self.mockgun,
+            sgtk.descriptor.Descriptor.APP,
+            {
+                "type": "shotgun",
+                "version": 1,
+                "entity_type": "Shot",
+                "field": "sg_field",
+                "id": 567
+            },
+            bundle_cache_root_override=self.bundle_cache
+        )
+
+        self.assertEquals(desc.version, "v1")
+        latest_cached = desc.find_latest_cached_version()
+        self.assertEquals(latest_cached, None)


### PR DESCRIPTION
A typical Shotgun descriptor path on Windows would look like this,

`C:\Users\user.login\AppData\Roaming\Shotgun\bundle_cache\sg\PipelineConfiguration.sg_uploaded_config\123/v12345`

which can cause the file length to go over the 260 character limit on Windows.

To solve this, we're making that path a lot shorter by using removing the entity and field name part. This comes at the cost of get_latest_cached_descriptor, which is sorta moot because you need a working Shotgun connection to use a descriptor, so that functionality is essentially useless, since get_latest_cached_descriptor is only meant to be used in offline mode.