### PR TITLE
SG-14303 Added a fix and tests for Task folder creation,

### DIFF
--- a/python/tank/folder/folder_io.py
+++ b/python/tank/folder/folder_io.py
@@ -149,7 +149,7 @@ class FolderIOReceiver(object):
             
             
             # now that we are synced up with all remote sites,
-            # validate the data before we push it into the databse. 
+            # validate the data before we push it into the database.
             # to properly cover some edge cases        
             try:
                 path_cache.validate_mappings(db_entries)

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -487,20 +487,24 @@ class PathCache(object):
         except Exception as e:
             raise TankError("Critical! Could not update Shotgun with folder "
                             "data. Please contact support. Error details: %s" % e)
-        
+
         # now create a dictionary where input path cache rowid (path_cache_row_id)
         # is mapped to the shotgun ids that were just created
-        def _rowid_from_path(path):
+        def _rowid_from_filesystem_entity(fsl_entity):
+            path = fsl_entity[SG_PATH_FIELD]["local_path"]
             for d in data:
-                if d["path"] == path:
-                    return d["path_cache_row_id"] 
+                # We need to match not only the path but also the entity type when associating the FilesystemLocation
+                # entities with the local cache's row ids, because Task folders generate two entries with the same
+                # path, one for the Task and one for the Step.
+                if d["path"] == path and d["entity"]["type"] == fsl_entity["linked_entity_type"]:
+                    return d["path_cache_row_id"]
             raise TankError("Could not resolve row id for path! Please contact support! "
                             "trying to resolve path '%s'. Source data set: %s" % (path, data))
-        
+
         rowid_sgid_lookup = {}
         for sg_obj in response:
             sg_id = sg_obj["id"]
-            pc_row_id = _rowid_from_path( sg_obj[SG_PATH_FIELD]["local_path"] )
+            pc_row_id = _rowid_from_filesystem_entity(sg_obj)
             rowid_sgid_lookup[pc_row_id] = sg_id
         
         # now register the created ids in the event log
@@ -1265,7 +1269,7 @@ class PathCache(object):
                 # Note! We are only comparing against the type and the id
                 # not against the name. It should be perfectly valid to rename something
                 # in shotgun and if folders are then recreated for that item, nothing happens
-                # because there is already a folder which repreents that item. (although now with
+                # because there is already a folder which represents that item. (although now with
                 # an incorrect name)
                 #
                 # also note that we have already done this once as part of the validation checks -

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -308,7 +308,7 @@ class Template(object):
             if token.startswith('['):
                 # check that optional contains a key
                 if not re.search("{*%s}" % constants.TEMPLATE_KEY_NAME_REGEX, token): 
-                    raise TankError("Optional sections must include a key definition.")
+                    raise TankError("Optional sections must include a key definition. Token: \"%s\" Template: %s" % (token, self))
 
                 # Add definitions skipping this optional value
                 temp_definitions = definitions[:]

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -738,8 +738,6 @@ class TestFolderCreationPathCache(TankTestBase):
                      "id": 3,
                      "code": "step_code",
                      "short_name": "step_short_name"}
-
-
         self.task = {"type": "Task",
                      "id": 23,
                      "entity": self.shot,
@@ -747,12 +745,11 @@ class TestFolderCreationPathCache(TankTestBase):
                      "step": self.step,
                      "project": self.project}
 
-
         entities = [self.shot,
                     self.seq,
                     self.step,
                     self.project,
-                    self.task,]
+                    self.task]
 
         # Add these to mocked shotgun
         self.add_to_sg_mock_db(entities)
@@ -795,7 +792,7 @@ class TestFolderCreationPathCache(TankTestBase):
         shotgun_status_entries = res.fetchall()
 
         # get all the filesystemlocation entities.
-        filesystemlocation_entries = self.tk.shotgun.find("FilesystemLocation",[], ["linked_entity_type"])
+        filesystemlocation_entries = self.tk.shotgun.find("FilesystemLocation", [], ["linked_entity_type"])
 
         # There should be equal numbers of path_cache items, to shotgun_status items to FilesystemLocation entities
         self.assertEqual(len(shotgun_status_entries), len(path_cache_entries))
@@ -816,7 +813,7 @@ class TestFolderCreationPathCache(TankTestBase):
 
             # Now check a matching FilesystemLocation entity is found to ensure the relationship record is correct.
             filesystemlocation_entity = next(
-                (fl for fl in filesystemlocation_entries if check_match(fl,shotgun_status_row, path_cache_row )), None)
+                (fl for fl in filesystemlocation_entries if check_match(fl, shotgun_status_row, path_cache_row )), None)
             self.assertIsNotNone(filesystemlocation_entity)
 
 

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -775,9 +775,10 @@ class TestFolderCreationPathCache(TankTestBase):
         super(TestFolderCreationPathCache, self).tearDown()
 
     def test_shotgun_path_cache_counts(self):
