### PR TITLE
Adding context information to metrics logs

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -483,20 +483,39 @@ class Engine(TankBundle):
         this engine.
 
         The dictionary contains information about this engine: its name and version,
-        and informations about the application hosting the engine: its name and
-        version::
-        
+        information about the application hosting the engine: its name and
+        version, and the current context: all of its data, like entity, project and uses,
+        as a dictionary::
+
             {
                 'Host App': 'Maya',
                 'Host App Version': '2017',
                 'Engine': 'tk-maya',
                 'Engine Version': 'v0.4.1',
+                'Context': {
+                    'entity': {
+                        'name': 'Box',
+                        'type': 'Asset'
+                    },
+                    'project': {
+                        'name': 'Demo Project'
+                    },
+                    'source_entity': {
+                        'content': 'Modeling',
+                        'type': 'Task'
+                    },
+                    'user': {
+                        'login': 'john.doe',
+                        'email': 'john.doe@example.com'
+                    }
+                }
             }
 
         :returns: A dictionary with metrics properties as per above.
         """
         # Always create a new dictionary so the caller can safely modify it.
         return {
+            EventMetric.KEY_CONTEXT: self.context.to_dict(),
             EventMetric.KEY_ENGINE: self.name,
             EventMetric.KEY_ENGINE_VERSION: self.version,
             EventMetric.KEY_HOST_APP: self.host_info.get("name", "unknown"),

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -619,6 +619,7 @@ class EventMetric(object):
     KEY_APP = "App"
     KEY_APP_VERSION = "App Version"
     KEY_COMMAND = "Command"
+    KEY_CONTEXT = "Context"
     KEY_ENGINE = "Engine"
     KEY_ENGINE_VERSION = "Engine Version"
     KEY_ENTITY_TYPE = "Entity Type"


### PR DESCRIPTION
This pull request contains changes which will add all context information to the metrics populated by an engine. Adding this information makes the metrics log entries more meaningful. We are currently using Logstash as part of the Elastic Stack to evaluate the metrics logs.

Pushing all the entire context as a dictionary may be too extensive. I'm open to any feedback on how to cut this back the best. But maybe it's also good as it is because we won't miss out on any information that may be useful and we can leave the decision to the monitoring stack.

In general, having more information being part of the default log metrics would be very beneficial and avoid the customization of the package.

Thank you for considering this pull request.