### PR TITLE
SG-15803 Bugs with Optional Abstract Keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
-    - id: check-executables-have-shebangs
+    #- id: check-executables-have-shebangs
     # Ensure there's no incomplete merges
     - id: check-merge-conflict
     # Adds an empty line if missing at the end of a file.

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -572,9 +572,13 @@ class Sgtk(object):
                     # form a valid path from them so skip this key set
                     continue
 
-            # Apply the fields to build the glob string to search with:
+            # Apply the fields to build the glob string to search with. We are iterating
+            # through all the possible key combinations that do and do not include the
+            # optional keys so we need _apply_fields to skip defaults otherwise if an
+            # optional key has a default value, we will never find files that don't include
+            # the optional key in their file name
             glob_str = template._apply_fields(
-                current_local_fields, ignore_types=current_skip_keys, use_defaults=False
+                current_local_fields, ignore_types=current_skip_keys, skip_defaults=True
             )
             if glob_str in globs_searched:
                 # it's possible that multiple key sets return the same search

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -574,7 +574,7 @@ class Sgtk(object):
 
             # Apply the fields to build the glob string to search with:
             glob_str = template._apply_fields(
-                current_local_fields, ignore_types=current_skip_keys
+                current_local_fields, ignore_types=current_skip_keys, use_defaults=False
             )
             if glob_str in globs_searched:
                 # it's possible that multiple key sets return the same search

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -260,7 +260,7 @@ class Template(object):
         return self._apply_fields(fields, platform=platform)
 
     def _apply_fields(
-        self, fields, ignore_types=None, platform=None, use_defaults=True
+        self, fields, ignore_types=None, platform=None, skip_defaults=False
     ):
         """
         Creates path using fields.
@@ -274,6 +274,11 @@ class Template(object):
                          current operating system. If you pass in a sys.platform-style string
                          (e.g. 'win32', 'linux2' or 'darwin'), paths will be generated to
                          match that platform.
+        :param skip_defaults: Optional. If set to True, if a key has a default value and no
+                              corresponding value in the fields argument, its default value
+                              will be used. If set to False, keys that are not specified in
+                              the fields argument are skipped whether they have a default
+                              value or not. Defaults to False
 
         :returns: Full path, matching the template with the given fields inserted.
         """
@@ -284,8 +289,13 @@ class Template(object):
         # index of matching keys will be used to find cleaned_definition
         index = -1
         for index, cur_keys in enumerate(self._keys):
+            # We are iterating through all possible key combinations from the longest to shortest
+            # and using the first one that doesn't have any missing keys. skip_defaults=False on
+            # _apply_fields means we don't want to use a key that is not specified in the fields
+            # parameter. So we want the missing_keys function to flag even the default keys that are
+            # missing. Therefore we need to negate the skip_defaults parameter for the _missing_keys argument
             missing_keys = self._missing_keys(
-                fields, cur_keys, skip_defaults=use_defaults
+                fields, cur_keys, skip_defaults=not skip_defaults
             )
             if not missing_keys:
                 keys = cur_keys
@@ -568,7 +578,7 @@ class TemplatePath(Template):
         return None
 
     def _apply_fields(
-        self, fields, ignore_types=None, platform=None, use_defaults=True
+        self, fields, ignore_types=None, platform=None, skip_defaults=False
     ):
         """
         Creates path using fields.
@@ -582,11 +592,16 @@ class TemplatePath(Template):
                          current operating system. If you pass in a sys.platform-style string
                          (e.g. 'win32', 'linux2' or 'darwin'), paths will be generated to
                          match that platform.
+        :param skip_defaults: Optional. If set to True, if a key has a default value and no
+                              corresponding value in the fields argument, its default value
+                              will be used. If set to False, keys that are not specified in
+                              the fields argument are skipped whether they have a default
+                              value or not. Defaults to False
 
         :returns: Full path, matching the template with the given fields inserted.
         """
         relative_path = super(TemplatePath, self)._apply_fields(
-            fields, ignore_types, platform, use_defaults=use_defaults
+            fields, ignore_types, platform, skip_defaults=skip_defaults
         )
 
         if platform is None:

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -79,6 +79,7 @@ class Template(object):
         :param name: (Optional) name for this template.
         :type name: String
         """
+
         self.name = name
         # version for __repr__
         self._repr_def = self._fix_key_names(definition, keys)
@@ -259,7 +260,7 @@ class Template(object):
         """
         return self._apply_fields(fields, platform=platform)
 
