### PR TITLE
Optional Abstract Key Name Breaks Publish

### DIFF
--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -661,7 +661,9 @@ def _translate_abstract_fields(tk, path):
                 # we want to use the default values for abstract keys
                 cur_fields = template.get_fields(path)
                 for abstract_key_name in abstract_key_names:
-                    del cur_fields[abstract_key_name]
+                    # If we don't have a set value for the abstract key, it's default.
+                    if abstract_key_name in cur_fields:
+                        del cur_fields[abstract_key_name]
                 path = template.apply_fields(cur_fields)
         else:
             log.debug(


### PR DESCRIPTION
Only delete abstract_key_name if we have set it

So, from my understanding this bit of code at
    https://github.com/shotgunsoftware/tk-core/blob/aa11fe1ac91ec56c9cb17dd72be65f9baed83d6b/python/tank/util/shotgun/publish_creation.py#L655-L665 is meant to remove the values from our abstract keys. So for stuff like `'SEQ'` that is the frame number in '%04d', we don't want to populate that with the specific frame. Makes sense.  
    
If your abstract key is optional, there can be a case where we create a path that resolves back to that original template but does not use it's optional abstract key name.  
    
For example a template path that accecpts `'%04d'` optionally.  
We have done this for a reference template that should match '.mov' files and '%04d.jpg' for example.  
    
In this case, if we try to publish our scene, it grabs our reference '.mov' and the fields that the 'mov' returns do not include the optional abstract key `'SEQ'`.  Line 664 does not actually check if we have set that abstract key name and will fail with a KeyError because it's not first checking that the key exists.  
    
This PR is simple but will first check that the key exists before we try to delete it.  
This preserves the functionality of the function because if we don't have a value, it will fallback to the default anyways.  