-
-        # Check that the status table has entries for all the path_cache, and FilesystemLocation entities
-        # and checking that the relationships are correctly matched up.
+        """
+        Check that the status table has entries for all the path_cache, and FilesystemLocation entities
+        and checking that the relationships are correctly matched up.
+        """
 
         # get all the path_cache table rows
         res = self.db_cursor.execute(
@@ -795,26 +796,33 @@ class TestFolderCreationPathCache(TankTestBase):
         filesystemlocation_entries = self.tk.shotgun.find("FilesystemLocation", [], ["linked_entity_type"])
 
         # There should be equal numbers of path_cache items, to shotgun_status items to FilesystemLocation entities
-        self.assertEqual(len(shotgun_status_entries), len(path_cache_entries))
-        self.assertEqual(len(shotgun_status_entries), len(filesystemlocation_entries))
+        # The task fixtures schema should generate 5 patch cache entries, so we should check they are all 5.
+        self.assertEqual(len(shotgun_status_entries), 5)
+        self.assertEqual(len(path_cache_entries), 5)
+        self.assertEqual(len(shotgun_status_entries), 5)
 
         def check_match(fl_entity, shotgun_status_row, path_cache_row):
-            # check that filesystemlocation that matches the shotgun_status_row's shotgun_id also matches the
-            # path_cache_rows's entity type.
+            """
+            check that FilesystemLocation entity that matches the shotgun_status_row's shotgun_id also matches the
+            path_cache_rows's entity type.
+            :param fl_entity: FilesystemLocation entity
+            :param shotgun_status_row: A shotgun_status table row
+            :param path_cache_row: A path_cache table row
+            :return:
+            """
             return shotgun_status_row[1] == fl_entity["id"] and path_cache_row[1] == fl_entity["linked_entity_type"]
 
         # Now loop over the path cache rows, and ensure that the path_cache to shotgun_status to filesystemLocation entity
         # relationships all line up.
         for path_cache_row in path_cache_entries:
             # Make sure we find a matching shotgun_status table row.
-            shotgun_status_row = next(
-                (s_row for s_row in shotgun_status_entries if path_cache_row[0] == s_row[0]), None)
-            self.assertIsNotNone(shotgun_status_row)
+            shotgun_status_rows = [s_row for s_row in shotgun_status_entries if path_cache_row[0] == s_row[0]]
+            self.assertEqual(len(shotgun_status_rows), 1)
 
             # Now check a matching FilesystemLocation entity is found to ensure the relationship record is correct.
-            filesystemlocation_entity = next(
-                (fl for fl in filesystemlocation_entries if check_match(fl, shotgun_status_row, path_cache_row )), None)
-            self.assertIsNotNone(filesystemlocation_entity)
+            filesystemlocation_entitys = [fl for fl in filesystemlocation_entries if
+                                         check_match(fl, shotgun_status_rows[0], path_cache_row)]
+            self.assertEqual(len(filesystemlocation_entitys), 1)
 
 
 class TestFolderCreationEdgeCases(TankTestBase):

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -792,7 +792,7 @@ class TestFolderCreationPathCache(TankTestBase):
         )
         shotgun_status_entries = res.fetchall()
 
-        # get all the filesystemlocation entities.
+        # get all the FilesystemLocation entities.
         filesystemlocation_entries = self.tk.shotgun.find("FilesystemLocation", [], ["linked_entity_type"])
 
         # There should be equal numbers of path_cache items, to shotgun_status items to FilesystemLocation entities
@@ -812,16 +812,17 @@ class TestFolderCreationPathCache(TankTestBase):
             """
             return shotgun_status_row[1] == fl_entity["id"] and path_cache_row[1] == fl_entity["linked_entity_type"]
 
-        # Now loop over the path cache rows, and ensure that the path_cache to shotgun_status to filesystemLocation entity
-        # relationships all line up.
+        # Now loop over the path cache rows, and ensure that the path_cache to shotgun_status to
+        # FilesystemLocation entity relationships all line up.
         for path_cache_row in path_cache_entries:
             # Make sure we find a matching shotgun_status table row.
             shotgun_status_rows = [s_row for s_row in shotgun_status_entries if path_cache_row[0] == s_row[0]]
             self.assertEqual(len(shotgun_status_rows), 1)
 
             # Now check a matching FilesystemLocation entity is found to ensure the relationship record is correct.
-            filesystemlocation_entitys = [fl for fl in filesystemlocation_entries if
-                                         check_match(fl, shotgun_status_rows[0], path_cache_row)]
+            filesystemlocation_entitys = [fl for fl in filesystemlocation_entries if check_match(fl,
+                                                                                                 shotgun_status_rows[0],
+                                                                                                 path_cache_row)]
             self.assertEqual(len(filesystemlocation_entitys), 1)
 
 

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -799,7 +799,7 @@ class TestFolderCreationPathCache(TankTestBase):
         # The task fixtures schema should generate 5 patch cache entries, so we should check they are all 5.
         self.assertEqual(len(shotgun_status_entries), 5)
         self.assertEqual(len(path_cache_entries), 5)
-        self.assertEqual(len(shotgun_status_entries), 5)
+        self.assertEqual(len(filesystemlocation_entries), 5)
 
         def check_match(fl_entity, shotgun_status_row, path_cache_row):
             """

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -21,15 +21,15 @@ from tank_test.tank_test_base import *
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
-# test against a step node where create_with_parent is false
+# test against a Task node where create_with_parent is false
 