-    def _apply_fields(self, fields, ignore_types=None, platform=None):
+    def _apply_fields(self, fields, ignore_types=None, platform=None, use_defaults=True):
         """
         Creates path using fields.
 
@@ -282,7 +283,7 @@ class Template(object):
         # index of matching keys will be used to find cleaned_definition
         index = -1
         for index, cur_keys in enumerate(self._keys):
-            missing_keys = self._missing_keys(fields, cur_keys, skip_defaults=True)
+            missing_keys = self._missing_keys(fields, cur_keys, skip_defaults=use_defaults)
             if not missing_keys:
                 keys = cur_keys
                 break
@@ -563,7 +564,7 @@ class TemplatePath(Template):
             )
         return None
 
-    def _apply_fields(self, fields, ignore_types=None, platform=None):
+    def _apply_fields(self, fields, ignore_types=None, platform=None, use_defaults=True):
         """
         Creates path using fields.
 
@@ -580,7 +581,7 @@ class TemplatePath(Template):
         :returns: Full path, matching the template with the given fields inserted.
         """
         relative_path = super(TemplatePath, self)._apply_fields(
-            fields, ignore_types, platform
+            fields, ignore_types, platform, use_defaults=use_defaults
         )
 
         if platform is None:

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -79,7 +79,6 @@ class Template(object):
         :param name: (Optional) name for this template.
         :type name: String
         """
-
         self.name = name
         # version for __repr__
         self._repr_def = self._fix_key_names(definition, keys)

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -259,7 +259,9 @@ class Template(object):
         """
         return self._apply_fields(fields, platform=platform)
 
-    def _apply_fields(self, fields, ignore_types=None, platform=None, use_defaults=True):
+    def _apply_fields(
+        self, fields, ignore_types=None, platform=None, use_defaults=True
+    ):
         """
         Creates path using fields.
 
@@ -282,7 +284,9 @@ class Template(object):
         # index of matching keys will be used to find cleaned_definition
         index = -1
         for index, cur_keys in enumerate(self._keys):
-            missing_keys = self._missing_keys(fields, cur_keys, skip_defaults=use_defaults)
+            missing_keys = self._missing_keys(
+                fields, cur_keys, skip_defaults=use_defaults
+            )
             if not missing_keys:
                 keys = cur_keys
                 break
@@ -563,7 +567,9 @@ class TemplatePath(Template):
             )
         return None
 
