### PR TITLE
SG-13264: python 3 compat integration tests

### DIFF
--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -224,10 +224,6 @@ class CoreImportHandler(object):
                         # and remove the official entry
                         # log.debug("Removing sys.modules[%s]" % module_name)
                         del sys.modules[module_name]
-                    else:
-                        print("None module", module_name)
-
-
 
             # reset importer to point at new core for future imports
             self._module_info = {}

--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -129,7 +129,13 @@ class CoreImportHandler(object):
         # no import handler found, so create one.
         current_folder = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
         handler = cls(current_folder)
-        sys.meta_path.append(handler)
+        # Insert our handler at the front of the list. In Python 2, the position of the
+        # handler is not important because meta path is scanned first and then sys.path
+        # In Python 3 however, the sys.path importer IS a meta_path importer as well.
+        # If we simply append our handler, it means we'll run after the path importer,
+        # which means the old copy of core will be imported instead of the
+        # new one.
+        sys.meta_path.insert(0, handler)
         log.debug("Added import handler to sys.meta_path to support core swapping.")
         return handler
 
@@ -218,6 +224,8 @@ class CoreImportHandler(object):
                         # and remove the official entry
                         # log.debug("Removing sys.modules[%s]" % module_name)
                         del sys.modules[module_name]
+                    else:
+                        print("None module", module_name)
 
 
 

--- a/tests/fixtures/config/bundles/simple_test_app/app.py
+++ b/tests/fixtures/config/bundles/simple_test_app/app.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+A simple app to support unit tests.
+"""
+
+from tank.platform import Application
+import tank
+
+
+class TestApp(Application):
+    def init_app(self):
+        pass

--- a/tests/fixtures/config/bundles/simple_test_app/app.py
+++ b/tests/fixtures/config/bundles/simple_test_app/app.py
@@ -13,7 +13,6 @@ A simple app to support unit tests.
 """
 
 from tank.platform import Application
-import tank
 
 
 class TestApp(Application):

--- a/tests/fixtures/config/bundles/simple_test_app/info.yml
+++ b/tests/fixtures/config/bundles/simple_test_app/info.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# Metadata defining the behaviour and requirements for this app
+
+
+# General items
+display_name: Test App
+author: Shotgun Software
+description: Unit testing
+
+configuration:
+
+frameworks:

--- a/tests/integration_tests/data/simple_config/core/core_api.yml
+++ b/tests/integration_tests/data/simple_config/core/core_api.yml
@@ -11,4 +11,4 @@
 
 location:
     type: path
-    path: $TK_CORE_REPO_ROOT
+    path: $SHOTGUN_REPO_ROOT

--- a/tests/integration_tests/data/simple_config/env/project.yml
+++ b/tests/integration_tests/data/simple_config/env/project.yml
@@ -18,12 +18,12 @@ description: Small environment to test the offline workflow.
 # configuration for all engines to load in a project context
 
 engines:
-  tk-shell:
+  tk-testengine:
     apps:
       tk-test-app:
         location: 
           type: path
-          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/simple_test_app
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine

--- a/tests/integration_tests/data/simple_config/env/project.yml
+++ b/tests/integration_tests/data/simple_config/env/project.yml
@@ -23,17 +23,14 @@ engines:
       tk-multi-launchapp:
         use_software_entity: true
         location: 
-          type: app_store
-          name: tk-multi-launchapp
-          version: v0.9.15
+          type: path
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
     location:
-      type: app_store
-      name: tk-shell
-      version: v0.6.0
+      type: path
+      path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine
 
 frameworks:
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.3.4
-      type: app_store
-      name: tk-framework-shotgunutils
+      type: path
+      path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_framework_v1

--- a/tests/integration_tests/data/simple_config/env/project.yml
+++ b/tests/integration_tests/data/simple_config/env/project.yml
@@ -24,7 +24,7 @@ engines:
         use_software_entity: true
         location: 
           type: path
-          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
+          path: "{CONFIG_FOLDER}/../bundles/test_app"
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine

--- a/tests/integration_tests/data/simple_config/env/project.yml
+++ b/tests/integration_tests/data/simple_config/env/project.yml
@@ -20,17 +20,16 @@ description: Small environment to test the offline workflow.
 engines:
   tk-shell:
     apps:
-      tk-multi-launchapp:
-        use_software_entity: true
+      tk-test-app:
         location: 
           type: path
-          path: "{CONFIG_FOLDER}/../bundles/test_app"
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine
 
 frameworks:
-  tk-framework-shotgunutils_v5.x.x:
+  tk-framework-test:
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_framework_v1

--- a/tests/integration_tests/data/site_config/core/core_api.yml
+++ b/tests/integration_tests/data/site_config/core/core_api.yml
@@ -11,4 +11,4 @@
 
 location:
     type: path
-    path: $TK_CORE_REPO_ROOT
+    path: $SHOTGUN_REPO_ROOT

--- a/tests/integration_tests/data/site_config/env/project.yml
+++ b/tests/integration_tests/data/site_config/env/project.yml
@@ -20,17 +20,17 @@ description: Small environment to test the offline workflow.
 engines:
   tk-shell:
     apps:
-      tk-multi-launchapp:
-        use_software_entity: true
+      tk-test-app:
+        path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
         location: 
           type: path
-          path: "{CONFIG_FOLDER}/../bundles/test_app"
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine
 
 frameworks:
-  tk-framework-shotgunutils_v5.x.x:
+  tk-framework-test:
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_framework_v1

--- a/tests/integration_tests/data/site_config/env/project.yml
+++ b/tests/integration_tests/data/site_config/env/project.yml
@@ -23,17 +23,14 @@ engines:
       tk-multi-launchapp:
         use_software_entity: true
         location: 
-          type: app_store
-          name: tk-multi-launchapp
-          version: v0.9.15
+          type: path
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
     location:
-      type: app_store
-      name: tk-shell
-      version: v0.6.0
+      type: path
+      path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine
 
 frameworks:
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.3.4
-      type: app_store
-      name: tk-framework-shotgunutils
+      type: path
+      path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_framework_v1

--- a/tests/integration_tests/data/site_config/env/project.yml
+++ b/tests/integration_tests/data/site_config/env/project.yml
@@ -24,7 +24,7 @@ engines:
         use_software_entity: true
         location: 
           type: path
-          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
+          path: "{CONFIG_FOLDER}/../bundles/test_app"
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine

--- a/tests/integration_tests/data/site_config/env/project.yml
+++ b/tests/integration_tests/data/site_config/env/project.yml
@@ -18,13 +18,12 @@ description: Small environment to test the offline workflow.
 # configuration for all engines to load in a project context
 
 engines:
-  tk-shell:
+  tk-testengine:
     apps:
       tk-test-app:
-        path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
         location: 
           type: path
-          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_app
+          path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/simple_test_app
     location:
       type: path
       path: $SHOTGUN_REPO_ROOT/tests/fixtures/config/bundles/test_engine

--- a/tests/integration_tests/multi_bootstrap.py
+++ b/tests/integration_tests/multi_bootstrap.py
@@ -18,6 +18,7 @@ import traceback
 import unittest2
 from sgtk_integration_test import SgtkIntegrationTest
 import sgtk
+from tank_vendor.shotgun_api3.lib import sgsix
 
 logger = sgtk.LogManager.get_logger(__name__)
 
@@ -59,7 +60,7 @@ class MultipleBootstrapAcrossCoreSwap(SgtkIntegrationTest):
         # Bootstrap into the tk-shell123 engine.
         manager = sgtk.bootstrap.ToolkitManager(self.user)
         manager.do_shotgun_config_lookup = False
-        manager.base_configuration = "sgtk:descriptor:app_store?name=tk-config-basic"
+        manager.base_configuration = "sgtk:descriptor:path?path=$SHOTGUN_REPO_ROOT/tests/integration_tests/data/site_config"
         manager.caching_policy = sgtk.bootstrap.ToolkitManager.CACHE_SPARSE
         try:
             engine = manager.bootstrap_engine("tk-shell123", self.project)
@@ -74,10 +75,10 @@ class MultipleBootstrapAcrossCoreSwap(SgtkIntegrationTest):
                 print("Error detected was:")
                 print(traceback_str)
                 raise
-            engine = manager.bootstrap_engine("tk-shell", self.project)
+            engine = manager.bootstrap_engine("tk-testengine", self.project)
 
