### PR TITLE
For SG-6464, core hooks sphinx documentation

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -113,6 +113,145 @@ get_hook_baseclass
 
 .. autofunction:: get_hook_baseclass
 
+Core Hooks
+=========================================
+
+The Toolkit core comes with a set of hooks that can help you tweak how the core behaves. If you
+want to take over a certain behavior, copy the hook found inside the core's ``hooks`` folder
+and copy it to your configuration's ``core/hooks`` folder.
+
+Here is the list of hooks that be taken over in the Toolkit core.
+
+before_register_publish.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: before_register_publish
+
+.. autoclass:: before_register_publish.BeforeRegisterPublish
+    :members:
+
+bundle_init.py
+~~~~~~~~~~~~~~
+
+.. automodule:: bundle_init
+
+.. autoclass:: bundle_init.BundleInit
+    :members:
+
+cache_location.py
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: cache_location
+
+.. autoclass:: cache_location.CacheLocation
+    :members:
+
+context_additional_entities.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: context_additional_entities
+
+.. autoclass:: context_additional_entities.ContextAdditionalEntities
+    :members:
+
+context_change.py
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: context_change
+
+.. autoclass:: context_change.ContextChange
+    :members:
+
+engine_init.py
+~~~~~~~~~~~~~~
+
+.. automodule:: engine_init
+
+.. autoclass:: engine_init.EngineInit
+    :members:
+
+ensure_folder_exists.py
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ensure_folder_exists
+
+.. autoclass:: ensure_folder_exists.EnsureFolderExists
+    :members:
+
+example_template_hook.py
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: example_template_hook
+
+.. autoclass:: example_template_hook.ExampleTemplateHook
+    :members:
+
+get_current_login.py
+~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: get_current_login
+
+.. autoclass:: get_current_login.GetCurrentLogin
+    :members:
+
+log_metrics.py
+~~~~~~~~~~~~~~
+
+.. automodule:: log_metrics
+
+.. autoclass:: log_metrics.LogMetrics
+    :members:
+    :exclude-members: execute
+
+pick_environment.py
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: pick_environment
+
+.. autoclass:: pick_environment.PickEnvironment
+    :members:
+
+pipeline_configuration_init.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: pipeline_configuration_init
+
+.. autoclass:: pipeline_configuration_init.PipelineConfigurationInit
+    :members:
+
+process_folder_creation.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: process_folder_creation
+
+.. autoclass:: process_folder_creation.ProcessFolderCreation
+    :members:
+
+process_folder_name.py
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: process_folder_name
+
+.. autoclass:: process_folder_name.ProcessFolderName
+    :members:
+
+resolve_publish.py
+~~~~~~~~~~~~~~~~~~
+
+.. automodule:: resolve_publish
+
+.. autoclass:: resolve_publish.ResolvePublish
+    :members:
+
+tank_init.py
+~~~~~~~~~~~~
+
+.. automodule:: tank_init
+
+.. autoclass:: tank_init.TankInit
+    :members:
+
+.. currentmodule:: sgtk
 
 Templates
 -----------------------------------------

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -126,7 +126,6 @@ before_register_publish.py
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: before_register_publish
-
 .. autoclass:: before_register_publish.BeforeRegisterPublish
     :members:
 
@@ -134,7 +133,6 @@ bundle_init.py
 ~~~~~~~~~~~~~~
 
 .. automodule:: bundle_init
-
 .. autoclass:: bundle_init.BundleInit
     :members:
 
@@ -142,23 +140,13 @@ cache_location.py
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: cache_location
-
 .. autoclass:: cache_location.CacheLocation
-    :members:
-
-context_additional_entities.py
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: context_additional_entities
-
-.. autoclass:: context_additional_entities.ContextAdditionalEntities
     :members:
 
 context_change.py
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: context_change
-
 .. autoclass:: context_change.ContextChange
     :members:
 
@@ -166,7 +154,6 @@ engine_init.py
 ~~~~~~~~~~~~~~
 
 .. automodule:: engine_init
-
 .. autoclass:: engine_init.EngineInit
     :members:
 
@@ -174,23 +161,13 @@ ensure_folder_exists.py
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ensure_folder_exists
-
 .. autoclass:: ensure_folder_exists.EnsureFolderExists
-    :members:
-
-example_template_hook.py
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: example_template_hook
-
-.. autoclass:: example_template_hook.ExampleTemplateHook
     :members:
 
 get_current_login.py
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: get_current_login
-
 .. autoclass:: get_current_login.GetCurrentLogin
     :members:
 
@@ -198,7 +175,6 @@ log_metrics.py
 ~~~~~~~~~~~~~~
 
 .. automodule:: log_metrics
-
 .. autoclass:: log_metrics.LogMetrics
     :members:
     :exclude-members: execute
@@ -207,7 +183,6 @@ pick_environment.py
 ~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: pick_environment
-
 .. autoclass:: pick_environment.PickEnvironment
     :members:
 
@@ -215,7 +190,6 @@ pipeline_configuration_init.py
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: pipeline_configuration_init
-
 .. autoclass:: pipeline_configuration_init.PipelineConfigurationInit
     :members:
 
@@ -223,7 +197,6 @@ process_folder_creation.py
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: process_folder_creation
-
 .. autoclass:: process_folder_creation.ProcessFolderCreation
     :members:
 
@@ -231,7 +204,6 @@ process_folder_name.py
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: process_folder_name
-
 .. autoclass:: process_folder_name.ProcessFolderName
     :members:
 
@@ -239,7 +211,6 @@ resolve_publish.py
 ~~~~~~~~~~~~~~~~~~
 
 .. automodule:: resolve_publish
-
 .. autoclass:: resolve_publish.ResolvePublish
     :members:
 
@@ -247,8 +218,14 @@ tank_init.py
 ~~~~~~~~~~~~
 
 .. automodule:: tank_init
-
 .. autoclass:: tank_init.TankInit
+    :members:
+
+Template Hooks
+=============
+
+.. automodule:: example_template_hook
+.. autoclass:: example_template_hook.ExampleTemplateHook
     :members:
 
 .. currentmodule:: sgtk

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -117,7 +117,7 @@ Core Hooks
 =========================================
 
 The Toolkit core comes with a set of hooks that can help you tweak how the core behaves. If you
-want to take over a certain behavior, copy the hook found inside the core's ``hooks`` folder
+want to take over a certain behavior, copy the hook found inside the core's `hooks <https://github.com/shotgunsoftware/tk-core/tree/master/hooks>`_ folder
 and copy it to your configuration's ``core/hooks`` folder.
 
 Here is the list of hooks that be taken over in the Toolkit core.

