### PR TITLE
Hot fix for Desktop error with locked desktopstartup with new core.

### DIFF
--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -839,8 +839,11 @@ class TemplateConfiguration(object):
         # load the required storage roots for the config
         self._storage_roots = StorageRoots.from_config(self._cfg_folder)
 
-        # populate any missing defaults in the file
-        self._storage_roots.populate_defaults()
+        # if the file doesn't exist, create some defaults. if the file does
+        # exist, we'll assume that the intention is not to define any storage
+        # roots, as is the case with the basic and site config.
+        if not os.path.exists(self._storage_roots.roots_file):
+            self._storage_roots.populate_defaults()
 
         # ensure a default root can be determined from the required roots
         if self._storage_roots.required_roots and not self._storage_roots.default:

--- a/python/tank/util/storage_roots.py
+++ b/python/tank/util/storage_roots.py
@@ -436,6 +436,7 @@ class StorageRoots(object):
         If there are no roots defined, this method will create a default root
         definition.
         """
+
         if self.required_roots:
             # there are roots required by this configuration. ensure all are
             # populated with the expected platform keys
@@ -600,7 +601,7 @@ class StorageRoots(object):
                 )
                 self._default_storage_name = sole_storage_root
             elif self.LEGACY_DEFAULT_STORAGE_NAME in roots_metadata:
-                # legacy primary storage name defined. that is the defautl
+                # legacy primary storage name defined. that is the default
                 log.debug(
                     "Storage %s identified as the default root because it "
                     "matches the legacy default root name." %

--- a/tests/fixtures/util/storage_roots/empty_roots/config/core/roots.yml
+++ b/tests/fixtures/util/storage_roots/empty_roots/config/core/roots.yml
@@ -1,0 +1,1 @@
+# this file should be empty

--- a/tests/util_tests/test_storage_roots.py
+++ b/tests/util_tests/test_storage_roots.py
@@ -77,6 +77,15 @@ class TestStorageRoots(ShotgunTestBase):
         # these tests assume the metadata matches the corresponding fixture roots
         self._no_roots_metadata = {}
 
+        # empty roots
+        self._empty_roots_config_folder = os.path.join(
+            roots_fixtures_folder,
+            "empty_roots",
+            "config"
+        )
+        # these tests assume the metadata matches the corresponding fixture roots
+        self._empty_roots_metadata = {}
+
         # single root
         self._single_root_config_folder = os.path.join(
             roots_fixtures_folder,
@@ -140,6 +149,7 @@ class TestStorageRoots(ShotgunTestBase):
         self.assertTrue(StorageRoots.file_exists(self._single_root_config_folder))
         self.assertTrue(StorageRoots.file_exists(self._multiple_roots_config_folder))
         self.assertTrue(StorageRoots.file_exists(self._corrupt_roots_config_folder))
+        self.assertTrue(StorageRoots.file_exists(self._empty_roots_config_folder))
         self.assertFalse(StorageRoots.file_exists(self._no_roots_config_folder))
 
     def test_storage_roots_from_config(self):
@@ -150,6 +160,9 @@ class TestStorageRoots(ShotgunTestBase):
 
         multiple_roots = StorageRoots.from_config(self._multiple_roots_config_folder)
         self.assertIsInstance(multiple_roots, StorageRoots)
+
+        empty_roots = StorageRoots.from_config(self._empty_roots_config_folder)
+        self.assertIsInstance(empty_roots, StorageRoots)
 
         no_roots = StorageRoots.from_config(self._no_roots_config_folder)
         self.assertIsInstance(no_roots, StorageRoots)
@@ -166,6 +179,9 @@ class TestStorageRoots(ShotgunTestBase):
         multiple_roots = StorageRoots.from_metadata(self._multiple_roots_metadata)
         self.assertIsInstance(multiple_roots, StorageRoots)
 
+        empty_roots = StorageRoots.from_metadata(self._empty_roots_metadata)
+        self.assertIsInstance(empty_roots, StorageRoots)
+
         no_roots = StorageRoots.from_metadata(self._no_roots_metadata)
         self.assertIsInstance(no_roots, StorageRoots)
 
@@ -175,6 +191,7 @@ class TestStorageRoots(ShotgunTestBase):
         config_root_folders = [
             self._single_root_config_folder,
             self._multiple_roots_config_folder,
+            self._empty_roots_config_folder,
             self._no_roots_config_folder
         ]
 
@@ -225,6 +242,7 @@ class TestStorageRoots(ShotgunTestBase):
         config_root_folders = [
             self._single_root_config_folder,
             self._multiple_roots_config_folder,
+            self._empty_roots_config_folder,
             self._no_roots_config_folder
         ]
 
@@ -242,6 +260,9 @@ class TestStorageRoots(ShotgunTestBase):
         multiple_roots = StorageRoots.from_config(self._multiple_roots_config_folder)
         self.assertEqual(multiple_roots.default, "work")
 
+        empty_roots = StorageRoots.from_config(self._empty_roots_config_folder)
+        self.assertEqual(empty_roots.default, None)
+
         no_roots = StorageRoots.from_config(self._no_roots_config_folder)
         self.assertEqual(no_roots.default, None)
 
@@ -258,6 +279,9 @@ class TestStorageRoots(ShotgunTestBase):
             self._multiple_roots_metadata["work"])
         self.assertTrue(multiple_roots.default_path, multiple_roots_default_path)
 
+        empty_roots = StorageRoots.from_config(self._empty_roots_config_folder)
+        self.assertEqual(empty_roots.default_path, None)
+
         no_roots = StorageRoots.from_config(self._no_roots_config_folder)
         self.assertEqual(no_roots.default_path, None)
 
@@ -269,6 +293,9 @@ class TestStorageRoots(ShotgunTestBase):
 
         multiple_roots = StorageRoots.from_metadata(self._multiple_roots_metadata)
         self.assertEqual(multiple_roots.metadata, self._multiple_roots_metadata)
+
+        empty_roots = StorageRoots.from_metadata(self._empty_roots_metadata)
+        self.assertEqual(empty_roots.metadata, self._empty_roots_metadata)
 
         no_roots = StorageRoots.from_metadata(self._no_roots_metadata)
         self.assertEqual(no_roots.metadata, self._no_roots_metadata)
@@ -290,6 +317,12 @@ class TestStorageRoots(ShotgunTestBase):
             os.path.join(self._multiple_roots_config_folder, relative_roots_path)
         )
 
+        empty_roots = StorageRoots.from_config(self._empty_roots_config_folder)
+        self.assertEqual(
+            empty_roots.roots_file,
+            os.path.join(self._empty_roots_config_folder, relative_roots_path)
+        )
+
         no_roots = StorageRoots.from_config(self._no_roots_config_folder)
         self.assertEqual(
             no_roots.roots_file,
@@ -308,6 +341,9 @@ class TestStorageRoots(ShotgunTestBase):
         multiple_roots_required_storage_names = multiple_roots.required_roots
         for root_name in self._multiple_roots_metadata:
             self.assertTrue(root_name in multiple_roots_required_storage_names)
+
+        empty_roots = StorageRoots.from_config(self._empty_roots_config_folder)
+        self.assertEqual(empty_roots.required_roots, [])
 
         no_roots = StorageRoots.from_config(self._no_roots_config_folder)
         self.assertEqual(no_roots.required_roots, [])
@@ -341,7 +377,7 @@ class TestStorageRoots(ShotgunTestBase):
         self.assertEqual(multiple_roots_storage_paths, ShotgunPath.from_shotgun_dict(multiple_roots_default))
         self.assertEqual(unmapped_roots, ["foobar"])
 
-    def test_storage_rotos_populate_defaults(self):
+    def test_storage_roots_populate_defaults(self):
         """Test the populate_defaults method."""
 
         empty_roots_metadata = {}


### PR DESCRIPTION
The issue was a subtle bug related to populating default values for storage roots. The old core would only do this if there were no roots.yml file. The recent changes were always populating defaults no matter if the file existed or not. Configs like basic and site define this file is empty and don't require storage roots. So populating the roots with a default primary was problematic.