### PR TITLE
AppVeyor build now uses Python 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python26"
+    - PYTHON: "C:\\Python27"
 
   # To update these values, visit AppVeyor's site, click the user icon and scroll down to Encrypt Data.
   SHOTGUN_HOST:


### PR DESCRIPTION
Due to the move to TLS 1.2 for Shotgun, Python 2.6 does not work anymore on AppVeyor. As such, we're going to bump the Python version to 2.7.9+, which does support TLS 1.2