--- a/hooks/before_register_publish.py
+++ b/hooks/before_register_publish.py
@@ -1,34 +1,36 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Hook that gets executed before a publish record is created in Shotgun.
 This hook makes it possible to add custom fields to a publish before it gets created
-aswell as modifying the content that is being pushed to shotgun.
-
+as well as modifying the content that is being pushed to shotgun.
 """
 
 from tank import Hook
-import os
- 
+
+
 class BeforeRegisterPublish(Hook):
-    
+
     def execute(self, shotgun_data, context, **kwargs):
         """
-        Gets executed just before a new publish entity is created in Shotgun.
-        
-        :param shotgun_data: All the data which will be passed to the shotgun create call
+        Executed just before a new publish entity is created in Shotgun.
+
+        The default implementation returns ``shotgun_data`` untouched.
+
+        :param dict shotgun_data: All the data which will be passed to the shotgun create call
         :param context: The context of the publish
-        
+        :type context: :class:`~sgtk.Context`
+
         :returns: return (potentially) modified data dictionary
+        :rtype: dict
         """
-        
         # default implementation is just a pass-through.
         return shotgun_data

--- a/hooks/before_register_publish.py
+++ b/hooks/before_register_publish.py
@@ -11,7 +11,7 @@
 """
 Hook that gets executed before a publish record is created in Shotgun.
 This hook makes it possible to add custom fields to a publish before it gets created
-as well as modifying the content that is being pushed to shotgun.
+as well as modifying the content that is being pushed to Shotgun.
 """
 
 from tank import Hook
@@ -25,7 +25,7 @@ class BeforeRegisterPublish(Hook):
 
         The default implementation returns ``shotgun_data`` untouched.
 
-        :param dict shotgun_data: All the data which will be passed to the shotgun create call
+        :param dict shotgun_data: All the data which will be passed to the Shotgun create call
         :param context: The context of the publish
         :type context: :class:`~sgtk.Context`
 

--- a/hooks/bundle_init.py
+++ b/hooks/bundle_init.py
@@ -1,26 +1,30 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Hook that gets executed every time an bundle has fully initialized.
-
+Hook that gets executed every time a bundle is fully initialized.
 """
 
 from tank import Hook
-import os
- 
+
+
 class BundleInit(Hook):
-    
+
     def execute(self, bundle, **kwargs):
         """
-        Gets executed when the Toolkit bundle super class __init__
-        is fully initialized.
+        Executed when the Toolkit bundle is fully initialized.
+
+        The default implementation does nothing.
+
+        :param bundle: The Toolkit bundle that has been initialized.
+        :type bundle: :class:`~sgtk.platform.Engine`, :class:`~sgtk.platform.Framework`
+            or :class:`~sgtk.platform.Application`
         """
         pass

--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -1,15 +1,15 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Hook to control the various cache locations in the system.
+Hook to control path cache and bundle cache folder creation.
 """
 
 import sgtk
@@ -19,37 +19,35 @@ from sgtk.util import filesystem, LocalFileStorageManager
 HookBaseClass = sgtk.get_hook_baseclass()
 log = sgtk.LogManager.get_logger(__name__)
 
+
 class CacheLocation(HookBaseClass):
-    """
-    Hook to control cache folder creation.
-    
-    For further details, see individual cache methods below.
-    """
-    
     def get_path_cache_path(self, project_id, plugin_id, pipeline_configuration_id):
         """
         Establish a location for the path cache database file.
 
-        This hook method was introduced in Toolkit v0.18 and replaces path_cache.
-        If you already have implemented path_cache, this will be detected and called instead,
-        however we strongly recommend that you tweak your hook.
+        This hook method was introduced in Toolkit v0.18 and replaces the previous
+        ``path_cache`` method. If you already have implemented ``path_cache``,
+        this will be detected and called instead, however we strongly recommend
+        that you tweak your hook.
 
         Overriding this method in a hook allows a user to change the location on disk where
         the path cache file is located. The path cache file holds a temporary cache representation
-        of the FilesystemLocation entities stored in Shotgun for a project. Typically, this cache
-        is stored on a local machine, separate for each user.  
+        of the ``FilesystemLocation`` entities stored in Shotgun for a project.
 
-        Note! In the case of the site configuration, project id will be set to None.
-        In the case of an unmanaged pipeline configuration, pipeline config
-        id will be set to None.
+        The default implementation will create a folder inside the user's home folder or
+        under ``SHOTGUN_HOME``.
 
-        :param project_id: The shotgun id of the project to store caches for
-        :param plugin_id: Unique string to identify the scope for a particular plugin
-                          or integration. For more information,
-                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
-                          non-plugin based toolkit projects, this value is None.
-        :param pipeline_configuration_id: The shotgun pipeline config id to store caches for
+        :param int project_id: The shotgun id of the project to store caches for. None if
+                               the configuration is a site configuration.
+        :param str plugin_id: Unique string to identify the scope for a particular plugin
+                              or integration. For more information,
+                              see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                              non-plugin based toolkit projects, this value is None.
+        :param int pipeline_configuration_id: The shotgun pipeline configuration id to store caches
+                                              for. If the pipeline configuration is unmanaged, it
+                                              will be ``None``
         :returns: The path to a path cache file. This file should exist when this method returns.
+        :rtype: str
         """
         # backwards compatibility with custom hooks created before 0.18
         if hasattr(self, "path_cache") and callable(getattr(self, "path_cache")):
@@ -67,7 +65,6 @@ class CacheLocation(HookBaseClass):
                 project_id = 0
 
             return self.path_cache(project_id, pipeline_configuration_id)
-
 
         cache_filename = "path_cache.db"
 
@@ -115,34 +112,41 @@ class CacheLocation(HookBaseClass):
 
     def get_bundle_data_cache_path(self, project_id, plugin_id, pipeline_configuration_id, bundle):
         """
-        Establish a cache folder for an app, engine or framework.
+        Establish a cache folder for an application, engine or framework.
 
-        This hook method was introduced in Toolkit v0.18 and replaces bundle_cache.
-        If you already have implemented bundle_cache, this will be detected and called instead,
-        however we strongly recommend that you tweak your hook.
-        
-        Apps, Engines or Frameworks commonly caches data on disk. This can be 
-        small files, shotgun queries, thumbnails etc. This method implements the 
-        logic which defines this location on disk. The cache should be organized in 
-        a way so that all instances of the app can re-use the same data. (Apps 
+        This hook method was introduced in Toolkit v0.18 and replaces the previous ``bundle_cache``
+        method. If you already have implemented ``bundle_cache``, this will be detected and called
+        instead, however we strongly recommend that you tweak your hook.
+
+        Applications, Engines or Frameworks commonly cache data on disk. This can be
+        small files, shotgun queries, thumbnails, etc. This method implements the
+        logic which defines this location on disk. The cache should be organized in
+        a way so that all instances of the app can re-use the same data. Applications
         which needs to cache things per-instance can implement this using a sub
-        folder inside the bundle cache location).
+        folder inside the bundle cache location.
 
         It is possible to omit some components of the path by explicitly passing
