### PR TITLE
For SG-8310: initial support for Unified Login Flow

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -129,7 +129,7 @@ Exception Classes
     :inherited-members:
     :members:
 
-.. autoclass:: ConsoleLoginSupportedError
+.. autoclass:: ConsoleLoginNotSupportedError
     :show-inheritance:
     :inherited-members:
     :members:

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -129,3 +129,8 @@ Exception Classes
     :inherited-members:
     :members:
 
+.. autoclass:: ConsoleLoginSupportedError
+    :show-inheritance:
+    :inherited-members:
+    :members:
+

--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -25,6 +25,10 @@ from .errors import (  # noqa
     IncompleteCredentials,
     ShotgunAuthenticationError,
 )
+from .web_login_support import (
+    get_shotgun_authenticator_support_web_login,
+    set_shotgun_authenticator_support_web_login,
+)
 from .shotgun_authenticator import ShotgunAuthenticator
 from .defaults_manager import DefaultsManager
 from .core_defaults_manager import CoreDefaultsManager

--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -21,7 +21,8 @@ credentials are reused if available.
 from .errors import (  # noqa
     AuthenticationCancelled,
     AuthenticationError,
-    ConsoleLoginWithSSONotSupportedError,
+    ConsoleLoginWithSSONotSupportedError,  # For backward compatibility.
+    ConsoleLoginNotSupportedError,
     IncompleteCredentials,
     ShotgunAuthenticationError,
 )

--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -33,4 +33,5 @@ from .user import (  # noqa
     serialize_user,
     ShotgunSamlUser,
     ShotgunUser,
+    ShotgunWebUser,
 )

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -22,15 +22,34 @@ from __future__ import print_function
 
 from . import session_cache
 from .. import LogManager
-from .errors import AuthenticationError, AuthenticationCancelled, ConsoleLoginWithSSONotSupportedError
-from tank_vendor import shotgun_api3
+from .errors import (
+    AuthenticationError,
+    AuthenticationCancelled,
+    ConsoleLoginWithAutodeskIdentityNotSupportedError,
+    ConsoleLoginWithSSONotSupportedError,
+)
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
-from .sso_saml2 import is_sso_enabled_on_site
+from .sso_saml2 import (
+    is_autodesk_identity_enabled_on_site,
+    is_sso_enabled_on_site,
+)
 from ..util.shotgun.connection import sanitize_url
 
 from getpass import getpass
 
 logger = LogManager.get_logger(__name__)
+
+
+def _validate_console_session_is_supported(hostname, http_proxy):
+    """
+    Simple utility method which will raise an exception if using a
+    username/password pair is not supported by the Shotgun server.
+    Which is the case when using SSO or Autodesk Identity.
+    """
+    if is_sso_enabled_on_site(hostname, http_proxy):
+        raise ConsoleLoginWithSSONotSupportedError(hostname)
+    if is_autodesk_identity_enabled_on_site(hostname, http_proxy):
+        raise ConsoleLoginWithAutodeskIdentityNotSupportedError(hostname)
 
 
 class ConsoleAuthenticationHandlerBase(object):
@@ -165,8 +184,7 @@ class ConsoleRenewSessionHandler(ConsoleAuthenticationHandlerBase):
         """
         print("%s, your current session has expired." % login)
 
-        if is_sso_enabled_on_site(shotgun_api3, hostname, http_proxy):
-            raise ConsoleLoginWithSSONotSupportedError(hostname)
+        _validate_console_session_is_supported(hostname, http_proxy)
 
         print("Please enter your password to renew your session for %s" % hostname)
         return hostname, login, self._get_password()
@@ -195,15 +213,13 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
         :returns: A tuple of (login, password) strings.
         """
         if self._fixed_host:
-            if is_sso_enabled_on_site(shotgun_api3, hostname, http_proxy):
-                raise ConsoleLoginWithSSONotSupportedError(hostname)
+            _validate_console_session_is_supported(hostname, http_proxy)
             print("Please enter your login credentials for %s" % hostname)
 
         else:
             print("Please enter your login credentials.")
             hostname = self._get_keyboard_input("Host", hostname)
-            if is_sso_enabled_on_site(shotgun_api3, hostname, http_proxy):
-                raise ConsoleLoginWithSSONotSupportedError(hostname)
+            _validate_console_session_is_supported(hostname, http_proxy)
 
         login = self._get_keyboard_input("Login", login)
         password = self._get_password()

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -45,11 +45,10 @@ def _assert_console_session_is_supported(hostname, http_proxy):
     username/password pair is not supported by the Shotgun server.
     Which is the case when using SSO or Autodesk Identity.
     """
-    if (
-        is_sso_enabled_on_site(hostname, http_proxy) or
-        is_autodesk_identity_enabled_on_site(hostname, http_proxy)
-    ):
-        raise ConsoleLoginNotSupportedError(hostname)
+    if is_sso_enabled_on_site(hostname, http_proxy):
+        raise ConsoleLoginNotSupportedError(hostname, "Single Sign-On")
+    if is_autodesk_identity_enabled_on_site(hostname, http_proxy):
+        raise ConsoleLoginNotSupportedError(hostname, "Autodesk Identity")
 
 
 class ConsoleAuthenticationHandlerBase(object):

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -89,5 +89,5 @@ class ConsoleLoginWithAutodeskIdentityNotSupportedError(AuthenticationSSOError):
         """
         super(ConsoleLoginWithAutodeskIdentityNotSupportedError, self).__init__(
             "Authentication using username/password is not supported on "
-            "the console for %s, an SSO-enabled site." % url
+            "the console for %s, an Autodesk Identity-enabled site." % url
         )

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -61,13 +61,15 @@ class ConsoleLoginNotSupportedError(ShotgunAuthenticationError):
     an SSO-enabled site.
     """
 
-    def __init__(self, url):
+    def __init__(self, url, site_auth_type="Single Sign-On"):
         """
         :param str url: Url of the site where login was attempted.