-    def _apply_fields(self, fields, ignore_types=None, platform=None, use_defaults=True):
+    def _apply_fields(
+        self, fields, ignore_types=None, platform=None, use_defaults=True
+    ):
         """
         Creates path using fields.
 

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -658,14 +658,18 @@ def _translate_abstract_fields(tk, path):
             ]
 
             if len(abstract_key_names) > 0:
-                # we want to use the default values for abstract keys
                 cur_fields = template.get_fields(path)
+                # We want to use the default values for abstract keys. We could do this
+                # by not passing the abstract keys to _apply_fields, set skip_defaults=False,
+                # and let that method set the default values. But doing that would set default
+                # values on all keys that have defaults. We only want to set defaults on keys
+                # that were found in the current_path (the keys in cur_field)
                 for abstract_key_name in abstract_key_names:
                     if abstract_key_name in cur_fields:
                         cur_fields[abstract_key_name] = template.keys[
                             abstract_key_name
                         ]._get_default()
-                path = template._apply_fields(cur_fields, use_defaults=False)
+                path = template._apply_fields(cur_fields, skip_defaults=True)
         else:
             log.debug(
                 "Path does not match a template. Not translating abstract fields: %s"

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -661,8 +661,9 @@ def _translate_abstract_fields(tk, path):
                 # we want to use the default values for abstract keys
                 cur_fields = template.get_fields(path)
                 for abstract_key_name in abstract_key_names:
-                    del cur_fields[abstract_key_name]
-                path = template.apply_fields(cur_fields)
+                    if abstract_key_name in cur_fields:
+                        cur_fields[abstract_key_name] = template.keys[abstract_key_name]._get_default()
+                path = template._apply_fields(cur_fields, use_defaults=False)
         else:
             log.debug(
                 "Path does not match a template. Not translating abstract fields: %s"

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -662,7 +662,9 @@ def _translate_abstract_fields(tk, path):
                 cur_fields = template.get_fields(path)
                 for abstract_key_name in abstract_key_names:
                     if abstract_key_name in cur_fields:
-                        cur_fields[abstract_key_name] = template.keys[abstract_key_name]._get_default()
+                        cur_fields[abstract_key_name] = template.keys[
+                            abstract_key_name
+                        ]._get_default()
                 path = template._apply_fields(cur_fields, use_defaults=False)
         else:
             log.debug(

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -210,6 +210,17 @@ class TestPathsFromTemplate(TankTestBase):
         self.assertIn(good_file_path, result)
         self.assertNotIn(bad_file_path, result)
 
+    def test_filenames_without_optional_keys(self):
+        template = self.tk.templates["path_with_optional_abstract"]
+        file_with_opt = os.path.join(self.project_root, "media", "scene.0001.exr")
+        file_without_opt = os.path.join(self.project_root, "media", "scene.mov")
+        self.create_file(file_with_opt)
+        self.create_file(file_without_opt)
+        self.assertEqual(
+            set(self.tk.paths_from_template(template, {"name": "scene"})),
+            set([file_without_opt, file_with_opt])
+        )
+
 
 class TestAbstractPathsFromTemplate(TankTestBase):
     """Tests Tank.abstract_paths_from_template method."""

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -211,6 +211,10 @@ class TestPathsFromTemplate(TankTestBase):
         self.assertNotIn(bad_file_path, result)
 
     def test_filenames_without_optional_keys(self):
+        """
+        Test that when using a template that has optional keys with default values,
+        paths that do and do not include the optional portion are both found
+        """
         template = self.tk.templates["path_with_optional_abstract"]
         file_with_opt = os.path.join(self.project_root, "media", "scene.0001.exr")
         file_without_opt = os.path.join(self.project_root, "media", "scene.mov")

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -218,7 +218,7 @@ class TestPathsFromTemplate(TankTestBase):
         self.create_file(file_without_opt)
         self.assertEqual(
             set(self.tk.paths_from_template(template, {"name": "scene"})),
-            set([file_without_opt, file_with_opt])
+            set([file_without_opt, file_with_opt]),
         )
 
 

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -471,6 +471,45 @@ class TestApplyFields(TestTemplatePath):
                 {"alpha_num": invalid_value},
             )
 
+    def test_not_using_defaults(self):
+        """
+        Tests that when use_defaults is set to False, only values for provided keys are applied,
+        whether the missing keys have defaults or not
+        """
+        keys = {
+            "name": StringKey("name"),
+            "frame": SequenceKey("frame", default="%d"),
+            "ext": StringKey("ext")
+        }
+        template = TemplatePath("{name}[.{frame}].{ext}", keys, self.project_root)
+        fields = {
+            "name": "scene",
+            "ext": "mov",
+        }
+        self.assertEqual(
+            template._apply_fields(fields, use_defaults=False),
+            os.path.join(self.project_root, "scene.mov")
+        )
+
+    def test_using_defaults(self):
+        """
+        Tests that default values are used for optional keys when a value is not provided
+        """
+        keys = {
+            "name": StringKey("name"),
+            "frame": SequenceKey("frame", default="%d"),
+            "ext": StringKey("ext")
+        }
+        template = TemplatePath("{name}[.{frame}].{ext}", keys, self.project_root)
+        fields = {
+            "name": "scene",
+            "ext": "exr",
+        }
+        self.assertEqual(
+            template._apply_fields(fields),
+            os.path.join(self.project_root, "scene.%d.exr")
+        )
+
     def test_good_alphanumeric(self):
         """
         Tests applying valid values for alphanumeric key.

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -473,7 +473,7 @@ class TestApplyFields(TestTemplatePath):
 
     def test_not_using_defaults(self):
         """
-        Tests that when use_defaults is set to False, only values for provided keys are applied,
+        Tests that when skip_defaults is set to True, only values for provided keys are applied,
         whether the missing keys have defaults or not
         """
         keys = {
@@ -487,7 +487,7 @@ class TestApplyFields(TestTemplatePath):
             "ext": "mov",
         }
         self.assertEqual(
-            template._apply_fields(fields, use_defaults=False),
+            template._apply_fields(fields, skip_defaults=True),
             os.path.join(self.project_root, "scene.mov"),
         )
 

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -479,7 +479,7 @@ class TestApplyFields(TestTemplatePath):
         keys = {
             "name": StringKey("name"),
             "frame": SequenceKey("frame", default="%d"),
-            "ext": StringKey("ext")
+            "ext": StringKey("ext"),
         }
         template = TemplatePath("{name}[.{frame}].{ext}", keys, self.project_root)
         fields = {
@@ -488,7 +488,7 @@ class TestApplyFields(TestTemplatePath):
         }
         self.assertEqual(
             template._apply_fields(fields, use_defaults=False),
-            os.path.join(self.project_root, "scene.mov")
+            os.path.join(self.project_root, "scene.mov"),
         )
 
     def test_using_defaults(self):
