### PR TITLE
SG-6314 Fixes bugs in publish path computation

### DIFF
--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -712,7 +712,7 @@ def _calc_path_cache(tk, path):
     # Note: paths may be c:/foo in Maya on Windows - don't rely on os.sep here!
 
     # normalize input path to remove double slashes etc.
-    norm_path = os.path.normpath(path)
+    norm_path = ShotgunPath.normalize(path)
 
     # normalize to only use forward slashes
     norm_path = norm_path.replace("\\", "/")
@@ -725,15 +725,14 @@ def _calc_path_cache(tk, path):
     project_disk_name = tk.pipeline_configuration.get_project_disk_name()
 
     for root_name, root_path in storage_roots.items():
-        norm_root_path = root_path.replace(os.sep, "/")
 
-        # append the project name to the root path
-        # handle the special case where the normalized
-        # root path ends with a slash, e.g. 'P:/'
-        if norm_root_path.endswith("/"):
-            proj_path = "%s%s" % (norm_root_path, project_disk_name)
-        else:  
-            proj_path = "%s/%s" % (norm_root_path, project_disk_name)
+        root_path_obj = ShotgunPath.from_current_os_path(root_path)
+        # normalize the root path
+        norm_root_path = root_path_obj.current_os.replace(os.sep, "/")
+
+        # append project and normalize
+        proj_path = root_path_obj.join(project_disk_name).current_os
+        proj_path = proj_path.replace(os.sep, "/")
 
         if norm_path.lower().startswith(proj_path.lower()):
             # our path matches this storage!

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -711,8 +711,11 @@ def _calc_path_cache(tk, path):
     """
     # Note: paths may be c:/foo in Maya on Windows - don't rely on os.sep here!
 
-    # normalize input path first c:\foo -> c:/foo
-    norm_path = path.replace(os.sep, "/")
+    # normalize input path to remove double slashes etc.
+    norm_path = os.path.normpath(path)
+
+    # normalize to only use forward slashes
+    norm_path = norm_path.replace("\\", "/")
 
     # get roots - dict keyed by storage name
     storage_roots = tk.pipeline_configuration.get_local_storage_roots()
@@ -725,7 +728,12 @@ def _calc_path_cache(tk, path):
         norm_root_path = root_path.replace(os.sep, "/")
 
         # append the project name to the root path
-        proj_path = "%s/%s" % (norm_root_path, project_disk_name)
+        # handle the special case where the normalized
+        # root path ends with a slash, e.g. 'P:/'
+        if norm_root_path.endswith("/"):
+            proj_path = "%s%s" % (norm_root_path, project_disk_name)
+        else:  
+            proj_path = "%s/%s" % (norm_root_path, project_disk_name)
 
         if norm_path.lower().startswith(proj_path.lower()):
             # our path matches this storage!

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -64,7 +64,7 @@ def only_run_on_windows(func):
     :param func: Function to be decorated.
     :returns: The decorated function.
     """