-        a `None` value for them, only the bundle name is required. For example,
-        with `project_id=None`, a site level cache path will be returned.
-        Ommitting the `project_id` can be used to cache data for the site
+        a ``None`` value for them. Only the bundle name is required. For example,
+        with ``project_id=None``, a site level cache path will be returned.
+        Omitting the ``project_id`` can be used to cache data for the site
         configuration, or to share data accross all projects belonging to a
         common site.
 
-        :param project_id: The shotgun id of the project to store caches for, or None.
-        :param plugin_id: Unique string to identify the scope for a particular plugin
-                          or integration, or None. For more information,
-                          see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
-                          non-plugin based toolkit projects, this value is None.
-        :param pipeline_configuration_id: The shotgun pipeline config id to store caches for, or None.
-        :param bundle: The app, engine or framework object which is requesting the cache folder.
+        The default implementation will create a folder inside the user's home folder or
+        under ``SHOTGUN_HOME``.
+
+        :param int project_id: The shotgun id of the project to store caches for, or None.
+        :param str plugin_id: Unique string to identify the scope for a particular plugin
+                              or integration, or None. For more information,
+                              see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
+                              non-plugin based toolkit projects, this value is None.
+        :param int pipeline_configuration_id: The shotgun pipeline config id to store caches for
+                                              or ``None`` if the pipeline configuration is unmanaged.
+        :param bundle: The application, engine or framework object which is requesting the cache folder.
+        :type bundle: :class:`~sgtk.platform.Engine`, :class:`~sgtk.platform.Framework` or
+                      :class:`~sgtk.platform.Application`
         :returns: The path to a folder which should exist on disk.
+        :rtype: str
         """
         # backwards compatibility with custom hooks created before 0.18
         if hasattr(self, "bundle_cache") and callable(getattr(self, "bundle_cache")):
@@ -160,7 +164,6 @@ class CacheLocation(HookBaseClass):
                 project_id = 0
 
             return self.bundle_cache(project_id, pipeline_configuration_id, bundle)
-
 
         tk = self.parent
         cache_root = LocalFileStorageManager.get_configuration_root(
@@ -211,4 +214,3 @@ class CacheLocation(HookBaseClass):
         filesystem.ensure_folder_exists(target_path)
 
         return target_path
-

--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -37,13 +37,13 @@ class CacheLocation(HookBaseClass):
         The default implementation will create a folder inside the user's home folder or
         under ``SHOTGUN_HOME``.
 
-        :param int project_id: The shotgun id of the project to store caches for. None if
+        :param int project_id: The Shotgun id of the project to store caches for. None if
                                the configuration is a site configuration.
         :param str plugin_id: Unique string to identify the scope for a particular plugin
                               or integration. For more information,
                               see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
                               non-plugin based toolkit projects, this value is None.
-        :param int pipeline_configuration_id: The shotgun pipeline configuration id to store caches
+        :param int pipeline_configuration_id: The Shotgun pipeline configuration id to store caches
                                               for. If the pipeline configuration is unmanaged, it
                                               will be ``None``
         :returns: The path to a path cache file. This file should exist when this method returns.
@@ -112,17 +112,17 @@ class CacheLocation(HookBaseClass):
 
     def get_bundle_data_cache_path(self, project_id, plugin_id, pipeline_configuration_id, bundle):
         """
-        Establish a cache folder for an application, engine or framework.
+        Establish a cache folder for an app, engine or framework.
 
         This hook method was introduced in Toolkit v0.18 and replaces the previous ``bundle_cache``
         method. If you already have implemented ``bundle_cache``, this will be detected and called
         instead, however we strongly recommend that you tweak your hook.
 
-        Applications, Engines or Frameworks commonly cache data on disk. This can be
-        small files, shotgun queries, thumbnails, etc. This method implements the
+        Apps, Engines or Frameworks commonly cache data on disk. This can be
+        small files, Shotgun queries, thumbnails, etc. This method implements the
         logic which defines this location on disk. The cache should be organized in
-        a way so that all instances of the app can re-use the same data. Applications
-        which needs to cache things per-instance can implement this using a sub
+        a way so that all instances of the app can re-use the same data. Bundles
+        which need to cache things per-instance can implement this using a sub
         folder inside the bundle cache location.
 
         It is possible to omit some components of the path by explicitly passing
@@ -135,14 +135,14 @@ class CacheLocation(HookBaseClass):
         The default implementation will create a folder inside the user's home folder or
         under ``SHOTGUN_HOME``.
 
-        :param int project_id: The shotgun id of the project to store caches for, or None.
+        :param int project_id: The Shotgun id of the project to store caches for, or None.
         :param str plugin_id: Unique string to identify the scope for a particular plugin
                               or integration, or None. For more information,
                               see :meth:`~sgtk.bootstrap.ToolkitManager.plugin_id`. For
                               non-plugin based toolkit projects, this value is None.
-        :param int pipeline_configuration_id: The shotgun pipeline config id to store caches for
+        :param int pipeline_configuration_id: The Shotgun pipeline config id to store caches for
                                               or ``None`` if the pipeline configuration is unmanaged.
-        :param bundle: The application, engine or framework object which is requesting the cache folder.
+        :param bundle: The app, engine or framework object which is requesting the cache folder.
         :type bundle: :class:`~sgtk.platform.Engine`, :class:`~sgtk.platform.Framework` or
                       :class:`~sgtk.platform.Application`
         :returns: The path to a folder which should exist on disk.

--- a/hooks/context_additional_entities.py
+++ b/hooks/context_additional_entities.py
@@ -1,49 +1,50 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-*******************************************************************************
-* DEPRECATION WARNING!                                                        *
-*******************************************************************************
-This hook should not be used if you aren't already using it.  It probably 
-doesn't do what you think it does and it will likely be removed in a future 
-release.
-
-Email support@shotgunsoftware.com if you have any questions about how to 
-migrate away from this hook.
-*******************************************************************************
-
 Hook which provides advanced customization of context creation.
-Returns a dict with two keys:
 
