### PR TITLE
Make Context hashable in Python 3

### DIFF
--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -16,7 +16,6 @@ Management of the current context, e.g. the current shotgun entity/step/task.
 import os
 import copy
 import json
-import hashlib
 
 from tank_vendor import yaml
 from . import authentication
@@ -234,6 +233,14 @@ class Context(object):
         return not is_equal
 
     def __hash__(self):
+        """
+        Generates a unique hash for the Context.
+
+        :returns: int hash for this Context.
+        """
+        # Use sort_keys to ensure dict order does not affect hash.
+        # This hash is only guaranteed to be stable within a Python session,
+        # however this is expected behavior for __hash__.
         return hash(json.dumps(self.to_dict(), sort_keys=True))
 
     def __deepcopy__(self, memo):

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -16,6 +16,7 @@ Management of the current context, e.g. the current shotgun entity/step/task.
 import os
 import copy
 import json
+import hashlib
 
 from tank_vendor import yaml
 from . import authentication
@@ -61,9 +62,6 @@ class Context(object):
     belongs to the project. The exception to this is the user, which simply reflects the
     currently operating user.
     """
-
-    # TODO is there a cleaner way to accomplish this?
-    __hash__ = object.__hash__
 
     def __init__(
         self,
@@ -234,6 +232,9 @@ class Context(object):
         if is_equal is NotImplemented:
             return NotImplemented
         return not is_equal
+
+    def __hash__(self):
+        return hash(json.dumps(self.to_dict(), sort_keys=True))
 
     def __deepcopy__(self, memo):
         """

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -62,6 +62,9 @@ class Context(object):
     currently operating user.
     """
 
+    # TODO is there a cleaner way to accomplish this?
+    __hash__ = object.__hash__
+
     def __init__(
         self,
         tk,

--- a/python/tank/util/sgre.py
+++ b/python/tank/util/sgre.py
@@ -60,15 +60,16 @@ else:
                 # so we should just wrap the callable untouched.
                 return fn(*args, **kwargs)
             if len(args) > flags_arg_position:
-                # If flags is provided positionally, and the UNICODE flag
+                # If flags are provided positionally, and the UNICODE flag
                 # is not present, add the ASCII flag
                 if not args[flags_arg_position] & _re.UNICODE:
                     args = list(args)
                     args[flags_arg_position] |= _re.ASCII
-            elif "flags" in kwargs and not kwargs["flags"] & _re.UNICODE:
-                # If flags is provided as a kwarg, and the UNICODE flag
-                # is not present, add the ASCII flag
-                kwargs["flags"] |= _re.ASCII
+            elif "flags" in kwargs:
+                if not kwargs["flags"] & _re.UNICODE:
+                    # If flags are provided as a kwarg, and the UNICODE flag
+                    # is not present, add the ASCII flag
+                    kwargs["flags"] |= _re.ASCII
             else:
                 # If no flags were specified, add a flags kwarg with the ASCII
                 # flag.

--- a/python/tank/util/sgre.py
+++ b/python/tank/util/sgre.py
@@ -51,9 +51,14 @@ if six.PY2:
 # to maintain the previous behavior.
 else:
     import re as _re
+    import typing as _typing
 
     def _re_wrap(fn, flags_arg_position):
         def wrapper(*args, **kwargs):
+            if args and isinstance(args[0], _typing.Pattern):
+                # If we've been passed a compiled pattern, we can't apply flags,
+                # so we should just wrap the callable untouched.
+                return fn(*args, **kwargs)
             if len(args) > flags_arg_position:
                 # If flags is provided positionally, and the UNICODE flag
                 # is not present, add the ASCII flag

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -158,6 +158,7 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertEqual(context_1, context_2)
         # Assert that hashing function treats these as unequal
+        # even though we consider the contexts the same.
         self.assertNotEqual(hash(context_1), hash(context_2))
 
     def test_additional_entities_not_equal(self):

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -116,30 +116,27 @@ class TestEq(TestContext):
         # other differing fields in the dictionary should be ignored
         kws2["entity"]["foo"] = "bar"
         context_2 = context.Context(self.tk, **kws2)
-        self.assertTrue(context_1 == context_2)
-        self.assertFalse(context_1 != context_2)
+        self.assertEqual(context_1, context_2)
         # Assert that hashing function treats these as equal
-        self.assertTrue(hash(context_1) == hash(context_2))
+        self.assertEqual(hash(context_1), hash(context_2))
 
     def test_not_equal(self):
         context_1 = context.Context(self.tk, **self.kws)
         kws2 = copy.deepcopy(self.kws)
         kws2["task"] = {"id": 45, "type": "Task"}
         context_2 = context.Context(self.tk, **kws2)
-        self.assertFalse(context_1 == context_2)
-        self.assertTrue(context_1 != context_2)
+        self.assertNotEqual(context_1, context_2)
         # Assert that hashing function treats these as unequal
-        self.assertFalse(hash(context_1) == hash(context_2))
+        self.assertNotEqual(hash(context_1), hash(context_2))
 
     def test_not_equal_with_none(self):
         context_1 = context.Context(self.tk, **self.kws)
         kws2 = copy.deepcopy(self.kws)
         kws2["entity"] = None
         context_2 = context.Context(self.tk, **kws2)
-        self.assertFalse(context_1 == context_2)
-        self.assertTrue(context_1 != context_2)
+        self.assertNotEqual(context_1, context_2)
         # Assert that hashing function treats these as unequal
-        self.assertFalse(hash(context_1) == hash(context_2))
+        self.assertNotEqual(hash(context_1), hash(context_2))
 
     def test_additional_entities_equal(self):
         kws1 = copy.deepcopy(self.kws)
@@ -159,10 +156,9 @@ class TestEq(TestContext):
             {"type": "Sequence", "id": 456, "bar": "foo"},
         ]
         context_2 = context.Context(self.tk, **kws2)
-        self.assertTrue(context_1 == context_2)
-        self.assertFalse(context_1 != context_2)
+        self.assertEqual(context_1, context_2)
         # Assert that hashing function treats these as unequal
-        self.assertFalse(hash(context_1) == hash(context_2))
+        self.assertNotEqual(hash(context_1), hash(context_2))
 
     def test_additional_entities_not_equal(self):
         kws1 = copy.deepcopy(self.kws)
@@ -177,18 +173,16 @@ class TestEq(TestContext):
             {"type": "Sequence", "id": 456},
         ]
         context_2 = context.Context(self.tk, **kws2)
-        self.assertFalse(context_1 == context_2)
-        self.assertTrue(context_1 != context_2)
+        self.assertNotEqual(context_1, context_2)
         # Assert that hashing function treats these as unequal
-        self.assertFalse(hash(context_1) == hash(context_2))
+        self.assertNotEqual(hash(context_1), hash(context_2))
 
     def test_not_context(self):
         context_1 = context.Context(self.tk, **self.kws)
         not_context = object()
-        self.assertFalse(context_1 == not_context)
-        self.assertTrue(context_1 != not_context)
+        self.assertNotEqual(context_1, not_context)
         # Assert that hashing function treats these as unequal
-        self.assertFalse(hash(context_1) == hash(not_context))
+        self.assertNotEqual(hash(context_1), hash(not_context))
 
     @patch("tank.util.login.get_current_user")
     def test_lazy_load_user(self, get_current_user):
@@ -207,8 +201,7 @@ class TestEq(TestContext):
         # the other context should pick up the context
         # automatically by the equals operator
         context_2 = context.Context(self.tk, **kws2)
-        self.assertTrue(context_1 == context_2)
-        self.assertFalse(context_1 != context_2)
+        self.assertEqual(context_1, context_2)
 
 
 class TestUser(TestContext):
@@ -564,7 +557,7 @@ class TestFromEntity(TestContext):
 
         # Check that the shotgun method find_one was used
         num_finds_after = self.tk.shotgun.finds
-        self.assertTrue((num_finds_after - num_finds_before) == 1)
+        self.assertEqual((num_finds_after - num_finds_before), 1)
 
     @patch("tank.util.login.get_current_user")
     def test_data_missing_non_task(self, get_current_user):

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -118,6 +118,8 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertTrue(context_1 == context_2)
         self.assertFalse(context_1 != context_2)
+        # Assert that hashing function treats these as equal
+        self.assertTrue(hash(context_1) == hash(context_2))
 
     def test_not_equal(self):
         context_1 = context.Context(self.tk, **self.kws)
@@ -126,6 +128,8 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertFalse(context_1 == context_2)
         self.assertTrue(context_1 != context_2)
+        # Assert that hashing function treats these as unequal
+        self.assertFalse(hash(context_1) == hash(context_2))
 
     def test_not_equal_with_none(self):
         context_1 = context.Context(self.tk, **self.kws)
@@ -134,6 +138,8 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertFalse(context_1 == context_2)
         self.assertTrue(context_1 != context_2)
+        # Assert that hashing function treats these as unequal
+        self.assertFalse(hash(context_1) == hash(context_2))
 
     def test_additional_entities_equal(self):
         kws1 = copy.deepcopy(self.kws)
@@ -155,6 +161,8 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertTrue(context_1 == context_2)
         self.assertFalse(context_1 != context_2)
+        # Assert that hashing function treats these as unequal
+        self.assertFalse(hash(context_1) == hash(context_2))
 
     def test_additional_entities_not_equal(self):
         kws1 = copy.deepcopy(self.kws)
@@ -171,12 +179,16 @@ class TestEq(TestContext):
         context_2 = context.Context(self.tk, **kws2)
         self.assertFalse(context_1 == context_2)
         self.assertTrue(context_1 != context_2)
+        # Assert that hashing function treats these as unequal
+        self.assertFalse(hash(context_1) == hash(context_2))
 
     def test_not_context(self):
         context_1 = context.Context(self.tk, **self.kws)
         not_context = object()
         self.assertFalse(context_1 == not_context)
         self.assertTrue(context_1 != not_context)
+        # Assert that hashing function treats these as unequal
+        self.assertFalse(hash(context_1) == hash(not_context))
 
     @patch("tank.util.login.get_current_user")
     def test_lazy_load_user(self, get_current_user):

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -9,9 +9,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from unittest2 import TestCase, skipIf
-import sgtk
-from tank_vendor import six
+from unittest2 import TestCase
 import re
 from tank.util import sgre
 

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -21,7 +21,7 @@ class TestSgre(TestCase):
         unicode characters do not match `\w` in Python 2 or 3.
         """
         char = u"漢字"
