### PR TITLE
Appveyor PR fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,14 @@ environment:
   matrix:
     - PYTHON: "C:\\Python26"
 
+  # To update these values, visit AppVeyor's site, click the user icon and scroll down to Encrypt Data.
+  SHOTGUN_HOST:
+    secure: 1klEyyzGkwq7KyTgI+9nqiqCNcdOXLVR/P8nXGgKu2kLke3ui81KhoAkckJqa9da
+  SHOTGUN_SCRIPT_NAME:
+    secure: snTNqoprEkQTVQD3cK9mpQ==
+  SHOTGUN_SCRIPT_KEY:
+    secure: 59Vs3pq1DhG2V7z4hGKNMAmiKC41wW8dnfw4fe47KTHWTSmXbgsjPW4vPyeO2JRUxKEseQOBn+7jVdeb7XWIE9LgP9n34/lWTyblJGvfqyM=
+
 build: off
 
 test_script:


### PR DESCRIPTION
Seems like for some reason environment variables set from the AppVeyor website are not set properly for the `appveyor/pr` builds. Using the secure value inside appveyor.yml instead, which seems to work.

Those variables will not be available from Pull Requests coming from other repos.