### PR TITLE
SG-6255: Include files order

### DIFF
--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -50,7 +50,7 @@ def _resolve_includes(file_name, data, context):
     Parses the includes section and returns a list of valid paths
     """
     includes = []
-    resolved_includes = set()
+    resolved_includes = list()
     
     if constants.SINGLE_INCLUDE_SECTION in data:
         # single include section
@@ -111,10 +111,10 @@ def _resolve_includes(file_name, data, context):
         else:
             path = resolve_include(file_name, include)
 
-        if path:
-            resolved_includes.add(path)
+        if path and path not in resolved_includes:
+            resolved_includes.append(path)
 
-    return list(resolved_includes)
+    return resolved_includes
 
 
 

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -45,7 +45,7 @@ def _get_includes(file_name, data):
     """
     includes = []
 
-    resolved_includes = set()
+    resolved_includes = list()
 
     if constants.SINGLE_INCLUDE_SECTION in data:
         # single include section
@@ -57,21 +57,21 @@ def _get_includes(file_name, data):
 
     for include in includes:
         resolved = resolve_include(file_name, include)
-        if resolved:
-            resolved_includes.add(resolved)
+        if resolved and resolved not in resolved_includes:
+            resolved_includes.append(resolved)
 
-    return list(resolved_includes)
+    return resolved_includes
 
 
 def _process_template_includes_r(file_name, data):
     """
     Recursively add template include files.
-    
+
     For each of the sections keys, strings, path, populate entries based on
     include files.
     """
-    
-    # return data    
+
+    # return data
     output_data = {}
     # add items for keys, paths, strings etc
     for ts in constants.TEMPLATE_SECTIONS:
@@ -82,42 +82,42 @@ def _process_template_includes_r(file_name, data):
 
     # process includes
     included_paths = _get_includes(file_name, data)
-    
+
     for included_path in included_paths:
         included_data = yaml_cache.g_yaml_cache.get(included_path, deepcopy_data=False) or dict()
-        
+
         # before doing any type of processing, allow the included data to be resolved.
         included_data = _process_template_includes_r(included_path, included_data)
-        
+
         # add the included data's different sections
         for ts in constants.TEMPLATE_SECTIONS:
             if ts in included_data:
                 output_data[ts].update( included_data[ts] )
-        
+
     # now all include data has been added into the data structure.
     # now add the template data itself
     for ts in constants.TEMPLATE_SECTIONS:
         if ts in data:
             output_data[ts].update( data[ts] )
-    
+
     return output_data
-        
+
 def process_includes(file_name, data):
     """
-    Processes includes for the main templates file. Will look for 
+    Processes includes for the main templates file. Will look for
     any include data structures and transform them into real data.
-    
+
     Algorithm (recursive):
-    
+
     1. first load in include data into keys, strings, path sections.
        if there are multiple files, they are loaded in order.
     2. now, on top of this, load in this file's keys, strings and path defs
     3. lastly, process all @refs in the paths section
-        
+
     """
     # first recursively load all template data from includes
     resolved_includes_data = _process_template_includes_r(file_name, data)
-    
+
     # Now recursively process any @resolves.
     # these are of the following form:
     #   foo: bar
@@ -131,24 +131,24 @@ def process_includes(file_name, data):
     # Would result in:
     #   bar/something/@/_bar_
     template_paths = resolved_includes_data[constants.TEMPLATE_PATH_SECTION]
-    template_strings = resolved_includes_data[constants.TEMPLATE_STRING_SECTION] 
-    
+    template_strings = resolved_includes_data[constants.TEMPLATE_STRING_SECTION]
+
     # process the template paths section:
     for template_name, template_definition in template_paths.iteritems():