-        self.assertEqual(engine.name, "tk-shell")
-
+        self.assertEqual(engine.name, "test_engine")
 
 if __name__ == "__main__":
     ret_val = unittest2.main(failfast=True, verbosity=2)
+

--- a/tests/integration_tests/multi_bootstrap.py
+++ b/tests/integration_tests/multi_bootstrap.py
@@ -18,7 +18,6 @@ import traceback
 import unittest2
 from sgtk_integration_test import SgtkIntegrationTest
 import sgtk
-from tank_vendor.shotgun_api3.lib import sgsix
 
 logger = sgtk.LogManager.get_logger(__name__)
 

--- a/tests/integration_tests/offline_workflow.py
+++ b/tests/integration_tests/offline_workflow.py
@@ -122,7 +122,7 @@ class OfflineWorkflow(SgtkIntegrationTest):
         self.sg.upload(
             "PipelineConfiguration", pc["id"],
             "{temp_dir}/config.zip".format(temp_dir=self.temp_dir),
-            "sg_uploaded_config",
+            "uploaded_config",
             "Uploaded by tk-core integration tests."
         )
 
@@ -145,7 +145,7 @@ class OfflineWorkflow(SgtkIntegrationTest):
         # Bootstrap into the tk-shell engine.
         manager = sgtk.bootstrap.ToolkitManager(self.user)
         manager.pipeline_configuration = pc["id"]
-        engine = manager.bootstrap_engine("tk-shell", project)
+        engine = manager.bootstrap_engine("tk-testengine", project)
         engine.destroy_engine()
 
         # Make sure we only have a sg descriptor cache.

--- a/tests/integration_tests/run_integration_tests.py
+++ b/tests/integration_tests/run_integration_tests.py
@@ -39,6 +39,7 @@ def main():
     environ["SHOTGUN_SCRIPT_NAME"] = os.environ.get("SHOTGUN_SCRIPT_NAME")
     environ["SHOTGUN_SCRIPT_KEY"] = os.environ.get("SHOTGUN_SCRIPT_KEY")
     environ["SHOTGUN_HOST"] = os.environ.get("SHOTGUN_HOST")
+    environ["SHOTGUN_REPO_ROOT"] = os.path.join(os.path.dirname(__file__), "..", "..")
 
     current_folder, current_file = os.path.split(__file__)
 

--- a/tests/integration_tests/run_integration_tests.py
+++ b/tests/integration_tests/run_integration_tests.py
@@ -45,7 +45,7 @@ def main():
 
     before = time.time()
     try:
-        filenames = glob.iglob(os.path.join(current_folder, "*.py"))
+        filenames = sys.argv[1:] or glob.iglob(os.path.join(current_folder, "*.py"))
         for filename in filenames:
 
             # Skip the launcher. :)

--- a/tests/integration_tests/run_integration_tests.py
+++ b/tests/integration_tests/run_integration_tests.py
@@ -45,6 +45,13 @@ def main():
 
     before = time.time()
     try:
+        # Pop --with-coverage from the command line so we're left with just the script name
+        # or the script name and the tests to run.
+        with_coverage = False
+        while sys.argv.count("--with-coverage") > 0:
+            sys.argv.remove("--with-coverage")
+            with_coverage = True
+
         filenames = sys.argv[1:] or glob.iglob(os.path.join(current_folder, "*.py"))
         for filename in filenames:
 
@@ -56,7 +63,7 @@ def main():
             print("Running %s" % os.path.basename(filename))
             print("=" * 79)
 
-            if "--with-coverage" in sys.argv:
+            if with_coverage:
                 args = [
                     "coverage",
                     "run",


### PR DESCRIPTION
This fixes integration tests for the Python 3 branch. Here's what was fixed:

- The one big issue was with the core swapper, whose import handler was not getting invoked in Python 3. I've fixed the issue and documented the fix.
- The rest of the changes was fixing laziness on our part when I wrote these tests originally, which introduced dependencies on tk-config-basic. This causes a problem at the moment because none of the apps are Python 3 compatible and this broke the tests when loading engines and apps. Therefore, I've fixed the tests so that the repo is self-contained and does not pull a config from another repo.
- I introduced a simple app that doesn't require any configuration that can be used in any test.
- Integration tests can now be run individually.