+        :param str site_auth_type: type of authentication, e.g. SSO, Identity.
+                                   The default value is for backward compatibility.
         """
         super(ConsoleLoginNotSupportedError, self).__init__(
             "Authentication using username/password is not supported on "
-            "the console for %s." % url
+            "the console %s for sites using %s." % (url, site_auth_type)
         )
 
 

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -55,13 +55,7 @@ class AuthenticationCancelled(ShotgunAuthenticationError):
         )
 
 
-class AuthenticationSSOError(ShotgunAuthenticationError):
-    """
-    Base class for all SSO-related exceptions coming out from this module.
-    """
-
-
-class ConsoleLoginWithSSONotSupportedError(AuthenticationSSOError):
+class ConsoleLoginNotSupportedError(ShotgunAuthenticationError):
     """
     Thrown when attempting to use Username/Password pair to login onto
     an SSO-enabled site.
@@ -71,23 +65,10 @@ class ConsoleLoginWithSSONotSupportedError(AuthenticationSSOError):
         """
         :param str url: Url of the site where login was attempted.
         """
-        super(ConsoleLoginWithSSONotSupportedError, self).__init__(
+        super(ConsoleLoginNotSupportedError, self).__init__(
             "Authentication using username/password is not supported on "
-            "the console for %s, an SSO-enabled site." % url
+            "the console for %s." % url
         )
 
-
-class ConsoleLoginWithAutodeskIdentityNotSupportedError(AuthenticationSSOError):
-    """
-    Thrown when attempting to use Username/Password pair to login onto
-    an Autodesk Identity-enabled site.
-    """
-
-    def __init__(self, url):
-        """
-        :param str url: Url of the site where login was attempted.
-        """
-        super(ConsoleLoginWithAutodeskIdentityNotSupportedError, self).__init__(
-            "Authentication using username/password is not supported on "
-            "the console for %s, an Autodesk Identity-enabled site." % url
-        )
+# For backward compatibility.
+ConsoleLoginWithSSONotSupportedError = ConsoleLoginNotSupportedError

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -70,5 +70,6 @@ class ConsoleLoginNotSupportedError(ShotgunAuthenticationError):
             "the console for %s." % url
         )
 
+
 # For backward compatibility.
 ConsoleLoginWithSSONotSupportedError = ConsoleLoginNotSupportedError

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -64,13 +64,30 @@ class AuthenticationSSOError(ShotgunAuthenticationError):
 class ConsoleLoginWithSSONotSupportedError(AuthenticationSSOError):
     """
     Thrown when attempting to use Username/Password pair to login onto
-    a SSO-enabled site.
+    an SSO-enabled site.
     """
 
     def __init__(self, url):
         """
         :param str url: Url of the site where login was attempted.
         """
-        ShotgunAuthenticationError.__init__(
-            self, "Authentication using username/password is not supported on the console for %s, an SSO-enabled site." % url
+        super(ConsoleLoginWithSSONotSupportedError, self).__init__(
+            "Authentication using username/password is not supported on "
+            "the console for %s, an SSO-enabled site." % url
+        )
+
+
+class ConsoleLoginWithAutodeskIdentityNotSupportedError(AuthenticationSSOError):
+    """
+    Thrown when attempting to use Username/Password pair to login onto
+    an Autodesk Identity-enabled site.
+    """
+
+    def __init__(self, url):
+        """
+        :param str url: Url of the site where login was attempted.
+        """
+        super(ConsoleLoginWithAutodeskIdentityNotSupportedError, self).__init__(
+            "Authentication using username/password is not supported on "
+            "the console for %s, an SSO-enabled site." % url
         )

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -354,6 +354,11 @@ class LoginDialog(QtGui.QDialog):
         # environment, use the Unified Login Flow for all authentication modes.
         if get_shotgun_authenticator_support_web_login():
             use_web = use_web or self._query_task.unified_login_flow_enabled
+
+        # if we are switching from one mode (using the web) to another (not using
+        # the web), or vice-versa, we need to update the GUI.
+        # In web-based authentication, the web form is in charge of obtaining
+        # and validating the user credentials.
         if self._use_web != use_web:
             self._use_web = not self._use_web
             if self._use_web:

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -17,8 +17,6 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
-import os
-
 from tank_vendor import shotgun_api3
 from .web_login_support import get_shotgun_authenticator_support_web_login
 from .ui import resources_rc # noqa
@@ -71,17 +69,17 @@ class QuerySiteAndUpdateUITask(QtCore.QThread):
 
     @property
     def sso_enabled(self):
-        """Bool Read-only property."""
+        """returns: `True` if SSO is enabled, `False` otherwise."""
         return self._sso_enabled
 
     @property
     def autodesk_identity_enabled(self):
-        """Bool Read-only property."""
+        """returns: `True` if Identity is enabled, `False` otherwise."""
         return self._autodesk_identity_enabled
 
     @property
     def unified_login_flow_enabled(self):
-        """Bool Read-only property."""
+        """returns: `True` if ULF is enabled, `False` otherwise."""
         return self._unified_login_flow_enabled
 
     @property
@@ -354,7 +352,7 @@ class LoginDialog(QtGui.QDialog):
 
         # If we have full support for Web-based login, or if we enable it in our
         # environment, use the Unified Login Flow for all authentication modes.
-        if get_shotgun_authenticator_support_web_login() or "SHOTGUN_USE_ULF" in os.environ:
+        if get_shotgun_authenticator_support_web_login():
             use_web = use_web or self._query_task.unified_login_flow_enabled
         if self._use_web != use_web:
             self._use_web = not self._use_web

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -129,9 +129,9 @@ class LoginDialog(QtGui.QDialog):
             "QtWebKit": QtWebKit,
         }
         try:
