### PR TITLE
#47012 adds Delivery entity support

### DIFF
--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -304,14 +304,9 @@ class Entity(Folder):
                     additional_filters.append(condition)
             
             # add some extra fields apart from the stuff in the config
-            if self._entity_type == "Project":
-                fields_to_retrieve.append("name")
-            elif self._entity_type == "Task":
-                fields_to_retrieve.append("content")
-            elif self._entity_type == "HumanUser":
-                fields_to_retrieve.append("login")
-            else:
-                fields_to_retrieve.append("code")
+            field_name = shotgun_entity.get_sg_entity_name_field(self._entity_type)
+            fields_to_retrieve.append(field_name)
+
             
             # TODO: AND the id query with this folder's query to make sure this path is
             # valid for the current entity. Throw error if not so driver code knows to 
@@ -345,19 +340,10 @@ class Entity(Folder):
                     raise EntityLinkTypeMismatch()
             
             # and append the 'name field' which is always needed.
-            name = None # used for error reporting
-            if self._entity_type == "Project":
-                name = rec["name"]
-                tokens[ my_sg_data_key ]["name"] = rec["name"]
-            elif self._entity_type == "Task":
-                name = rec["content"]
-                tokens[ my_sg_data_key ]["content"] = rec["content"]
-            elif self._entity_type == "HumanUser":
-                name = rec["login"]
-                tokens[ my_sg_data_key ]["login"] = rec["login"]
-            else:
-                name = rec["code"]
-                tokens[ my_sg_data_key ]["code"] = rec["code"]
+            # we are OK with getting back a None value as its used for error reporting
+            name = rec.get(field_name)
+            if name is not None:
+                tokens[my_sg_data_key][field_name] = name
 
             # Step through our token key map and process
             #

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -24,6 +24,7 @@ from tank.commands.clone_configuration import clone_pipeline_configuration_html
 from tank.commands.core_upgrade import TankCoreUpdater
 from tank.commands.action_base import Action
 from tank.util import shotgun
+from tank.util import shotgun_entity
 from tank.platform import constants as platform_constants
 from tank.authentication import ShotgunAuthenticator
 from tank.authentication import AuthenticationError
@@ -736,22 +737,6 @@ def _shotgun_run_action(install_root, pipeline_config_root, is_localized, action
 ###############################################################################################
 # Shell Actions Management
 
-def _get_sg_name_field(entity_type):
-    """
-    Returns the standard Shotgun name field given an entity type.
-
-    :param entity_type: shotgun entity type
-    :returns: name field as string
-    """
-    name_field = "code"
-    if entity_type == "Project":
-        name_field = "name"
-    elif entity_type == "Task":
-        name_field = "content"
-    elif entity_type == "HumanUser":
-        name_field = "login"
-    return name_field
-
 def _resolve_shotgun_pattern(entity_type, name_pattern):
     """
     Resolve a pattern given an entity. Search the 'name' field
@@ -763,7 +748,7 @@ def _resolve_shotgun_pattern(entity_type, name_pattern):
     :returns: (entity id, name)
     """
 
-    name_field = _get_sg_name_field(entity_type)
+    name_field = shotgun_entity.get_sg_entity_name_field(entity_type)
 
     sg = shotgun.get_sg_connection()
 
@@ -911,7 +896,7 @@ def _resolve_shotgun_entity(entity_type, entity_search_token, constrain_by_proje
     """
 
     sg = shotgun.get_sg_connection()
-    name_field = _get_sg_name_field(entity_type)
+    name_field = shotgun_entity.get_sg_entity_name_field(entity_type)
 
     try:
         # build up filters
@@ -1224,7 +1209,7 @@ def run_engine_cmd(pipeline_config_root, context_items, command, using_cwd, args
             # first look if there is an exact match for it.
             # If not, assume it is an id.
             sg = shotgun.get_sg_connection()
-            name_field = _get_sg_name_field(entity_type)
+            name_field = shotgun_entity.get_sg_entity_name_field(entity_type)
 
             # first try by name - e.g. a shot named "123"
             filters = [[name_field, "is", entity_search_token]]


### PR DESCRIPTION
Adds support for the `Delivery` entity, in folder creation and unregistering.

I have also updated the code to use the field name finding logic from the `tank/utils/shotgun_entity` module so that we have fewer places in our code where we state the entity to field name relationship.

This is based on @reformstudios commit that they provided:
https://github.com/reformstudios/tk-core/commit/770efe47236af9c3f47cff14caa5aca0ddc95719