### PR TITLE
In copy_file method replace shutil.copy to shutil.copyfile to avoid errors in write only filesystems

### DIFF
--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -161,8 +161,12 @@ def copy_file(src, dst, permissions=0o666):
     :param permissions: Permissions to use for target file. Default permissions will
                         be readable and writable for all users.
     """
-    shutil.copy(src, dst)
-    os.chmod(dst, permissions)
+    shutil.copyfile(src, dst)
+
+    try:
+        os.chmod(dst, permissions)
+    except Exception as e:
+        pass
 
 
 def safe_delete_file(path):


### PR DESCRIPTION
When we have filesystems with permissions like

![files_perms](https://user-images.githubusercontent.com/2762494/49648810-379add80-f9f5-11e8-8487-daac34863937.jpg)
![folder_perms](https://user-images.githubusercontent.com/2762494/49648811-379add80-f9f5-11e8-854d-31d9fe9c90b0.jpg)

We're gonna have problems using the `sgtk.util.filesystem.copy_file` method because it uses `shutil.copy` and `os.chmod` which raise `[Error 5] Access is denied`.

The idea is replace `shutil.copy` to `shutil.copyfile` and make the `os.chmod` only if possible (try-except)