### PR TITLE
Logger message fix in the authentication utility script

### DIFF
--- a/developer/utils/authentication.py
+++ b/developer/utils/authentication.py
@@ -91,7 +91,7 @@ def authenticate(options):
             logger.error("Need to provide, host, script name and script key! Run with -h for more info.")
             return 2
 
-        logger.info("Connecting to %s using script user %s..." % (options.shotgun_host, script_name))
+        logger.info("Connecting to %s using script user %s..." % (shotgun_host, script_name))
         sg_user = sg_auth.create_script_user(script_name, script_key, shotgun_host)
 
     else:


### PR DESCRIPTION
When running the script `populate_bundle_cache.py` I discovered that the logger message was not correct, because it was saying that the Shotgun Host is None.

This message is generated in the authentication utility. The issue was that the `options.shotgun_host` variable was used instead of `shotgun_host`

![shotgun_host](https://user-images.githubusercontent.com/2762494/46848807-89d2d000-cdb1-11e8-9417-14a2449cb33e.png)