-            self._sso_saml2 = SsoSaml2Toolkit("SSO Login", qt_modules=qt_modules)
+            self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)
         except SsoSaml2MissingQtModuleError as e:
-            logger.info("SSO login not supported due to missing Qt module: %s" % e)
+            logger.info("Web login not supported due to missing Qt module: %s" % e)
             self._sso_saml2 = None
 
         hostname = hostname or ""

--- a/python/tank/authentication/sso_saml2/__init__.py
+++ b/python/tank/authentication/sso_saml2/__init__.py
@@ -36,6 +36,9 @@ from .utils import (  # noqa
     get_logger,
     get_saml_claims_expiration,
     has_sso_info_in_cookies,
+    has_unified_login_flow_info_in_cookies,
     is_sso_enabled_on_site,
+    is_autodesk_identity_enabled_on_site,
+    is_unified_login_flow_enabled_on_site,
     set_logger_parent,
 )

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 """
-Module to support SSO login via a web browser and automated session renewal.
+Module to support Web login via a web browser and automated session renewal.
 """
 
 import base64
@@ -51,11 +51,11 @@ SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
 
 
 class SsoSaml2Core(object):
-    """Performs Shotgun SSO login and pre-emptive renewal."""
+    """Performs Shotgun Web login and pre-emptive renewal for SSO sessions."""
 
-    def __init__(self, window_title="SSO", qt_modules=None):
+    def __init__(self, window_title="Web Login", qt_modules=None):
         """
-        Create a SSO login dialog, using a Web-browser like environment.
+        Create a Web login dialog, using a Web-browser like environment.
 
         :param window_title: Title to use for the window.
         :param qt_modules:   a dictionnary of required Qt modules.
@@ -485,7 +485,7 @@ class SsoSaml2Core(object):
 
         :returns: 1 if successful, 0 otherwise.
         """
-        self._logger.debug("SSO login attempt")
+        self._logger.debug("Web login attempt")
         QtCore = self._QtCore  # noqa
 
         if event_data is not None:

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -447,6 +447,10 @@ class SsoSaml2Core(object):
         """
         url = self._view.page().mainFrame().url().toString().encode("utf-8")
         if (
+                # This callback may be triggered outside the actual auth process
+                # like when we clear the page to use the "about:blank".
+                # or after there has been a prior error. So we ensure that we
+                # update our session and accept only when we really have to.
                 self._session is not None and self._event_data is not None and
                 url.startswith(self._session.host + self._event_data["landing_path"])
         ):

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -86,7 +86,7 @@ def _get_shotgun_user_id(cookies):
     user_id = None
     user_domain = None
     for cookie in cookies:
-        if cookie.startswith("csrf_token_u") or cookie == "shotgun_current_user_id":
+        if cookie.startswith("csrf_token_u"):
             # Shotgun appends the unique numerical ID of the user to the cookie name:
             # ex: csrf_token_u78
             if user_id is not None:
@@ -100,10 +100,7 @@ def _get_shotgun_user_id(cookies):
                 # have no way to identify the proper user id in the lot.
                 message = "The cookies for this user seem to come from two different shotgun sites: '%s' and '%s'"
                 raise SsoSaml2MultiSessionNotSupportedError(message % (user_domain, cookies[cookie]['domain']))
-            if cookie.startswith("csrf_token_u"):
-                user_id = cookie[12:]
-            else:
-                user_id = cookies[cookie].value
+            user_id = cookie[12:]
             user_domain = cookies[cookie]["domain"]
     return user_id
 
@@ -193,7 +190,8 @@ def get_session_expiration(encoded_cookies):
 
     :param encoded_cookies: An encoded string representing the cookie jar.
 
-    :returns: An int with the time in seconds since January 1st 1970 UTC, or None
+    :returns: An int with the time in seconds since January 1st 1970 UTC, or None if the cookie
+              'shotgun_current_session_expiration' is not defined.
     """
     session_expiration = _get_cookie(encoded_cookies, "shotgun_current_session_expiration")
     if session_expiration is not None:

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -86,18 +86,42 @@ def _get_shotgun_user_id(cookies):
     user_id = None
     user_domain = None
     for cookie in cookies:
-        # Shotgun appends the unique numerical ID of the user to the cookie name:
-        # ex: shotgun_sso_session_userid_u78
-        if cookie.startswith("shotgun_sso_session_userid_u"):
+        if cookie.startswith("csrf_token_u") or cookie == "shotgun_current_user_id":
+            # Shotgun appends the unique numerical ID of the user to the cookie name:
+            # ex: csrf_token_u78
             if user_id is not None:
+                # For backward compatibility, we support both the old SAML cookies
+                # and the new Unified Login Flow cookies. Some information may
+                # be present in both formats, under a different cookie name.
+                if user_domain == cookies[cookie]["domain"]:
+                    continue
                 # Should we find multiple cookies with the same prefix, it means
                 # that we are using cookies from a multi-session environment. We
                 # have no way to identify the proper user id in the lot.
                 message = "The cookies for this user seem to come from two different shotgun sites: '%s' and '%s'"
                 raise SsoSaml2MultiSessionNotSupportedError(message % (user_domain, cookies[cookie]['domain']))
-            user_id = cookie[28:]
-            user_domain = cookies[cookie]['domain']
+            if cookie.startswith("csrf_token_u"):
+                user_id = cookie[12:]
+            else:
+                user_id = cookies[cookie].value
+            user_domain = cookies[cookie]["domain"]
     return user_id