-    entity_types_in_path: a list of Shotgun entity types (ie. CustomNonProjectEntity05) that
-        context_from_path should recognize and use to fill its additional_entities list.
-    
-    entity_fields_on_task: a list of Shotgun fields (ie. sg_extra_link) on the Task entity
-        that context_from_entity should query Shotgun for and insert the resulting entities
-        into its additional_entities_list.
+.. deprecated:: v0.17.26
+    This hook should not be used if you aren't already using it.  It probably
+    doesn't do what you think it does and it will likely be removed in a future
+    release.
 
+    Email support@shotgunsoftware.com if you have any questions about how to
+    migrate away from this hook.
 """
-
 from tank import Hook
 
-class ContextAdditionalEntities(Hook):
 
+class ContextAdditionalEntities(Hook):
     def execute(self, **kwargs):
         """
-        The default implementation does not do anything.
+        Provides a list of additional entity types and task fields to be
+        used when populating :attr:`sgtk.Context.additional_entities`
+
+        The method should return a dictionary with two lists:
+
+        **entity_types_in_path** (:class:`list`) - A list of Shotgun entity types
+        (ie. CustomNonProjectEntity05) that :meth:`sgtk.Sgtk.context_from_path`
+        should recognize and insert into :attr:`sgtk.Context.additional_entities`.
+
+        **entity_types_in_path** (:class:`list`) - A list of Shotgun fields on the ``Task`` entity
+        that meth:`sgtk.context_from_entity` should query Shotgun for and
+        insert the resulting entities into :attr:`sgtk.Context.additional_entities`.
+
+        The default implementation returns empty lists.
+
+        :returns: A dictionary with keys ``entity_types_in_path`` and ``entity_fields_on_task``.
+        :rtype dict:
         """
-        
         val = {
             "entity_types_in_path": [],
             "entity_fields_on_task": []
         }
-        
         return val

--- a/hooks/context_change.py
+++ b/hooks/context_change.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Shotgun Software Inc.
+# Copyright (c) 2018 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -9,50 +9,57 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Context change hook.
+This hook gets executed before and after the context changes in Toolkit.
 """
 
 from tank import get_hook_baseclass
 
 
-class ContextChangeHook(get_hook_baseclass()):
+class ContextChange(get_hook_baseclass()):
     """
-    Hook that gets executed every single time there is a context change in Toolkit.
+    - If an engine **starts up**, the ``current_context`` passed to the hook
+      methods will be ``None`` and the ``next_context`` parameter will be set
+      to the context that the engine is starting in.
 
-        - If an engine **starts up**, the ``current_context`` passed to the hook
-        methods will be ``None`` and the ``next_context`` parameter will be set
-        to the context that the engine is starting in.
+    - If an engine is being **reloaded**, in the context of an engine restart
+      for example, the ``current_context`` and ``next_context`` will usually be
+      the same.
 
-        - If an engine is being **reloaded**, in the context of an engine restart
-        for example, the ``current_context`` and ``next_context`` will usually be
-        the same.
-
-        - If a **context switch** is requested, for example when a user switches
-        from project to shot mode in Nuke Studio, ``current_context`` and ``next_context``
-        will contain two different context.
+    - If a **context switch** is requested, for example when a user switches
+      from project to shot mode in Nuke Studio, ``current_context`` and ``next_context``
+      will contain two different context.
 
     .. note::
 
        These hooks are called whenever the context is being set in Toolkit. It is
        possible that the new context will be the same as the old context. If
-       you want to trigger some behaviour only when the new one is different
-       from the old one, you'll need to compare the two arguments.
+       you want to trigger some behavior only when the new one is different
+       from the old one, you'll need to compare the two arguments using the
+       ``!=`` operator.
     """
 
     def pre_context_change(self, current_context, next_context):
         """
-        Called before the context has changed.
+        Executed before the context has changed.
+
+        The default implementation does nothing.
 
         :param current_context: The context of the engine.
+        :type current_context: :class:`~sgtk.Context`
         :param next_context: The context the engine is switching to.
+        :type next_context: :class:`~sgtk.Context`
         """
         pass
 
     def post_context_change(self, previous_context, current_context):
         """
-        Called after the context has changed.
+        Executed after the context has changed.
+
+        The default implementation does nothing.
 
         :param previous_context: The previous context of the engine.
+        :type previous_context: :class:`~sgtk.Context`
         :param current_context: The current context of the engine.
+        :type current_context: :class:`~sgtk.Context`
         """
         pass

--- a/hooks/engine_init.py
+++ b/hooks/engine_init.py
@@ -1,27 +1,32 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Hook that gets executed every time an engine has fully initialized.
-
+Hook that gets executed every time an engine has been fully initialized.
 """
 
 from tank import Hook
-import os
- 
+
+
 class EngineInit(Hook):
-    
+
     def execute(self, engine, **kwargs):
         """
-        Gets executed when a Toolkit engine has fully initialized.
+        Executed when a Toolkit engine has been fully initialized.
+
         At this point, all applications and frameworks have been loaded,
         and the engine is fully operational.
+
+        The default implementation does nothing.
+
+        :param engine: Engine that has been initialized.
+        :type engine: :class:`~sgtk.platform.Engine`
         """
         pass

--- a/hooks/engine_init.py
+++ b/hooks/engine_init.py
@@ -21,7 +21,7 @@ class EngineInit(Hook):
         """
         Executed when a Toolkit engine has been fully initialized.
 
-        At this point, all applications and frameworks have been loaded,
+        At this point, all apps and frameworks have been loaded,
         and the engine is fully operational.
 
         The default implementation does nothing.

--- a/hooks/ensure_folder_exists.py
+++ b/hooks/ensure_folder_exists.py
@@ -1,42 +1,40 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-This hook is called when an engine, app or framework calls 
-
-> self.ensure_folder_exists(path)
-
-Typically apps, engines and frameworks call this method
-when they want to ensure that leaf-level folder structure
-exists on disk. The default implementation just creates these
-folders with very open permissions, and will typically not need
-to be customized.
-
-In case customization is required, the hook is passed the app/engine/framework
-that issued the original request - this gives access to configuration,
-app methods, environment etc. and should allow for some sophisticated
-introspection inside the hook.
+This hook is called when an engine, application or framework's
+:class:`~sgtk.platform.Application.ensure_folder_exists` method is called.
 """
 
 from sgtk.util import filesystem
 from sgtk import Hook
 
+
 class EnsureFolderExists(Hook):
-    
+
     def execute(self, path, bundle_obj, **kwargs):
         """
