### PR TITLE
SG-8369: Allows a parent to be passed into the async boostrapper.

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -542,7 +542,12 @@ class ToolkitManager(object):
         :type entity: Dictionary with keys ``type`` and ``id``, or ``None`` for the site.
         :param completed_callback: Callback function that handles cleanup after successful completion of the bootstrap.
         :param failed_callback: Callback function that handles cleanup after failed completion of the bootstrap.
-        :param parent: The parent object used for the async bootstrapper.
+        :param parent: The parent object used for the async bootstrapper. This will be necessary
+            in some environments, as it will prevent the thread used to bootstrap from being
+            garbage collected before it completes its work. An example input for this argument would
+            be to provide a reference to the main window of the parent application being integrated
+            with (ie: Maya, Nuke, etc), which is guaranteed to remain in memory for the duration of
+            bootstrap process.
         """
         self._log_startup_message(engine_name, entity)
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -482,7 +482,8 @@ class ToolkitManager(object):
                                engine_name,
                                entity=None,
                                completed_callback=None,
-                               failed_callback=None):
+                               failed_callback=None,
+                               parent=None):
         """
         Asynchronous version of :meth:`bootstrap_engine`.
 
@@ -541,6 +542,7 @@ class ToolkitManager(object):
         :type entity: Dictionary with keys ``type`` and ``id``, or ``None`` for the site.
         :param completed_callback: Callback function that handles cleanup after successful completion of the bootstrap.
         :param failed_callback: Callback function that handles cleanup after failed completion of the bootstrap.
+        :param parent: The parent object used for the async bootstrapper.
         """
         self._log_startup_message(engine_name, entity)
 
@@ -564,7 +566,14 @@ class ToolkitManager(object):
             # Bootstrap an Sgtk instance asynchronously in a background thread,
             # followed by launching the engine synchronously in the main application thread.
 
-            self._bootstrapper = AsyncBootstrapWrapper(self, engine_name, entity, completed_callback, failed_callback)
+            self._bootstrapper = AsyncBootstrapWrapper(
+                self,
+                engine_name,
+                entity,
+                completed_callback,
+                failed_callback,
+                parent,
+            )
             self._bootstrapper.bootstrap()
 
         else:


### PR DESCRIPTION
* The current implementation doesn't set any parents for any of the QObject/QThread instances created by the async bootstrapper. This causes stability problems in PySide2/Qt5 environments.

* Works around one other crash bug in PySide2/Qt5 environments by not calling a moveToThread in that context.