### PR TITLE
SG-16901 log an exception when running find_app_settings and invalid

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -3222,27 +3222,32 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
                 schema = app_desc.configuration_schema
                 settings = env.get_app_settings(eng, app)
 
-                # check that the context contains all the info that the app needs
+                # Check that the context contains all the info that the app needs.
                 validation.validate_context(app_desc, context)
 
-                # make sure the current operating system platform is supported
+                # Make sure the current operating system platform is supported.
                 validation.validate_platform(app_desc)
 
-                # for multi engine apps, make sure our engine is supported
+                # For multi engine apps, make sure our engine is supported.
                 supported_engines = app_desc.supported_engines
                 if supported_engines and engine_name not in supported_engines:
                     raise TankError(
-                        "The app could not be loaded since it only supports "
-                        "the following engines: %s" % supported_engines
+                        "The app doesn't support the engine %s. It supports "
+                        "the following engines: %s" % (engine_name, supported_engines)
                     )
 
-                # finally validate the configuration.
+                # Finally validate the configuration.
                 # Note: context is set to None as we don't
                 # want to fail validation because of an
                 # incomplete context at this stage!
                 validation.validate_settings(app, tk, None, schema, settings)
             except TankError:
-                # ignore any Tank exceptions to skip invalid apps
+                core_logger.exception(
+                    "Warning: Could not validate app settings for the "
+                    '"%s" app instance in the "%s" environment '
+                    'on the "%s" engine.' % (app, env_name, engine_name)
+                )
+                # Ignore any Tank exceptions to skip invalid apps.
                 continue
 
             # settings are valid so add them to return list:

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -3241,11 +3241,12 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
                 # want to fail validation because of an
                 # incomplete context at this stage!
                 validation.validate_settings(app, tk, None, schema, settings)
-            except TankError:
-                core_logger.exception(
-                    "Warning: Could not validate app settings for the "
+            except TankError as e:
+                core_logger.info("test")
+                core_logger.debug(
+                    "Could not validate app settings for the "
                     '"%s" app instance in the "%s" environment '
-                    'on the "%s" engine.' % (app, env_name, engine_name)
+                    'on the "%s" engine.\nError: %s' % (app, env_name, engine_name, e)
                 )
                 # Ignore any Tank exceptions to skip invalid apps.
                 continue

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -3242,7 +3242,6 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
                 # incomplete context at this stage!
                 validation.validate_settings(app, tk, None, schema, settings)
             except TankError as e:
-                core_logger.info("test")
                 core_logger.debug(
                     "Could not validate app settings for the "
                     '"%s" app instance in the "%s" environment '

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -3242,7 +3242,7 @@ def find_app_settings(engine_name, app_name, tk, context, engine_instance_name=N
                 # incomplete context at this stage!
                 validation.validate_settings(app, tk, None, schema, settings)
             except TankError as e:
-                core_logger.debug(
+                core_logger.warning(
                     "Could not validate app settings for the "
                     '"%s" app instance in the "%s" environment '
                     'on the "%s" engine.\nError: %s' % (app, env_name, engine_name, e)


### PR DESCRIPTION
When using `sgtk.platform.find_app_settings()` it used to just catch all app setting validation errors silently and not give any feedback on why settings were not available.

This PR logs an exception now:

```
engine: Warning: Could not validate app settings for the "tk-multi-pythonconsole_bad" app instance in the "project" environment on the tk-desktop "engine".
Traceback (most recent call last):
  File "/Users/bob/Library/Caches/Shotgun/mysite/p89c1.basic.shell/cfg/install/core/python/tank/platform/engine.py", line 3243, in find_app_settings
    validation.validate_settings(app, tk, None, schema, settings)
  File "/Users/bob/Library/Caches/Shotgun/mysite/p89c1.basic.shell/cfg/install/core/python/tank/platform/validation.py", line 51, in validate_settings
    v.validate(settings)
  File "/Users/bob/Library/Caches/Shotgun/mysite/p89c1.basic.shell/cfg/install/core/python/tank/platform/validation.py", line 531, in validate
    self.__validate_settings_value(settings_key, value_schema, settings_value)
  File "/Users/bob/Library/Caches/Shotgun/mysite/p89c1.basic.shell/cfg/install/core/python/tank/platform/validation.py", line 569, in __validate_settings_value
    raise TankError(err_msg)
tank.errors.TankError: Invalid type for value in setting 'external_sources_hook' for 'tk-multi-pythonconsole_bad' - found 'int', expected 'hook'
```