### PR TITLE
SG-16672 Better error reporting for missing location key

### DIFF
--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -108,6 +108,25 @@ class Environment(object):
         self.__framework_locations = {}
         self.__extract_locations()
 
+    def __validate_settings(self, name, settings):
+        """
+        Validates the engine/app/framework settings dictionary
+        """
+
+        # Make sure the settings dict is not empty
+        if not settings:
+            raise TankError(
+                'No settings found for "{}" in {}'.format(name, self.disk_location)
+            )
+
+        # Make sure the location key exists
+        if "location" not in settings:
+            raise TankError(
+                '"location" key missing in the definition of "{}" in file {}'.format(
+                    name, self.disk_location
+                )
+            )
+
     def __is_item_disabled(self, settings):
         """
         handles the checks to see if an item is disabled
@@ -140,6 +159,7 @@ class Environment(object):
             return
         # iterate over the apps dict
         for app, app_settings in data.items():
+            self.__validate_settings(app, app_settings)
             if not self.__is_item_disabled(app_settings):
                 self.__app_settings[(engine, app)] = app_settings
 
@@ -151,6 +171,7 @@ class Environment(object):
             return
         # iterate over the engine dict
         for engine, engine_settings in engines.items():
+            self.__validate_settings(engine, engine_settings)
             # Check for engine disabled
             if not self.__is_item_disabled(engine_settings):
                 engine_apps = engine_settings.pop("apps")
@@ -165,6 +186,7 @@ class Environment(object):
             return
 
         for fw, fw_settings in frameworks.items():
+            self.__validate_settings(fw, fw_settings)
             # Check for framework disabled
             if not self.__is_item_disabled(fw_settings):
                 self.__framework_settings[fw] = fw_settings

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -119,13 +119,21 @@ class Environment(object):
                 'No settings found for "{}" in {}'.format(name, self.disk_location)
             )
 
-        # Make sure the location key exists
-        if "location" not in settings:
-            raise TankError(
-                '"location" key missing in the definition of "{}" in file {}'.format(
-                    name, self.disk_location
+        # Make sure the required keys exist and have values
+        required_keys = [constants.ENVIRONMENT_LOCATION_KEY]
+        for key in required_keys:
+            if key not in settings:
+                raise TankError(
+                    '"{}" key missing in the definition of "{}" in file {}'.format(
+                        key, name, self.disk_location
+                    )
                 )
-            )
+            if settings[key] is None:
+                raise TankError(
+                    '"{}" key of "{}" has an empty definition in file {}'.format(
+                        key, name, self.disk_location
+                    )
+                )
 
     def __is_item_disabled(self, settings):
         """

--- a/tests/fixtures/config/env/invalid_settings/empty_app_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_app_location.yml
@@ -1,0 +1,6 @@
+engines:
+    test_engine:
+        location: {"type": "dev", "path": "engine/path"}
+        apps:
+            test_app:
+                location:

--- a/tests/fixtures/config/env/invalid_settings/empty_app_settings.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_app_settings.yml
@@ -1,0 +1,5 @@
+engines:
+    test_engine:
+        location: {"type": "dev", "path": "engine/path"}
+        apps:
+            test_app:

--- a/tests/fixtures/config/env/invalid_settings/empty_engine_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_engine_location.yml
@@ -1,0 +1,3 @@
+engines:
+    test_engine:
+        location:

--- a/tests/fixtures/config/env/invalid_settings/empty_engine_settings.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_engine_settings.yml
@@ -1,0 +1,2 @@
+engines:
+    test_engine:

--- a/tests/fixtures/config/env/invalid_settings/empty_framework_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_framework_location.yml
@@ -1,0 +1,4 @@
+engines: {}
+frameworks:
+    test_framework_v1.x.x:
+        location:

--- a/tests/fixtures/config/env/invalid_settings/empty_framework_settings.yml
+++ b/tests/fixtures/config/env/invalid_settings/empty_framework_settings.yml
@@ -1,0 +1,3 @@
+engines: {}
+frameworks:
+    test_framework_v1.x.x:

--- a/tests/fixtures/config/env/invalid_settings/missing_app_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/missing_app_location.yml
@@ -1,0 +1,6 @@
+engines:
+    test_engine:
+        location: {"type": "dev", "path": "engine/path"}
+        apps:
+            test_app:
+                test_setting: test

--- a/tests/fixtures/config/env/invalid_settings/missing_engine_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/missing_engine_location.yml
@@ -1,0 +1,3 @@
+engines:
+    test_engine:
+        apps: {}

--- a/tests/fixtures/config/env/invalid_settings/missing_framework_location.yml
+++ b/tests/fixtures/config/env/invalid_settings/missing_framework_location.yml
@@ -1,0 +1,4 @@
+engines: {}
+frameworks:
+    test_framework_v1.x.x:
+        test_setting: test

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -157,6 +157,27 @@ class TestEnvironment(TankTestBase):
         )
         self.assertRaises(TankError, Environment, env_file)
 
+    def test_app_empty_location(self):
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "empty_app_location.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_engine_empty_location(self):
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "empty_engine_location.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_framework_empty_location(self):
+        env_file = os.path.join(
+            self.project_config,
+            "env",
+            "invalid_settings",
+            "empty_framework_location.yml",
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
 
 class TestDumpEnvironment(TankTestBase):
     def setUp(self):

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -15,6 +15,7 @@ from tank.errors import TankError
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 from tank_vendor import yaml
+from tank.platform.environment import Environment
 
 import copy
 
@@ -104,6 +105,57 @@ class TestEnvironment(TankTestBase):
             self.env.get_app_descriptor("test_engine", "test_app").configuration_schema,
             self.raw_app_metadata["configuration"],
         )
+
+    def test_engine_missing_location(self):
+
+        env_file = os.path.join(
+            self.project_config,
+            "env",
+            "invalid_settings",
+            "missing_engine_location.yml",
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_app_missing_location(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "missing_app_location.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_framework_missing_location(self):
+
+        env_file = os.path.join(
+            self.project_config,
+            "env",
+            "invalid_settings",
+            "missing_framework_location.yml",
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_engine_empty_settings(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "empty_engine_settings.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_app_empty_settings(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "empty_app_settings.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_framework_empty_settings(self):
+
+        env_file = os.path.join(
+            self.project_config,
+            "env",
+            "invalid_settings",
+            "empty_framework_settings.yml",
+        )
+        self.assertRaises(TankError, Environment, env_file)
 
 
 class TestDumpEnvironment(TankTestBase):


### PR DESCRIPTION
Added validation and better error reporting for the engine/app/framework settings dict in the environment file

For example if you don't define the "tk-multi-workfiles2" location in your env you used to get:
![Screen Shot 2020-03-26 at 3 13 53 PM](https://user-images.githubusercontent.com/4356899/77701952-a3031880-6f74-11ea-857d-21482b9d574e.png)
and now the error looks like:
![Screen Shot 2020-03-26 at 3 13 02 PM](https://user-images.githubusercontent.com/4356899/77701995-ba420600-6f74-11ea-9782-8c2739e98712.png)
