### PR TITLE
[minor] setup.py fix for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ def get_version():
     # will be picked up from the most recently added tag.
     try:
         version_git = subprocess.check_output(
-            ["git", "describe", "--abbrev=0"]
+            ["git", "describe", "--abbrev=0"],
+            universal_newlines=True
         ).rstrip()
         return version_git
     except:

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ def get_version():
     # will be picked up from the most recently added tag.
     try:
         version_git = subprocess.check_output(
-            ["git", "describe", "--abbrev=0"],
-            universal_newlines=True
+            ["git", "describe", "--abbrev=0"], universal_newlines=True
         ).rstrip()
         return version_git
     except:


### PR DESCRIPTION
Fixes an issue reading version information when running setup.py under Python 3.
This applies the fix submitted to us by https://github.com/shotgunsoftware/tk-core/pull/760 and runs black on top of it.