### PR TITLE
SG-15468: logging unicode fix

### DIFF
--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -799,7 +799,7 @@ class LogManager(object):
             log_file,
             maxBytes=1024 * 1024 * 5,  # 5 MiB
             backupCount=1,  # Need at least one backup in order to rotate
-            # encoding="utf-8",
+            encoding="utf-8",
         )
 
         # set the level based on global debug flag

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -799,6 +799,7 @@ class LogManager(object):
             log_file,
             maxBytes=1024 * 1024 * 5,  # 5 MiB
             backupCount=1,  # Need at least one backup in order to rotate
+            encoding="utf-8",
         )
 
         # set the level based on global debug flag

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -799,7 +799,7 @@ class LogManager(object):
             log_file,
             maxBytes=1024 * 1024 * 5,  # 5 MiB
             backupCount=1,  # Need at least one backup in order to rotate
-            encoding="utf-8",
+            # encoding="utf-8",
         )
 
         # set the level based on global debug flag

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -230,6 +230,7 @@ import weakref
 import uuid
 from functools import wraps
 from . import constants
+from tank_vendor import six
 
 
 class LogManager(object):
@@ -787,19 +788,17 @@ class LogManager(object):
 
         # create a rotating log file with a max size of 5 megs -
         # this should make all log files easily attachable to support tickets.
-
-        # Python 2.5s implementation is way different that 2.6 and 2.7 and as such we can't
-        # as easily support it for safe rotation.
-        if sys.version_info[:2] > (2, 5):
-            handler_factory = self._SafeRotatingFileHandler
-        else:
-            handler_factory = RotatingFileHandler
-
-        self._std_file_handler = handler_factory(
+        self._std_file_handler = self._SafeRotatingFileHandler(
             log_file,
-            maxBytes=1024 * 1024 * 5,  # 5 MiB
-            backupCount=1,  # Need at least one backup in order to rotate
-            encoding="utf-8",
+            # 5 MiB
+            maxBytes=1024 * 1024 * 5,
+            # Need at least one backup in order to rotate
+            backupCount=1,
+            # Python 3 is pickier about the encoding type of a file.
+            # Python 2 treats str as bytes, so it writes them
+            # directly to disk. Putting utf8 encoding actually
+            # causes problems.
+            encoding="utf8" if six.PY3 else None,
         )
 
         # set the level based on global debug flag

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -14,8 +14,6 @@ import copy
 import sys
 
 import sgtk
-from tank_vendor import six
-from unittest2 import skipIf
 from mock import patch
 
 from tank_test.tank_test_base import setUpModule  # noqa

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
@@ -50,3 +51,12 @@ class TestLogManager(ShotgunTestBase):
         manager = sgtk.log.LogManager()
         self.assertTrue(hasattr(manager, "log_file"))
         self.assertIsNotNone(manager.log_file)
+
+    def test_writing_unicode_to_log(self):
+        manager = sgtk.log.LogManager()
+        unicode_str = "司狼 神威"
+        manager.root_logger.warning(unicode_str)
+        manager.base_file_handler.flush()
+        with open(manager.base_file_handler.baseFilename, "rt") as f:
+            # Read the whole file, the text should have been written as is.
+            assert unicode_str in f.read()

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -57,6 +57,9 @@ class TestLogManager(ShotgunTestBase):
         self.assertIsNotNone(manager.log_file)
 
     def test_writing_unicode_to_log(self):
+        """
+        Ensure we can write unicode to a log file on all platforms.
+        """
         manager = sgtk.log.LogManager()
         unicode_str = "司狼 神威"
         # install handler for exceptions

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -11,7 +11,6 @@
 
 import os
 import copy
-import sys
 
 import sgtk
 from mock import patch

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -60,11 +60,6 @@ class TestLogManager(ShotgunTestBase):
         """
         manager = sgtk.log.LogManager()
         unicode_str = "司狼 神威"
-        # install handler for exceptions
-        previous_hook = sys.excepthook
-
-        def hook(exc_type, exc_value, exc_traceback):
-            self._handle_exception(previous_hook, exc_type, exc_value, exc_traceback)
 
         # When a logger's emit method fails, the handleError method is called.
         with patch.object(
@@ -75,8 +70,4 @@ class TestLogManager(ShotgunTestBase):
             # Flush the data to disk to make sure the data is emitted.
             manager.base_file_handler.flush()
 
-        # Make sure it isn't
-        import pdb
-
-        pdb.set_trace()
         assert handle_error_mock.call_count == 0

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -76,4 +76,7 @@ class TestLogManager(ShotgunTestBase):
             manager.base_file_handler.flush()
 
         # Make sure it isn't
+        import pdb
+
+        pdb.set_trace()
         assert handle_error_mock.call_count == 0


### PR DESCRIPTION
Fixes a warning printed to the console when logging unicode from Toolkit. On Windows with Python 3, the serializer is picky on the output format so we'll have to override the default.