-class TestSchemaCreateFoldersSingleStep(TankTestBase):
+class TestSchemaCreateFoldersSingleTask(TankTestBase):
     def setUp(self):
         """Sets up entities in mocked shotgun database and creates Mock objects
         to pass in as callbacks to Schema.create_folders. The mock objects are
         then queried to see what paths the code attempted to create.
         """
-        super(TestSchemaCreateFoldersSingleStep, self).setUp()
+        super(TestSchemaCreateFoldersSingleTask, self).setUp()
         
         self.setup_fixtures(parameters = {"core": "core.override/shotgun_single_task_core"})
         
@@ -91,7 +91,7 @@ class TestSchemaCreateFoldersSingleStep(TankTestBase):
     def tearDown(self):
         
         # important to call base class so it can clean up memory
-        super(TestSchemaCreateFoldersSingleStep, self).tearDown()
+        super(TestSchemaCreateFoldersSingleTask, self).tearDown()
         
         # and do local teardown                                                                                
         folder.folder_io.FolderIOReceiver.execute_folder_creation = self.FolderIOReceiverBackup
@@ -181,15 +181,15 @@ class TestSchemaCreateFoldersSingleStep(TankTestBase):
 
 
 
-# test against a step node where create_with_parent is true
+# test against a task node where create_with_parent is true
 
-class TestSchemaCreateFoldersMultiStep(TankTestBase):
+class TestSchemaCreateFoldersMultiTask(TankTestBase):
     def setUp(self):
         """Sets up entities in mocked shotgun database and creates Mock objects
         to pass in as callbacks to Schema.create_folders. The mock objects are
         then queried to see what paths the code attempted to create.
         """
-        super(TestSchemaCreateFoldersMultiStep, self).setUp()
+        super(TestSchemaCreateFoldersMultiTask, self).setUp()
         
         self.setup_fixtures(parameters = {"core": "core.override/shotgun_multi_task_core"})
                 
@@ -251,7 +251,7 @@ class TestSchemaCreateFoldersMultiStep(TankTestBase):
     def tearDown(self):
         
         # important to call base class so it can clean up memory
-        super(TestSchemaCreateFoldersMultiStep, self).tearDown()
+        super(TestSchemaCreateFoldersMultiTask, self).tearDown()
         
         # and do local teardown                                                                                        
         folder.folder_io.FolderIOReceiver.execute_folder_creation = self.FolderIOReceiverBackup

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -21,8 +21,8 @@ from tank_test.tank_test_base import *
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
-# test against a Task node where create_with_parent is false
 
+# test against a Task node where create_with_parent is false
 class TestSchemaCreateFoldersSingleTask(TankTestBase):
     def setUp(self):
         """Sets up entities in mocked shotgun database and creates Mock objects


### PR DESCRIPTION
The PR fixes an issue with the Task folder creation. 
Before this fix it would create two registries for for each generated task node path. Each would have the same path but one was registered to the Task as a primary path and the other was registered to the Step as a secondary entity.
During the registry it would first create the path_cache rows, and then the `FilesystemLocation` entities, and finally it would fill in the shotgun_status table in the local cache with a map of the relationships between the path_cache table and the FilesystemLocation entities.

The problem is that when it tried to map the created FilesystemLocation entities to the local path_cache table's row ids it only checked paths, and since the task folder generates two records with the same path, it wasn't correctly mapping all the relations, and the ones it was doing were wrong, ie step > task.

<img width="572" alt="path_cache" src="https://user-images.githubusercontent.com/3777228/66848089-5c90a300-ef6c-11e9-8578-bb1aadf499fa.png">

The PR contains the following changes:
+ Now considers entity type and path when mapping the `FilesystemLocation` entities to row ids. It also adds a test to ensure that the path_cache table, shotgun_status table, and `FilesystemLocation` entities are all of the same length and that they are lined up correctly, ie no step entries being linked to task entries.
+ Tidies up the naming of the test_task_node.py test as they appear to have been copied from the step ones without renaming.
+ a couple of small typo fixes.