### PR TITLE
SG-13264: fixing context.serialize signature

### DIFF
--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -298,17 +298,17 @@ class ShotgunSamlUser(ShotgunWebUser):
             return False
 
 
-def serialize_user(user, use_pickle=True):
+def serialize_user(user, use_json=False):
     """
     Serializes a user. Meant to be consumed by deserialize.
 
     :param user: User object that needs to be serialized.
-    :param use_pickle: If ``True``, the context will be ``pickle``d. Otherwise,
-        a ``json`` representation will be generated.
+    :param use_json: If ``True``, a ``json`` representation will be generated.
+        A pickled representation will be generated otherwise.
 
     :returns: The payload representing the user.
     """
-    return user_impl.serialize_user(user.impl, use_pickle=use_pickle)
+    return user_impl.serialize_user(user.impl, use_json=use_json)
 
 
 def deserialize_user(payload):

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -525,13 +525,13 @@ __factories = {
 }
 
 
-def serialize_user(user, use_pickle=True):
+def serialize_user(user, use_json=False):
     """
     Serializes a user. Meant to be consumed by deserialize.
 
     :param user: User object that needs to be serialized.
-    :param use_pickle: If ``True``, the context will be ``pickle``d. Otherwise,
-        a ``json`` representation will be generated.
+    :param use_json: If ``True``, a ``json`` representation will be generated.
+        A pickled representation will be generated otherwise.
 
     :returns: The payload representing the user.
     """
@@ -541,10 +541,10 @@ def serialize_user(user, use_pickle=True):
         "type": user.__class__.__name__,
         "data": user.to_dict()
     }
-    if use_pickle:
-        return pickle.dumps(user_data)
-    else:
+    if use_json:
         return json.dumps(user_data)
+    else:
+        return pickle.dumps(user_data)
 
 
 def deserialize_user(payload):

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -675,7 +675,7 @@ class Context(object):
     ################################################################################################
     # serialization
 
-    def serialize(self, with_user_credentials=True, use_pickle=True):
+    def serialize(self, with_user_credentials=True, use_json=False):
         """
         Serializes the context into a string.
 
@@ -694,8 +694,8 @@ class Context(object):
         :param with_user_credentials: If ``True``, the currently authenticated user's credentials, as
             returned by :meth:`sgtk.get_authenticated_user`, will also be serialized with the context.
 
-        :param use_pickle: If ``True``, the context will be ``pickle``d. Otherwise,
-            a ``json`` representation will be generated.
+        :param use_json: If ``True``, the context will be stored in the JSON representation
+            instead of using the pickled representation.
 
         .. note:: For example, credentials should be omitted (``with_user_credentials=False``) when
             serializing the context from a user's current session to send it to a render farm. By doing
@@ -716,12 +716,12 @@ class Context(object):
             if user:
                 # We should serialize it as well so that the next process knows who to
                 # run as.
-                data["_current_user"] = authentication.serialize_user(user, use_pickle=use_pickle)
+                data["_current_user"] = authentication.serialize_user(user, use_json=use_json)
 
-        if use_pickle:
-            return pickle.dumps(data)
-        else:
+        if use_json:
             return json.dumps(data)
+        else:
+            return pickle.dumps(data)
 
     @classmethod
     def deserialize(cls, context_str):

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -1241,7 +1241,7 @@ class TestSerialize(TestContext):
 
     def test_serialize_with_user(self):
         """
-        Make sure the user is serialized and restored.
+        Make sure the user is serialized and restored using pickle.
         """
         tank.set_authenticated_user(self._auth_user)
         ctx = context.Context(**self.kws)
@@ -1263,6 +1263,9 @@ class TestSerialize(TestContext):
         self._assert_same_user(tank.get_authenticated_user(), self._auth_user)
 
     def test_serialize_with_user_using_json(self):
+        """
+        Make sure the user is serialized and restored using json.
+        """
         tank.set_authenticated_user(self._auth_user)
         ctx = context.Context(**self.kws)
         ctx_str = tank.Context.serialize(ctx, use_json=True)

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -13,7 +13,8 @@ from __future__ import with_statement
 import os
 import copy
 import datetime
-import pickle
+from sgtk.util import pickle
+import json
 
 from tank_test.tank_test_base import TankTestBase, setUpModule # noqa
 
@@ -1244,7 +1245,33 @@ class TestSerialize(TestContext):
         """
         tank.set_authenticated_user(self._auth_user)
         ctx = context.Context(**self.kws)
-        ctx_str = tank.Context.serialize(ctx)
+        ctx_str = tank.Context.serialize(ctx, use_json=False)
+
+        # Everything should have been serialized using the pickle module.
+        # If an exception is raised, then it wasn't.
+        unserialized_pickle = pickle.loads(ctx_str)
+        pickle.loads(unserialized_pickle["_current_user"])
+
+        # Ensure the serialized context is a string
+        self.assertIsInstance(ctx_str, six.string_types)
+
+        # Reset the current user to later check if it is restored.
+        tank.set_authenticated_user(None)
+
+        # Unserializing should restore the user.
+        tank.Context.deserialize(ctx_str)
+        self._assert_same_user(tank.get_authenticated_user(), self._auth_user)
+
+    def test_serialize_with_user_using_json(self):
+        tank.set_authenticated_user(self._auth_user)
+        ctx = context.Context(**self.kws)
+        ctx_str = tank.Context.serialize(ctx, use_json=True)
+
+        # Everything should have been serialized using the json module.
+        # If an exception is raised, then it wasn't.
+        unserialized_json = json.loads(ctx_str)
+        json.loads(unserialized_json["_current_user"])
+
         # Ensure the serialized context is a string
         self.assertIsInstance(ctx_str, six.string_types)
 


### PR DESCRIPTION
The API feels saner this way. The default behaviour is the same as before, but you get JSON by "asking for JSON" instead of "asking not to pickle".

Also, added test!