-        Handle folder creation issued from an app, framework or engine.
-        
-        :param path: path to create
-        :param bundle_object: object requesting the creation. This is a legacy
+        Creates folders on disk.
+
+        Toolkit bundles call this method when they want to ensure that
+        a leaf-level folder structure exists on disk. In the case where customization
+        is required, the hook is passed the bundle that issued the original request.
+        This should allow for some sophisticated introspection inside the hook.
+
+        The default implementation creates these folders with read/write
+        permissions for everyone.
+
+        :param str path: path to create
+        :param bundle_object: Object requesting the creation. This is a legacy
                               parameter and we recommend using self.parent instead.
+        :type bundle_object: :class:`~sgtk.platform.Engine`, :class:`~sgtk.platform.Framework`
+            or :class:`~sgtk.platform.Application`
         """
         filesystem.ensure_folder_exists(path, permissions=0777)
-

--- a/hooks/ensure_folder_exists.py
+++ b/hooks/ensure_folder_exists.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-This hook is called when an engine, application or framework's
+This hook is called when an engine, app or framework's
 :class:`~sgtk.platform.Application.ensure_folder_exists` method is called.
 """
 

--- a/hooks/example_template_hook.py
+++ b/hooks/example_template_hook.py
@@ -34,15 +34,13 @@ class ExampleTemplateHook(Hook):
 
     def execute(self, setting, bundle_obj, extra_params, **kwargs):
         """
-        Example pass-through implementation. One option is expected in extra_params,
-        and this will be returned.
+        Example pass-through implementation. One option is expected in ``extra_params``
+        and it will be returned.
 
         So the following two things will evaluate to the same thing:
 
         > template_snapshot: maya_shot_publish
         > template_snapshot: hook:example_template_hook:maya_shot_publish
-
-
 
         :param setting: The name of the setting for which we are evaluating
                         In our example above, it would be template_snapshot.

--- a/hooks/example_template_hook.py
+++ b/hooks/example_template_hook.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -13,49 +13,48 @@ This hook is a simple example to illustrate how template settings in an app
 can be evaluated at runtime based on complex conditions.
 
 If you have an app which has a template parameter, you would typically use a setting
-which points to one of your templates. So in the environment config, you would have:
+which points to one of your templates. So in the environment config, you would have::
 
-template_snapshot: maya_shot_publish
+    template_snapshot: maya_shot_publish
 
-However if you want more complex behaviour, it is possible to specify that a hook
-should be used to evaluate the setting at runtime rather than just set it. 
-For example:
+However if you want more complex behavior, it is possible to specify that a hook
+should be used to evaluate the setting at runtime rather than just set it.
+For example::
 
-template_snapshot: "hook:example_template_hook:maya_shot_publish"
+    template_snapshot: "hook:example_template_hook:maya_shot_publish"
 
-This setting would look for a core hook named example_template_hook and execute it.
+This setting would look for a core hook named ``example_template_hook`` and execute it.
 See below for an example implementation and parameter descriptions.
 """
 
 from tank import Hook
-import os
 
-class ProceduralTemplateEvaluator(Hook):
-    
+
+class ExampleTemplateHook(Hook):
+
     def execute(self, setting, bundle_obj, extra_params, **kwargs):
         """
         Example pass-through implementation. One option is expected in extra_params,
         and this will be returned.
-        
+
         So the following two things will evaluate to the same thing:
-        
+
         > template_snapshot: maya_shot_publish
         > template_snapshot: hook:example_template_hook:maya_shot_publish
-        
-        
-        
-        :param setting: The name of the setting for which we are evaluating 
+
+
+
+        :param setting: The name of the setting for which we are evaluating
                         In our example above, it would be template_snapshot.
-                         
+
         :param bundle_obj: The app, engine or framework object that the setting
                            is associated with.
-        
+
         :param extra_params: List of options passed from the setting. If the settings
                              string is "hook:hook_name:foo:bar", extra_params would
-                             be ['foo', 'bar'] 
-                             
+                             be ['foo', 'bar']
+
         returns: needs to return the name of a template, as a string.
         """
         template_name = extra_params[0]
         return template_name
-        

--- a/hooks/get_current_login.py
+++ b/hooks/get_current_login.py
@@ -1,44 +1,52 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Hook that gets executed when the current user is being retrieved.
 
-Please note that this hook will only be called whenever Toolkit doesn't 
-have an authenticated user present. In releases prior to v0.16, this was the case 
-for all users and projects, however as of Core v0.16 and above, projects are set
+Please note that this hook will only be called whenever Toolkit doesn't
+have an authenticated user present. In releases prior to v0.16, this was the case
+for all users and projects. However, as of Core v0.16 and above, projects are set
 up to require users to log in by default, meaning that there already is a well
 established notion of who the current user is.
 
-But even in such projects, there are environments (render farms for example),
-where a user cannot easily log in, and a Shotgun script user typically is being
-used for "headless" operation of Toolkit. In these cases, Toolkit doesn't know
-which Shotgun user is associated with the operation and this hook will be called.
+Even with such projects, there are environments, e.g. render farms, where a user
+cannot easily log in, and a Shotgun script user typically is being used for
+"headless" operation of Toolkit. In these cases, Toolkit doesn't know which
+Shotgun user is associated with the operation and this hook will be called.
 
-The return value from this hook will then be compared with the availalble logins
-for all users in Shotgun and if a match is found, this is deemed to be the 
+The return value from this hook will then be compared with the available logins
+for all users in Shotgun and if a match is found, this is deemed to be the
 current user.
 """
 
 from tank import Hook
-import os, sys
- 
+import os
+import sys
+
+
 class GetCurrentLogin(Hook):
-    
+
     def execute(self, **kwargs):
         """
