### PR TITLE
For SG-13474: prompt user for credentials if NTLM negociation fails o…

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -25,7 +25,6 @@ from .errors import (
     SsoSaml2MissingQtNetwork,
     SsoSaml2MissingQtWebKit,
 )
-from .username_password_dialog import UsernamePasswordDialog
 from .utils import (
     _decode_cookies,
     _encode_cookies,
@@ -37,6 +36,14 @@ from .utils import (
     get_session_id,
     get_user_name,
 )
+
+try:
+    from .username_password_dialog import UsernamePasswordDialog
+except ImportError:
+    # Silently ignore the import error, as we are likely not in a Qt
+    # environment.
+    pass
+
 
 # Error messages for events.
 HTTP_CANT_CONNECT_TO_SHOTGUN = "Cannot Connect To Shotgun site."

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -14,8 +14,8 @@ Module to support Web login via a web browser and automated session renewal.
 import base64
 from Cookie import SimpleCookie
 import logging
-import platform
 import os
+import sys
 import time
 
 from .authentication_session_data import AuthenticationSessionData
@@ -569,10 +569,8 @@ class SsoSaml2Core(object):
         # We take for granted that if we are on Windows, proper NTLM negociation
         # is possible between the machine and the IdP. For other platforms, we
         # pop an authentication dialog.
-        if platform.system() != "Windows":
+        if sys.platform != "win32":
             auth_dialog = UsernamePasswordDialog()
-            auth_dialog.show()
-            auth_dialog.raise_()
             if auth_dialog.exec_():
                 authenticator.setUser(auth_dialog.username)
                 authenticator.setPassword(auth_dialog.password)
@@ -580,7 +578,7 @@ class SsoSaml2Core(object):
                 self._logger.debug("User prompted for username/password but canceled")
         else:
             # Setting the user to an empty string tells the QAuthenticator to
-            # negociate the authentication with the user's credentials.
+            # negotiate the authentication with the user's credentials.
             authenticator.setUser("")
 
     ############################################################################

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -576,7 +576,7 @@ class SsoSaml2Core(object):
         # We take for granted that if we are on Windows, proper NTLM negociation
         # is possible between the machine and the IdP. For other platforms, we
         # pop an authentication dialog.
-        if sys.platform != "win32": and UsernamePasswordDialog is not None:
+        if sys.platform != "win32" and UsernamePasswordDialog is not None:
             auth_dialog = UsernamePasswordDialog()
             if auth_dialog.exec_():
                 authenticator.setUser(auth_dialog.username)

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     # Silently ignore the import error, as we are likely not in a Qt
     # environment.
-    pass
+    UsernamePasswordDialog = None
 
 
 # Error messages for events.
@@ -88,7 +88,7 @@ if (!Function.prototype.bind) (function(){
 
     if (this.prototype) {
       // Function.prototype doesn't have a prototype property
-      fNOP.prototype = this.prototype; 
+      fNOP.prototype = this.prototype;
     }
     fBound.prototype = new fNOP();
 
@@ -576,7 +576,7 @@ class SsoSaml2Core(object):
         # We take for granted that if we are on Windows, proper NTLM negociation
         # is possible between the machine and the IdP. For other platforms, we
         # pop an authentication dialog.
-        if sys.platform != "win32":
+        if sys.platform != "win32": and UsernamePasswordDialog is not None:
             auth_dialog = UsernamePasswordDialog()
             if auth_dialog.exec_():
                 authenticator.setUser(auth_dialog.username)
@@ -584,6 +584,8 @@ class SsoSaml2Core(object):
             else:
                 self._logger.debug("User prompted for username/password but canceled")
         else:
+            if UsernamePasswordDialog is None:
+                self._logger.debug("Unable to prompt user for username/password, due to missing username_password_dialog module")
             # Setting the user to an empty string tells the QAuthenticator to
             # negotiate the authentication with the user's credentials.
             authenticator.setUser("")

--- a/python/tank/authentication/sso_saml2/core/username_password_dialog.py
+++ b/python/tank/authentication/sso_saml2/core/username_password_dialog.py
@@ -19,6 +19,10 @@ from ...ui.qt_abstraction import (
     QtGui,
 )
 
+# No point in proceeding if QtGui is None.
+if QtGui is None:
+    raise ImportError("Unable to import QtGui")
+
 
 class UsernamePasswordDialog(QtGui.QDialog):
     """Simple dialog to request a username and password from the user."""

--- a/python/tank/authentication/sso_saml2/core/username_password_dialog.py
+++ b/python/tank/authentication/sso_saml2/core/username_password_dialog.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2017 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+"""
+Module to support Web login via a web browser and automated session renewal.
+"""
+
+from __future__ import print_function
+
+# pylint: disable=import-error
+from PySide.QtGui import (
+    QApplication,
+    QDialog,
+    QGridLayout,
+    QLineEdit,
+    QLabel,
+    QDialogButtonBox,
+)
+
+
+# pylint: disable=too-few-public-methods
+class UsernamePasswordDialog(QDialog):
+    """Simple dialog to request a username and password from the user."""
+
+    def __init__(self):
+        super(UsernamePasswordDialog, self).__init__()
+
+        # For now we fix the GUI size.
+        self.setWindowTitle("Authentication Required")
+        self.setMinimumWidth(420)
+        self.setMinimumHeight(120)
+
+        # set up the layout
+        form_grid_layout = QGridLayout(self)
+
+        # initialize the username combo box so that it is editable
+        self._edit_username = QLineEdit(self)
+
+        # initialize the password field so that it does not echo characters
+        self._edit_password = QLineEdit(self)
+        self._edit_password.setEchoMode(QLineEdit.Password)
+
+        # initialize the labels
+        label_username = QLabel(self)
+        label_password = QLabel(self)
+        label_username.setText("Username:")
+        label_password.setText("Password:")
+
+        # initialize buttons
+        buttons = QDialogButtonBox(self)
+        buttons.addButton(QDialogButtonBox.Ok)
+        buttons.addButton(QDialogButtonBox.Cancel)
+        buttons.button(QDialogButtonBox.Ok).setText("Login")
+        buttons.button(QDialogButtonBox.Cancel).setText("Cancel")
+
+        # place components into the dialog
+        form_grid_layout.addWidget(label_username, 0, 0)
+        form_grid_layout.addWidget(self._edit_username, 0, 1)
+        form_grid_layout.addWidget(label_password, 1, 0)
+        form_grid_layout.addWidget(self._edit_password, 1, 1)
+        form_grid_layout.setRowStretch(2, 1)
+        form_grid_layout.addWidget(buttons, 3, 1)
+
+        self.setLayout(form_grid_layout)
+
+        buttons.button(QDialogButtonBox.Ok).clicked.connect(self._on_enter_credentials)
+        buttons.button(QDialogButtonBox.Cancel).clicked.connect(self.close)
+
+    @property
+    def username(self):
+        """Getter for username."""
+        return self._edit_username.text()
+
+    @username.setter
+    def username(self, username):
+        """Setter for username."""
+        self._edit_username.setText(username)
+
+    @property
+    def password(self):
+        """Getter for password."""
+        return self._edit_password.text()
+
+    @password.setter
+    def password(self, password):
+        """Setter for password."""
+        self._edit_password.setText(password)
+
+    def _on_enter_credentials(self):
+        """Callback when clicking Ok."""
+        if self._edit_username.text() == "":
+            self._edit_username.setFocus()
+            return
+
+        if self._edit_password.text() == "":
+            self._edit_password.setFocus()
+            return
+
+        self.accept()
+
+
+def main():
+    """Simple test"""
+    _ = QApplication([])
+    login_dialog = UsernamePasswordDialog()
+    login_dialog.username = "TheUsername"
+    login_dialog.password = "ThePassword"
+    login_dialog.show()
+    login_dialog.raise_()
+    if login_dialog.exec_():
+        print("Username: %s" % login_dialog.username)
+        print("Password: %s" % login_dialog.password)
+    else:
+        print("Canceled the operation")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tank/authentication/sso_saml2/core/username_password_dialog.py
+++ b/python/tank/authentication/sso_saml2/core/username_password_dialog.py
@@ -14,126 +14,91 @@ Module to support Web login via a web browser and automated session renewal.
 from __future__ import print_function
 
 # pylint: disable=import-error
-try:
-    from .ui.qt_abstraction import QtGui
+from ...ui.qt_abstraction import (
+    QtCore,
+    QtGui,
+)
 
-    class UsernamePasswordDialog(QtGui.QDialog):
-        """Simple dialog to request a username and password from the user."""
 
-        def __init__(self):
-            super(UsernamePasswordDialog, self).__init__()
+class UsernamePasswordDialog(QtGui.QDialog):
+    """Simple dialog to request a username and password from the user."""
 
-            # For now we fix the GUI size.
-            self.setWindowTitle("Authentication Required")
-            self.setMinimumWidth(420)
-            self.setMinimumHeight(120)
+    def __init__(self, *args, **kwargs):
+        super(UsernamePasswordDialog, self).__init__(*args, **kwargs)
 
-            # set up the layout
-            form_grid_layout = QtGui.QGridLayout(self)
+        # For now we fix the GUI size.
+        self.setWindowTitle("Authentication Required")
+        self.setMinimumWidth(420)
+        self.setMinimumHeight(120)
+        self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
 
-            # initialize the username combo box so that it is editable
-            self._edit_username = QtGui.QLineEdit(self)
+        # set up the layout
+        form_grid_layout = QtGui.QGridLayout(self)
 
-            # initialize the password field so that it does not echo characters
-            self._edit_password = QtGui.QLineEdit(self)
-            self._edit_password.setEchoMode(QtGui.QLineEdit.Password)
+        # initialize the username combo box so that it is editable
+        self._edit_username = QtGui.QLineEdit(self)
 
-            # initialize the labels
-            label_username = QtGui.QLabel(self)
-            label_password = QtGui.QLabel(self)
-            label_username.setText("Username:")
-            label_password.setText("Password:")
+        # initialize the password field so that it does not echo characters
+        self._edit_password = QtGui.QLineEdit(self)
+        self._edit_password.setEchoMode(QtGui.QLineEdit.Password)
 
-            # initialize buttons
-            buttons = QtGui.QDialogButtonBox(self)
-            buttons.addButton(QtGui.QDialogButtonBox.Ok)
-            buttons.addButton(QtGui.QDialogButtonBox.Cancel)
-            buttons.button(QtGui.QDialogButtonBox.Ok).setText("Login")
-            buttons.button(QtGui.QDialogButtonBox.Cancel).setText("Cancel")
+        # initialize the labels
+        label_username = QtGui.QLabel(self)
+        label_password = QtGui.QLabel(self)
+        label_username.setText("Username:")
+        label_password.setText("Password:")
 
-            # place components into the dialog
-            form_grid_layout.addWidget(label_username, 0, 0)
-            form_grid_layout.addWidget(self._edit_username, 0, 1)
-            form_grid_layout.addWidget(label_password, 1, 0)
-            form_grid_layout.addWidget(self._edit_password, 1, 1)
-            form_grid_layout.setRowStretch(2, 1)
-            form_grid_layout.addWidget(buttons, 3, 1)
+        # initialize buttons
+        buttons = QtGui.QDialogButtonBox(self)
+        buttons.addButton(QtGui.QDialogButtonBox.Ok)
+        buttons.addButton(QtGui.QDialogButtonBox.Cancel)
+        buttons.button(QtGui.QDialogButtonBox.Ok).setText("Login")
+        buttons.button(QtGui.QDialogButtonBox.Cancel).setText("Cancel")
 
-            self.setLayout(form_grid_layout)
+        # place components into the dialog
+        form_grid_layout.addWidget(label_username, 0, 0)
+        form_grid_layout.addWidget(self._edit_username, 0, 1)
+        form_grid_layout.addWidget(label_password, 1, 0)
+        form_grid_layout.addWidget(self._edit_password, 1, 1)
+        form_grid_layout.setRowStretch(2, 1)
+        form_grid_layout.addWidget(buttons, 3, 1)
 
-            buttons.button(QtGui.QDialogButtonBox.Ok).clicked.connect(self._on_enter_credentials)
-            buttons.button(QtGui.QDialogButtonBox.Cancel).clicked.connect(self.close)
+        self.setLayout(form_grid_layout)
 
-        @property
-        def username(self):
-            """Getter for username."""
-            return self._edit_username.text()
+        buttons.button(QtGui.QDialogButtonBox.Ok).clicked.connect(self._on_enter_credentials)
+        buttons.button(QtGui.QDialogButtonBox.Cancel).clicked.connect(self.close)
 
-        @username.setter
-        def username(self, username):
-            """Setter for username."""
-            self._edit_username.setText(username)
+    @property
+    def username(self):
+        """Getter for username."""
+        return self._edit_username.text()
 
-        @property
-        def password(self):
-            """Getter for password."""
-            return self._edit_password.text()
+    @username.setter
+    def username(self, username):
+        """Setter for username."""
+        self._edit_username.setText(username)
 
-        @password.setter
-        def password(self, password):
-            """Setter for password."""
-            self._edit_password.setText(password)
+    @property
+    def password(self):
+        """Getter for password."""
+        return self._edit_password.text()
 
-        def _on_enter_credentials(self):
-            """Callback when clicking Ok."""
-            if self._edit_username.text() == "":
-                self._edit_username.setFocus()
-                return
+    @password.setter
+    def password(self, password):
+        """Setter for password."""
+        self._edit_password.setText(password)
 
-            if self._edit_password.text() == "":
-                self._edit_password.setFocus()
-                return
+    def _on_enter_credentials(self):
+        """Callback when clicking Ok."""
+        if self._edit_username.text() == "":
+            self._edit_username.setFocus()
+            return
 
-            self.accept()
-except ImportError:
-    class UsernamePasswordDialog(object):
-        """Minimalistic implementation."""
-        def __init__(self):
-            self._username = ""
-            self._password = ""
+        if self._edit_password.text() == "":
+            self._edit_password.setFocus()
+            return
 
-        @property
-        def username(self):
-            """Getter for username."""
-            return self._username
-
-        @username.setter
-        def username(self, username):
-            """Setter for username."""
-            self._username = username
-
-        @property
-        def password(self):
-            """Getter for password."""
-            return self._password
-
-        @password.setter
-        def password(self, password):
-            """Setter for password."""
-            self._password = password
-
-        def show(self):
-            """Stub implementation"""
-            pass
-
-        def raise_(self):
-            """Stub implementation"""
-            pass
-
-        # pylint: disable=no-self-use
-        def exec_(self):
-            """Stub implementation"""
-            return 1
+        self.accept()
 
 
 def main():
@@ -142,8 +107,6 @@ def main():
     login_dialog = UsernamePasswordDialog()
     login_dialog.username = "TheUsername"
     login_dialog.password = "ThePassword"
-    login_dialog.show()
-    login_dialog.raise_()
     if login_dialog.exec_():
         print("Username: %s" % login_dialog.username)
         print("Password: %s" % login_dialog.password)

--- a/python/tank/authentication/sso_saml2/core/username_password_dialog.py
+++ b/python/tank/authentication/sso_saml2/core/username_password_dialog.py
@@ -14,100 +14,131 @@ Module to support Web login via a web browser and automated session renewal.
 from __future__ import print_function
 
 # pylint: disable=import-error
-from PySide.QtGui import (
-    QApplication,
-    QDialog,
-    QGridLayout,
-    QLineEdit,
-    QLabel,
-    QDialogButtonBox,
-)
+try:
+    from .ui.qt_abstraction import QtGui
 
+    class UsernamePasswordDialog(QtGui.QDialog):
+        """Simple dialog to request a username and password from the user."""
 
-# pylint: disable=too-few-public-methods
-class UsernamePasswordDialog(QDialog):
-    """Simple dialog to request a username and password from the user."""
+        def __init__(self):
+            super(UsernamePasswordDialog, self).__init__()
 
-    def __init__(self):
-        super(UsernamePasswordDialog, self).__init__()
+            # For now we fix the GUI size.
+            self.setWindowTitle("Authentication Required")
+            self.setMinimumWidth(420)
+            self.setMinimumHeight(120)
 
-        # For now we fix the GUI size.
-        self.setWindowTitle("Authentication Required")
-        self.setMinimumWidth(420)
-        self.setMinimumHeight(120)
+            # set up the layout
+            form_grid_layout = QtGui.QGridLayout(self)
 
-        # set up the layout
-        form_grid_layout = QGridLayout(self)
+            # initialize the username combo box so that it is editable
+            self._edit_username = QtGui.QLineEdit(self)
 
-        # initialize the username combo box so that it is editable
-        self._edit_username = QLineEdit(self)
+            # initialize the password field so that it does not echo characters
+            self._edit_password = QtGui.QLineEdit(self)
+            self._edit_password.setEchoMode(QtGui.QLineEdit.Password)
 
-        # initialize the password field so that it does not echo characters
-        self._edit_password = QLineEdit(self)
-        self._edit_password.setEchoMode(QLineEdit.Password)
+            # initialize the labels
+            label_username = QtGui.QLabel(self)
+            label_password = QtGui.QLabel(self)
+            label_username.setText("Username:")
+            label_password.setText("Password:")
 
-        # initialize the labels
-        label_username = QLabel(self)
-        label_password = QLabel(self)
-        label_username.setText("Username:")
-        label_password.setText("Password:")
+            # initialize buttons
+            buttons = QtGui.QDialogButtonBox(self)
+            buttons.addButton(QtGui.QDialogButtonBox.Ok)
+            buttons.addButton(QtGui.QDialogButtonBox.Cancel)
+            buttons.button(QtGui.QDialogButtonBox.Ok).setText("Login")
+            buttons.button(QtGui.QDialogButtonBox.Cancel).setText("Cancel")
 
-        # initialize buttons
-        buttons = QDialogButtonBox(self)
-        buttons.addButton(QDialogButtonBox.Ok)
-        buttons.addButton(QDialogButtonBox.Cancel)
-        buttons.button(QDialogButtonBox.Ok).setText("Login")
-        buttons.button(QDialogButtonBox.Cancel).setText("Cancel")
+            # place components into the dialog
+            form_grid_layout.addWidget(label_username, 0, 0)
+            form_grid_layout.addWidget(self._edit_username, 0, 1)
+            form_grid_layout.addWidget(label_password, 1, 0)
+            form_grid_layout.addWidget(self._edit_password, 1, 1)
+            form_grid_layout.setRowStretch(2, 1)
+            form_grid_layout.addWidget(buttons, 3, 1)
 
-        # place components into the dialog
-        form_grid_layout.addWidget(label_username, 0, 0)
-        form_grid_layout.addWidget(self._edit_username, 0, 1)
-        form_grid_layout.addWidget(label_password, 1, 0)
-        form_grid_layout.addWidget(self._edit_password, 1, 1)
-        form_grid_layout.setRowStretch(2, 1)
-        form_grid_layout.addWidget(buttons, 3, 1)
+            self.setLayout(form_grid_layout)
 
-        self.setLayout(form_grid_layout)
+            buttons.button(QtGui.QDialogButtonBox.Ok).clicked.connect(self._on_enter_credentials)
+            buttons.button(QtGui.QDialogButtonBox.Cancel).clicked.connect(self.close)
 
-        buttons.button(QDialogButtonBox.Ok).clicked.connect(self._on_enter_credentials)
-        buttons.button(QDialogButtonBox.Cancel).clicked.connect(self.close)
+        @property
+        def username(self):
+            """Getter for username."""
+            return self._edit_username.text()
 
-    @property
-    def username(self):
-        """Getter for username."""
-        return self._edit_username.text()
+        @username.setter
+        def username(self, username):
+            """Setter for username."""
+            self._edit_username.setText(username)
 
-    @username.setter
-    def username(self, username):
-        """Setter for username."""
-        self._edit_username.setText(username)
+        @property
+        def password(self):
+            """Getter for password."""
+            return self._edit_password.text()
 
-    @property
-    def password(self):
-        """Getter for password."""
-        return self._edit_password.text()
+        @password.setter
+        def password(self, password):
+            """Setter for password."""
+            self._edit_password.setText(password)
 
-    @password.setter
-    def password(self, password):
-        """Setter for password."""
-        self._edit_password.setText(password)
+        def _on_enter_credentials(self):
+            """Callback when clicking Ok."""
+            if self._edit_username.text() == "":
+                self._edit_username.setFocus()
+                return
 
-    def _on_enter_credentials(self):
-        """Callback when clicking Ok."""
-        if self._edit_username.text() == "":
-            self._edit_username.setFocus()
-            return
+            if self._edit_password.text() == "":
+                self._edit_password.setFocus()
+                return
 
-        if self._edit_password.text() == "":
-            self._edit_password.setFocus()
-            return
+            self.accept()
+except ImportError:
+    class UsernamePasswordDialog(object):
+        """Minimalistic implementation."""
+        def __init__(self):
+            self._username = ""
+            self._password = ""
 
-        self.accept()
+        @property
+        def username(self):
+            """Getter for username."""
+            return self._username
+
+        @username.setter
+        def username(self, username):
+            """Setter for username."""
+            self._username = username
+
+        @property
+        def password(self):
+            """Getter for password."""
+            return self._password
+
+        @password.setter
+        def password(self, password):
+            """Setter for password."""
+            self._password = password
+
+        def show(self):
+            """Stub implementation"""
+            pass
+
+        def raise_(self):
+            """Stub implementation"""
+            pass
+
+        # pylint: disable=no-self-use
+        def exec_(self):
+            """Stub implementation"""
+            return 1
 
 
 def main():
     """Simple test"""
-    _ = QApplication([])
+    _ = QtGui.QApplication([])
     login_dialog = UsernamePasswordDialog()
     login_dialog.username = "TheUsername"
     login_dialog.password = "ThePassword"


### PR DESCRIPTION
…r is not available

When SSO Desktop Integration is on (usually on Windows machine), the tk-core/Qt will automatically log in the user.

But on Mac (and possibly Linux), this negotiation may fail or not be available. To get around that and allow the user to proceed, they need to enter their credentials.

Up to now, we did not have clients using SSO Desktop integration with Mac... Now Nickelodeon is using it. Users were not able to authenticate with the Shotgun Desktop, being presented with a blank HTML canvas and no way to proceed.

So in this branch, I've have:
- added a new UsernamePasswordDialog class, which creates a Qt dialog to ask for credentials,
- modified my 'on_authentication_required' to prompt the user on non-Windows platforms.

![UsernamePasswordDialog](https://user-images.githubusercontent.com/8060460/62902246-12513280-bd2d-11e9-8e21-b73d951e1f7c.gif)

(Please note that the GUI will be themed appropriately when called from the Shotgun Desktop)