### PR TITLE
Fix login dialog popup behaviour

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -414,12 +414,6 @@ class LoginDialog(QtGui.QDialog):
         self.raise_()
         self.activateWindow()
 
-        # the trick of activating + raising does not seem to be enough for
-        # modal dialogs. So force put them on top as well.
-        # On PySide2, or-ring the current window flags with WindowStaysOnTopHint causes the dialog
-        # to freeze, so only set the WindowStaysOnTopHint flag as this appears to not disable the
-        # other flags.
-        self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         return QtGui.QDialog.exec_(self)
 
     def result(self):


### PR DESCRIPTION
**Setup:**
Dual monitor with one very wide window (spanning both monitors) on CentOS 7.4. The main monitor (to the right) is 1920x1200, second monitor (to the left) is 1920x1080.

**Issue:**
When requesting for the login dialog to pop up, it seems to pop up under the main window on the main monitor. The login dialog is therefore inaccessible. In order to see it, you have to alt-tab to another window that is on the second monitor.

When using a single monitor, the login dialog displays as expected except for the field focus which is in the first field instead of the first empty field. It also behaves the same way if I use two monitors but make my monitor to the left vertical (1080x1920) instead.

**Potential fix:**
Removing the StaysOnTop hint given to the login dialog fixes this weird behaviour. It also fixes the focusing which seems to behave wrongly at the moment. It now focuses on the first empty field like it should. One byproduct of this potential fix is that when switching to other windows, the Shotgun login dialog will not always be on top. It is nonetheless always in the foreground when focusing on the main program window (the window that spawned the dialog).