### PR TITLE
SG-12126 - Fixes bug where bootstrap fails to auto update.

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -1580,12 +1580,23 @@ class Engine(TankBundle):
                     # the actual font file
                     font_file = os.path.join(font_dir, font_file_name)
 
-                    # load the font into the font db
-                    if QtGui.QFontDatabase.addApplicationFont(font_file) == -1:
-                        self.log_warning(
-                            "Unable to load font file: %s" % (font_file,))
-                    else:
-                        self.log_debug("Loaded font file: %s" % (font_file,))
+                    # rather than registering the file path with the QT
+                    # font system, first load the font data into memory
+                    # and then register that data.
+                    #
+                    # this is to avoid QT keeping an open file handle to
+                    # the font files - this causes issues on windows and
+                    # results in bootstrap changes sometimes not being 
+                    # picked up.                    
+                    with open(font_file, "rb") as fh:
+                        # load binary data into memory
+                        font_data = fh.read()
+                        # load the font into the font db
+                        if QtGui.QFontDatabase.addApplicationFontFromData(font_data) == -1:
+                            self.log_warning(
+                                "Unable to load font file: %s" % (font_file,))
+                        else:
+                            self.log_debug("Loaded font file into memory: %s" % (font_file,))
 
         self.__fonts_loaded = True
 


### PR DESCRIPTION
### Background
If you are using a distributed config and push an updated config to the cloud, when a client bootstraps and it attempts to update to the latest config on Windows there is a chance that it won't update and will silently just load up the previously cached config with no warning at all to the user.

The problem is that a TD will push a config with updates and fixes to the artists, and ask them to reload their project, and they think everything is fine until they realise the fixes haven't been applied. The workaround currently is to ask the user to log out and back in at a OS level.

### Fix
It turns out that QT keeps open file handles to the font files we provide, thereby preventing the bootstrap from moving the old core into a backup location at runtime.

This fix tweaks the font loading so that fonts are loaded into memory first and then registered with QT, thereby preventing the file locking to happen.

### How to test
The issue can be reproduced by:

- launch desktop with cloud config
- launch maya from desktop
- upload new zip config to shotgun
- exit the project in desktop
- enter the project again in desktop - you get an error in the console.

With this fix, the error goes away.
