### PR TITLE
Added warning for no path cache found

### DIFF
--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -692,6 +692,8 @@ class IODescriptorBase(object):
             if self._exists_local(path):
                 return path
 
+        log.warn('No cache path found for: %s', self.get_uri())
+        log.warn('Please consider running "tank cache_apps"')
         return None
 
     def clone_cache(self, cache_root):


### PR DESCRIPTION
Ran into an error while trying to launch an app. Turns out it was just not cached from `tank cache_apps`
but the error message looked like this in `~/.shotgun/logs/tk-shotgun.log`

```
2019-06-12 12:58:29,697 [21599 ERROR sgtk.ext...tk_desktop.site_communication] [PROXY] Error calling __commands::katana_3.1_(arnold_5.3)((), {}):
Traceback (most recent call last):
  File "/path/to/config/install/app_store/tk-desktop/v2.4.12/python/tk_desktop/desktop_engine_project_implementation.py", line 164, in _trigger_callback
    callback(*args, **kwargs)
  File "/path/to/config/install/core/python/tank/platform/engine.py", line 1084, in callback_wrapper
    return callback(*args, **kwargs)
  File "/path/to/config/install/app_store/tk-multi-launchapp/v0.10.3/python/tk_multi_launchapp/base_launcher.py", line 125, in launch_version
    *args, **kwargs
  File "/path/to/config/install/app_store/tk-multi-launchapp/v0.10.3/python/tk_multi_launchapp/base_launcher.py", line 354, in _launch_callback
    file_to_open,
  File "/path/to/config/install/app_store/tk-multi-launchapp/v0.10.3/python/tk_multi_launchapp/base_launcher.py", line 167, in _launch_app
    app_engine, app_path, app_args, context, file_to_open
  File "/path/to/config/install/app_store/tk-multi-launchapp/v0.10.3/python/tk_multi_launchapp/prepare_apps.py", line 47, in prepare_launch_for_engine
    launch_info = launcher.prepare_launch(app_path, app_args, file_to_open)
  File "/path/to/config/install/git/tk-katana.git/v0.1.0+wwfx.1.5.0/startup.py", line 102, in prepare_launch
    startup_paths.extend(self._get_resource_paths())
  File "/path/to/config/install/git/tk-katana.git/v0.1.0+wwfx.1.5.0/startup.py", line 73, in _get_resource_paths
    resource_path = os.path.join(path, "resources", "Katana")
  File "/path/to/shotgun_desktop/Python/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```
To make it more obvious, I added a simple warning about non-cached descriptors.

Now the (potential) cause of the error is more obvious from the logs:

```
2019-06-12 13:22:29,499 [21599 DEBUG sgtk.ext...tk_desktop.site_communication] [PROXY] Loading environment data from path: /path/to/config/config/env/project.yml
2019-06-12 13:22:29,800 [21599 WARNING sgtk.ext...tk_desktop.site_communication] [PROXY] No cache path found for: sgtk:descriptor:git?path=git@gitlab.wwfx.co.uk:shotgun/tk-katana-lookfilebakenode.git&version=v1.0.1
2019-06-12 13:22:29,810 [21599 WARNING sgtk.ext...tk_desktop.site_communication] [PROXY] Please consider running "tank cache_apps"
2019-06-12 13:22:29,819 [21599 ERROR sgtk.ext...tk_desktop.site_communication] [PROXY] Error calling __commands::katana_3.1_(arnold_5.3)((), {}):
Traceback (most recent call last):
  File "/path/to/config/install/app_store/tk-desktop/v2.4.12/python/tk_desktop/desktop_engine_project_implementation.py", line 164, in _trigger_callback
    callback(*args, **kwargs)
  File "/path/to/config/install/core/python/tank/platform/engine.py", line 1084, in callback_wrapper
    return callback(*args, **kwargs)
...etc...
```