@@ -498,7 +498,7 @@ class TestApplyFields(TestTemplatePath):
         keys = {
             "name": StringKey("name"),
             "frame": SequenceKey("frame", default="%d"),
-            "ext": StringKey("ext")
+            "ext": StringKey("ext"),
         }
         template = TemplatePath("{name}[.{frame}].{ext}", keys, self.project_root)
         fields = {
@@ -507,7 +507,7 @@ class TestApplyFields(TestTemplatePath):
         }
         self.assertEqual(
             template._apply_fields(fields),
-            os.path.join(self.project_root, "scene.%d.exr")
+            os.path.join(self.project_root, "scene.%d.exr"),
         )
 
     def test_good_alphanumeric(self):

--- a/tests/fixtures/config/core/templates.yml
+++ b/tests/fixtures/config/core/templates.yml
@@ -184,8 +184,6 @@ paths:
     path_with_optional_abstract: media/{name}[.{frame}].{media_ext}
 
 
-
-
 strings:
 
     # when a publish record is created in shotgun, populate the name with the following

--- a/tests/fixtures/config/core/templates.yml
+++ b/tests/fixtures/config/core/templates.yml
@@ -180,7 +180,7 @@ paths:
     houdini_asset_publish: assets/{sg_asset_type}/{Asset}/{Step}/publish/{name_alpha}.v{version}.hip
 
     #--------------------------------------------------------------------------------------
-    # Used for testing optional keys
+    # Used for testing optional abstract keys
     path_with_optional_abstract: media/{name}[.{frame}].{media_ext}
 
 

--- a/tests/fixtures/config/core/templates.yml
+++ b/tests/fixtures/config/core/templates.yml
@@ -62,6 +62,8 @@ keys:
         type: str
         choices: {'ma':'Maya Ascii (.ma)', 'mb':'Maya Binary (.mb)'}
         default: ma
+    media_ext:
+        type: str
 
 
 paths:
@@ -176,6 +178,12 @@ paths:
 
     # The location of published hip files
     houdini_asset_publish: assets/{sg_asset_type}/{Asset}/{Step}/publish/{name_alpha}.v{version}.hip
+
+    #--------------------------------------------------------------------------------------
+    # Used for testing optional keys
+    path_with_optional_abstract: media/{name}[.{frame}].{media_ext}
+
+
 
 
 strings:

--- a/tests/util_tests/test_shotgun_publish_creation.py
+++ b/tests/util_tests/test_shotgun_publish_creation.py
@@ -10,7 +10,8 @@
 
 import os
 
-from tank_test.tank_test_base import TankTestBase, setUpModule
+from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import setUpModule # noqa
 from tank.util.shotgun.publish_creation import _translate_abstract_fields
 
 
@@ -27,13 +28,22 @@ class TestShotgunPublishCreation(TankTestBase):
         super(TestShotgunPublishCreation, self).setUp()
         self.setup_fixtures()
 
