### PR TITLE
For SG-8449, path cache sandboxing fix

### DIFF
--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -190,8 +190,8 @@ class PathCache(object):
                 constants.CACHE_LOCATION_HOOK_NAME,
                 "get_path_cache_path",
                 project_id=self._tk.pipeline_configuration.get_project_id(),
-                # Do NOT use the plugin_id as a suffix for the path cache folder.
-                # This will prevent a sync from an engine to be reused by another.
+                # Do NOT use the plugin_id as a suffix for the path cache folder. This would
+                # prevent a path cache sync from an engine to be reused by another plugiin.
                 plugin_id=None,
                 pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id()
             )

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -190,7 +190,9 @@ class PathCache(object):
                 constants.CACHE_LOCATION_HOOK_NAME,
                 "get_path_cache_path",
                 project_id=self._tk.pipeline_configuration.get_project_id(),
-                plugin_id=self._tk.pipeline_configuration.get_plugin_id(),
+                # Do NOT use the plugin_id as a suffix for the path cache folder.
+                # This will prevent a sync from an engine to be reused by another.
+                plugin_id=None,
                 pipeline_configuration_id=self._tk.pipeline_configuration.get_shotgun_id()
             )
 

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -108,6 +108,28 @@ class TestInit(TestPathCache):
         column_names = [x[1] for x in ret.fetchall()]
         self.assertEquals(expected, column_names)
 
+    def test_db_location(self):
+        """
+        Ensure the path cache
+            - is always located in a folder named after the pipeline configuration
+            id and the project id
+            - doesn't use the plugin id.
+        """
+        expected = "p{0}c{1}".format(
+            self.tk.pipeline_configuration.get_project_id(),
+            self.tk.pipeline_configuration.get_shotgun_id()
+        )
+        with patch.object(self.tk.pipeline_configuration, "get_plugin_id", return_value="basic.maya"):
+            self.assertEqual(
+                expected,
+                os.path.basename(os.path.dirname(self.path_cache._get_path_cache_location()))
+            )
+
+        with patch.object(self.tk.pipeline_configuration, "get_plugin_id", return_value=None):
+            self.assertEqual(
+                expected,
+                os.path.basename(os.path.dirname(self.path_cache._get_path_cache_location()))
+            )
 
 
 class TestAddMapping(TestPathCache):


### PR DESCRIPTION
Path caches for descriptor-based configurations will now NOT use the `plugin_id` in the folder suffix for the path cache.

This will allow reuse of the path cache between DCCs that use the same pipeline configuration and project, requiring less syncs of the path cache. It also fixes an issue when launching apps in an asset or task context from Shotgun.