### PR TITLE
Do not run integration tests from forks

### DIFF
--- a/tests/run_appveyor.bat
+++ b/tests/run_appveyor.bat
@@ -13,6 +13,7 @@
 ::
 
 set PYTHONPATH=tests/python/third_party
-:: %PYTHON%\python -3 tests/run_tests.py
+%PYTHON%\python -3 tests/run_tests.py
 
+:: Run these tests only if the integration tests environment variables are set.
 IF DEFINED SHOTGUN_HOST (%PYTHON%\python -3 tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests.")

--- a/tests/run_appveyor.bat
+++ b/tests/run_appveyor.bat
@@ -13,7 +13,7 @@
 ::
 
 set PYTHONPATH=tests/python/third_party
-%PYTHON%\python -3 tests/run_tests.py
+%PYTHON%\python tests/run_tests.py
 
 :: Run these tests only if the integration tests environment variables are set.
-IF DEFINED SHOTGUN_HOST (%PYTHON%\python -3 tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests.")
+IF DEFINED SHOTGUN_HOST (%PYTHON%\python tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests.")

--- a/tests/run_appveyor.bat
+++ b/tests/run_appveyor.bat
@@ -16,4 +16,4 @@ set PYTHONPATH=tests/python/third_party
 %PYTHON%\python tests/run_tests.py
 
 :: Run these tests only if the integration tests environment variables are set.
-IF DEFINED SHOTGUN_HOST (%PYTHON%\python tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests.")
+IF DEFINED SHOTGUN_HOST (%PYTHON%\python tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests, SHOTGUN_HOST is not set.")

--- a/tests/run_appveyor.bat
+++ b/tests/run_appveyor.bat
@@ -15,4 +15,4 @@
 set PYTHONPATH=tests/python/third_party
 :: %PYTHON%\python -3 tests/run_tests.py
 
-IF "%TRAVIS_SECURE_ENV_VARS%"=="true" (%PYTHON%\python -3 tests/integration_tests/offline_workflow.py)
+IF DEFINED SHOTGUN_HOST (%PYTHON%\python -3 tests/integration_tests/offline_workflow.py) ELSE (ECHO "Skipping integration tests.")

--- a/tests/run_appveyor.bat
+++ b/tests/run_appveyor.bat
@@ -13,5 +13,6 @@
 ::
 
 set PYTHONPATH=tests/python/third_party
-%PYTHON%\python -3 tests/run_tests.py
-%PYTHON%\python -3 tests/integration_tests/offline_workflow.py
+:: %PYTHON%\python -3 tests/run_tests.py
+
+IF "%TRAVIS_SECURE_ENV_VARS%"=="true" (%PYTHON%\python -3 tests/integration_tests/offline_workflow.py)

--- a/tests/run_travis.sh
+++ b/tests/run_travis.sh
@@ -44,8 +44,8 @@ fi
 
 
 # PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
-echo TRAVIS_SECURE_ENV_VARS $TRAVIS_SECURE_ENV_VARS
-if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
-    echo "in if"
+if [ -z ${SHOTGUN_HOST+x} ]; then
+    echo "Skipping integration tests"
+else
     PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
 fi

--- a/tests/run_travis.sh
+++ b/tests/run_travis.sh
@@ -42,8 +42,9 @@ if [[ $TRAVIS -eq true ]]; then
     export QT_QPA_PLATFORM=offscreen
 fi
 
+PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
 
-# PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
+# Run these tests only if the integration tests environment variables are set.
 if [ -z ${SHOTGUN_HOST+x} ]; then
     echo "Skipping integration tests"
 else

--- a/tests/run_travis.sh
+++ b/tests/run_travis.sh
@@ -43,5 +43,9 @@ if [[ $TRAVIS -eq true ]]; then
 fi
 
 
-PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
-PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
+# PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
+echo TRAVIS_SECURE_ENV_VARS $TRAVIS_SECURE_ENV_VARS
+if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
+    echo "in if"
+    PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
+fi

--- a/tests/run_travis.sh
+++ b/tests/run_travis.sh
@@ -42,11 +42,11 @@ if [[ $TRAVIS -eq true ]]; then
     export QT_QPA_PLATFORM=offscreen
 fi
 
-PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run tests/run_tests.py
+PYTHONPATH=tests/python/third_party python tests/python/third_party/coverage run tests/run_tests.py
 
 # Run these tests only if the integration tests environment variables are set.
 if [ -z ${SHOTGUN_HOST+x} ]; then
     echo "Skipping integration tests"
 else
-    PYTHONPATH=tests/python/third_party python -3 tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
+    PYTHONPATH=tests/python/third_party python tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
 fi

--- a/tests/run_travis.sh
+++ b/tests/run_travis.sh
@@ -46,7 +46,7 @@ PYTHONPATH=tests/python/third_party python tests/python/third_party/coverage run
 
 # Run these tests only if the integration tests environment variables are set.
 if [ -z ${SHOTGUN_HOST+x} ]; then
-    echo "Skipping integration tests"
+    echo "Skipping integration tests, SHOTGUN_HOST is not set."
 else
     PYTHONPATH=tests/python/third_party python tests/python/third_party/coverage run -a tests/integration_tests/offline_workflow.py
 fi


### PR DESCRIPTION
This allows forks to submit PRs that will not immediately fail on submission. We'll need to run the integration tests ourselves before merging however.