### PR TITLE
SG-9978 fixes a bug with "tank validate".

### DIFF
--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -98,7 +98,7 @@ class ValidateConfigAction(Action):
 
             env = self.tk.pipeline_configuration.get_environment(env_name)
             log.info("Environment path: %s" % (env.disk_location))
-            self._process_environment(self, log, self.tk, env)
+            self._process_environment(log, self.tk, env)
     
         log.info("")
         log.info("")

--- a/tests/commands_tests/test_validate.py
+++ b/tests/commands_tests/test_validate.py
@@ -14,14 +14,11 @@ Unit tests tank validate.
 
 from __future__ import with_statement
 
-import os
 import logging
 
 from tank_test.tank_test_base import TankTestBase, setUpModule # noqa
 
-from tank.platform.environment import InstalledEnvironment
-
-from tank_test.mock_appstore import TankMockStoreDescriptor, patch_app_store
+from tank_test.mock_appstore import patch_app_store
 
 
 class TestSimpleValidate(TankTestBase):
@@ -58,4 +55,4 @@ class TestSimpleValidate(TankTestBase):
         # Run validate.
         command = self.tk.get_command("validate")
         command.set_logger(logging.getLogger("/dev/null"))
-        command.execute({"envs":["simple"]})
+        command.execute({"envs": ["simple"]})

--- a/tests/commands_tests/test_validate.py
+++ b/tests/commands_tests/test_validate.py
@@ -50,7 +50,7 @@ class TestSimpleValidate(TankTestBase):
     def test_simple_validate(self):
         """
         Test Simple validate.
-        Just makes sure that the command runs with out and error in a simple environment.
+        Makes sure that the command runs without an error in a simple environment.
         """
         # Run validate.
         command = self.tk.get_command("validate")

--- a/tests/commands_tests/test_validate.py
+++ b/tests/commands_tests/test_validate.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Unit tests tank validate.
+"""
+
+from __future__ import with_statement
+
+import os
+import logging
+
+from tank_test.tank_test_base import TankTestBase, setUpModule # noqa
+
+from tank.platform.environment import InstalledEnvironment
+
+from tank_test.mock_appstore import TankMockStoreDescriptor, patch_app_store
+
+
+class TestSimpleValidate(TankTestBase):
+    """
+    Makes sure environment code works with the app store mocker.
+    """
+
+    def setUp(self):
+        """
+        Prepare unit test.
+        """
+        TankTestBase.setUp(self)
+
+        patcher = patch_app_store()
+        self._mock_store = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # Test is running validate on the configuration files, so we'll copy the config into the
+        # pipeline configuration.
+        self.setup_fixtures("app_store_tests", parameters={"installed_config": True})
+
+        self._mock_store.add_engine("tk-test", "v1.0.0")
+        self._mock_store.add_application("tk-multi-nodep", "v1.0.0")
+        self._mock_store.add_application("tk-multi-nodep", "v2.0.0")
+        self._mock_store.add_framework("tk-framework-test", "v1.0.0")
+        self._mock_store.add_framework("tk-framework-test", "v1.0.1")
+        self._mock_store.add_framework("tk-framework-test", "v1.1.0")
+
+    def test_simple_validate(self):
+        """
+        Test Simple validate.
+        Just makes sure that the command runs with out and error in a simple environment.
+        """
+        # Run validate.
+        command = self.tk.get_command("validate")
+        command.set_logger(logging.getLogger("/dev/null"))
+        command.execute({"envs":["simple"]})


### PR DESCRIPTION
`tank validate` was recently broken in [this](https://github.com/shotgunsoftware/tk-core/commit/a1ef81d6a667954d585933ef78a3ebb1f217a965#diff-f42a05817c04a0145683452a91722c3bR101) update, causing the following error:

```
ERROR: A general error was reported: _process_environment() takes exactly 4
arguments (5 given)
Traceback (most recent call last):
  File "/sg_toolkit/greyhounddev.shotgunstudio.com/configs/new_config_project/install/core/scripts/tank_cmd.py", line 1630, in <module>
    exit_code = run_engine_cmd(pipeline_config_root, ctx_list, cmd_name, using_cwd, cmd_args)
  File "/sg_toolkit/greyhounddev.shotgunstudio.com/configs/new_config_project/install/core/scripts/tank_cmd.py", line 1290, in run_engine_cmd
    return run_action(logger, tk, ctx, command, args)
  File "/sg_toolkit/greyhounddev.shotgunstudio.com/configs/new_config_project/install/core/python/tank/commands/tank_command.py", line 528, in run_action
    return found_action.run_interactive(log, args)
  File "/sg_toolkit/greyhounddev.shotgunstudio.com/configs/new_config_project/install/core/python/tank/commands/validate_config.py", line 72, in run_interactive
    return self._run(log, self._validate_parameters({"envs": args}))
  File "/sg_toolkit/greyhounddev.shotgunstudio.com/configs/new_config_project/install/core/python/tank/commands/validate_config.py", line 101, in _run
    self._process_environment(self, log, self.tk, env)
TypeError: _process_environment() takes exactly 4 arguments (5 given)
```

This fixes that.