### PR TITLE
SG-9437 Fix: Removes the temporary duplicate commands

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1092,6 +1092,10 @@ class Engine(TankBundle):
             "properties": properties,
         }
 
+        # If there was a duplicate, now clean up the temporary duplicate command.
+        if name in self.__commands_that_need_prefixing:
+            del(self.__commands[new_name_for_existing])
+
 
     def register_panel(self, callback, panel_name="main", properties=None):
         """


### PR DESCRIPTION
<img width="391" alt="untitled_and_shotgun_and_menubar" src="https://user-images.githubusercontent.com/3777228/48358978-e0267d80-e693-11e8-8cdb-f9fe6d0eeebf.png">

This fixes an issue with duplicate menu entries being created when registering commands.

Repro:

1. Use a standard default config, and enable `show_convert_actions: true` on the nuke writenode.
2. Launch Nuke and switch to a context via the open app, that will use the settings you just set.
3. Menu's for convert options should now appear.
4. Now change context to a different entity task, and the menus should duplicate up.

With this fix, this should no longer happen.
I'm also curious as to if this is the right fix to do, and also if [this](https://github.com/shotgunsoftware/tk-core/blob/master/python/tank/platform/engine.py#L1037-L1046) code is needed. Or at least the `self.__commands_that_need_prefixing` variable seems like we could get away without it.
