### PR TITLE
SG-13264: Promoting six to tank_vendor

### DIFF
--- a/developer/shotgun_api_update.sh
+++ b/developer/shotgun_api_update.sh
@@ -91,9 +91,12 @@ pushd $DEST_REPO
 git rev-parse HEAD > $DEST/commit_id
 popd
 
+cp $DEST/lib/six.py $DEST/../six.py
+
 # Put files in the staging area.
 echo "adding new files to git..."
 git add -A $DEST
+git add -A $DEST/../six.py
 
 # Cleanup!
 echo "cleaning up..."

--- a/hooks/process_folder_creation.py
+++ b/hooks/process_folder_creation.py
@@ -17,7 +17,7 @@ from tank import Hook
 import os
 import sys
 import shutil
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank.util import is_windows
 
 

--- a/hooks/process_folder_name.py
+++ b/hooks/process_folder_name.py
@@ -26,7 +26,7 @@ is being used, for example:
 
 from tank import Hook
 import re
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class ProcessFolderName(Hook):

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -26,8 +26,8 @@ from . import pipelineconfig
 from . import pipelineconfig_utils
 from . import pipelineconfig_factory
 from . import LogManager
-from tank_vendor.shotgun_api3.lib import six
-from tank_vendor.shotgun_api3.lib.six.moves import zip
+from tank_vendor import six
+from tank_vendor.six.moves import zip
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -35,7 +35,7 @@ from .sso_saml2 import (
 from ..util.shotgun.connection import sanitize_url
 
 from getpass import getpass
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -18,7 +18,7 @@ at any point.
 --------------------------------------------------------------------------------
 """
 from tank_vendor import shotgun_api3
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from .web_login_support import get_shotgun_authenticator_support_web_login
 from .ui import resources_rc # noqa
 from .ui import login_dialog

--- a/python/tank/authentication/shotgun_wrapper.py
+++ b/python/tank/authentication/shotgun_wrapper.py
@@ -15,10 +15,10 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
-from tank_vendor.shotgun_api3.lib.six.moves import http_client
+from tank_vendor.six.moves import http_client
 
 from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault
-from tank_vendor.shotgun_api3.lib.six.moves.xmlrpc_client import ProtocolError
+from tank_vendor.six.moves.xmlrpc_client import ProtocolError
 from . import interactive_authentication, session_cache
 from .. import LogManager
 

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -21,8 +21,8 @@ at any point.
 
 from .shotgun_wrapper import ShotgunWrapper
 from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault, ProtocolError
-from tank_vendor.shotgun_api3.lib import six
-from tank_vendor.shotgun_api3.lib.six.moves import http_client
+from tank_vendor import six
+from tank_vendor.six.moves import http_client
 
 from . import session_cache
 from .errors import IncompleteCredentials

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -22,7 +22,7 @@ from ..util.version import is_version_older
 from .action_base import Action
 from .. import pipelineconfig_utils
 from .. import pipelineconfig_factory
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
 
 # these are the items that need to be copied across

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -22,7 +22,8 @@ from ..util.version import is_version_older
 from .action_base import Action
 from .. import pipelineconfig_utils
 from .. import pipelineconfig_factory
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 
 # these are the items that need to be copied across
 # when a configuration is upgraded to contain a core API

--- a/python/tank/commands/dump_config.py
+++ b/python/tank/commands/dump_config.py
@@ -11,7 +11,7 @@
 from __future__ import print_function
 
 import os
-from tank_vendor.shotgun_api3.lib.six import StringIO
+from tank_vendor.six import StringIO
 
 from ..errors import TankError
 from .action_base import Action

--- a/python/tank/commands/interaction.py
+++ b/python/tank/commands/interaction.py
@@ -14,7 +14,7 @@ Interfaces for prompting the user for input during tank command execution.
 
 from __future__ import print_function
 from .. import LogManager
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 
 log = LogManager.get_logger(__name__)

--- a/python/tank/commands/move_pc.py
+++ b/python/tank/commands/move_pc.py
@@ -16,7 +16,7 @@ from .action_base import Action
 import os
 import shutil
 from tank_vendor.shotgun_api3.lib import sgsix
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 
 class MovePCAction(Action):

--- a/python/tank/commands/path_cache.py
+++ b/python/tank/commands/path_cache.py
@@ -17,7 +17,7 @@ from .. import path_cache
 from .. import folder
 
 from .action_base import Action
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 
 class SynchronizePathCache(Action):

--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -22,7 +22,7 @@ from ..util import ShotgunPath
 import os
 import datetime
 import shutil
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 # Core configuration files which are associated with the core API installation and not
 # the pipeline configuration.

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -28,7 +28,7 @@ from .setup_project_core import run_project_setup
 from .setup_project_params import ProjectSetupParameters
 from .interaction import YesToEverythingInteraction
 from tank_vendor.shotgun_api3.lib import sgsix
-from tank_vendor.shotgun_api3.lib.six.moves import input
+from tank_vendor.six.moves import input
 
 class SetupProjectAction(Action):
     """

--- a/python/tank/commands/unregister_folders.py
+++ b/python/tank/commands/unregister_folders.py
@@ -16,7 +16,7 @@ from ..errors import TankError
 from .. import path_cache
 from .action_base import Action
 from ..util.login import get_current_user
-from tank_vendor.shotgun_api3.lib.six.moves import input, zip
+from tank_vendor.six.moves import input, zip
 
 class UnregisterFoldersAction(Action):
     """

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -18,7 +18,6 @@ import copy
 import json
 
 from tank_vendor import yaml
-from tank_vendor import six
 from . import authentication
 
 from .util import login

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -18,7 +18,7 @@ import copy
 import json
 
 from tank_vendor import yaml
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from . import authentication
 
 from .util import login

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -13,9 +13,9 @@ Toolkit App Store Descriptor.
 """
 
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 import fnmatch
-from tank_vendor.shotgun_api3.lib.six.moves import http_client
+from tank_vendor.six.moves import http_client
 from tank_vendor.shotgun_api3.lib import httplib2
 
 from ...util import shotgun
@@ -36,7 +36,7 @@ from ...constants import SUPPORT_EMAIL
 
 # use api json to cover py 2.5
 from tank_vendor import shotgun_api3
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 json = shotgun_api3.shotgun.json
 
 log = LogManager.get_logger(__name__)

--- a/python/tank/descriptor/io_descriptor/base.py
+++ b/python/tank/descriptor/io_descriptor/base.py
@@ -18,7 +18,7 @@ from ...util.version import is_version_newer
 from ..errors import TankDescriptorError, TankMissingManifestError
 
 from tank_vendor import yaml
-from tank_vendor.shotgun_api3.lib.six.moves import map, urllib
+from tank_vendor.six.moves import map, urllib
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -14,7 +14,7 @@ from ..errors import TankDescriptorError
 from .base import IODescriptorBase
 
 from ... import LogManager
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 log = LogManager.get_logger(__name__)
 
 

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -21,7 +21,7 @@ from ..errors import TankError
 from ...util import filesystem
 from ...util import is_windows
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -21,8 +21,6 @@ from ..errors import TankError
 from ...util import filesystem
 from ...util import is_windows
 
-from tank_vendor import six
-
 log = LogManager.get_logger(__name__)
 
 

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -14,7 +14,7 @@ from .git import IODescriptorGit
 from ..errors import TankDescriptorError
 from ... import LogManager
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -14,7 +14,7 @@ from .git import IODescriptorGit
 from ..errors import TankDescriptorError
 from ... import LogManager
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/github_release.py
+++ b/python/tank/descriptor/io_descriptor/github_release.py
@@ -10,7 +10,7 @@
 
 import json
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 from .downloadable import IODescriptorDownloadable
 from ..errors import TankError, TankDescriptorError

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 from .downloadable import IODescriptorDownloadable
 from ...util import filesystem, shotgun

--- a/python/tank/folder/folder_types/base.py
+++ b/python/tank/folder/folder_types/base.py
@@ -12,7 +12,7 @@ import os
 import copy
 
 from .expression_tokens import SymlinkToken
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class Folder(object):

--- a/python/tank/folder/folder_types/expression_tokens.py
+++ b/python/tank/folder/folder_types/expression_tokens.py
@@ -18,7 +18,7 @@ dynamic tokens such as $something.
 import os
 
 from ...errors import TankError
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class SymlinkToken(object):

--- a/python/tank/folder/folder_types/util.py
+++ b/python/tank/folder/folder_types/util.py
@@ -17,7 +17,7 @@ import copy
 from ...errors import TankError
 
 from .expression_tokens import FilterExpressionToken, CurrentStepExpressionToken, CurrentTaskExpressionToken
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 def resolve_shotgun_filters(filters, sg_data):

--- a/python/tank/folder/operations.py
+++ b/python/tank/folder/operations.py
@@ -17,7 +17,7 @@ from .configuration import FolderConfiguration
 from .folder_io import FolderIOReceiver
 from .folder_types import EntityLinkTypeMismatch
 from ..errors import TankError
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 def create_single_folder_item(tk, config_obj, io_receiver, entity_type, entity_id, sg_task_data, engine):

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -23,9 +23,9 @@ import itertools
 # use api json to cover py 2.5
 # todo - replace with proper external library  
 from tank_vendor import shotgun_api3  
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
-from tank_vendor.shotgun_api3.lib.six.moves import range
+from tank_vendor.six.moves import range
 json = shotgun_api3.shotgun.json
 
 from .platform.engine import show_global_busy, clear_global_busy 

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -23,7 +23,8 @@ import itertools
 # use api json to cover py 2.5
 # todo - replace with proper external library  
 from tank_vendor import shotgun_api3  
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 from tank_vendor.shotgun_api3.lib.six.moves import range
 json = shotgun_api3.shotgun.json
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -16,7 +16,7 @@ import os
 import glob
 
 from tank_vendor import yaml
-import tank_vendor.shotgun_api3.lib.six.moves.cPickle as pickle
+import tank_vendor.six.moves.cPickle as pickle
 
 from .errors import TankError, TankUnreadableFileError
 from .util.version import is_version_older
@@ -32,7 +32,7 @@ from . import template_includes
 from . import LogManager
 
 from .descriptor import Descriptor, create_descriptor, descriptor_uri_to_dict
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -23,7 +23,7 @@ from . import constants
 from . import pipelineconfig_utils
 from .pipelineconfig import PipelineConfiguration
 from .util import LocalFileStorageManager
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -26,7 +26,7 @@ from ..errors import TankError, TankNoDefaultValueError
 from .errors import TankContextChangeNotSupportedError
 from . import constants
 from .import_stack import ImportStack
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 core_logger = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -23,7 +23,7 @@ import inspect
 import weakref
 import threading
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 from ..util.qt_importer import QtImporter
 from ..util.loader import load_plugin

--- a/python/tank/platform/engine_logging.py
+++ b/python/tank/platform/engine_logging.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import logging
-from tank_vendor.shotgun_api3.lib.six.moves import queue
+from tank_vendor.six.moves import queue
 import sys
 
 class ToolkitEngineHandler(logging.Handler):

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -26,7 +26,8 @@ from .errors import TankMissingEnvironmentFile
 
 from ..util.yaml_cache import g_yaml_cache
 from .. import LogManager
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -26,7 +26,7 @@ from .errors import TankMissingEnvironmentFile
 
 from ..util.yaml_cache import g_yaml_cache
 from .. import LogManager
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
 
 logger = LogManager.get_logger(__name__)

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -42,7 +42,7 @@ from . import constants
 from ..util import sgre as re
 from ..util.yaml_cache import g_yaml_cache
 from ..util.includes import resolve_include
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -25,7 +25,7 @@ from ...errors import TankError
 import sys
 import os
 import inspect
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 class TankQDialog(TankDialogBase):
     """

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -19,9 +19,9 @@ from . import templatekey
 from .errors import TankError
 from . import constants
 from .template_path_parser import TemplatePathParser
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
-from tank_vendor.shotgun_api3.lib.six.moves import zip
+from tank_vendor.six.moves import zip
 from tank.util import is_linux, is_macos, is_windows, sgre as re
 
 class Template(object):

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -19,7 +19,8 @@ from . import templatekey
 from .errors import TankError
 from . import constants
 from .template_path_parser import TemplatePathParser
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 from tank_vendor.shotgun_api3.lib.six.moves import zip
 from tank.util import is_linux, is_macos, is_windows, sgre as re
 

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -34,7 +34,7 @@ from .errors import TankError
 from . import constants
 from .util import yaml_cache
 from .util.includes import resolve_include
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 def _get_includes(file_name, data):

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -17,8 +17,8 @@ import datetime
 from . import constants
 from .errors import TankError
 from .util import sgre as re
-from tank_vendor.shotgun_api3.lib import six
-from tank_vendor.shotgun_api3.lib.six.moves import zip
+from tank_vendor import six
+from tank_vendor.six.moves import zip
 
 class TemplateKey(object):
     """

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 from .. import LogManager
 from .platforms import is_linux, is_macos, is_windows
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -16,7 +16,6 @@ Utility methods for unserializing JSON documents.
 from __future__ import absolute_import
 
 import json
-from tank_vendor import six
 
 from .unicode import ensure_contains_str
 

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -16,7 +16,7 @@ Utility methods for unserializing JSON documents.
 from __future__ import absolute_import
 
 import json
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 from .unicode import ensure_contains_str
 

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 from . import filesystem
 from .platforms import is_linux, is_macos, is_windows
 from .. import LogManager

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -22,7 +22,7 @@ are not part of the public Sgtk API.
 from collections import deque
 from threading import Event, Thread, Lock
 import platform
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 from copy import deepcopy
 
 from . import constants, sgre as re

--- a/python/tank/util/pickle.py
+++ b/python/tank/util/pickle.py
@@ -13,8 +13,8 @@ import os
 from .. import LogManager
 from .unicode import ensure_contains_str
 
-from tank_vendor.shotgun_api3.lib.six.moves import cPickle
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.six.moves import cPickle
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/process.py
+++ b/python/tank/util/process.py
@@ -13,7 +13,7 @@ import pprint
 
 from .platforms import is_windows
 from ..log import LogManager
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/util/sgre.py
+++ b/python/tank/util/sgre.py
@@ -20,7 +20,7 @@ some functionality.
 # module and we get an ImportError. Renaming the module to anything else
 # works however, so that's what we are doing.
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 # Import constants and functions that won't be wrapped
 from re import (DEBUG, I, IGNORECASE, L, LOCALE, # noqa import into namespace

--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -16,7 +16,7 @@ from __future__ import with_statement
 
 import os
 import threading
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 # use api json to cover py 2.5
 from tank_vendor import shotgun_api3

--- a/python/tank/util/shotgun/download.py
+++ b/python/tank/util/shotgun/download.py
@@ -16,7 +16,7 @@ from __future__ import with_statement
 import os
 import sys
 import uuid
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 import time
 import tempfile
 import zipfile
@@ -122,7 +122,7 @@ def __setup_sg_auth_and_proxy(sg):
     """
     # Importing this module locally to reduce clutter and facilitate clean up when/if this
     # functionality gets ported back into the Shotgun API.
-    from tank_vendor.shotgun_api3.lib.six.moves import http_cookiejar
+    from tank_vendor.six.moves import http_cookiejar
 
     sid = sg.get_session_token()
     cj = http_cookiejar.LWPCookieJar()

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -14,7 +14,7 @@ Logic for publishing files to Shotgun.
 from __future__ import with_statement
 
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 import pprint
 
 from .publish_util import get_published_file_entity_type, get_cached_local_storages, find_publish
@@ -24,7 +24,7 @@ from ...log import LogManager
 from ..shotgun_path import ShotgunPath
 from .. import constants
 from .. import login
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/shotgun/publish_resolve.py
+++ b/python/tank/util/shotgun/publish_resolve.py
@@ -16,7 +16,7 @@ from __future__ import with_statement
 
 import os
 from tank_vendor.shotgun_api3.lib import sgsix
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 import pprint
 
 from .publish_util import get_cached_local_storages

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -14,7 +14,7 @@ Utilities relating to Shotgun entities
 
 from . import constants, sgre as re
 from ..errors import TankError
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 # A dictionary for Shotgun entities which do not store their name
 # in the standard "code" field.

--- a/python/tank/util/system_settings.py
+++ b/python/tank/util/system_settings.py
@@ -13,7 +13,7 @@ System settings management.
 """
 
 
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 
 class SystemSettings(object):

--- a/python/tank/util/unicode.py
+++ b/python/tank/util/unicode.py
@@ -11,7 +11,7 @@
 Utility methods for filtering dictionaries
 """
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 def _ensure_contains_str(input_value, visited):

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -13,8 +13,8 @@ User settings management.
 """
 
 import os
-from tank_vendor.shotgun_api3.lib.six.moves import configparser
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.six.moves import configparser
+from tank_vendor import six
 
 from .local_file_storage import LocalFileStorageManager
 from .errors import EnvironmentVariableFileLookupError, TankError

--- a/python/tank_vendor/six.py
+++ b/python/tank_vendor/six.py
@@ -1,0 +1,963 @@
+# Copyright (c) 2010-2019 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.13.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("collections_abc", "collections", "collections.abc" if sys.version_info >= (3, 3) else "collections"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("dbm_ndbm", "dbm", "dbm.ndbm"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    del io
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            if sys.version_info[:2] >= (3, 7):
+                # This version introduced PEP 560 that requires a bit
+                # of extra care (we mimic what is done by __build_class__).
+                resolved_bases = types.resolve_bases(bases)
+                if resolved_bases is not bases:
+                    d['__orig_bases__'] = bases
+            else:
+                resolved_bases = bases
+            return meta(name, resolved_bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -39,7 +39,7 @@ from tank_vendor.shotgun_api3.lib.sgsix import normalize_platform
 from tank.platform import engine
 from tank import pipelineconfig_utils
 from tank import LogManager
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 # the logger used by this file is sgtk.tank_cmd
 logger = LogManager.get_logger("tank_cmd")

--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -13,7 +13,7 @@ from mock import patch
 import os
 import base64
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule # noqa

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -18,7 +18,7 @@ from mock import patch
 
 from tank.authentication import user, user_impl
 from tank_vendor.shotgun_api3 import AuthenticationFault
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 # Create a set of valid cookies, for SSO and Web related tests.
 # For a Web session, we detect the presence of the shotgun_current_session_expiration cookie.

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -26,7 +26,7 @@ from tank.errors import TankError, TankContextDeserializationError
 from tank.template import TemplatePath
 from tank.templatekey import StringKey, IntegerKey
 from tank_vendor import yaml
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank.authentication import ShotgunAuthenticator
 
 

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -13,8 +13,8 @@ from __future__ import with_statement, print_function
 import os
 import sys
 import time
-from tank_vendor.shotgun_api3.lib.six.moves.queue import Empty
-from tank_vendor.shotgun_api3.lib.six import StringIO
+from tank_vendor.six.moves.queue import Empty
+from tank_vendor.six import StringIO
 import shutil
 import contextlib
 import logging
@@ -32,7 +32,7 @@ from tank.util import is_windows
 import tank
 
 from tank.util import StorageRoots
-from tank_vendor.shotgun_api3.lib.six.moves import range
+from tank_vendor.six.moves import range
 
 log = LogManager.get_logger(__name__)
 

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -18,7 +18,7 @@ from tank.errors import TankInitError
 from sgtk.util import ShotgunPath
 from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule # noqa
 from mock import patch
-import tank_vendor.shotgun_api3.lib.six.moves.cPickle as pickle
+import tank_vendor.six.moves.cPickle as pickle
 from tank_vendor.shotgun_api3.lib import sgsix
 
 

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -22,7 +22,7 @@ from mock import patch
 from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule # noqa
 from tank.templatekey import StringKey, IntegerKey, SequenceKey, TimestampKey, make_keys
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class TestTemplateKey(ShotgunTestBase):

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -277,7 +277,7 @@ class TestAppStoreConnectivity(ShotgunTestBase):
         self.assertEqual(mock.call_count, 0)
 
     @patch("tank_vendor.shotgun_api3.Shotgun")
-    @patch("tank_vendor.shotgun_api3.lib.six.moves.urllib.request.urlopen")
+    @patch("tank_vendor.six.moves.urllib.request.urlopen")
     def test_disabling_access_to_app_store(self, urlopen_mock, shotgun_mock):
         """
         Tests that we can prevent connection to the app store based on usage

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -28,7 +28,6 @@ from mock import Mock, patch
 
 from tank_vendor.shotgun_api3.lib.mockgun import Shotgun as Mockgun
 from tank_vendor import yaml
-from tank_vendor import six
 
 
 class TestCachedConfigDescriptor(ShotgunTestBase):

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -28,7 +28,7 @@ from mock import Mock, patch
 
 from tank_vendor.shotgun_api3.lib.mockgun import Shotgun as Mockgun
 from tank_vendor import yaml
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class TestCachedConfigDescriptor(ShotgunTestBase):

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -26,7 +26,7 @@ from tank_test.tank_test_base import setUpModule # noqa
 import sgtk
 import tank
 from tank.util import is_windows
-from tank_vendor.shotgun_api3.lib.six import b
+from tank_vendor.six import b
 
 
 def _raise_exception(placeholder_a="default_a", placeholder_b="default_b"):

--- a/tests/descriptor_tests/test_github.py
+++ b/tests/descriptor_tests/test_github.py
@@ -12,7 +12,7 @@ import mock
 from mock import patch
 import os
 from sgtk.util import sgre as re
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 import sgtk
 from sgtk.descriptor import Descriptor

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -19,7 +19,7 @@ from tank import TankError
 from tank import hook
 from tank import path_cache
 from tank import folder
-from tank_vendor.shotgun_api3.lib.six import b, ensure_str
+from tank_vendor.six import b, ensure_str
 from tank_test.tank_test_base import *
 
 from . import assert_paths_to_create, execute_folder_creation_proxy

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -24,8 +24,8 @@ from tank.errors import TankError, TankHookMethodDoesNotExistError
 from tank.platform import application, constants, validation
 from tank.template import Template
 from tank.deploy import descriptor
-from tank_vendor.shotgun_api3.lib import six
-from tank_vendor.shotgun_api3.lib.six import StringIO
+from tank_vendor import six
+from tank_vendor.six import StringIO
 
 
 class TestApplication(TankTestBase):

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -24,7 +24,7 @@ from tank.platform import SoftwareVersion
 from tank.platform import LaunchInformation
 
 from tank.errors import TankEngineInitError
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class TestEngineLauncher(TankTestBase):

--- a/tests/python/sgtk_integration_test.py
+++ b/tests/python/sgtk_integration_test.py
@@ -29,7 +29,8 @@ import unittest2
 import sgtk
 from sgtk.util import sgre as re
 from sgtk.util.filesystem import safe_delete_folder, safe_delete_file
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 from tank_vendor import yaml
 
 

--- a/tests/python/sgtk_integration_test.py
+++ b/tests/python/sgtk_integration_test.py
@@ -29,7 +29,7 @@ import unittest2
 import sgtk
 from sgtk.util import sgre as re
 from sgtk.util.filesystem import safe_delete_folder, safe_delete_file
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
 from tank_vendor import yaml
 

--- a/tests/util_tests/test_json_and_pickle.py
+++ b/tests/util_tests/test_json_and_pickle.py
@@ -18,7 +18,7 @@ from unittest2 import TestCase
 from sgtk.util import json as tk_json
 from sgtk.util import pickle
 
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 
 class Impl:

--- a/tests/util_tests/test_load_publish.py
+++ b/tests/util_tests/test_load_publish.py
@@ -18,7 +18,7 @@ import sgtk
 from tank import context, errors
 from tank.util import is_linux, is_macos, is_windows
 from tank_test.tank_test_base import TankTestBase, setUpModule
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 from tank_vendor.shotgun_api3.lib import sgsix
 
 

--- a/tests/util_tests/test_load_publish.py
+++ b/tests/util_tests/test_load_publish.py
@@ -18,7 +18,8 @@ import sgtk
 from tank import context, errors
 from tank.util import is_linux, is_macos, is_windows
 from tank_test.tank_test_base import TankTestBase, setUpModule
-from tank_vendor.shotgun_api3.lib import six, sgsix
+from tank_vendor.shotgun_api3.lib import six
+from tank_vendor.shotgun_api3.lib import sgsix
 
 
 class TestCoreHook(TankTestBase):

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -219,7 +219,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         self._create_engine()
 
         # Patch & Mock the `urlopen` method
-        self._urlopen_mock = patch("tank_vendor.shotgun_api3.lib.six.moves.urllib.request.urlopen")
+        self._urlopen_mock = patch("tank_vendor.six.moves.urllib.request.urlopen")
         self._mocked_method = self._urlopen_mock.start()
 
     def setUp(self):

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -33,8 +33,8 @@ import json
 import time
 import threading
 import unittest2
-from tank_vendor.shotgun_api3.lib import six
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor import six
+from tank_vendor.six.moves import urllib
 
 
 class TestEventMetric(ShotgunTestBase):
@@ -696,7 +696,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         self._urlopen_mock.stop()
         self._urlopen_mock = None
         self._urlopen_mock = patch(
-            "tank_vendor.shotgun_api3.lib.six.moves.urllib.request.urlopen",
+            "tank_vendor.six.moves.urllib.request.urlopen",
             side_effect=TestMetricsDispatchWorkerThread._mocked_urlopen_for_test_maximum_batch_size
         )
         self._mocked_method = self._urlopen_mock.start()
@@ -760,7 +760,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         self._urlopen_mock.stop()
         self._urlopen_mock = None
         self._urlopen_mock = patch(
-            "tank_vendor.shotgun_api3.lib.six.moves.urllib.request.urlopen",
+            "tank_vendor.six.moves.urllib.request.urlopen",
             side_effect=TestMetricsDispatchWorkerThread._mocked_urlopen_for_test_maximum_batch_size
         )
         self._mocked_method = self._urlopen_mock.start()

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -12,7 +12,7 @@ from __future__ import with_statement
 import os
 import shutil
 import datetime
-from tank_vendor.shotgun_api3.lib.six.moves import urllib
+from tank_vendor.six.moves import urllib
 
 from mock import patch, MagicMock
 

--- a/tests/util_tests/test_unicode.py
+++ b/tests/util_tests/test_unicode.py
@@ -11,7 +11,7 @@
 
 from unittest2 import TestCase, skipIf
 import sgtk
-from tank_vendor.shotgun_api3.lib import six
+from tank_vendor import six
 
 if six.PY2:
     char = "漢字"


### PR DESCRIPTION
`six` has been promoted to `tank_vendor`. This will clean up a lot of code using `six`, as the import statement will be

`from tank_vendor.six import xyz` instead of `from tank_vendor.shotgun_api3.lib.six import xyz`.

The reason why this is important is that `six` is not part of the shotgun api. It's there for the `shotgun_api` to use to deal with the 2/3 transition, but not necessarily for our clients to use. Think of it this way: if we were to move to `requests` in the future, it is possible our code in `shotgun_api3` wouldn't be using `six` anymore as `requests` would be the one dealing with the 2/3 discrepancies.

I originally wanted to simply add `from .shotgun_api3.lib import six` in `tank_vendor/__init__.py` and call it a day, but that was ill-advised. The problem with that approach was when dealing with submodule importing.

It's very common when porting with `six` to write something like

`from six.moves import cPickle` so that the only code in your file that changes during the port to Python 3 is the import.

However, `moves` is a module that is being imported via a meta-path importer and is added to `sys.modules` under `tank_vendor.shotgun_api3.lib.six.moves` and not `tank_vendor.six.moves`, which means trying to do `from tank_vendor.six.moves import cPickle` is not going to work and you'll get an error about the `tank_vendor.six.moves` module not existing.

I decided it was not worth monkey patching `sys.modules` so that `six.moves.*` could be imported from inside `tank_vendor`. I instead went with simply copying `six` inside `tank_vendor`. As it turns out, the `six` meta path importer is perfectly fine to be added multiple times to `sys.meta_path`, as `six` is designed to be usable as a hidden dependency inside your package code.

To make sure that `six` was kept in sync, I've updated the `shotgun_api3_update.sh` script so that it copies the `six` module from the python api into Toolkit.

The next step will be to update all frameworks and apps before merging them to master with that new simplified import.