### PR TITLE
add support for _MAPID_ UDIM padding for katana/renderman

### DIFF
--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -994,7 +994,7 @@ class SequenceKey(IntegerKey):
     # special keywork used when format is specified directly in value
     FRAMESPEC_FORMAT_INDICATOR = "FORMAT:"
     # valid format strings that can be used with this Key type
-    VALID_FORMAT_STRINGS = ["%d", "#", "@", "$F", "<UDIM>", "$UDIM"]
+    VALID_FORMAT_STRINGS = ["%d", "#", "@", "$F", "<UDIM>", "$UDIM", "_MAPID_"]
     # flame sequence pattern regex ('[1234-5434]')
     FLAME_PATTERN_REGEX = "^\[[0-9]+-[0-9]+\]$"
     
@@ -1142,7 +1142,7 @@ class SequenceKey(IntegerKey):
                 frame_spec = "@"*places
             elif format_string == "$F":
                 frame_spec = "$F%d" % places
-            elif format_string in ("<UDIM>", "$UDIM"):
+            elif format_string in ("<UDIM>", "$UDIM", "_MAPID_"):
                 # UDIM's aren't padded!
                 frame_spec = format_string
             else:
@@ -1157,7 +1157,7 @@ class SequenceKey(IntegerKey):
                 frame_spec = "@"
             elif format_string == "$F":
                 frame_spec = "$F"
-            elif format_string in ("<UDIM>", "$UDIM"):
+            elif format_string in ("<UDIM>", "$UDIM", "_MAPID_"):
                 # UDIM's aren't padded!
                 frame_spec = format_string
             else:


### PR DESCRIPTION
I had to extend our local install of tk-core in order to support the _MAPID_ UDIM padding used by Katana/Renderman, to be used in in tank templates for textures.  

I thought this change may be useful in the official tk-core repo, cheers.