### PR TITLE
For SG-9118, better handling of local file linking errors when publishing

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -2308,25 +2308,23 @@ class Engine(TankBundle):
         THIS METHOD HAS BEEN DEPRECATED AND SHOULD NOT BE USED!
         Instead, call _initialize_standard_look_and_feel()
         **********************************************************************
-        
+
         For environments which do not have a well defined QT style sheet,
         Toolkit maintains a "standard style" which is similar to the look and
-        feel that Maya and Nuke has. 
-        
+        feel that Maya and Nuke has.
+
         This is intended to be used in conjunction with QTs cleanlooks mode.
         The init code inside an engine would typically look something like this:
-        
+
             QtGui.QApplication.setStyle("cleanlooks")
             qt_application = QtGui.QApplication([])
-            qt_application.setStyleSheet( self._get_standard_qt_stylesheet() )         
-        
+            qt_application.setStyleSheet( self._get_standard_qt_stylesheet() )
+
         :returns: The style sheet data, as a string.
         """
         css_file = self.__get_platform_resource_path("toolkit_std_dark.css")
-        f = open(css_file)
-        css_data = f.read()
-        f.close()
-        return css_data
+        with open(css_file) as f:
+            return f.read()
 
     def _register_shared_framework(self, instance_name, fw_obj):
         """

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -316,12 +316,18 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     except Exception as e:
         # Log the exception so the original traceback is available
         log.exception(e)
-        # Raise our own exception with the original message and the created entity,
-        # if any
-        raise ShotgunPublishError(
-            error_message="%s" % e,
-            entity=entity
-        )
+        if "[Attachment.local_storage] does not exist" in str(e):
+            raise ShotgunPublishError(
+                "Local File Linking seems to be turned off. "
+                "Turn it on on your Site Preferences Page."
+            )
+        else:
+            # Raise our own exception with the original message and the created entity,
+            # if any
+            raise ShotgunPublishError(
+                error_message="%s" % e,
+                entity=entity
+            )
 
 
 def _create_published_file(tk, context, path, name, version_number, task, comment, published_file_type,

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -319,7 +319,8 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
         if "[Attachment.local_storage] does not exist" in str(e):
             raise ShotgunPublishError(
                 "Local File Linking seems to be turned off. "
-                "Turn it on on your Site Preferences Page."
+                "Turn it on on your Site Preferences Page.",
+                entity
             )
         else:
             # Raise our own exception with the original message and the created entity,

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -83,7 +83,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         ):
 
             if sys.platform == "win32":
-                local_path = r"x:\tmp\win\path\to\file.txt",
+                local_path = r"x:\tmp\win\path\to\file.txt"
             else:
                 local_path = "/tmp/nix/path/to/file.txt"
 

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -72,6 +72,30 @@ class TestShotgunRegisterPublish(TankTestBase):
         self.name = "Test Publish"
         self.version = 1
 
+    def test_local_storage_disabled(self):
+        """
+        Checks that if local storage is disabled that we raise a more user friendly error
+        than a CRUD message.
+        """
+        with patch.object(
+            self.tk.shotgun, "create",
+            side_effect=Exception("[Attachment.local_storage] does not exist")
+        ):
+
+            if sys.platform == "win32":
+                local_path = r"x:\tmp\win\path\to\file.txt",
+            else:
+                local_path = "/tmp/nix/path/to/file.txt"
+
+            with self.assertRaisesRegex(tank.util.ShotgunPublishError, "Local File Linking seems to be turned off"):
+                tank.util.register_publish(
+                    self.tk,
+                    self.context,
+                    local_path,
+                    self.name,
+                    self.version
+                )
+
     def test_sequence_abstracted_path(self):
         """Test that if path supplied represents a sequence, the abstract version of that
         sequence is used."""


### PR DESCRIPTION
Catches the Attachment.local_storage error and raises a more meaningful error message.

This is how the error shows up in the publisher. Ideally we would get better formatting in the app itself.
![screen shot 2018-11-01 at 13 43 16](https://user-images.githubusercontent.com/8126447/47869001-21897400-dddc-11e8-88aa-103482106ed1.png)