-        expr = r'\w+'
+        expr = r"\w+"
 
         # test all wrapped methods
         self.assertFalse(bool(sgre.compile(expr).match(char)))
@@ -38,7 +38,7 @@ class TestSgre(TestCase):
         in Python 2 or 3.
         """
         char = u"a漢字"
-        expr = r'a\w+'
+        expr = r"a\w+"
 
         # test all wrapped methods
         self.assertFalse(bool(sgre.compile(expr, re.I).match(char)))
@@ -55,7 +55,7 @@ class TestSgre(TestCase):
         match `\w` in Python 2 or 3.
         """
         char = u"a漢字"
-        expr = r'a\w+'
+        expr = r"a\w+"
 
         # test all wrapped methods
         self.assertFalse(bool(sgre.compile(expr, flags=re.I).match(char)))
@@ -70,7 +70,7 @@ class TestSgre(TestCase):
         Ensure that the unicode flag overrides the flag insertion behavior.
         """
         char = u"a漢字"
-        expr = r'a\w+'
+        expr = r"a\w+"
 
         # test all wrapped methods
         self.assertTrue(bool(sgre.compile(expr, flags=re.U).match(char)))
@@ -85,5 +85,5 @@ class TestSgre(TestCase):
         Ensure that no flag injection is performed when using a compiled
         expression, as this raises an exception.
         """
