### PR TITLE
Adds feature info for storage roots API

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -21,3 +21,9 @@ features:
    # v1: When bootstrapping with a descriptor based configuration, the
    #     config folder is run from the bundle cache.
    bootstrap.lean_config.version: 1
+
+   # storage roots api history
+   # v1: Core includes a storage roots API that encapsulates all interaction
+   #     with the roots.yml file in a configuration. Prior to this feature, the
+   #     file was read/write by various code independently in core.
+   storage_roots.api.version: 1

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -120,7 +120,7 @@ class CachedConfiguration(Configuration):
 
         # see if the storage roots api is available in the config's core
         if self._descriptor.get_associated_core_feature_info(
-            "storage_roots.api.version", 0) < 1:
+                "storage_roots.api.version", 0) < 1:
 
             # bootstrapping into an older core. we need to verify storages the
             # old way, by reading the roots file manually.

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -899,7 +899,8 @@ class TestFeaturesApi(unittest2.TestCase):
         desc = sgtk.descriptor.CoreDescriptor(io_desc)
 
         features = {
-            "bootstrap.lean_config.version": 1
+            "bootstrap.lean_config.version": 1,
+            "storage_roots.api.version": 1
         }
 
         # Make sure every feature is at the expected version.


### PR DESCRIPTION
During bootstrap, use old roots verification logic if storage roots api doesn't exist in the target core.