### PR TITLE
For SG-7259, adds JSON serialization utilities and Context to dict serializer

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -114,7 +114,7 @@ get_hook_baseclass
 .. autofunction:: get_hook_baseclass
 
 Core Hooks
-=========================================
+==========
 
 The Toolkit core comes with a set of hooks that can help you tweak how the core behaves. If you
 want to take over a certain behavior, copy the hook found inside the core's `hooks <https://github.com/shotgunsoftware/tk-core/tree/master/hooks>`_ folder
@@ -222,7 +222,7 @@ tank_init.py
     :members:
 
 Template Hooks
-=============
+==============
 
 .. automodule:: example_template_hook
 .. autoclass:: example_template_hook.ExampleTemplateHook

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -148,6 +148,16 @@ sgtk.util.filesystem
 .. autofunction:: create_valid_filename
 .. autofunction:: get_unused_path
 
+.. currentmodule:: sgtk.util.json
+
+
+sgtk.util.json
+-----------------------------------
+
+.. autofunction:: load
+.. autofunction:: loads
+
+
 ShotgunPath
 -----------------------------------
 

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -819,7 +819,7 @@ class Context(object):
         # Create a context with the items in data, but only if there is an argument
         # of the same name.
         return Context(
-            **{k: v for k, v in data.iteritems() if k in argument_names}
+            **dict((k, v) for k, v in data.iteritems() if k in argument_names)
         )
 
     ################################################################################################

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -13,7 +13,6 @@ Management of the current context, e.g. the current shotgun entity/step/task.
 
 """
 
-import inspect
 import os
 import pickle
 import copy
@@ -815,11 +814,15 @@ class Context(object):
         :returns: :class:`Context`
         """
         # Get all argument names except for self.
-        argument_names = inspect.getargspec(Context.__init__).args[1:]
-        # Create a context with the items in data, but only if there is an argument
-        # of the same name.
         return Context(
-            **dict((k, v) for k, v in data.iteritems() if k in argument_names)
+            tk=data.get("tk"),
+            project=data.get("project"),
+            entity=data.get("entity"),
+            step=data.get("step"),
+            task=data.get("task"),
+            user=data.get("user"),
+            additional_entities=data.get("additional_entities"),
+            source_entity=data.get("source_entity")
         )
 
     ################################################################################################

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -762,10 +762,10 @@ class Context(object):
     def to_dict(self):
         """
         Converts the context into a dictionary with keys ``project``,
-            ``entity``, ``user``, ``step``, ``task``, ``additional_entities`` and
-            ``source_entity``.
+        ``entity``, ``user``, ``step``, ``task``, ``additional_entities`` and
+        ``source_entity``.
 
-        ..note::
+        .. note ::
             Contrary to :meth:`Context.serialize`, this method discards information
             about the Toolkit instance associated with the context or the currently
             authenticated user.

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -33,6 +33,7 @@ from .metrics import EventMetric
 from .shotgun_path import ShotgunPath
 
 from . import filesystem
+from . import json
 
 from .local_file_storage import LocalFileStorageManager
 

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Utility methods for unserializing JSON documents.
+"""
+
+# We need to add this to the file or the import json will reimport this
+# module instead of importing the global json module.
+from __future__ import absolute_import
+
+import json
+
+
+def _convert_unicode_keys_to_string(input_value):
+    """
+    Converts any :class:`unicode` instances in the input value into a utf-8
+    encoded :class`str` instance.
+
+    :param input_value: Value to convert. Can be a scalar, list or dictionary.
+
+    :returns: A value with utf-8 encoded :class:`str` instances.
+    """
+
+    if isinstance(input_value, unicode):
+        return input_value.encode("utf8")
+
+    if isinstance(input_value, list):
+        return [_convert_unicode_keys_to_string(item) for item in input_value]
+
+    if isinstance(input_value, dict):
+        return {
+            _convert_unicode_keys_to_string(k):
+            _convert_unicode_keys_to_string(v)
+            for k, v in input_value.iteritems()
+        }
+
+    return input_value
+
+
+def load(
+    fp, encoding=None, cls=None, object_hook=None, parse_float=None,
+    parse_int=None, parse_constant=None, object_pairs_hook=None, **kw
+):
+    """
+    Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
+    a JSON document) to a Python object.
+
+    This method is a simple thin wrapper around :func:`json.load` that
+    ensures unserialized strings are utf-8 encoded :class:`str` objects.
+
+    See the documentation for :func:`json.load` to learn more about this method.
+    """
+    loaded_value = json.load(
+        fp, encoding, cls, object_hook, parse_float,
+        parse_int, parse_constant, object_pairs_hook, **kw
+    )
+
+    return _convert_unicode_keys_to_string(loaded_value)
+
+
+def loads(
+    fp, encoding=None, cls=None, object_hook=None, parse_float=None,
+    parse_int=None, parse_constant=None, object_pairs_hook=None, **kw
+):
+    """
+    Deserialize ``s`` (a ``str`` or ``unicode`` instance containing a JSON
+    document) to a Python object.
+
+    This method is a simple thin wrapper around :func:`json.loads` that
+    ensures unserialized strings are utf-8 encoded :class:`str` objects.
+
+    See the documentation for :func:`json.loads` to learn more about this method.
+    """
+    loaded_value = json.loads(
+        fp, encoding, cls, object_hook, parse_float,
+        parse_int, parse_constant, object_pairs_hook, **kw
+    )
+
+    return _convert_unicode_keys_to_string(loaded_value)

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -35,11 +35,10 @@ def _convert_unicode_keys_to_string(input_value):
         return [_convert_unicode_keys_to_string(item) for item in input_value]
 
     if isinstance(input_value, dict):