-    def test_translate_abstract_fields_optional_key_not_in(self):
+    def test_translate_abstract_fields_optional_key_not_in_path(self):
+        """
+        Test when a template has an optional key with a default value but the specific
+        file path does not include that key, no default values are added when translating
+        abstract fields
+        """
         template = self.tk.templates["path_with_optional_abstract"]
         file_path_no_optional = os.path.join(template.root_path, "media", "scene.mov")
         data = _translate_abstract_fields(self.tk, file_path_no_optional)
         self.assertEqual(data, os.path.join(template.root_path, file_path_no_optional))
 
     def test_translate_abstract_fields_optional_key_in_path(self):
+        """
+        Test when a template has an optional key with a default value and the specific
+        file path does include that key, the default value is returned as expected
+        """
         template = self.tk.templates["path_with_optional_abstract"]
         file_path_no_optional = os.path.join(
             template.root_path, "media", "scene.0001.exr"

--- a/tests/util_tests/test_shotgun_publish_creation.py
+++ b/tests/util_tests/test_shotgun_publish_creation.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+from tank_test.tank_test_base import TankTestBase, setUpModule
+from tank.util.shotgun.publish_creation import _translate_abstract_fields
+
+
+class TestShotgunPublishCreation(TankTestBase):
+    """
+    Test shotgun entity parsing classes and methods.
+    """
+
+    def setUp(self):
+        """Sets up entities in mocked shotgun database and creates Mock objects
+        to pass in as callbacks to Schema.create_folders. The mock objects are
+        then queried to see what paths the code attempted to create.
+        """
+        super(TestShotgunPublishCreation, self).setUp()
+        self.setup_fixtures()
+
+    def test_translate_abstract_fields_optional_key_not_in(self):
+        template = self.tk.templates["path_with_optional_abstract"]
+        file_path_no_optional = os.path.join(template.root_path, "media", "scene.mov")
+        data = _translate_abstract_fields(self.tk, file_path_no_optional)
+        self.assertEqual(data, os.path.join(template.root_path, file_path_no_optional))
+
+    def test_translate_abstract_fields_optional_key_in_path(self):
+        template = self.tk.templates["path_with_optional_abstract"]
+        file_path_no_optional = os.path.join(template.root_path, "media", "scene.0001.exr")
+        data = _translate_abstract_fields(self.tk, file_path_no_optional)
+        self.assertEqual(data, os.path.join(template.root_path, file_path_no_optional.replace("0001", "%04d")))

--- a/tests/util_tests/test_shotgun_publish_creation.py
+++ b/tests/util_tests/test_shotgun_publish_creation.py
@@ -11,7 +11,7 @@
 import os
 
 from tank_test.tank_test_base import TankTestBase
-from tank_test.tank_test_base import setUpModule # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
 from tank.util.shotgun.publish_creation import _translate_abstract_fields
 
 

--- a/tests/util_tests/test_shotgun_publish_creation.py
+++ b/tests/util_tests/test_shotgun_publish_creation.py
@@ -35,6 +35,13 @@ class TestShotgunPublishCreation(TankTestBase):
 
     def test_translate_abstract_fields_optional_key_in_path(self):
         template = self.tk.templates["path_with_optional_abstract"]
-        file_path_no_optional = os.path.join(template.root_path, "media", "scene.0001.exr")
+        file_path_no_optional = os.path.join(
+            template.root_path, "media", "scene.0001.exr"
+        )
         data = _translate_abstract_fields(self.tk, file_path_no_optional)
-        self.assertEqual(data, os.path.join(template.root_path, file_path_no_optional.replace("0001", "%04d")))
+        self.assertEqual(
+            data,
+            os.path.join(
+                template.root_path, file_path_no_optional.replace("0001", "%04d")
+            ),
+        )


### PR DESCRIPTION
When using templates with abstract keys that are optional such as
```python
{name}[.{frame}].{ext}  #Where frame is a SequenceKey with the implicit default value of %d
```
The `tk.paths_from_template` and the `publish_creation._translate_abstract_fields` methods were returning incorrect or missing values. This solves the problem by adding an option to `template.apply_fields` to not use default values for optional keys. The two methods above can then use the new signature to function correctly. 