-    running_nix = os.system != "win32"
+    running_nix = sys.platform != "win32"
     return unittest.skipIf(
         running_nix,
         "Windows only test."
@@ -77,7 +77,7 @@ def only_run_on_nix(func):
     :param func: Function to be decorated.
     :returns: The decorated function.
     """
-    running_windows = os.system == "win32"
+    running_windows = sys.platform == "win32"
     return unittest.skipIf(
         running_windows,
         "Linux/Macosx only test."

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -58,6 +58,32 @@ def interactive(func):
     )(func)
 
 
+def only_run_on_windows(func):
+    """
+    Decorator that allows to skip a test if not running on windows.
+    :param func: Function to be decorated.
+    :returns: The decorated function.
+    """
+    running_nix = os.system != "win32"
+    return unittest.skipIf(
+        running_nix,
+        "Windows only test."
+    )(func)
+
+
+def only_run_on_nix(func):
+    """
+    Decorator that allows to skip a test if not running on linux/macosx.
+    :param func: Function to be decorated.
+    :returns: The decorated function.
+    """
+    running_windows = os.system == "win32"
+    return unittest.skipIf(
+        running_windows,
+        "Linux/Macosx only test."
+    )(func)
+
+
 def _is_git_missing():
     """
     Tests is git is available in PATH

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -16,7 +16,7 @@ from mock import patch, call
 
 import tank
 from tank import context, errors
-from tank_test.tank_test_base import TankTestBase, setUpModule
+from tank_test.tank_test_base import TankTestBase, setUpModule, only_run_on_windows, only_run_on_nix
 
 
 class TestShotgunRegisterPublish(TankTestBase):
@@ -479,15 +479,13 @@ class TestCalcPathCache(TankTestBase):
         self.assertEqual("primary", root_name)
         self.assertEqual(expected, path_cache)
 
+    @only_run_on_windows
     @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_win_drive_letter(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
         a path into a storage + path cache field while using a windows drive letter path.
         """
-        if sys.platform != "win32":
-            return
-
         # note - this return value is guaranteed to be normalized
         # so no need to test for edge cases
         get_local_storage_roots.return_value = {"primary": "P:\\"}
@@ -507,15 +505,13 @@ class TestCalcPathCache(TankTestBase):
             self.assertEqual("primary", root_name)
             self.assertEqual("project_code/3d/Assets", path_cache)
 
+    @only_run_on_windows
     @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_win_unc(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
         a path into a storage + path cache field while using a windows unc path
         """
-        if sys.platform != "win32":
-            return
-
         # note - this return value is guaranteed to be normalized
         # so no need to test for edge cases
         get_local_storage_roots.return_value = {"primary": "\\\\share"}
@@ -533,15 +529,13 @@ class TestCalcPathCache(TankTestBase):
             self.assertEqual("primary", root_name)
             self.assertEqual("project_code/3d/Assets", path_cache)
 
+    @only_run_on_nix
     @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_nix(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
         a path into a storage + path cache field while using linux or mac
         """
-        if sys.platform == "win32":
-            return
-
         # note - this return value is guaranteed to be normalized
         # so no need to test for edge cases
         get_local_storage_roots.return_value = {"primary": "/mnt"}

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -198,8 +198,6 @@ class TestShotgunRegisterPublish(TankTestBase):
         if sys.platform == "win32":
             values = [
                 r"x:\tmp\win\path\to\file.txt",
-                #r"x:\\tmp\\win\\path\\to\\file.txt",
-                #r"x:/tmp/win/path/to/file.txt",
                 r"\\server\share\path\to\file.txt",
             ]
 
@@ -525,6 +523,33 @@ class TestCalcPathCache(TankTestBase):
         input_paths = [
             r"\\share\project_code\3d\Assets",
             r"//share/project_code/3d/Assets",
+        ]
+
+        for input_path in input_paths:
+            root_name, path_cache = tank.util.shotgun.publish_creation._calc_path_cache(
+                self.tk,
+                input_path
+            )
+            self.assertEqual("primary", root_name)
+            self.assertEqual("project_code/3d/Assets", path_cache)
+
+    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    def test_path_normalization_nix(self, get_local_storage_roots):
+        """
+        Ensures that a variety of different slash syntaxes are valid when splitting
+        a path into a storage + path cache field while using linux or mac
+        """
+        if sys.platform == "win32":
+            return
+
+        # note - this return value is guaranteed to be normalized
+        # so no need to test for edge cases
+        get_local_storage_roots.return_value = {"primary": "/mnt"}
+
+        input_paths = [
+            r"/mnt\project_code\3d\Assets",
+            r"\mnt\project_code\3d\Assets",
+            r"/mnt/project_code//3d///Assets",
         ]
 
         for input_path in input_paths:

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -461,6 +461,7 @@ class TestMultiRoot(TankTestBase):
 
 
 class TestCalcPathCache(TankTestBase):
+
     @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_case_difference(self, get_local_storage_roots):
         """
@@ -477,6 +478,33 @@ class TestCalcPathCache(TankTestBase):
         root_name, path_cache = tank.util.shotgun.publish_creation._calc_path_cache(self.tk, input_path)
         self.assertEqual("primary", root_name)
         self.assertEqual(expected, path_cache)
+
+    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    def test_slashes_win(self, get_local_storage_roots):
+        """
+        Ensures that a variety of different slash syntaxes are valid when splitting
+        a path into a storage + path cache field.
+        """
+        if sys.platform != "win32":
+            return
+
+        get_local_storage_roots.return_value = {"primary": "P:\\"}
+
+        input_paths = [
+            r"P://rnd//3d//Assets",
+            r"P:\\rnd\\3d\\Assets",
+            r"P:\rnd\3d\Assets",
+            r"P:/rnd/3d/Assets",
+        ]
+
+        for input_path in input_paths:
+            print input_path
+            root_name, path_cache = tank.util.shotgun.publish_creation._calc_path_cache(
+                self.tk,
+                input_path
+            )
+            self.assertEqual("primary", root_name)
+            self.assertEqual("aa", path_cache)
 
 
 class TestCalcPathCacheProjectWithSlash(TankTestBase):


### PR DESCRIPTION
Fixes a bug where the logic for splitting paths into storages + normalized path chunks (which are later on passed to the `PublishedFile.path_cache` field) was incorrect if your local storage was a windows drive letter path with no folder (e..g `P:\`). Added tests.