### PR TITLE
get_sg_entity_name_field() returning bad value for Tags

### DIFF
--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -26,6 +26,7 @@ SG_ENTITY_SPECIAL_NAME_FIELDS = {
     "Note": "subject",
     "Department": "name",
     "Delivery": "title",
+    "Tag": "name",
 }
 
 


### PR DESCRIPTION
The tank.util.shotgun_entity.get_sg_entity_name_field() method does not currently account for the relatively new "Tag" entity.  It is currently returning 'code', but should return 'name'.