### PR TITLE
SG-14617: fixes for Python 3 port of tk-desktop

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -164,6 +164,13 @@ sgtk.util.json
 sgtk.util.pickle
 -----------------------------------
 
+Toolkit's ``pickle`` module isn't a drop-in replacement for Python's, but a wrapper around Python's :mod:`pickle` module so collections and scalar types can be exchanged freely between Python 2 and Python 3 processes without having to worry about the subtle pickle serialization differences between the two.
+
+If you wish to serialize your own custom classes to be exchanged between Python 2 and Python 3, you will need to sanitize data unpickled with Python 2 that was pickled with Python 3 and vice-versa. Otheriwse, your data will contain unexpected ``bytes`` or ``unicode`` objects instead of utf-8 encoded ``str`` instances.
+
+.. note::
+    In the ``load``/``loads`` methods, Python 3's ``bytes`` is always decoded back to a utf-8 encoded ``str``. If you need to store arbitrary binary data, consider saving it as a base64 string instead.
+
 .. autofunction:: dump
 .. autofunction:: dumps
 .. autofunction:: load

--- a/python/tank/util/unicode.py
+++ b/python/tank/util/unicode.py
@@ -56,7 +56,7 @@ def _ensure_contains_str(input_value, visited):
         # converted so far.
         #
         # We could start to track tuples instances that have been converted and reinsert
-        # those, but it make the code a lot more complex for very little benefit.
+        # those, but it would make the code a lot more complex for very little benefit.
         # We need to modify other types in place as we can create circular dependencies,
         # but you cannot create a circular dependency of tuples, so this is not an issue.
         return tuple(

--- a/python/tank/util/unicode.py
+++ b/python/tank/util/unicode.py
@@ -51,6 +51,17 @@ def _ensure_contains_str(input_value, visited):
             item = input_value[i]
             input_value[i] = _ensure_contains_str(item, visited)
         return input_value
+    elif isinstance(input_value, tuple):
+        # Tuples are immutable, so we don't need to track which one have been
+        # converted so far.
+        #
+        # We could start to track tuples instances that have been converted and reinsert
+        # those, but it make the code a lot more complex for very little benefit.
+        # We need to modify other types in place as we can create circular dependencies,
+        # but you cannot create a circular dependency of tuples, so this is not an issue.
+        return tuple(
+            _ensure_contains_str(tuple_item, visited) for tuple_item in input_value
+        )
     # If we've found a new dict, we must ensure each key and value
     # is not a unicode object.
     elif isinstance(input_value, dict) and id(input_value) not in visited:

--- a/tests/util_tests/test_unicode.py
+++ b/tests/util_tests/test_unicode.py
@@ -64,3 +64,21 @@ class TestUnicode(TestCase):
         # The second element should always be pointing back to the original
         # array object.
         self.assertEqual(id(value), id(converted_value[1]))
+
+    def test_tuple_are_converted(self):
+        """
+        Ensure tuples are properly iterated on and converted.
+        """
+        # Create an array with a circular reference.
+        value = ["item"]
+        a_tuple = (value, value, value)
+        value.append(a_tuple)
+
+        converted_value = sgtk.util.unicode.ensure_contains_str(value)
+
+        # We should still have a tuple at position 1.
+        self.assertIsInstance(converted_value[1], tuple)
+        # Each item of the tuple should be the same instance
+        self.assertEqual(id(value), id(converted_value[1][0]))
+        self.assertEqual(id(value), id(converted_value[1][1]))
+        self.assertEqual(id(value), id(converted_value[1][2]))


### PR DESCRIPTION
This ensures that pickles of tuples are properly converted to ensure utf-8 encoded `str` objects are found in the unpickled data instead of Python `bytes`.