### PR TITLE
Allow per-project overrides of env setting ymls.

### DIFF
--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -213,31 +213,33 @@ def _process_includes_r(file_name, data, context):
     fw_lookup = {}
     for include_file in include_files:
 
-        # path exists, so try to read it
-        included_data = g_yaml_cache.get(include_file) or {}
+        
+        if os.path.exists(include_file):
+            # path exists, so try to read it
+            included_data = g_yaml_cache.get(include_file) or {}
 
-        # now resolve this data before proceeding
-        included_data, included_fw_lookup = _process_includes_r(
-            include_file, included_data, context
-        )
+            # now resolve this data before proceeding
+            included_data, included_fw_lookup = _process_includes_r(
+                include_file, included_data, context
+            )
 
-        # update our big lookup dict with this included data:
-        if "frameworks" in included_data and isinstance(
-            included_data["frameworks"], dict
-        ):
-            # special case handling of frameworks to merge them from the various
-            # different included files rather than have frameworks section from
-            # one file overwrite the frameworks from previous includes!
-            lookup_dict = _resolve_frameworks(included_data, lookup_dict)
+            # update our big lookup dict with this included data:
+            if "frameworks" in included_data and isinstance(
+                included_data["frameworks"], dict
+            ):
+                # special case handling of frameworks to merge them from the various
+                # different included files rather than have frameworks section from
+                # one file overwrite the frameworks from previous includes!
+                lookup_dict = _resolve_frameworks(included_data, lookup_dict)
 
-            # also, keey track of where the framework has been referenced from:
-            for fw_name in included_data["frameworks"].keys():
-                fw_lookup[fw_name] = include_file
+                # also, keey track of where the framework has been referenced from:
+                for fw_name in included_data["frameworks"].keys():
+                    fw_lookup[fw_name] = include_file
 
-            del included_data["frameworks"]
+                del included_data["frameworks"]
 
-        fw_lookup.update(included_fw_lookup)
-        lookup_dict.update(included_data)
+            fw_lookup.update(included_fw_lookup)
+            lookup_dict.update(included_data)
 
     # now go through our own data, recursively, and replace any refs.
     # recurse down in dicts and lists

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -16,7 +16,9 @@ import ntpath
 from .shotgun_path import ShotgunPath
 from .platforms import is_windows
 from ..errors import TankError
+from .. import LogManager
 
+log = LogManager.get_logger(__name__)
 
 def _is_abs(path):
     """
@@ -86,9 +88,11 @@ def resolve_include(file_name, include):
 
     # make sure that the paths all exist
     if not os.path.exists(path):
-        raise TankError(
-            "Include resolve error in '%s': '%s' resolved to '%s' which does not exist!"
-            % (file_name, include, path)
-        )
+        log.warning("Include resolve error in '%s': '%s' resolved to '%s' which does not exist!"
+            % (file_name, include, path))
+        # raise TankError(
+        #     "Include resolve error in '%s': '%s' resolved to '%s' which does not exist!"
+        #     % (file_name, include, path)
+        # )
 
     return path


### PR DESCRIPTION
It is currently not possible to have env setting yml includes pointing to files that don't exist. 
The specific use-case for this would be where you want to override a centralised config (eg a studio's single site config) on a per-project basis. One example of this might be where you need to customise tk-nuke-writenode profiles on a per-project basis. 

SG Support suggested using the process order of includes to achieve some kind of "override" ability, but this isn't possible currently as any `include` that points to a file that doesn't exist, causes toolkit to raise a tankError. The specific failure here is when launching SG Desktop, which will process includes from a "site" context, prior to any project-path being defined.

The workflow this update allows is as follows:-

To override the studio's tk-nuke-writenode.yml

1. Add the pipeline_configuration_init.py hook to your pipeline config.
2. Inside this hook, add the following lines to store the path to the project root.

```
dp = self.parent._storage_roots.default_path
project_name = self.parent._project_name 
project_path = os.path.join(dp.current_os, project_name)
os.environ['PROJECT_PATH'] = project_path
```

3. In your nuke.yml env settings file add the following path to your list of includes. Make sure it is placed AFTER your normal `./tk-nuke-writenode.yml` entry.

```
- "$PROJECT_PATH/config/shotgun/settings/tk-nuke-writenode.yml" 
```

4. Duplicate your tk-nuke-writenode.yml to the project path indicated above. eg "/jobs/a_job/config/shotgun/settings/tk-nuke-writenode.ym"

5. Make any changes you require for your project specific override in this yml file.

6. Update your pipeline config `core_api.yml`as shown below, replacing "path-to-this-code" with the location of your local checkout of this repo branch.

```
location:
  type: dev
  path: /path-to-this-tk-core
```

You should be good to go. If the yml doesn't exist for your project, you should see warning logs when opening the project in SG Desktop. If you DO have the yml in the correct location of your project, then it should override the studio (pipeline config) writenode settings.