### PR TITLE
For SG-6617: Forces site urls to lowercase to make url comparisons reliable.

### DIFF
--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -275,7 +275,11 @@ def sanitize_url(server_url):
     # - https (scheme)
     # - test.shogunstudio.com (network location)
     # - /... (path)
-    return __sanitize_url(first_pass)
+    #
+    # We also lowercase the entire url. This will allow us to reliably compare site addresses
+    # against each other elsewhere in the code and not have to worry about STUDIO.shotgunstudio.com
+    # and studio.shotgunstudio.com not matching when they should be considered the same site.
+    return __sanitize_url(first_pass).lower()
 
 
 def get_associated_sg_base_url():

--- a/tests/authentication_tests/test_session_cache.py
+++ b/tests/authentication_tests/test_session_cache.py
@@ -200,10 +200,14 @@ class SessionCacheTests(ShotgunTestBase):
         Makes sure current host is saved appropriately.
         """
         # Write the host and make sure we read it back.
-        # Use mixed case to make sure we are case preserving
+        #
+        # Use mixed case to make sure we are not case preserving. If we did,
+        # as we used to, we would run into problems with some site url
+        # comparisons incorrectly determining that hOsT.shotgunstudio.com
+        # isn't the same site as host.shotgunstudio.com.
         host = "https://hOsT.shotgunstudio.com"
         session_cache.set_current_host(host)
-        self.assertEqual(session_cache.get_current_host(), host)
+        self.assertEqual(session_cache.get_current_host(), host.lower())
 
         # Update the host and make sure we read it back.
         other_host = "https://other_host.shotgunstudio.com"

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -156,6 +156,12 @@ class TestGetSgConfigData(ShotgunTestBase):
             sanitize_url("no.scheme.com")
         )
 
+        # Ensure that we lowercase the URL.
+        self.assertEquals(
+            "https://caps.site.com",
+            sanitize_url("https://CAPS.site.com")
+        )
+
         # Ensure https is not modified if specified.
         self.assertEquals(
             "https://no.scheme.com",


### PR DESCRIPTION
We have a situation where some of our code stops functioning properly when Shotgun site urls don't match exactly. This becomes a problem when someone logs into Desktop using `https://SITE.shotgunstudio.com` instead of `https://site.shotgunstudio.com`, and results in most of our apps breaking after launching a DCC. This fix simply lowers the casing of the url when going through our existing sanitization routine.