### PR TITLE
For SG-4682: [minor] Tweaks to fix Open Sans style on Windows 10 in PySide2.

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1561,7 +1561,15 @@ class Engine(TankBundle):
             if os.path.isdir(font_dir):
 
                 # iterate over the font files and attempt to load them
-                for font_file_name in os.listdir(font_dir):
+                #
+                # NOTE: We're loading the ttf files in reverse order to work around
+                # a Windows 10 oddity in Qt5/PySide2. It appears as though Windows
+                # prefers the first ttf installed for a given font weight, so when
+                # we're setting weight in qss (publish2 is a good example), if we're
+                # going for a lighter-weight font, we end up getting condensed light
+                # instead of the regular style. So...we're going to install these in
+                # reverse order so that the regular light style is preferred.
+                for font_file_name in reversed(list(os.listdir(font_dir))):
 
                     # only process actual font files. It appears as though .ttf
                     # is the most common extension for use on win/mac/linux so


### PR DESCRIPTION
This contains a minor tweak/hack to make Windows 10 pick the correct font style when font-weight is used in conjunction with Open Sans. We're installing the ttfs for Open Sans in reverse alphanumeric order now, so that the "light" style font is installed before the "condensed light" style. Windows seems to prefer what's installed first when it's determining style based on font-weight settings in qss.