+
+
+def _get_cookie(encoded_cookies, cookie_name):
+    """
+    Returns a cookie value based on its name.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+    :param cookie_name:     The name of the cookie.
+
+    :returns: A string of the cookie value, or None.
+    """
+    value = None
+    cookies = _decode_cookies(encoded_cookies)
+    if cookie_name in cookies:
+        value = cookies[cookie_name].value
+    return value
 
 
 def _get_cookie_from_prefix(encoded_cookies, cookie_prefix):
@@ -154,15 +178,32 @@ def get_saml_claims_expiration(encoded_cookies):
     """
     # Shotgun appends the unique numerical ID of the user to the cookie name:
     # ex: shotgun_sso_session_expiration_u78
-    saml_claims_expiration = _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_expiration_u")
+    saml_claims_expiration = (
+        _get_cookie(encoded_cookies, "shotgun_current_user_sso_claims_expiration") or
+        _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_expiration_u")
+    )
     if saml_claims_expiration is not None:
         saml_claims_expiration = int(saml_claims_expiration)
     return saml_claims_expiration
 
 
-def get_saml_user_name(encoded_cookies):
+def get_session_expiration(encoded_cookies):
     """
-    Obtain the saml user name from the Shotgun cookies.
+    Obtain the expiration time of the Shotgun session from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: An int with the time in seconds since January 1st 1970 UTC, or None
+    """
+    session_expiration = _get_cookie(encoded_cookies, "shotgun_current_session_expiration")
+    if session_expiration is not None:
+        session_expiration = int(session_expiration)
+    return session_expiration
+
+
+def get_user_name(encoded_cookies):
+    """
+    Obtain the user name from the Shotgun cookies.
 
     :param encoded_cookies: An encoded string representing the cookie jar.
 
@@ -170,7 +211,10 @@ def get_saml_user_name(encoded_cookies):
     """
     # Shotgun appends the unique numerical ID of the user to the cookie name:
     # ex: shotgun_sso_session_userid_u78
-    user_name = _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_userid_u")
+    user_name = (
+        _get_cookie(encoded_cookies, "shotgun_current_user_login") or
+        _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_userid_u")
+    )
     if user_name is not None:
         user_name = urllib.unquote(user_name)
     return user_name

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -43,7 +43,7 @@ class SsoSaml2(object):
 
     def __init__(self, window_title=None, qt_modules=None):
         """
-        Create a SSO login dialog, using a Web-browser like environment.
+        Create a Web login dialog, using a Web-browser like environment.
 
         :param window_title: Title to use for the window.
         :param qt_modules:   a dictionnary of required Qt modules.
@@ -51,7 +51,7 @@ class SsoSaml2(object):
 
         :returns: The SsoSaml2 oject.
         """
-        window_title = window_title or "SSO"
+        window_title = window_title or "Web Login"
         qt_modules = qt_modules or {}
 
         self._core = SsoSaml2Core(window_title=window_title, qt_modules=qt_modules)
@@ -75,7 +75,7 @@ class SsoSaml2(object):
 
         :returns: True if the login was successful.
         """
-        product = product or "Undefined"
+        product = product or "undefined"
 
         renew_path = self.renew_paths[self.Saml_flow]
         landing_path = self.landing_paths[self.Saml_flow]

--- a/python/tank/authentication/sso_saml2/sso_saml2_rv.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2_rv.py
@@ -25,7 +25,7 @@ class SsoSaml2Rv(SsoSaml2):
 
     def __init__(self, window_title=None, qt_modules=None):
         """
-        Create a SSO login dialog, using a Web-browser like environment.
+        Create a Web login dialog, using a Web-browser like environment.
 
         :param window_title: Title to use for the window.
         :param qt_modules:   a dictionnary of required Qt modules.
@@ -41,7 +41,7 @@ class SsoSaml2Rv(SsoSaml2):
 
         :param event: RV event. Not used.
         """
