### PR TITLE
#SG-5392 Addresses storage misdirection bug related to publishes

### DIFF
--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -685,6 +685,8 @@ class TankTestBase(unittest.TestCase):
         project_name = os.path.basename(self.project_root)
         self.alt_root_1 = os.path.join(self.tank_temp, "alternate_1", project_name)
         self.alt_root_2 = os.path.join(self.tank_temp, "alternate_2", project_name)
+        self.alt_root_3 = os.path.join(self.tank_temp, "alternate_3", project_name)
+        self.alt_root_4 = os.path.join(self.tank_temp, "alternate_4", project_name)
 
         # add local storages to represent the alternate root points
         self.alt_storage_1 = {"type": "LocalStorage",
@@ -703,13 +705,38 @@ class TankTestBase(unittest.TestCase):
                               "mac_path": os.path.join(self.tank_temp, "alternate_2")}
         self.add_to_sg_mock_db(self.alt_storage_2)
 
+        self.alt_storage_3 = {"type": "LocalStorage",
+                              "id": 7780,
+                              "code": "alternate_3",
+                              "windows_path": os.path.join(self.tank_temp, "alternate_3"),
+                              "linux_path": os.path.join(self.tank_temp, "alternate_3"),
+                              "mac_path": os.path.join(self.tank_temp, "alternate_3")}
+        self.add_to_sg_mock_db(self.alt_storage_3)
+
+        self.alt_storage_4 = {"type": "LocalStorage",
+                              "id": 7781,
+                              "code": "alternate_4",
+                              "windows_path": os.path.join(self.tank_temp, "alternate_4"),
+                              "linux_path": os.path.join(self.tank_temp, "alternate_4"),
+                              "mac_path": os.path.join(self.tank_temp, "alternate_4")}
+        self.add_to_sg_mock_db(self.alt_storage_4)
+
         # Write roots file
-        roots = {"primary": {}, "alternate_1": {}, "alternate_2": {}}
+        roots = {"primary": {}, "alternate_1": {}, "alternate_2": {}, "alternate_3": {}, "alternate_4": {}}
         for os_name in ["windows_path", "linux_path", "mac_path"]:
             # TODO make os specific roots
             roots["primary"][os_name]     = os.path.dirname(self.project_root)
             roots["alternate_1"][os_name] = os.path.dirname(self.alt_root_1)
             roots["alternate_2"][os_name] = os.path.dirname(self.alt_root_2)
+
+            # NOTE: swap the mapped roots
+            roots["alternate_3"][os_name] = os.path.dirname(self.alt_root_4)
+            roots["alternate_4"][os_name] = os.path.dirname(self.alt_root_3)
+
+        # swap the mapped storage ids
+        roots["alternate_3"]["shotgun_storage_id"] = 7781  # local storage 4
+        roots["alternate_4"]["shotgun_storage_id"] = 7780  # local storage 3
+
         roots_path = os.path.join(self.pipeline_config_root, "config", "core", "roots.yml")
         roots_file = open(roots_path, "w")
         roots_file.write(yaml.dump(roots))

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -197,9 +197,11 @@ class TestShotgunFindPublish(TankTestBase):
 
 class TestMultiRoot(TankTestBase):
 
-    def test_multi_root(self):
-
+    def setUp(self):
+        super(TestMultiRoot, self).setUp()
         self.setup_multi_root_fixtures()
+
+    def test_multi_root(self):
 
         project_name = os.path.basename(self.project_root)
 
@@ -225,6 +227,44 @@ class TestMultiRoot(TankTestBase):
         # make sure we are only getting the ID back.
         self.assertEqual(sg_data.keys(), ["type", "id"])
 
+    def test_storage_misdirection(self):
+
+        project_name = os.path.basename(self.project_root)
+
+        # define 2 publishes with the same path, different storages
+        self.pub_6 = {"type": "PublishedFile",
+                      "id": 6,
+                      "code": "storage misdirection",
+                      "path_cache": "%s/foo/bar" % project_name,
+                      "created_at": datetime.datetime(2012, 10, 12, 12, 1),
+                      "path_cache_storage": self.alt_storage_3}
+
+        self.pub_7 = {"type": "PublishedFile",
+                      "id": 7,
+                      "code": "storage misdirection2",
+                      "path_cache": "%s/foo/bar" % project_name,
+                      "created_at": datetime.datetime(2012, 10, 12, 12, 1),
+                      "path_cache_storage": self.alt_storage_4}
+
+        self.add_to_sg_mock_db([self.pub_6, self.pub_7])
+
+        # querying root 3 path which is used by the "alternate_4" root in
+        # roots.yml. the returned data should point to local storage 3 which
+        # alt root 4 points to explicitly.
+        paths = [os.path.join(self.alt_root_3, "foo", "bar")]
+        pub_data = tank.util.find_publish(self.tk, paths, fields=["path_cache_storage"])
+        self.assertEqual(len(pub_data), 1)
+        self.assertEqual(pub_data.keys(), paths)
+        self.assertEqual(pub_data[paths[0]]["path_cache_storage"]["id"], self.alt_storage_3["id"])
+
+        # querying root 4 path which is used by the "alternate_3" root in
+        # roots.yml. the returned data should point to local storage 4 which
+        # alt root 3 points to explicitly.
+        paths = [os.path.join(self.alt_root_4, "foo", "bar")]
+        pub_data = tank.util.find_publish(self.tk, paths, fields=["path_cache_storage"])
+        self.assertEqual(len(pub_data), 1)
+        self.assertEqual(pub_data.keys(), paths)
+        self.assertEqual(pub_data[paths[0]]["path_cache_storage"]["id"], self.alt_storage_4["id"])
 
 class TestShotgunDownloadUrl(ShotgunTestBase):
 


### PR DESCRIPTION
This is a fix for an oversight on my part during the storage mapping work. This is all related to creating/querying `PublishedFiles`.

On the creation side, the local storage associated with the publish was assigned based on the matching root name (used to query a local storage of the same name). This code now goes through the new API which handles all that logic. 

On the querying side, `find_publishes`  no longer queries the local storage by name and relies on the roots api to get the proper storage.

Two new methods were added to pipeline config: 
- `get_local_storage_for_root()` - allows you to directly get the local storage for a required root name.
- `get_local_storage_mapping()` - allows you to get all root -> storage mappings. this is exposing the same method on the underlying storage roots object used by the pipeline config.

Code has been updated in the publish create/query code to make the distinction between required storage root and local storage in SG clearer.

Tests were added to check for these types of root -> storage misdirections. 