### PR TITLE
For #46757, gentler error when `tank_name` is not set.

### DIFF
--- a/docs/initializing.rst
+++ b/docs/initializing.rst
@@ -624,6 +624,11 @@ Exception Classes
     :inherited-members:
     :members:
 
+.. autoclass:: TankMissingTankNameError
+    :show-inheritance:
+    :inherited-members:
+    :members:
+
 
 Factory methods
 ========================================

--- a/python/tank/bootstrap/__init__.py
+++ b/python/tank/bootstrap/__init__.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2016 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .manager import ToolkitManager
-from .errors import TankBootstrapError
+from .errors import TankBootstrapError, TankMissingTankNameError

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -14,7 +14,7 @@ import pprint
 
 from . import constants
 
-from .errors import TankBootstrapError
+from .errors import TankBootstrapError, TankMissingTankNameError
 
 from ..util import filesystem
 
@@ -164,9 +164,9 @@ class CachedConfiguration(Configuration):
             ["tank_name"]
         )
         if proj_data["tank_name"] is None:
-            raise TankBootstrapError(
-                "The configuration requires you to specify a value for the "
-                "Project.tank_name field in Shotgun."
+            raise TankMissingTankNameError(
+                "The configuration requires you to specify a value for the project's "
+                "tank_name field in Shotgun."
             )
 
     def status(self):

--- a/python/tank/bootstrap/errors.py
+++ b/python/tank/bootstrap/errors.py
@@ -22,6 +22,13 @@ class TankBootstrapError(TankError):
     pass
 
 
+class TankMissingTankNameError(TankBootstrapError):
+    """
+    Raised when a project's ``tank_name`` field is not set.
+    """
+    pass
+
+
 class TankBootstrapInvalidPipelineConfigurationError(TankBootstrapError):
     """
     Raised when an invalid pipeline configuration record is detected.

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -443,13 +443,16 @@ class TestBakedConfiguration(TestConfigurationBase):
 class TestCachedConfiguration(ShotgunTestBase):
 
     def test_verifies_tank_name(self):
+        """
+        Ensures that missing tank name on project is detected when using roots.
+        """
 
         # Reset the tank_name and create a storage named after the one in the config.
         self.mockgun.update("Project", self.project["id"], {"tank_name": None})
         self.mockgun.create("LocalStorage", {"code": "primary"})
 
         # Initialize a cached configuration pointing to the config.
-        config_root = os.path.join(self.fixtures_root, "bootstrap_tests", "config")    
+        config_root = os.path.join(self.fixtures_root, "bootstrap_tests", "config")
         cached_config = CachedConfiguration(
             self.tank_temp,
             self.mockgun,

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -470,3 +470,7 @@ class TestCachedConfiguration(ShotgunTestBase):
         # Make sure that the missing tank name is detected.
         with self.assertRaises(sgtk.bootstrap.TankMissingTankNameError):
             cached_config.verify_required_shotgun_fields()
+
+        # Ensure our change is backwards compatible.
+        with self.assertRaises(sgtk.bootstrap.TankBootstrapError):
+            cached_config.verify_required_shotgun_fields()


### PR DESCRIPTION
Upgraded the error to it's own exception type so we could catch it explicitly in Shotgun Desktop.

Updated doc:
![screen shot 2018-03-27 at 09 39 47](https://user-images.githubusercontent.com/8126447/37970983-d6840186-31a2-11e8-8f94-6b973e4de368.png)
