### PR TITLE
Fixes broken metrics in Python 3.

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -28,7 +28,7 @@ from copy import deepcopy
 from . import constants, sgre as re
 
 # use api json to cover py 2.5
-from tank_vendor import shotgun_api3
+from tank_vendor import shotgun_api3, six
 
 json = shotgun_api3.shotgun.json
 
@@ -538,7 +538,7 @@ class MetricsDispatchWorkerThread(Thread):
             "auth_args": {"session_token": sg_connection.get_session_token()},
             "metrics": filtered_metrics_data,
         }
-        payload_json = json.dumps(payload)
+        payload_json = six.ensure_binary(json.dumps(payload))
 
         header = {"Content-Type": "application/json"}
         try:


### PR DESCRIPTION
Fixes a bug with Python 3 where metrics weren't logged.

The urlopen method was being passed a str payload rather than a bytes.