### PR TITLE
SG-3025: Ensures that some supplementary config files exist in baked configs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@
 # travis-ci.org CI unit tests integration configuration file.
 
 language: python
+sudo: required
 
 matrix:
   include:

--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -171,6 +171,11 @@ class BakedConfiguration(Configuration):
         )
 
         config_writer.ensure_project_scaffold()
+        # The install_location.yml file isn't really needed for the baked config itself,
+        # but we have logic in tk-core that is used to introspect the current config
+        # for some actions, like the setup project wizard and core localization. Those
+        # commands fail if we don't have this additional config content in place.
+        config_writer.write_install_location_file()
         config_descriptor.copy(os.path.join(path, "config"))
         config_writer.install_core(config_descriptor.resolve_core_descriptor())
 
@@ -184,6 +189,11 @@ class BakedConfiguration(Configuration):
             bundle_cache_fallback_paths=[],
             source_descriptor=None
         )
+
+        # Same thing here as above for the install_location file. We don't really
+        # need the tank command and interpreter_*.cfg files for the config itself,
+        # but other logic in tk-core relies on them existing.
+        config_writer.create_tank_command()
 
     @property
     def requires_dynamic_bundle_caching(self):

--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -171,11 +171,6 @@ class BakedConfiguration(Configuration):
         )
 
         config_writer.ensure_project_scaffold()
-        # The install_location.yml file isn't really needed for the baked config itself,
-        # but we have logic in tk-core that is used to introspect the current config
-        # for some actions, like the setup project wizard and core localization. Those
-        # commands fail if we don't have this additional config content in place.
-        config_writer.write_install_location_file()
         config_descriptor.copy(os.path.join(path, "config"))
         config_writer.install_core(config_descriptor.resolve_core_descriptor())
 

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -310,8 +310,9 @@ class ConfigurationWriter(object):
         )
 
         if os.path.exists(sg_code_location):
-            # warn if this file already exists
-            log.warning(
+            # We want to log that we're overwriting an existing file, but this file
+            # is almost exclusively auto generated, so we can do it as a debug.
+            log.debug(
                 "The file 'core/install_location.yml' exists in the configuration "
                 "but will be overwritten with an auto generated file."
             )

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -522,10 +522,37 @@ class SetupProjectWizard(object):
 
         # the defaults is to localize and pick up current core API
         curr_core_path = pipelineconfig_utils.get_path_to_current_core()
+
+        try:
+            core_path_object = pipelineconfig_utils.resolve_all_os_paths_to_core(curr_core_path)
+        except TankError:
+            self._log.debug(
+                "Unable to resolve all OS paths for the current tk-core path. Forging ahead with "
+                "only the current OS's core location."
+            )
+
+            # We really only the current OS path to continue with the project setup
+            # anyway, so we'll fall back on that if we're in a situation where the
+            # config doesn't contain an install_locations.yml file, which is the
+            # most likely situation we'd be in here. That's an intentional omission
+            # from baked configurations, as an example, and we don't want to stop
+            # project setups if the process is being run from an environment running
+            # from a baked config.
+            if sys.platform.startswith("linux"):
+                path_args = [None, os.path.expandvars(curr_core_path), None]
+            elif sys.platform == "darwin":
+                path_args = [None, None, os.path.expandvars(curr_core_path)]
+            elif sys.platform == "win32":
+                path_args = [os.path.expandvars(curr_core_path), None, None]
+            else:
+                msg = "Unsupported OS detected: %s" % sys.platform
+                raise TankError(msg)
+
+            core_path_object = ShotgunPath(*path_args).as_system_dict()
         
         return_data = { "localize": True,
                         "using_runtime": True,
-                        "core_path" : pipelineconfig_utils.resolve_all_os_paths_to_core(curr_core_path), 
+                        "core_path" : core_path_object, 
                         "pipeline_config": None
                       }
         

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -552,7 +552,7 @@ class SetupProjectWizard(object):
         
         return_data = { "localize": True,
                         "using_runtime": True,
-                        "core_path" : core_path_object, 
+                        "core_path": core_path_object, 
                         "pipeline_config": None
                       }
         

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -409,7 +409,8 @@ class TestBakedConfiguration(TestConfigurationBase):
 
     @patch("tank.authentication.ShotgunAuthenticator.get_user")
     @patch("sgtk.bootstrap.configuration_writer.ConfigurationWriter.install_core")
-    def test_build_and_use(self, core_install_mock, get_user_mock):
+    @patch("sgtk.bootstrap.configuration_writer.ConfigurationWriter.create_tank_command")
+    def test_build_and_use(self, core_install_mock, get_user_mock, create_tank_command_mock):
         """
         Test baking a plugin and bootstrapping it with current tk-core.
         """


### PR DESCRIPTION
Baked configs built into an sgtk plugin don't really need to contain install_location.yml, interpreter_*.cfg, and the tank command to function. However, we have some logic in places like the setup project wizard and core localization where the current config (which might be baked) is introspected in ways that require these files exist. This change ensures that they're created when an SGTK plugin is built with a baked config.