### PR TITLE
Ticket/sg 12669 polyfill bind

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -49,6 +49,42 @@ WATCHDOG_TIMEOUT_MS = 5000
 PREEMPTIVE_RENEWAL_THRESHOLD = 0.9
 SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
 
+# Some IdP will use JavaScript code which makes use of ES6. Our Qt4
+# environment is unfortunately missing some definitions which we
+# need to inject prior to running the IdP code.
+FUNCTION_PROTOTYPE_BIND_POLYFILL = """
+// Yes, it does work with `new funcA.bind(thisArg, args)`
+if (!Function.prototype.bind) (function(){
+  var ArrayPrototypeSlice = Array.prototype.slice;
+  Function.prototype.bind = function(otherThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var baseArgs= ArrayPrototypeSlice .call(arguments, 1),
+        baseArgsLength = baseArgs.length,
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          baseArgs.length = baseArgsLength; // reset to default base arguments
+          baseArgs.push.apply(baseArgs, arguments);
+          return fToBind.apply(
+                 fNOP.prototype.isPrototypeOf(this) ? this : otherThis, baseArgs
+          );
+        };
+
+    if (this.prototype) {
+      // Function.prototype doesn't have a prototype property
+      fNOP.prototype = this.prototype; 
+    }
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+})();
+"""
 
 class SsoSaml2Core(object):
     """Performs Shotgun Web login and pre-emptive renewal for SSO sessions."""
@@ -132,6 +168,13 @@ class SsoSaml2Core(object):
         self._view.setPage(TKWebPage())
         self._view.page().networkAccessManager().authenticationRequired.connect(self.on_authentication_required)
         self._view.loadFinished.connect(self.on_load_finished)
+
+        # We want to inject custom JavaScript code before any code is
+        # executed in the loaded web pages. This is to polyfill any
+        # missing functionality.
+        frame = self._view.page().currentFrame()
+        frame.javaScriptWindowObjectCleared.connect(self._polyfill)
+
 
         # Purposely disable the 'Reload' contextual menu, as it should not be
         # used for SSO. Reloading the page confuses the server.
@@ -465,6 +508,13 @@ class SsoSaml2Core(object):
     # Qt event handlers
     #
     ############################################################################
+
+    def _polyfill(self):
+        """
+        Called by Qt when the Web Page has changed and before it is loaded.
+        """
+        frame = self._view.page().currentFrame()
+        frame.evaluateJavaScript(FUNCTION_PROTOTYPE_BIND_POLYFILL)
 
     def on_load_finished(self, succeeded):
         """

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -49,9 +49,9 @@ WATCHDOG_TIMEOUT_MS = 5000
 PREEMPTIVE_RENEWAL_THRESHOLD = 0.9
 SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
 
-# Some IdP will use JavaScript code which makes use of ES6. Our Qt4
-# environment is unfortunately missing some definitions which we
-# need to inject prior to running the IdP code.
+# Some IdP (Identity Providers) will use JavaScript code which makes use of ES6.
+# Our Qt4 environment is unfortunately missing some definitions which we need to
+# inject prior to running the IdP code.
 # The reference for this code is:
 #     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind#Polyfill
 FUNCTION_PROTOTYPE_BIND_POLYFILL = """
@@ -514,9 +514,15 @@ class SsoSaml2Core(object):
     def _polyfill(self):
         """
         Called by Qt when the Web Page has changed and before it is loaded.
+
+        The purpose of this function is to inject JavaScript code in a page
+        before any of its code is run. This gives us a way to modify the code's
+        environment and define functions which would be required by that code.
         """
         frame = self._view.page().currentFrame()
         frame.evaluateJavaScript(FUNCTION_PROTOTYPE_BIND_POLYFILL)
+        self._logger.debug("Injected polyfill JavaScript code for Function.prototype.bind")
+
 
     def on_load_finished(self, succeeded):
         """

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -52,6 +52,8 @@ SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
 # Some IdP will use JavaScript code which makes use of ES6. Our Qt4
 # environment is unfortunately missing some definitions which we
 # need to inject prior to running the IdP code.
+# The reference for this code is:
+#     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind#Polyfill
 FUNCTION_PROTOTYPE_BIND_POLYFILL = """
 // Yes, it does work with `new funcA.bind(thisArg, args)`
 if (!Function.prototype.bind) (function(){


### PR DESCRIPTION
An upcoming release of Okta will make use of the bind() function for Funtion objects.

Unfortunately, our current Qt4 version of WebView does not provide this natively. We need to polyfill the missing functionality.

Attempting to connect to an Okta/SSO enabled Shotgun site will show an incomplete login page, missing the important input fields and buttons.

Starting the SG Desktop on a site (here: https://hubertp-8-0-sso.shotgunstudio.com):
![Screen Shot 2019-06-04 at 10 17 23 AM](https://user-images.githubusercontent.com/8060460/58867402-474c6380-86b2-11e9-98d2-4b4b4cda9f06.png)

Without the polyfill, using the currently released code, we get:
![Screen Shot 2019-06-04 at 10 17 41 AM](https://user-images.githubusercontent.com/8060460/58867474-6ba84000-86b2-11e9-995d-1433c9a8b2a7.png)

But with the polyfill provided by the submitted code:
![Screen Shot 2019-06-04 at 10 18 10 AM](https://user-images.githubusercontent.com/8060460/58867514-81b60080-86b2-11e9-8e01-05c4a3164706.png)

Having the polyfill be injected at every page load should not be an issue with other non-Okta IdP portal, of incur a noticeable delay in the page rendering.

