### PR TITLE
SG-13074: Adds "Executed websockets command" to the list of known event names

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -611,7 +611,8 @@ class EventMetric(object):
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Published"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "New Workfile"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Opened Workfile"),
-        EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Saved Workfile")
+        EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Saved Workfile"),
+        EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Executed websockets command"),
     ]
 
     # Event property keys


### PR DESCRIPTION
Manne had already done the work to send these metrics to Amplitude by way of tk-core, but he hadn't whitelisted the event name, which resulted in an "Unknown event" being logged. This is just whitelisting the one new event name he added to tk-desktop2.