### PR TITLE
Log the context info using "format" to avoid unicode issues

### DIFF
--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -217,7 +217,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     :returns: The created entity dictionary.
     """
     log.debug(
-        "Publish: Begin register publish for context {0} and path {1}" % (context, path)
+        "Publish: Begin register publish for context {0} and path {1}".format(context, path)
     )
     entity = None
     try:

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -217,7 +217,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     :returns: The created entity dictionary.
     """
     log.debug(
-        "Publish: Begin register publish for context %s and path %s" % (context, path)
+        "Publish: Begin register publish for context {0} and path {1}" % (context, path)
     )
     entity = None
     try:


### PR DESCRIPTION
Changed string format from %s to .format in the logging message that displays the context.

This was a solution for Alias when the task name contains Chinese/Japanese characters.