### PR TITLE
For SG-8646, do not always write configuration on bootstrap

### DIFF
--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -182,13 +182,11 @@ class CachedConfiguration(Configuration):
 
         # Pass 1:
         # first check if there is any config at all
-        # probe for info.yaml manifest file
-        sg_config_file = os.path.join(
+        sg_config_folder = os.path.join(
             self._path.current_os,
-            "config",
-            constants.BUNDLE_METADATA_FILE
+            "config"
         )
-        if not os.path.exists(sg_config_file):
+        if not os.path.exists(sg_config_folder):
             return self.LOCAL_CFG_MISSING
 
         if self._config_writer.is_transaction_pending():
@@ -203,17 +201,15 @@ class CachedConfiguration(Configuration):
             # not sure what version this is.
             return self.LOCAL_CFG_INVALID
 
-        fh = open(config_info_file, "rt")
         try:
-            data = yaml.load(fh)
-            deploy_generation = data["deploy_generation"]
-            descriptor_dict = data["config_descriptor"]
+            with open(config_info_file, "rt") as fh:
+                data = yaml.load(fh)
+                deploy_generation = data["deploy_generation"]
+                descriptor_dict = data["config_descriptor"]
         except Exception as e:
             # yaml info not valid.
             log.warning("Cannot parse file '%s' - ignoring. Error: %s" % (config_info_file, e))
             return self.LOCAL_CFG_INVALID
-        finally:
-            fh.close()
 
         if deploy_generation != constants.BOOTSTRAP_LOGIC_GENERATION:
             # different format or logic of the deploy itself.

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -25,7 +25,10 @@ class Configuration(object):
     An abstraction representation around a toolkit configuration.
     """
 
-    (LOCAL_CFG_UP_TO_DATE, LOCAL_CFG_MISSING, LOCAL_CFG_DIFFERENT, LOCAL_CFG_INVALID) = range(4)
+    LOCAL_CFG_UP_TO_DATE = "LOCAL_CFG_UP_TO_DATE"
+    LOCAL_CFG_MISSING = "LOCAL_CFG_MISSING"
+    LOCAL_CFG_DIFFERENT = "LOCAL_CFG_DIFFERENT"
+    LOCAL_CFG_INVALID = "LOCAL_CFG_INVALID"
 
     def __init__(self, path, descriptor):
         """

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -449,12 +449,7 @@ class TestCachedConfiguration(ShotgunTestBase):
 
         # Reset the tank_name and create a storage named after the one in the config.
         self.mockgun.update("Project", self.project["id"], {"tank_name": None})
-        self.mockgun.create("LocalStorage", {
-            "code": "primary",
-            "mac_path": "/shotgun/primary",
-            "linux_path": "/shotgun/primary",
-            "windows_path": "C:\\shotgun\\primary"
-        })
+        self.mockgun.create("LocalStorage", {"code": "primary"})
 
         # Initialize a cached configuration pointing to the config.
         config_root = os.path.join(self.fixtures_root, "bootstrap_tests", "config")
@@ -480,6 +475,9 @@ class TestCachedConfiguration(ShotgunTestBase):
         # we are indeed in the up to date state, which means everything is ready to do, is
         # to cheat and make the descriptor immutable by monkey-patching it.
         self._cached_config._descriptor.is_immutable = lambda: True
+        # Seems up the test tremendously since installing core becomes a noop.
+        self._cached_config._config_writer.install_core = lambda _: None
+        self._cached_config._config_writer.create_tank_command = lambda: None
 
     def test_verifies_tank_name(self):
         """

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -573,7 +573,7 @@ class TestCachedConfiguration(ShotgunTestBase):
         """
         path = self._cached_config._config_writer.get_descriptor_metadata_file()
         if corrupt:
-            data ="corrupted"
+            data = "corrupted"
         else:
             with open(path, "rt") as fh:
                 data = yaml.load(fh)


### PR DESCRIPTION
This fixes a very bad regression introduced by the changes to be able to run a configuration from the bundle cache, which resulted in the cached configuration to be rewritten every single time Toolkit bootstrapped.

This feature has now been thoroughly tested.