### PR TITLE
For SG-5793, show application icon

### DIFF
--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -192,7 +192,10 @@ class TankQDialog(TankDialogBase):
             self.ui.label.setText(title)
             
         self.setWindowTitle("Shotgun: %s" % title)
-        
+        if os.path.exists(bundle.icon_256):
+            self._window_icon = QtGui.QIcon(bundle.icon_256)
+            self.setWindowIcon(self._window_icon)
+
         # set the visibility of the title bar:
         show_tk_title_bar = (not hasattr(self._widget, "hide_tk_title_bar") or not self._widget.hide_tk_title_bar)
         self.ui.top_group.setVisible(show_tk_title_bar)


### PR DESCRIPTION
Sets a bundle's icon at the dialog icon. Seems to work in every DCC except for certain versions of Maya or Mac and Windows (haven't tested Linux).