-        return {
-            _convert_unicode_keys_to_string(k):
-            _convert_unicode_keys_to_string(v)
+        return dict(
+            (_convert_unicode_keys_to_string(k), _convert_unicode_keys_to_string(v))
             for k, v in input_value.iteritems()
-        }
+        )
 
     return input_value
 

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -43,9 +43,10 @@ def _convert_unicode_keys_to_string(input_value):
     return input_value
 
 
+# This is the Python 2.6 signature. 2.7 has an extra object_hook_pairs argument.
 def load(
     fp, encoding=None, cls=None, object_hook=None, parse_float=None,
-    parse_int=None, parse_constant=None, object_pairs_hook=None, **kw
+    parse_int=None, parse_constant=None, **kw
 ):
     """
     Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
@@ -58,15 +59,16 @@ def load(
     """
     loaded_value = json.load(
         fp, encoding, cls, object_hook, parse_float,
-        parse_int, parse_constant, object_pairs_hook, **kw
+        parse_int, parse_constant, **kw
     )
 
     return _convert_unicode_keys_to_string(loaded_value)
 
 
+# This is the Python 2.6 signature. 2.7 has an extra object_hook_pairs argument.
 def loads(
     fp, encoding=None, cls=None, object_hook=None, parse_float=None,
-    parse_int=None, parse_constant=None, object_pairs_hook=None, **kw
+    parse_int=None, parse_constant=None, **kw
 ):
     """
     Deserialize ``s`` (a ``str`` or ``unicode`` instance containing a JSON
@@ -79,7 +81,7 @@ def loads(
     """
     loaded_value = json.loads(
         fp, encoding, cls, object_hook, parse_float,
-        parse_int, parse_constant, object_pairs_hook, **kw
+        parse_int, parse_constant, **kw
     )
 
     return _convert_unicode_keys_to_string(loaded_value)

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -67,7 +67,7 @@ def load(
 
 # This is the Python 2.6 signature. 2.7 has an extra object_hook_pairs argument.
 def loads(
-    fp, encoding=None, cls=None, object_hook=None, parse_float=None,
+    s, encoding=None, cls=None, object_hook=None, parse_float=None,
     parse_int=None, parse_constant=None, **kw
 ):
     """
@@ -80,7 +80,7 @@ def loads(
     See the documentation for :func:`json.loads` to learn more about this method.
     """
     loaded_value = json.loads(
-        fp, encoding, cls, object_hook, parse_float,
+        s, encoding, cls, object_hook, parse_float,
         parse_int, parse_constant, **kw
     )
 

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -1084,22 +1084,36 @@ class TestSerialize(TestContext):
         self.kws["step"] = self.step
         self.kws["task"] = {"id": 45, "type": "Task"}
         self.kws["additional_entities"] = [{"id": 42, "type": "Sequence"}]
+        self.kws["source_entity"] = {"id": 12, "type": "Version"}
 
         self._user = ShotgunAuthenticator().create_script_user(
             "script_user", "script_key", "https://abc.shotgunstudio.com"
+        )
+
+    def test_from_dict(self):
+        """
+        Ensures that Toolkit is forward compatible with newer versions of Toolkit
+        which may have more items in the serialized dictionary.
+        """
+        context.Context.from_dict(
+            self.tk,
+            {
+                "project": {"type": "Project", "id": 1},
+                "unknown_entity_parameter": {"type": "CustomEntity01", "id": 1}
+            }
         )
 
     def test_equal_yml(self):
         context_1 = context.Context(**self.kws)
         serialized = yaml.dump(context_1)
         context_2 = yaml.load(serialized)
-        self.assertTrue(context_1 == context_2)
+        self._assert_equal_contexts(context_1, context_2)
 
     def test_equal_custom(self):
         context_1 = context.Context(**self.kws)
         serialized = context_1.serialize(context_1)
         context_2 = tank.Context.deserialize(serialized)
-        self.assertTrue(context_1 == context_2)
+        self._assert_equal_contexts(context_1, context_2)
 
     def _assert_same_user(self, user_1, user_2):
         """
@@ -1147,8 +1161,18 @@ class TestSerialize(TestContext):
         """
         ctx = context.Context(**self.kws)
         ctx_dict = ctx.to_dict()
-        new_ctx = tank.Context.from_dict(ctx_dict, ctx.sgtk)
-        self.assertTrue(new_ctx == ctx)
+        new_ctx = tank.Context.from_dict(ctx.sgtk, ctx_dict)
+        self._assert_equal_contexts(new_ctx, ctx)
+
+    def _assert_equal_contexts(self, ctx_1, ctx_2):
+        """
+        Ensures two contexts are equal.
+        Note that source_entity is not part of the equality comparison,
+        but since we're interested into making sure everything gets serialized
+        property we'll add the value there.
+        """
+        self.assertTrue(ctx_1 == ctx_2)
+        self.assertTrue(ctx_1.source_entity == ctx_2.source_entity)
 
     def test_deserialized_invalid_data(self):
         """

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -1083,8 +1083,9 @@ class TestSerialize(TestContext):
         self.kws["entity"] = self.shot
         self.kws["step"] = self.step
         self.kws["task"] = {"id": 45, "type": "Task"}
+        self.kws["additional_entities"] = [{"id": 42, "type": "Sequence"}]
 
-        self._user =  ShotgunAuthenticator().create_script_user(
+        self._user = ShotgunAuthenticator().create_script_user(
             "script_user", "script_key", "https://abc.shotgunstudio.com"
         )
 
@@ -1139,6 +1140,15 @@ class TestSerialize(TestContext):
         # The unserialized context shouldn't have changed the current user.
         tank.Context.deserialize(ctx_str)
         self._assert_same_user(tank.get_authenticated_user(), other_user)
+
+    def test_serialize_to_dict(self):
+        """
+        Make sure a context serialized to a dictionary can be unserialized.
+        """
+        ctx = context.Context(**self.kws)
+        ctx_dict = ctx.to_dict()
+        new_ctx = tank.Context.from_dict(ctx_dict, ctx.sgtk)
+        self.assertTrue(new_ctx == ctx)
 
     def test_deserialized_invalid_data(self):
         """

--- a/tests/util_tests/test_json.py
+++ b/tests/util_tests/test_json.py
@@ -62,6 +62,9 @@ class JSONTests(TestCase):
             raise Exception("unicode string found in %r" % value)
 
     def test_repr_generates_u_strings(self):
+        """
+        Ensures the unicode detection method actually works.
+        """
         self._assert_no_unicode({})
         self._assert_no_unicode(1)
         self._assert_no_unicode(False)

--- a/tests/util_tests/test_json.py
+++ b/tests/util_tests/test_json.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import tempfile
+import json
+
+from unittest2 import TestCase
+from sgtk.util import json as tk_json
+
+
+class JSONTests(TestCase):
+    """
+    Ensures unserializing json from file or a string will always yield
+    str objects instead of unicode.
+    """
+
+    kanji = str("漢字")
+
+    def _value_to_string_to_value(self, value):
+        """
+        Dumps a value to a json formatted string and reloads it.
+
+        :param value: Value to dump to a string.
+
+        :returns: Value that was loaded back from the string.
+        """
+        return tk_json.loads(json.dumps(value))
+
+    def _value_to_file_to_value(self, value):
+        """
+        Dumps a value to a json formatted file and reloads it.
+
+        :param value: Value to dump to a file.
+
+        :returns: Value that was loaded back from the file.
+        """
+        with tempfile.TemporaryFile() as fp:
+            json.dump(value, fp)
+            # Return at the beginning of the file so the load method can read
+            # something.
+            fp.seek(0)
+            return tk_json.load(fp)
+
+    def _assert_no_unicode(self, value):
+        """
+        Ensures there is no unicode anywhere inside the value.
+
+        Just make sure there the string "u'" is not in the original value. ;)
+        """
+        # Get the repr of the value. If there is a unicode string,
+        # we'll get a u'value' somewhere in the output, which means
+        # there is a unicode string.
+        if "u'" in repr(value):
+            raise Exception("unicode string found in %r" % value)
+
+    def test_repr_generates_u_strings(self):
+        self._assert_no_unicode({})
+        self._assert_no_unicode(1)
+        self._assert_no_unicode(False)
+        self._assert_no_unicode(None)
+        self._assert_no_unicode(self.kanji)
+        self._assert_no_unicode({"k": "v"})
+
+        with self.assertRaisesRegexp(Exception, "unicode string found in u'allo'"):
+            self._assert_no_unicode(u"allo")
+
+    def test_scalar_values(self):
+        """
+        Ensures we can properly encode scalar values.
+        """
+        # Integer
+        self._assert_no_unicode_after_load(1)
+        # BigNum
+        self._assert_no_unicode_after_load(100000000000000000000000)
+        # Floats
+        self._assert_no_unicode_after_load(1.0)
+        # Booleans
+        self._assert_no_unicode_after_load(True)
+        self._assert_no_unicode_after_load(False)
+        # None
+        self._assert_no_unicode_after_load(None)
+        # Strings
+        self._assert_no_unicode_after_load("a")
+        self._assert_no_unicode_after_load(u"b")
+        self._assert_no_unicode_after_load(self.kanji)
+
+    def test_array_values(self):
+        """
+        Ensure we can properly encode an array.
+        """
+        self._assert_no_unicode_after_load([
+            1, 100000000000000000000000, 1.0, True, False, None,
+            {"a": "b", u"c": u"d"},
+            "e", u"f"
+        ])
+
+    def test_dict_value(self):
+        """
+        Ensures we can properly encode a dictionary.
+        """
+        self._assert_no_unicode_after_load({})
+        self._assert_no_unicode_after_load({"a": "b", u"c": u"d"})
+        self._assert_no_unicode_after_load({
+            "e": ["f"], u"g": [u"h"]
+        })
+        self._assert_no_unicode_after_load({
+            "i": [{"j": ["k"]}],
+            u"l": [{u"m": [u"n"]}],
+        })
+
+    def _assert_no_unicode_after_load(self, original_value, converter=None):
+        """
+        Ensures the values are the same after the serialize/unserialize and that the
+        strings are all str and not unicode objects.
+        """
+        # We need to test serialization to disk and to string for the input.
+        for converter in [self._value_to_string_to_value, self._value_to_file_to_value]:
+            converted_value = converter(original_value)
+
+            self._assert_no_unicode(converted_value)
+            self.assertEqual(original_value, converted_value)


### PR DESCRIPTION
Introduces two features related to the new publisher API:
- sgtk.util.json.{load,loads}, which are thin wrappers around the Python API and allows to json documents into dictionaries using utf-8 encoded strings.
- sgtk.Context.{to,from}_dict, which allow to serialize/unserialize a context to a dictionary.