-        self._logger.debug("Cancel SSO login attempt")
+        self._logger.debug("Cancel Web login attempt")
 
         # We only need to cancel if there is login attempt currently being made.
         if self.is_handling_event():

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -28,6 +28,11 @@ from .core.utils import (  # noqa
 
 # Cache the servers infos for 30 seconds.
 INFOS_CACHE_TIMEOUT = 30
+# This is a global state variable. It is used to cache information about the Shotgun servers we
+# are interacting with. This is purely to avoid making multiple calls to the servers which would
+# yield back the same information. (That info is relatively constant on a given server)
+# Should this variable be cleared when doing a Python Core swap, it is not an issue.
+# The side effect would be an additional call to the Shotgun site.
 INFOS_CACHE = {}
 
 

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -59,6 +59,7 @@ def _get_site_infos(url, http_proxy=None):
             get_logger().debug(
                 "Using HTTP proxy to connect to the Shotgun server: %s", http_proxy
             )
+        # Checks if the information is in the cache, is missing or out of date.
         if url not in INFOS_CACHE or ((time.time() - INFOS_CACHE[url][0]) > INFOS_CACHE_TIMEOUT):
             get_logger().info("Infos for site '%s' not in cache or expired", url)
             infos = shotgun_api3.Shotgun(
@@ -85,7 +86,8 @@ def _get_user_authentication_method(url, http_proxy=None):
     :param url:            Url of the site to query.
     :param http_proxy:     HTTP proxy to use, if any.
 
-    :returns:   A string, or None, indicating which mode is used.
+    :returns:   A string, such as 'default', 'ldap', 'saml' or 'oxygen', indicating the mode used.
+                None is returned when the information is unavailable or we could not reach the site.
     """
     infos = _get_site_infos(url, http_proxy)
     user_authentication_method = None

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -26,7 +26,7 @@ from .core.utils import (  # noqa
 )
 
 
-# Cache the servers infos foe 30 seconds.
+# Cache the servers infos for 30 seconds.
 INFOS_CACHE_TIMEOUT = 30
 INFOS_CACHE = {}
 

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -11,31 +11,41 @@
 SSO/SAML2 Utility functions.
 """
 
+import time
+
+from tank_vendor import shotgun_api3
+
 from .core.utils import (  # noqa
     get_logger,
     set_logger_parent,
     get_saml_claims_expiration,
+    get_session_expiration,
     _decode_cookies,
     _get_shotgun_user_id,
     _sanitize_http_proxy,
 )
 
 
-def is_sso_enabled_on_site(shotgun_module, url, http_proxy=None):
+# Cache the servers infos foe 30 seconds.
+INFOS_CACHE_TIMEOUT = 30
+INFOS_CACHE = {}
+
+
+def _get_site_infos(url, http_proxy=None):
     """
-    Check to see if the web site uses sso.
+    Get and cache the desired site infos.
 
     We want this method to fail as quickly as possible if there are any
     issues. Failure is not considered critical, thus known exceptions are
     silently ignored. At the moment this method is only used to make the
     GUI show/hide some of the input fields.
 
-    :param shotgun_module: Instance of the Shotgun API3 module.
     :param url:            Url of the site to query.
     :param http_proxy:     HTTP proxy to use, if any.
 
-    :returns:   A boolean indicating if SSO has been enabled or not.
+    :returns:   A dictionary with the site infos.
     """
+    infos = {}
     try:
         # Temporary shotgun instance, used only for the purpose of checking
         # the site infos.
@@ -46,16 +56,105 @@ def is_sso_enabled_on_site(shotgun_module, url, http_proxy=None):
         # require authentication.
         http_proxy = _sanitize_http_proxy(http_proxy).netloc
         if http_proxy:
-            get_logger().debug("Using HTTP proxy to connect to the Shotgun server: %s" % http_proxy)
-        info = shotgun_module.Shotgun(url, session_token="dummy", connect=False, http_proxy=http_proxy).info()
-        get_logger().debug("User authentication method for %s: %s" % (url, info["user_authentication_method"]))
-        if "user_authentication_method" in info:
-            return info["user_authentication_method"] == "saml2"
+            get_logger().debug(
+                "Using HTTP proxy to connect to the Shotgun server: %s", http_proxy
+            )
+        if url not in INFOS_CACHE or ((time.time() - INFOS_CACHE[url][0]) > INFOS_CACHE_TIMEOUT):
+            get_logger().info("Infos for site '%s' not in cache or expired", url)
+            infos = shotgun_api3.Shotgun(
+                url,
+                session_token="dummy",
+                connect=False,
+                http_proxy=http_proxy
+            ).info()
+            INFOS_CACHE[url] = (time.time(), infos)
+        else:
+            get_logger().info("Infos for site '%s' found in cache", url)
+            infos = INFOS_CACHE[url][1]
     except Exception as e:
         # Silently ignore exceptions
-        get_logger().debug("Unable to connect with %s, got exception '%s' assuming SSO is not enabled" % (url, e))
+        get_logger().debug("Unable to connect with %s, got exception '%s'", url, e)
 
+    return infos
+
+
+def _get_user_authentication_method(url, http_proxy=None):
+    """
+    Get the user authentication method for site.
+
+    :param url:            Url of the site to query.
+    :param http_proxy:     HTTP proxy to use, if any.
+
+    :returns:   A string, or None, indicating which mode is used.
+    """
+    infos = _get_site_infos(url, http_proxy)
+    user_authentication_method = None
+    if "user_authentication_method" in infos:
+        get_logger().debug(
+            "User authentication method for %s: %s",
+            url,
+            infos["user_authentication_method"]
+        )
+        user_authentication_method = infos["user_authentication_method"]
+    return user_authentication_method
+
+
+def is_unified_login_flow_enabled_on_site(url, http_proxy=None):
+    """
+    Check to see if the web site uses the unified login flow.
+
+    This setting appeared in the Shotgun 7.X serie, being rarely enabled.
+    It became enabled by default starting at Shotgun 8.0
+
+    :param url:            Url of the site to query.
+    :param http_proxy:     HTTP proxy to use, if any.
+
+    :returns:   A boolean indicating if the unified login flow is enabled or not.
+    """
+    infos = _get_site_infos(url, http_proxy)
+    if "unified_login_flow_enabled" in infos:
+        get_logger().debug(
+            "unified_login_flow_enabled for %s: %s",
+            url,
+            infos["unified_login_flow_enabled"]
+        )
+        return infos["unified_login_flow_enabled"]
     return False
+
+
+def is_sso_enabled_on_site(url, http_proxy=None):
+    """
+    Check to see if the web site uses sso.
+
+    :param url:            Url of the site to query.
+    :param http_proxy:     HTTP proxy to use, if any.
+
+    :returns:   A boolean indicating if SSO has been enabled or not.
+    """
+    return _get_user_authentication_method(url, http_proxy) == "saml2"
+
+
+def is_autodesk_identity_enabled_on_site(url, http_proxy=None):
+    """
+    Check to see if the web site uses Autodesk Identity.
+
+    :param url:            Url of the site to query.
+    :param http_proxy:     HTTP proxy to use, if any.
+
+    :returns:   A boolean indicating if Autodesk Identity has been enabled or not.
+    """
+    return _get_user_authentication_method(url, http_proxy) == "oxygen"
+
+
+def has_unified_login_flow_info_in_cookies(encoded_cookies):
+    """
+    Indicate if the Unified Login Flow is being used from the Shotgun cookies.
+
+    :param encoded_cookies: An encoded string representing the cookie jar.
+
+    :returns: True if there are ULF infos in the cookies.
+    """
+    return get_session_expiration(encoded_cookies) is not None
 
 
 def has_sso_info_in_cookies(encoded_cookies):
@@ -66,5 +165,4 @@ def has_sso_info_in_cookies(encoded_cookies):
 
     :returns: True if there are SSO-related infos in the cookies.
     """
-    cookies = _decode_cookies(encoded_cookies)
-    return _get_shotgun_user_id(cookies) is not None
+    return get_saml_claims_expiration(encoded_cookies) is not None

--- a/python/tank/authentication/web_login_support.py
+++ b/python/tank/authentication/web_login_support.py
@@ -1,0 +1,55 @@
+"""
+Web-based login is required when the target Shotgun site uses SSO or Autodesk
+Identity for authentication.
+
+This flag will control if the Unified Login Flow is to be used or not. By
+default, it will not be used.
+
+Unfortunately, not all DCCs/Scripts/Applications that use the Toolkit have all
+the required dependencies to fully support Web-based authentication and renewal.
+This can be a problem for programs not started by the Shotgun Desktop or if
+the Shotgun Desktop is closed after. When the program attemps to authenticate
+or renew a session against a Shotgun site that uses SSO/Autodesk Identity, it
+will fail to do so and will not provide meaningful feedback to the user.
+
+The requirements are:
+- Full support for WebKit/WebEngine with access to the cookie store,
+- SSL support
+- TLS v1.2 support
+- NTLM patch
+
+Some of these could be checked at run-time, but others (TLS v1.2 support,
+NTLM patch) are more difficult to detect.
+
+Unless this flag is explicitely set to True by the enclosing program, we
+will take for granted that the full web login flow is not supported.
+
+WARNING: while SSO login has been supported since tk-core 0.18.151/Shotgun
+Desktop 1.5.3, it was possible for a DCC to be unable to authenticate or renew
+a session. This flag will not change that behaviour.
+
+At this time, only the Shotgun Desktop and Shotgun Create fully support the
+Web based authentication.
+"""
+shotgun_authenticator_support_web_login = False
+
+
+def set_shotgun_authenticator_support_web_login(enable):
+    """
+    Setting this flag to True indicates that the DCC/Script/Application is
+    able to fully support the Unified Login Flow.
+
+    :param enable: Bool indicating if the Unified Login Flow is supported.
+    """
+    global shotgun_authenticator_support_web_login
+    shotgun_authenticator_support_web_login = enable
+
+
+def get_shotgun_authenticator_support_web_login():
+    """
+    Indicates the support for the Unified Login Flow.
+
+    :returns: Bool indicating support for the Unified Login Flow.
+    """
+    global shotgun_authenticator_support_web_login
+    return shotgun_authenticator_support_web_login

--- a/python/tank/authentication/web_login_support.py
+++ b/python/tank/authentication/web_login_support.py
@@ -31,6 +31,14 @@ a session. This flag will not change that behaviour.
 At this time, only the Shotgun Desktop and Shotgun Create fully support the
 Web based authentication.
 """
+
+# This global variable is meant to affect the way the authentication is
+# handled by the toolkit-using application.
+# Initially, the only clients that will modify this value will be the
+# Shotgun Desktop and Shotgun Create.
+# This is the way for an application to clearly state: yes I support the ULF.
+# This value will properly be propagated across a core swap if the new core
+# also defines this variable.
 shotgun_authenticator_support_web_login = False
 
 

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -100,16 +100,16 @@ class Configuration(object):
 
         # Swap the core out if needed and ensure we use the right login
         # Get the user before the core swapping and serialize it.
-        from ..authentication import serialize_user, ShotgunSamlUser
+        from ..authentication import (
+            get_shotgun_authenticator_support_web_login,
+            serialize_user,
+            ShotgunSamlUser,
+        )
         serialized_user = serialize_user(sg_user)
 
         # Caching support for the Web authentication flow.
-        support_web_login = False
-        try:
-            from ..authentication import get_shotgun_authenticator_support_web_login
-            support_web_login = get_shotgun_authenticator_support_web_login()
-        except ImportError:
-            log.warning("This core does not support the Unified Login Flow")
+        support_web_login = get_shotgun_authenticator_support_web_login()
+        log.debug("Caching the old core's support of the Unified Login Flow: %s" % support_web_login)
 
         # Stop claims renewal before swapping core, but only if the claims loop
         # is actually active.

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -120,7 +120,6 @@ class Configuration(object):
         else:
             uses_claims_renewal = False
 
-        # @HERE:
         if self._swap_core_if_needed(python_core_path):
             log.debug("Core swapped, authenticated user will be set.")
         else:

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -16,6 +16,11 @@ from .import_handler import CoreImportHandler
 from ..log import LogManager
 from .. import pipelineconfig_utils
 from .. import constants
+from ..authentication import (
+    get_shotgun_authenticator_support_web_login,
+    serialize_user,
+    ShotgunSamlUser,
+)
 
 log = LogManager.get_logger(__name__)
 
@@ -89,6 +94,8 @@ class Configuration(object):
         """
         Returns a tk instance for this configuration.
 
+        It swaps the core out if needed and ensure we use the right login.
+
         :param sg_user: Authenticated Shotgun user to associate
                         the tk instance with.
 
@@ -98,13 +105,7 @@ class Configuration(object):
         path = self._path.current_os
         python_core_path = pipelineconfig_utils.get_core_python_path_for_config(path)
 
-        # Swap the core out if needed and ensure we use the right login
         # Get the user before the core swapping and serialize it.
-        from ..authentication import (
-            get_shotgun_authenticator_support_web_login,
-            serialize_user,
-            ShotgunSamlUser,
-        )
         serialized_user = serialize_user(sg_user)
 
         # Caching support for the Web authentication flow.

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -100,14 +100,16 @@ class Configuration(object):
 
         # Swap the core out if needed and ensure we use the right login
         # Get the user before the core swapping and serialize it.
-        from ..authentication import (
-            get_shotgun_authenticator_support_web_login,
-            serialize_user,
-            ShotgunSamlUser,
-        )
+        from ..authentication import serialize_user, ShotgunSamlUser
         serialized_user = serialize_user(sg_user)
+
         # Caching support for the Web authentication flow.
-        support_web_login = get_shotgun_authenticator_support_web_login()
+        support_web_login = False
+        try:
+            from ..authentication import get_shotgun_authenticator_support_web_login
+            support_web_login = get_shotgun_authenticator_support_web_login()
+        except ImportError:
+            log.warning("This core does not support the Unified Login Flow")
 
         # Stop claims renewal before swapping core, but only if the claims loop
         # is actually active.

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -24,6 +24,7 @@ from mock import patch
 from tank.authentication import (
     console_authentication,
     ConsoleLoginNotSupportedError,
+    ConsoleLoginWithSSONotSupportedError,
     interactive_authentication,
     invoker,
     user_impl,
@@ -313,6 +314,24 @@ class InteractiveTests(ShotgunTestBase):
         "tank.authentication.console_authentication.is_sso_enabled_on_site",
         return_value=True
     )
+    def test_sso_enabled_site_with_legacy_exception_name(self, *mocks):
+        """
+        Ensure that an exception is thrown should we attempt console authentication
+        on an SSO-enabled site. We use the legacy exception-name to ensure backward
+        compatibility with older code.
+        """
+        handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
+        with self.assertRaises(ConsoleLoginWithSSONotSupportedError):
+            handler._get_user_credentials(None, None, None)
+
+    @patch(
+        "__builtin__.raw_input",
+        side_effect=["  https://test-sso.shotgunstudio.com "]
+    )
+    @patch(
+        "tank.authentication.console_authentication.is_sso_enabled_on_site",
+        return_value=True
+    )
     def test_sso_enabled_site(self, *mocks):
         """
         Ensure that an exception is thrown should we attempt console authentication
@@ -333,7 +352,7 @@ class InteractiveTests(ShotgunTestBase):
     def test_identity_enabled_site(self, *mocks):
         """
         Ensure that an exception is thrown should we attempt console authentication
-        on an SSO-enabled site.
+        on an Autodesk Identity-enabled site.
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
         with self.assertRaises(ConsoleLoginNotSupportedError):

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -327,7 +327,7 @@ class InteractiveTests(ShotgunTestBase):
         side_effect=["  https://test-identity.shotgunstudio.com "]
     )
     @patch(
-        "tank.authentication.console_authentication.is_identity_enabled_on_site",
+        "tank.authentication.console_authentication.is_autodesk_identity_enabled_on_site",
         return_value=True
     )
     def test_identity_enabled_site(self, *mocks):

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -23,7 +23,7 @@ from tank_test.tank_test_base import ShotgunTestBase, skip_if_pyside_missing, sk
 from mock import patch
 from tank.authentication import (
     console_authentication,
-    ConsoleLoginWithSSONotSupportedError,
+    ConsoleLoginSupportedError,
     interactive_authentication,
     invoker,
     user_impl,
@@ -319,7 +319,24 @@ class InteractiveTests(ShotgunTestBase):
         on an SSO-enabled site.
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
-        with self.assertRaises(ConsoleLoginWithSSONotSupportedError):
+        with self.assertRaises(ConsoleLoginSupportedError):
+            handler._get_user_credentials(None, None, None)
+
+    @patch(
+        "__builtin__.raw_input",
+        side_effect=["  https://test-identity.shotgunstudio.com "]
+    )
+    @patch(
+        "tank.authentication.console_authentication.is_identity_enabled_on_site",
+        return_value=True
+    )
+    def test_identity_enabled_site(self, *mocks):
+        """
+        Ensure that an exception is thrown should we attempt console authentication
+        on an SSO-enabled site.
+        """
+        handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
+        with self.assertRaises(ConsoleLoginSupportedError):
             handler._get_user_credentials(None, None, None)
 
     @skip_if_on_travis_ci("Offscreen XServer doesn't do focus changes.")

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -23,7 +23,7 @@ from tank_test.tank_test_base import ShotgunTestBase, skip_if_pyside_missing, sk
 from mock import patch
 from tank.authentication import (
     console_authentication,
-    ConsoleLoginSupportedError,
+    ConsoleLoginNotSupportedError,
     interactive_authentication,
     invoker,
     user_impl,
@@ -319,7 +319,7 @@ class InteractiveTests(ShotgunTestBase):
         on an SSO-enabled site.
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
-        with self.assertRaises(ConsoleLoginSupportedError):
+        with self.assertRaises(ConsoleLoginNotSupportedError):
             handler._get_user_credentials(None, None, None)
 
     @patch(
@@ -336,7 +336,7 @@ class InteractiveTests(ShotgunTestBase):
         on an SSO-enabled site.
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
-        with self.assertRaises(ConsoleLoginSupportedError):
+        with self.assertRaises(ConsoleLoginNotSupportedError):
             handler._get_user_credentials(None, None, None)
 
     @skip_if_on_travis_ci("Offscreen XServer doesn't do focus changes.")

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from __future__ import with_statement
+import base64
 
 from tank_test.tank_test_base import setUpModule # noqa
 from tank_test.tank_test_base import ShotgunTestBase
@@ -17,6 +18,13 @@ from mock import patch
 
 from tank.authentication import user, user_impl
 from tank_vendor.shotgun_api3 import AuthenticationFault
+
+# Create a set of valid cookies, for SSO and Web related tests.
+# For a Web session, we detect the presence of the shotgun_current_session_expiration cookie.
+valid_web_session_metadata = base64.b64encode('shotgun_current_session_expiration=1234')
+# For a Saml session, we detect the presence of the shotgun_sso_session_expiration_u* cookie.
+# But we also need to figure out what the user ID is, for which we use the csrf_token_u* suffix.
+valid_sso_session_metadata = base64.b64encode('csrf_token_u00=fedcba;shotgun_sso_session_expiration_u00=4321')
 
 
 class UserTests(ShotgunTestBase):
@@ -29,13 +37,22 @@ class UserTests(ShotgunTestBase):
             http_proxy="http_proxy"
         ))
 
+    def _create_test_web_user(self):
+        return user.ShotgunWebUser(user_impl.SessionUser(
+            host="https://tank.shotgunstudio.com",
+            login="login",
+            session_token="session_token",
+            http_proxy="http_proxy",
+            session_metadata=valid_web_session_metadata,
+        ))
+
     def _create_test_saml_user(self):
         return user.ShotgunSamlUser(user_impl.SessionUser(
             host="https://tank.shotgunstudio.com",
             login="login",
             session_token="session_token",
             http_proxy="http_proxy",
-            session_metadata="session_metadata",
+            session_metadata=valid_sso_session_metadata,
         ))
 
     def test_attributes_valid(self):
@@ -77,12 +94,23 @@ class UserTests(ShotgunTestBase):
         """
         Makes sure serialization and deserialization works for users
         """
-        # First start with a non-SAML user.
+        # First start with a non-Web/non-SAML user.
         su = self._create_test_user()
         self.assertNotIsInstance(su, user.ShotgunSamlUser)
         self.assertFalse("session_metadata" in su.impl.to_dict())
         su_2 = user.deserialize_user(user.serialize_user(su))
         self.assertNotIsInstance(su_2, user.ShotgunSamlUser)
+        self.assertEqual(su.host, su_2.host)
+        self.assertEqual(su.http_proxy, su_2.http_proxy)
+        self.assertEqual(su.login, su_2.login)
+        self.assertEqual(su.impl.get_session_token(), su_2.impl.get_session_token())
+
+        # Then, with a Web user.
+        su = self._create_test_web_user()
+        self.assertIsInstance(su, user.ShotgunWebUser)
+        self.assertTrue("session_metadata" in su.impl.to_dict())
+        su_2 = user.deserialize_user(user.serialize_user(su))
+        self.assertIsInstance(su_2, user.ShotgunWebUser)
         self.assertEqual(su.host, su_2.host)
         self.assertEqual(su.http_proxy, su_2.http_proxy)
         self.assertEqual(su.login, su_2.login)


### PR DESCRIPTION
Given that the SAML login flow and the new Unified Login Flow were very similar, we have updated the existing code base to support the ULF. As with SSO, a Web-browser Qt object (WebKit/WebEngine) is used for the authentication.

This required the addition of a new outside-world exposed class: ShotgunWebUser. This is in order to leverage the existing session_metadata structure (which contains the serialized cookies of the Web-browser used for authentication). This is to support re-authentication.

The existing ShotgunSamlUser class becomes a specialized version of ShotgunWebUser, which provides the Claims Renewal functionalities.

For pre SG 8.0 sites which uses default authentication mode or LDAP, the same existing GUI will be presented (Console and QApplication).

For sites using SSO or Autodesk Identity sites, we will use the Unified Login Flow for the connection if a QApplication exists.

We could also use the Web login for regular Username/Password authentication. But this needs to be set by the calling application (SG Desktop in this case, in startup.py). So the current SG Desktop  would use the default built-in dialog for authentication.

NOTE: for SSO and Autodesk Identity, console authentication is not allowed and will generate an exception.

Videos:
1. case where we use Username/Password on a pre-SG 8.0 site (https://tank.shotgunstudio.com):
![case_1](https://user-images.githubusercontent.com/8060460/48530535-17e51f00-e866-11e8-9c8a-ac53214b801b.gif)

2. case where we use Username/Password on a SG 8.0 site, and we do not force the use of the Unified Login Flow (with an old SG Desktop) (https://hubertp-8-0.shotgunstudio.com)
![case_2a](https://user-images.githubusercontent.com/8060460/48685599-1af14f80-eb85-11e8-8915-c5e195c85759.gif)

3. case where we use Username/Password on a SG 8.0 site, but we use a SG Desktop that forces the use of the Unified Login Flow, or if the environment variable SHOTGUN_USE_ULF is set. (https://uirefresh.shotgustudio.com):
![case_2](https://user-images.githubusercontent.com/8060460/48530773-5202f080-e867-11e8-8fe1-99e2765a8cb5.gif)

4. case where we use Autodesk Identity on a SG 8.0 site (https://hubertp-studio.shotgunstudio.com)
![case_3](https://user-images.githubusercontent.com/8060460/48530893-e40af900-e867-11e8-95c4-2d4860aad4fc.gif)

5. case where we use an SSO site (no matter which version) (https://hubertp-sso.shotgunstudio.com):
![case_4](https://user-images.githubusercontent.com/8060460/48530999-61366e00-e868-11e8-8aa0-30576117404b.gif)

PLANNED UPCOMING FOLLOW-UP WORK:
- Proper support for Qt5 in sso_saml2,
- Refactor the initial GUI so that the WebView is actually one of the Stacked Widget in the dialog, instead of popping up a new modal window,
- Addition of a authenticator dialog property to indicate if the full Unified Login Flow/SAML Login Flow and renewal are supported. Some DCCs (Maya, Flame, etc.) are missing critical parts of Qt or the NTLM patch to correctly support the full login/renewal flow. Instead of giving a confusing UX to users we would tell them that they need to authenticate/renew with the SG Desktop or SG Create (both of which properly support the authentication flow).