-        _resolve_template_r(template_paths, 
-                            template_strings, 
-                            template_name, 
-                            template_definition, 
+        _resolve_template_r(template_paths,
+                            template_strings,
+                            template_name,
+                            template_definition,
                             "path")
-        
+
     # and process the strings section:
     for template_name, template_definition in template_strings.iteritems():
-        _resolve_template_r(template_paths, 
-                            template_strings, 
-                            template_name, 
-                            template_definition, 
+        _resolve_template_r(template_paths,
+                            template_strings,
+                            template_name,
+                            template_definition,
                             "string")
-                
+
     # finally, resolve escaped @'s in template definitions:
     for templates in [template_paths, template_strings]:
         for template_name, template_definition in templates.iteritems():
@@ -163,20 +163,20 @@ def process_includes(file_name, data):
             if not template_str:
                 raise TankError("Invalid template configuration for '%s' - "
                                 "it looks like the definition is missing!" % (template_name))
-            
+
             # resolve escaped @'s
             resolved_template_str = template_str.replace("@@", "@")
             if resolved_template_str == template_str:
                 continue
-                
+
             # set the value back again:
             if complex_syntax:
                 templates[template_name]["definition"] = resolved_template_str
             else:
                 templates[template_name] = resolved_template_str
-                
+
     return resolved_includes_data
-        
+
 def _find_matching_ref_template(template_paths, template_strings, ref_string):
     """
     Find a template whose name matches a portion of ref_string.  This
@@ -184,13 +184,13 @@ def _find_matching_ref_template(template_paths, template_strings, ref_string):
     templates
     """
     matching_templates = []
-    
+
     # find all templates that match the start of the ref string:
     for templates, template_type in [(template_paths, "path"), (template_strings, "string")]:
         for name, definition in templates.iteritems():
             if ref_string.startswith(name):
                 matching_templates.append((name, definition, template_type))
-            
+
     # if there are more than one then choose the one with the longest
     # name/longest match:
     best_match = None
@@ -200,7 +200,7 @@ def _find_matching_ref_template(template_paths, template_strings, ref_string):
         if name_len > best_match_len:
             best_match_len = name_len
             best_match = (name, definition, template_type)
-            
+
     return best_match
 
 def _resolve_template_r(template_paths, template_strings, template_name, template_definition, template_type, template_chain = None):
@@ -208,15 +208,15 @@ def _resolve_template_r(template_paths, template_strings, template_name, templat
     Recursively resolve path templates so that they are fully expanded.
     """
 
-    # check we haven't searched this template before and keep 
+    # check we haven't searched this template before and keep
     # track of the ones we have visited
     template_key = (template_name, template_type)
     visited_templates = list(template_chain or [])
     if template_key in visited_templates:
-        raise TankError("A cyclic %s template was found - '%s' references itself (%s)" 
+        raise TankError("A cyclic %s template was found - '%s' references itself (%s)"
                         % (template_type, template_name, " -> ".join([name for name, _ in visited_templates[visited_templates.index(template_key):]] + [template_name])))
     visited_templates.append(template_key)
-    
+
     # find the template string from the definition:
     template_str = None
     complex_syntax = False
@@ -228,13 +228,13 @@ def _resolve_template_r(template_paths, template_strings, template_name, templat
     if not template_str:
         raise TankError("Invalid template configuration for '%s' - it looks like the "
                         "definition is missing!" % (template_name))
-    
+
     # look for @ specified in template definition.  This can be escaped by
     # using @@ so split out escaped @'s first:
     template_str_parts = template_str.split("@@")
     resolved_template_str_parts = []
     for part in template_str_parts:
-        
+
         # split to find seperate @ include parts:
         ref_parts = part.split("@")
         resolved_ref_parts = ref_parts[:1]
@@ -243,37 +243,37 @@ def _resolve_template_r(template_paths, template_strings, template_name, templat
             if not ref_part:
                 # this would have been an @ so ignore!
                 continue
-                
-            # find a template that matches the start of the template string:                
+
+            # find a template that matches the start of the template string:
             ref_template = _find_matching_ref_template(template_paths, template_strings, ref_part)
             if not ref_template:
                 raise TankError("Failed to resolve template reference from '@%s' defined by "
                                 "the %s template '%s'" % (ref_part, template_type, template_name))
-                
+
             # resolve the referenced template:
             ref_template_name, ref_template_definition, ref_template_type = ref_template
-            resolved_ref_str = _resolve_template_r(template_paths, 
-                                                   template_strings, 
-                                                   ref_template_name, 
-                                                   ref_template_definition, 
-                                                   ref_template_type, 
+            resolved_ref_str = _resolve_template_r(template_paths,
+                                                   template_strings,
+                                                   ref_template_name,
+                                                   ref_template_definition,
+                                                   ref_template_type,
                                                    visited_templates)
             resolved_ref_str = "%s%s" % (resolved_ref_str, ref_part[len(ref_template_name):])
-                                    
+
             resolved_ref_parts.append(resolved_ref_str)
-        
+
         # rejoin resolved parts:
         resolved_template_str_parts.append("".join(resolved_ref_parts))
-        
+
     # re-join resolved parts with escaped @:
     resolved_template_str = "@@".join(resolved_template_str_parts)
-    
+
     # put the value back:
     templates = {"path":template_paths, "string":template_strings}[template_type]
     if complex_syntax:
         templates[template_name]["definition"] = resolved_template_str
     else:
         templates[template_name] = resolved_template_str
-        
+
     return resolved_template_str
 

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -152,10 +152,15 @@ class Includes(object):
 
         @patch("os.path.exists", return_value=True)
         def test_includes_ordering(self, _):
-
+            """
+            Ensure include orders is preserved.
+            """
             # Try different permutations of the same set of includes and they should
-            # always return in the same order. They avoids the entries to be
-            # sorted.
+            # always return in the same order. This is important as values found
+            # in later includes override earlier ones.
+
+            # We do permutations here because Python 2 and Python 3 handle
+            # set ordering differently.
             for includes in itertools.permutations(["a.yml", "b.yml", "c.yml"]):
                 self.assertEqual(
                     self._resolve_includes(includes),

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -11,6 +11,7 @@
 from __future__ import with_statement
 import os
 import sys
+import itertools
 
 import tank
 from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
@@ -149,8 +150,20 @@ class Includes(object):
             with self.assertRaisesRegex(tank.TankError, "Include resolve error"):
                 self._resolve_includes("dead/path/to/a/file")
 
+        @patch("os.path.exists", return_value=True)
+        def test_includes_ordering(self, _):
 
-# TODO: These tests should be move within the respective test package, but because they share
+            # Try different permutations of the same set of includes and they should
+            # always return in the same order. They avoids the entries to be
+            # sorted.
+            for includes in itertools.permutations(["a.yml", "b.yml", "c.yml"]):
+                self.assertEqual(
+                    self._resolve_includes(includes),
+                    [os.path.join(os.getcwd(), include) for include in includes]
+                )
+
+
+# TODO: These tests should be moved within their respective test packages, but because they share
 # the same suite of tests there's no easy way to share the suite. However, once we finish the
 # refactoring of the include system, I suspect most of these tests will move to the refactored
 # framework location and this messiness will go away.


### PR DESCRIPTION
This merges a fix from the automotive team that ensures includes from environment files are always returned in the order they were found in the file.

I've added a test.

The use of a set to keep track of which files were visited screwed up the ordering of the includes because sets sort their input. The fix reverts the code back to using a list as it originally was and uses the in operator to exclude files.