-        Return the login name for the user currently logged in. This is typically used
-        by Toolkit to resolve against the 'login' field in the Shotgun users table in order
-        to extract further metadata.
+        Retrieves the login name for the Shotgun user.
+
+        This is used by Toolkit to resolve against the ``login`` field in the
+        Shotgun users table in order to extract further metadata.
+
+        The default implementation will return the OS user's login name.
+
+        :returns: A name that matches the user's ``login`` field in Shotgun.
+        :rtype: str
         """
-        if sys.platform == "win32": 
+        if sys.platform == "win32":
             # http://stackoverflow.com/questions/117014/how-to-retrieve-name-of-current-windows-user-ad-or-local-using-python
             return os.environ.get("USERNAME", None)
         else:
@@ -48,4 +56,3 @@ class GetCurrentLogin(Hook):
                 return pwd_entry[0]
             except:
                 return None
-        

--- a/hooks/log_metrics.py
+++ b/hooks/log_metrics.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2016 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-"""Hook that gets executed every time Toolkit logs user metrics."""
+"""
+Hook that gets executed every time Toolkit logs user metrics."""
 
 from tank import Hook
 
@@ -21,48 +22,27 @@ class LogMetrics(Hook):
             This method is deprecated and is not executed anymore.
 
             Please check :meth:`LogMetrics.log_metrics`.
-
-        Called when Toolkit logs user metrics.
-        
-        :param list metrics: list of dictionaries with logged data.
-
-        The metrics dictionaries will take one of two forms:
-
-        1. A user attribute metric. These typically log the version of
-           an app, engine, framework, DCC, etc.
-
-        {
-            "type": "user_attribute",
-            "attr_name": <attr name>
-            "attr_value": <attr value>
-        }
-
-        2. A user activity metric. These metrics are more common and
-           log the usage of a particular api, hook, engine, app, framework,
-           method, etc.
-
-        {
-            "type": "user_activity",
-            "module": <module name>
-            "action": <action name>
-        }
-
         """
         pass
 
     def log_metrics(self, metrics):
         """
-        Called when Toolkit logs metrics.
-        
-        :param list metrics: list of :attr:`~tank.util.EventMetric.data` dictionaries
-        with logged data.
+        Called when Toolkit logs a list of metrics.
 
+        A metric is a dictionary with three items:
 
-        .. note:: 
-            This hook will be executed within one or more
-            dedicated metrics logging worker threads and not in the main thread.
-            Overriding this hook may require additional care to avoid issues
-            related to accessing shared resources across multiple threads.
+        - **event_group** (:class:`str`) - Name of the event group.
+        - **event_name** (:class:`str`) - Name of the event.
+        - **event_properties** (:class:`list`) - List of properties for the event.
 
+        The default implementation does nothing.
+
+        :param list(dict) metrics: List of metrics.
+
+        .. note::
+            This hook will be executed within one or more dedicated metrics logging
+            worker threads and not in the main thread. Overriding this hook may
+            require additional care to avoid issues related to accessing shared
+            resources across multiple threads.
         """
         pass

--- a/hooks/pick_environment.py
+++ b/hooks/pick_environment.py
@@ -1,33 +1,41 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Hook which chooses an environment file to use based on the current context.
-This file is almost always overridden by a standard config.
-
+This file is almost always overridden by a configuration.
 """
 
 from tank import Hook
+
 
 class PickEnvironment(Hook):
 
     def execute(self, context, **kwargs):
         """
-        The default implementation assumes there are two environments, called shot 
-        and asset, and switches to these based on entity type.
+        Executed when Toolkit needs to pick an environment file.
+
+        The default implementation will return ``shot`` or ``asset`` based
+        on the type of the entity in :attr:`sgtk.Context.entity`. If the type
+        does not match ``Shot`` or ``Asset``, ``None`` will be returned.
+
+        :params context: The context for which an environment will be picked.
+        :type context: :class:`~sgtk.Context`
+
+        :returns: Name of the environment to use or ``None`` is there was no match.
+        :rtype: str
         """
-        
-        # must have an entity
+        # Must have an entity
         if context.entity is None:
             return None
-        
+
         if context.entity["type"] == "Shot":
             return "shot"
         elif context.entity["type"] == "Asset":

--- a/hooks/pipeline_configuration_init.py
+++ b/hooks/pipeline_configuration_init.py
@@ -1,31 +1,26 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Hook that gets executed every time a new PipelineConfiguration
-instance is created.
-
+Hook that gets executed every time a new PipelineConfiguration instance is created.
 """
-
-import os
-import sys
 
 from tank import Hook
 
-# Actual hook class.
-#
+
 class PipelineConfigurationInit(Hook):
 
     def execute(self, **kwargs):
         """
-        Gets executed when a new PipelineConfiguration instance is initialized.
+        Executed when a new PipelineConfiguration instance is initialized.
+
+        The default implementation does nothing.
         """
         pass
-

--- a/hooks/process_folder_creation.py
+++ b/hooks/process_folder_creation.py
@@ -1,16 +1,16 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-I/O Hook which creates folders on disk.
-
+This hook is invoked during folder creation when :meth:`sgtk.Sgtk.create_filesystem_structure` is
+called.
 """
 
 from tank import Hook
@@ -18,128 +18,135 @@ import os
 import sys
 import shutil
 
+
 class ProcessFolderCreation(Hook):
-    
+
     def execute(self, items, preview_mode, **kwargs):
         """
-        The default implementation creates folders recursively using open permissions.
-        
-        This hook should return a list of created items.
-        
-        Items is a list of dictionaries. Each dictionary can be of the following type:
-        
-        Standard Folder
-        ---------------
+        Creates a list of files and folders.
+
+        The default implementation creates files and folders recursively using
+        open permissions.
+
+        :param list(dict): List of actions that needs to take place.
+
+        Six different types of actions are supported.
+
+        **Standard Folder**
+
         This represents a standard folder in the file system which is not associated
         with anything in Shotgun. It contains the following keys:
-        
-        * "action": "folder"
-        * "metadata": The configuration yaml data for this item
-        * "path": path on disk to the item
-        
-        Entity Folder
-        -------------
-        This represents a folder in the file system which is associated with a 
+
+        - **action** (:class:`str`) - ``folder``
+        - **metadata** (:class:`dict`) - The configuration yaml data for this item
+        - **path** (:class:`str`) - path on disk to the item
+
+        **Entity Folder**
+
+        This represents a folder in the file system which is associated with a
         shotgun entity. It contains the following keys:
-        
-        * "action": "entity_folder"
-        * "metadata": The configuration yaml data for this item
-        * "path": path on disk to the item
-        * "entity": Shotgun entity link dict with keys type, id and name.
-        
-        Remote Entity Folder
-        --------------------
+
+        - **action** (:class:`str`) - ``entity_folder``
+        - **metadata** (:class:`dict`) - The configuration yaml data for this item
+        - **path** (:class:`str`) - path on disk to the item
+        - **entity** (:class:`dict`) - Shotgun entity link with keys ``type``, ``id`` and ``name``.
+
+        **Remote Entity Folder**
+
         This is the same as an entity folder, except that it was originally
         created in another location. A remote folder request means that your
         local toolkit instance has detected that folders have been created by
         a different file system setup. It contains the following keys:
-        
-        * "action": "remote_entity_folder"
-        * "metadata": The configuration yaml data for this item
-        * "path": path on disk to the item
-        * "entity": Shotgun entity link dict with keys type, id and name.
 
-        File Copy
-        ---------
+        - **action** (:class:`str`) - ``remote_entity_folder``
+        - **metadata** (:class:`dict`) - The configuration yaml data for this item
+        - **path** (:class:`str`) - path on disk to the item
+        - **entity** (:class:`dict`) - Shotgun entity link with keys ``type``, ``id`` and ``name``.
+
+        **File Copy**
+
         This represents a file copy operation which should be carried out.
         It contains the following keys:
-        
-        * "action": "copy"
-        * "metadata": The configuration yaml data associated with the directory level 
-                      on which this object exists.
-        * "source_path": location of the file that should be copied
-        * "target_path": target location to where the file should be copied.
-        
-        File Creation
-        -------------
+
+        - **action** (:class:`str`) - ``copy``
+        - **metadata** (:class:`dict`) - The configuration yaml data associated with the directory level
+          on which this object exists.
+        - **source_path** (:class:`str`) - location of the file that should be copied
+        - **target_path** (:class:`str`) - target location to where the file should be copied.
+
+        **File Creation**
+
         This is similar to the file copy, but instead of a source path, a chunk
         of data is specified. It contains the following keys:
-        
-        * "action": "create_file"
-        * "metadata": The configuration yaml data associated with the directory level 
-                      on which this object exists.
-        * "content": file content
-        * "target_path": target location to where the file should be copied.
- 
-        Symbolic Links
-        -------------
-        This represents a request that a symbolic link is created. Note that symbolic links are not 
+
+        - **action** (:class:`str`) - ``create_file``
+        - **metadata** (:class:`dict`) - The configuration yaml data associated with the directory level
+          on which this object exists.
+        - **content** (:class:`str`) -- file content
+        - **target_path** (:class:`str`) -- target location to where the file should be copied.
+
+        **Symbolic Links**
+
+        This represents a request that a symbolic link is created. Note that symbolic links are not
         supported in the same way on all operating systems. The default hook therefore does not
         implement symbolic link support on Windows systems. If you want to add symbolic link support
         on windows, simply copy this hook to your project configuration and make the necessary
         modifications.
-        
-        * "action": "symlink"
-        * "metadata": The raw configuration yaml data associated with symlink yml config file.
-        * "path": the path to the symbolic link
-        * "target": the target to which the symbolic link should point
+
+        - **action** (:class:`str`) - ``symlink``
+        - **metadata** (:class:`dict`) - The raw configuration yaml data associated with symlink yml config file.
+        - **path** (:class:`str`) - the path to the symbolic link
+        - **target** (:class:`str`) - the target to which the symbolic link should point
+
+        :returns: List of files and folders that have been created.
+        :rtype: list(str)
         """
-        
+
         # set the umask so that we get true permissions
         old_umask = os.umask(0)
-        folders = []
+        locations = []
         try:
 
             # loop through our list of items
             for i in items:
-                
+
                 action = i.get("action")
-                
+
                 if action in ["entity_folder", "folder"]:
                     # folder creation
-                    path = i.get("path")    
+                    path = i.get("path")
                     if not os.path.exists(path):
                         if not preview_mode:
                             # create the folder using open permissions
                             os.makedirs(path, 0777)
-                        folders.append(path)
-                        
+                        locations.append(path)
+
                 elif action == "remote_entity_folder":
                     # Remote folder creation
                     #
                     # NOTE! This action happens when another user has created
-                    # a folder on their machine and we are syncing our local path 
+                    # a folder on their machine and we are syncing our local path
                     # cache to be aware of this folder's existance.
-                    # 
+                    #
                     # For a traditional setup, where the project storage is shared,
                     # there is no need to do I/O for remote folders - these folders
                     # have already been created on the remote storage so you have access
-                    # to them already. 
-                    # 
+                    # to them already.
+                    #
                     # On a setup where each user or group of users is attached to
-                    # different, independendent file storages, which are synced, 
+                    # different, independendent file storages, which are synced,
                     # it may be meaningful to "replay" the remote folder creation
                     # on the local system. This would result in the same folder
                     # scaffold on each disk which is storing project data.
-                    # 
-                    # path = i.get("path")    
+                    #
+                    # path = i.get("path")
                     # if not os.path.exists(path):
                     #     if not preview_mode:
                     #         # create the folder using open permissions
                     #         os.makedirs(path, 0777)
-                    #     folders.append(path)
+                    #     locations.append(path)
                     pass
-                
+
                 elif action == "symlink":
                     # symbolic link
                     if sys.platform == "win32":
@@ -152,7 +159,7 @@ class ProcessFolderCreation(Hook):
                     if not os.path.lexists(path):
                         if not preview_mode:
                             os.symlink(target, path)
-                        folders.append(path)
+                        locations.append(path)
 
                 elif action == "copy":
                     # a file copy
@@ -164,8 +171,8 @@ class ProcessFolderCreation(Hook):
                             shutil.copy(source_path, target_path)
                             # set permissions to open
                             os.chmod(target_path, 0666)
-                        folders.append(target_path)
-    
+                        locations.append(target_path)
+
                 elif action == "create_file":
                     # create a new file based on content
                     path = i.get("path")
@@ -181,11 +188,9 @@ class ProcessFolderCreation(Hook):
                             fp.close()
                             # and set permissions to open
                             os.chmod(path, 0666)
-                        folders.append(path)
-                    
-        
+                        locations.append(path)
         finally:
             # reset umask
             os.umask(old_umask)
 
-        return folders
+        return locations

--- a/hooks/process_folder_creation.py
+++ b/hooks/process_folder_creation.py
@@ -44,7 +44,7 @@ class ProcessFolderCreation(Hook):
         **Entity Folder**
 
         This represents a folder in the file system which is associated with a
-        shotgun entity. It contains the following keys:
+        Shotgun entity. It contains the following keys:
 
         - **action** (:class:`str`) - ``entity_folder``
         - **metadata** (:class:`dict`) - The configuration yaml data for this item

--- a/hooks/process_folder_name.py
+++ b/hooks/process_folder_name.py
@@ -1,49 +1,54 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Core hook which handles conversion of shotgun field data into strings.
 
-This hook can be used to control how folders are named on disk given 
+This hook can be used to control how folders are named on disk given
 a field in shotgun. Should for example spaces be replaced by underscores
 or periods when folders are created?
 
-Also this conversion hook may raise exceptions in order to indicate a validation, 
-for example if an invalid naming convention is being used:
+This hook can also be used to raise an exception if an invalid naming convention
+is being used, for example:
 
-if entity_type == "Shot" and str_value.startswith("AA"):
-   raise TankError("Shot names cannot start with AA!")
+.. code-block:: python
 
+    if entity_type == "Shot" and str_value.startswith("AA"):
+       raise TankError("Shot names cannot start with AA!")
 """
 
 from tank import Hook
-from tank import TankError
 import re
