### PR TITLE
Silences flake8 on W503 errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -52,6 +52,7 @@ exclude =
 # W291 trailing whitespace
 # W293 blank line contains whitespace
 # W391 blank line at end of file
+# W503 Line break occurred before a binary operator
 # E221 multiple spaces before operator
 # E261 two whitespaces before end of line comment.
 # E402 module level import not top of file
@@ -59,5 +60,5 @@ exclude =
 # N806 Variables should be lower case. (clashes with Qt naming conventions)
 # E999 SyntaxError: invalid syntax (hack for hound CI which runs python 3.x)
 
-ignore = E501, W291, W293, W391, E221, E261, E402, N802, N806, E999
+ignore = E501, W291, W293, W391, W503, E221, E261, E402, N802, N806, E999
 


### PR DESCRIPTION
This warning emitted by flake8 will not be a warning in the future and will become the new best practice according to pep8. `black` already fixes code by using the new rule, which is causing errors in HoundCI on our repos that are being converted to the `black` code style. This will silence this error.

To learn more about this warning, see this: https://lintlyci.github.io/Flake8Rules/rules/W503.html

Note that this file is actually used by all our repo's when it comes to HoundCI, not just tk-core, which is why it's important to fix the problem here.