-        compiled_expression = sgre.compile('a')
-        self.assertTrue(bool(compiled_expression.match('a')))
+        compiled_expression = sgre.compile("a")
+        self.assertTrue(bool(compiled_expression.match("a")))

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from unittest2 import TestCase, skipIf
+import sgtk
+from tank_vendor import six
+import re
+from tank.util import sgre
+
+
+class TestSgre(TestCase):
+    def test_wrap(self):
+        r"""
+        Ensure that sgre injects the re.ASCII flag appropriately, and that
+        unicode characters do not match `\w` in Python 2 or 3.
+        """
+        char = u"漢字"
+        expr = r'\w+'
+
+        # test all wrapped methods
+        self.assertFalse(bool(sgre.compile(expr).match(char)))
+        self.assertEqual(len(sgre.findall(expr, char)), 0)
+        self.assertFalse(bool(sgre.match(expr, char)))
+        self.assertFalse(bool(sgre.search(expr, char)))
+        self.assertEqual(len(sgre.split(expr, "$ %s @" % char)), 1)
+        self.assertEqual(sgre.sub(expr, "@", char), char)
+
+    def test_wrap_positional(self):
+        r"""
+        Ensure that sgre injects the re.ASCII flag appropriately when flags are
+        also passed positonally, and that unicode characters do not match `\w`
+        in Python 2 or 3.
+        """
+        char = u"a漢字"
+        expr = r'a\w+'
+
+        # test all wrapped methods
+        self.assertFalse(bool(sgre.compile(expr, re.I).match(char)))
+        self.assertEqual(len(sgre.findall(expr, char, re.I)), 0)
+        self.assertFalse(bool(sgre.match(expr, char, re.I)))
+        self.assertFalse(bool(sgre.search(expr, char, re.I)))
+        self.assertEqual(len(sgre.split(expr, "$ %s @" % char, 0, re.I)), 1)
+        self.assertEqual(sgre.sub(expr, "@", char, 0, re.I), char)
+
+    def test_wrap_kwarg(self):
+        r"""
+        Ensure that sgre injects the re.ASCII flag appropriately when flags are
+        also passed as keyword arguments, and that unicode characters do not
+        match `\w` in Python 2 or 3.
+        """
+        char = u"a漢字"
+        expr = r'a\w+'
+
+        # test all wrapped methods
+        self.assertFalse(bool(sgre.compile(expr, flags=re.I).match(char)))
+        self.assertEqual(len(sgre.findall(expr, char, flags=re.I)), 0)
+        self.assertFalse(bool(sgre.match(expr, char, flags=re.I)))
+        self.assertFalse(bool(sgre.search(expr, char, flags=re.I)))
+        self.assertEqual(len(sgre.split(expr, "$ %s @" % char, flags=re.I)), 1)
+        self.assertEqual(sgre.sub(expr, "@", char, flags=re.I), char)
+
+    def test_unicode_override(self):
+        """
+        Ensure that the unicode flag overrides the flag insertion behavior.
+        """
+        char = u"a漢字"
+        expr = r'a\w+'
+
+        # test all wrapped methods
+        self.assertTrue(bool(sgre.compile(expr, flags=re.U).match(char)))
+        self.assertEqual(len(sgre.findall(expr, char, flags=re.U)), 1)
+        self.assertTrue(bool(sgre.match(expr, char, flags=re.U)))
+        self.assertTrue(bool(sgre.search(expr, char, flags=re.U)))
+        self.assertEqual(len(sgre.split(expr, "$ %s @" % char, flags=re.U)), 2)
+        self.assertEqual(sgre.sub(expr, "@", char, flags=re.U), "@")
+
+    def test_precompiled_expression(self):
+        """
+        Ensure that no flag injection is performed when using a compiled
+        expression, as this raises an exception.
+        """
+        compiled_expression = sgre.compile('a')
+        self.assertTrue(bool(compiled_expression.match('a')))


### PR DESCRIPTION
In Python 3 if `__eq__` is defined for a class, that class no longer inherits `__hash__` from its parent.  This defines `__hash__` on Context to ensure that Contexts are hashable in Python 3.