+
 
 class ProcessFolderName(Hook):
 
     def execute(self, entity_type, entity_id, field_name, value, **kwargs):
         """
-        Default implementation. The following parameters are passed:
-        
-        * entity_type: the shotgun entity type for which the value is taken
-        * entity_id: The entity id representing the data
-        * field_name: the shotgun field associated with the value
-        * value: the actual value in some form, as returned by shotgun        
-        
-        Generates a string value given some shotgun value.
-        Doing smart conversions, so that for example
-        a {"type":"Shot", "id":123, "name":"foo"} ==> "foo"
-        
+        Executed when an entity needs to be turned into a string token during folder
+        creation.
+
+        The default implementation will turn non-ascii characters into hyphens and
+        replace spaces with underscores.
+
+        For example, ``{"type":"Shot", "id":123, "name":"Pont de L\xc3\xa9vis"}`` would
+        be converted to ``Pont_de_L-vis``.
+
+        :param str entity_type: The Shotgun entity type for which the value is taken.
+        :param int entity_id: The entity id representing the data.
+        :param str field_name: The Shotgun field associated with the value.
+        :param object value: The actual value in some form, as returned by the Shotgun API.
+
+        :returns: A string repsenting the entity.
+        :rtype: str
         """
-                
         if value.__class__ == dict and "name" in value:
             # it is a dictionary with a name key - assume this is what we want
             # this is normally an entity link
@@ -51,14 +56,14 @@ class ProcessFolderName(Hook):
             # {"type":"Shot", "id":123, "name":"foo"} ==> "foo"
             #
             str_value = str(value["name"])
-            
+
         elif value.__class__ == list and len(value) == 0:
             # this an empty list.
             #
             # [] ==> ""
             #
             str_value = ""
-            
+
         elif value.__class__ == list and len(value) > 0:
             # this is a multi entity link with at least one element
             # that element is a dict with a name field
@@ -68,43 +73,43 @@ class ProcessFolderName(Hook):
             # [{"name":"foo"}, {"name":"bar"}] ==> "foo_bar"
             #
             try:
-                str_value = "_".join( [x["name"] for x in value] )
+                str_value = "_".join([x["name"] for x in value])
             except KeyError:
                 str_value = str(value)
-        
+
         elif isinstance(value, basestring):
             # no conversion required
             str_value = value
-            
+
         else:
             # assume all other value types convert to
             # a string
             str_value = str(value)
-            
-        # replace all non-alphanumeric characters with dashes, 
+
+        # replace all non-alphanumeric characters with dashes,
         # except for the project entity, where here are special rules
         is_project_name = (entity_type == "Project")
         str_value = self._replace_non_alphanumeric(str_value, is_project_name)
-        
+
         return str_value
-    
+
     def _replace_non_alphanumeric(self, src, is_project_name):
         """
-        Safely replace all non-alphanumeric characters 
+        Safely replace all non-alphanumeric characters
         with dashes (-).
-        
+
         Note, this handles non-ascii characters correctly
         """
-        
+
         if is_project_name:
             # regex to find non-word characters, except slashes and periods, which are preserved
             exp = re.compile(u"[^\w/\.]", re.UNICODE)
         else:
             # regex to find non-word characters - in ascii land, that is [^A-Za-z0-9_]
             # note that we use a unicode expression, meaning that it will include other
-            # "word" characters, not just A-Z.  
+            # "word" characters, not just A-Z.
             exp = re.compile(u"\W", re.UNICODE)
-        
+
         if isinstance(src, unicode):
             # src is unicode so we don't need to convert!
             return exp.sub("-", src)
@@ -113,4 +118,3 @@ class ProcessFolderName(Hook):
             # and re-encode the returned result
             u_src = src.decode("utf-8")
             return exp.sub("-", u_src).encode("utf-8")
-    

--- a/hooks/process_folder_name.py
+++ b/hooks/process_folder_name.py
@@ -9,10 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Core hook which handles conversion of shotgun field data into strings.
+Core hook which handles conversion of Shotgun field data into strings.
 
 This hook can be used to control how folders are named on disk given
-a field in shotgun. Should for example spaces be replaced by underscores
+a field in Shotgun. Should for example spaces be replaced by underscores
 or periods when folders are created?
 
 This hook can also be used to raise an exception if an invalid naming convention

--- a/hooks/resolve_publish.py
+++ b/hooks/resolve_publish.py
@@ -1,34 +1,36 @@
-# Copyright (c) 2017 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook used to resolve publish records in Shotgun into local form on a machine during
+a call to :meth:`sgtk.util.resolve_publish_path`.
+"""
+
 from sgtk import Hook
 
 
-class PublishResolver(Hook):
-    """
-    Hook used to resolve publish records in Shotgun into
-    local form on a machine.
-    """
+class ResolvePublish(Hook):
 
     def resolve_path(self, sg_publish_data):
         """
         Resolves a Shotgun publish record into a local file on disk.
-        If the method returns None, the default implementation will be used.
 
-        For more information, see
-        http://developer.shotgunsoftware.com/tk-core/utils.html#sgtk.util.resolve_publish_path
+        If this method returns ``None``, it indicates to Toolkit that the default
+        publish resolution logic should be used.
 
-        :param sg_publish_data: Dictionary containing Shotgun publish data.
+        The default implementation of this hook returns ``None``
+
+        :param dict sg_publish_data: Dictionary containing Shotgun publish data.
             Contains at minimum a code, type, id and a path key.
 
-        :returns: Local Path or None to indicate no resolve.
+        :returns: Path to the local file or ``None``.
+        :rtype str:
         """
         return None
-
-

--- a/hooks/tank_init.py
+++ b/hooks/tank_init.py
@@ -1,25 +1,28 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Hook that gets executed every time a new Toolkit API instance is created.
-
 """
 
 from tank import Hook
-import os
- 
+
+
 class TankInit(Hook):
-    
+
     def execute(self, **kwargs):
         """
-        Gets executed when a new Toolkit API instance is initialized.
+        Executed when a new Toolkit API instance is initialized.
+
+        You can access the Toolkit API instance through ``self.parent``.
+
+        The default implementation does nothing.
         """
         pass

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -233,7 +233,7 @@ class Hook(object):
         """
         The sgtk core API instance associated with the Hook parent.
 
-        .. deprecated::
+        .. deprecated:: v0.18.70
            Use :meth:`sgtk` instead.
         """
         return self.sgtk


### PR DESCRIPTION
With the help from this other [PR](https://github.com/shotgunsoftware/tk-internal/pull/28), we can now import the hooks from the hooks folder during documentation generation.

I've polished up the hooks docstrings to bring them at the same level as the rest of our docs.

Download this [zip](https://github.com/shotgunsoftware/tk-core/files/2402261/doc.zip) to see what it looks like. You can reach them by clicking on Core -> Hooks -> Core Hooks. 

