### PR TITLE
setup.py: decode git version output to string for py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ def get_version():
     # will be picked up from the most recently added tag.
     try:
         version_git = subprocess.check_output(
-            ["git", "describe", "--abbrev=0"]
+            ["git", "describe", "--abbrev=0"],
+            universal_newlines=True
         ).rstrip()
         return version_git
     except:


### PR DESCRIPTION
By default, subprocess.check_output returns bytes, which causes `python setup.py egg_info` to fail with a stack trace, like this:
```
% python setup.py egg_info                            
/Users/garyo/Library/Caches/pypoetry/virtualenvs/deliverables-nQKiRMb9-py3.7/lib/python3.7/site-packages/setuptools/dist.py:483: UserWarning: The version specified (b'v0.19.5') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
running egg_info
Traceback (most recent call last):
  File "setup.py", line 84, in <module>
    package_dir={"": "python"},
  File "/Users/garyo/Library/Caches/pypoetry/virtualenvs/deliverables-nQKiRMb9-py3.7/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/Users/garyo/.pyenv/versions/3.7.6/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Users/garyo/.pyenv/versions/3.7.6/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/Users/garyo/.pyenv/versions/3.7.6/lib/python3.7/distutils/dist.py", line 984, in run_command
    cmd_obj.ensure_finalized()
  File "/Users/garyo/.pyenv/versions/3.7.6/lib/python3.7/distutils/cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "/Users/garyo/Library/Caches/pypoetry/virtualenvs/deliverables-nQKiRMb9-py3.7/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 199, in finalize_options
    self.egg_version = self.tagged_version()
  File "/Users/garyo/Library/Caches/pypoetry/virtualenvs/deliverables-nQKiRMb9-py3.7/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 133, in tagged_version
    return safe_version(version + self.vtags)
TypeError: can't concat str to bytes
```

This fix adds `universal_newlines` which should work on py3 and py2.7. (I tested on 3.7.) An alternative would be to add `.decode('utf-8')` there instead.