### PR TITLE
#46177 bug fixes for folder creation

### DIFF
--- a/python/tank/util/constants.py
+++ b/python/tank/util/constants.py
@@ -37,9 +37,6 @@ PROCESS_FOLDER_NAME_HOOK_NAME = "process_folder_name"
 VALID_SG_ENTITY_NAME_EXPLANATION = ("letters, numbers and the characters period(.), "
                                     "dash(-) and underscore(_)")
 
-# regex pattern that all project folder names must validate against
-VALID_SG_PROJECT_NAME_REGEX = "^[\w\-\./]+$"
-
 # regex pattern that all folder names must validate against
 VALID_SG_ENTITY_NAME_REGEX = "^[\w\-\.]+$"
 

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -151,6 +151,22 @@ class TestShotgunEntity(TankTestBase):
         ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}/{code2}")
         self.assertEqual(ee.generate_name({"code": "foo", "code2": "bar"}), "foo/bar")
 
+        # make sure that we don't have any empty tokens - in static syntax
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}//{code2}")
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"code": "foo", "code2": "bar"}
+        )
+
+        # make sure that we don't have any empty tokens - in dynamic syntax
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code}/{code2}")
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"code": "foo", "code2": ""}
+        )
+
     def test_entity_expression_optional(self):
         """
         Tests basic expressions for entity objects with optional tokens
@@ -210,7 +226,14 @@ class TestShotgunEntity(TankTestBase):
 
         # test that we can repeat a token
         ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^(.)}/{code}")
-        self.assertEqual(ee.get_shotgun_fields(), set(["code"]))
-        self.assertEqual(ee.get_shotgun_link_fields(), set())
         self.assertEqual(ee.generate_name({"code": "hello"}), "h/hello")
+
+        # test what happens when regex fails to match
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^([A-Z]+)}")
+        self.assertEqual(ee.generate_name({"code": "Toolkitty"}), "T")
+        self.assertRaises(
+            tank.errors.TankError,
+            ee.generate_name,
+            {"code": "toolkitty"}
+        )
 

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -208,3 +208,9 @@ class TestShotgunEntity(TankTestBase):
         self.assertEqual(ee.generate_name({"code": "foo_bar", "status": "baz_boo"}), "fooXXXbaz")
         self.assertEqual(ee.generate_name({"code": "foo_bar", "status": None}), "foo")
 
+        # test that we can repeat a token
+        ee = sgtk.util.shotgun_entity.EntityExpression(self.tk, "Shot", "{code:^(.)}/{code}")
+        self.assertEqual(ee.get_shotgun_fields(), set(["code"]))
+        self.assertEqual(ee.get_shotgun_link_fields(), set())
+        self.assertEqual(ee.generate_name({"code": "hello"}), "h/hello")
+


### PR DESCRIPTION
Fixes two issues with folder creation. Both scenarios are covered with new tests:

- Expressions where the same token appears more than once `{code:^(.)}/{code}` now resolves correctly.
- Expressions with empty folders (`/foo//bar` as opposed to `/foo/hello/bar`) raise a validation error, just like an empty path would.