### PR TITLE
SG-4562: apostrophe in config path fix

### DIFF
--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -325,9 +325,13 @@ class ConfigurationWriter(object):
             fh.write("# This file reflects the paths in the pipeline\n")
             fh.write("# configuration defined for this project.\n")
             fh.write("\n")
-            fh.write("Windows: '%s'\n" % self._path.windows)
-            fh.write("Darwin: '%s'\n" % self._path.macosx)
-            fh.write("Linux: '%s'\n" % self._path.linux)
+
+            locations = {}
+            locations["Windows"] = self._path.windows
+            locations["Darwin"] = self._path.macosx
+            locations["Linux"] = self._path.linux
+
+            yaml.safe_dump(locations, fh, default_flow_style=False)
 
     def write_config_info_file(self, config_descriptor):
         """

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -478,6 +478,30 @@ class TestWritePipelineConfigFile(ShotgunTestBase):
         )
 
 
+class TestInstallationLocationFile(ShotgunTestBase):
+
+    def test_character_escaping(self):
+        """
+        Ensure that the ' and " charactes are properly escaped
+        when writing out install_location.yml
+        """
+        new_config_root = os.path.join(self.tank_temp, self.short_test_name, "O'Connell")
+
+        writer = ConfigurationWriter(
+            ShotgunPath.from_current_os_path(new_config_root), self.mockgun
+        )
+
+        install_location_path = os.path.join(new_config_root, "config", "core", "install_location.yml")
+
+        os.makedirs(os.path.dirname(install_location_path))
+
+        writer.write_install_location_file()
+
+        with open(install_location_path, "rt") as f:
+            path = ShotgunPath(yaml.safe_load(f))
+        assert path.current_os == new_config_root
+
+
 class TestTransaction(ShotgunTestBase):
     def test_transactions(self):
         """

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -498,7 +498,8 @@ class TestInstallationLocationFile(ShotgunTestBase):
         writer.write_install_location_file()
 
         with open(install_location_path, "rt") as f:
-            path = ShotgunPath(yaml.safe_load(f))
+            paths = yaml.safe_load(f)
+            path = ShotgunPath(paths["Windows"], paths["Linux"], paths["Darwin"])
         assert path.current_os == new_config_root
 
 

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -479,19 +479,22 @@ class TestWritePipelineConfigFile(ShotgunTestBase):
 
 
 class TestInstallationLocationFile(ShotgunTestBase):
-
     def test_character_escaping(self):
         """
-        Ensure that the ' and " charactes are properly escaped
+        Ensure that the ' characte is properly escaped
         when writing out install_location.yml
         """
-        new_config_root = os.path.join(self.tank_temp, self.short_test_name, "O'Connell")
+        new_config_root = os.path.join(
+            self.tank_temp, self.short_test_name, "O'Connell"
+        )
 
         writer = ConfigurationWriter(
             ShotgunPath.from_current_os_path(new_config_root), self.mockgun
         )
 
-        install_location_path = os.path.join(new_config_root, "config", "core", "install_location.yml")
+        install_location_path = os.path.join(
+            new_config_root, "config", "core", "install_location.yml"
+        )
 
         os.makedirs(os.path.dirname(install_location_path))
 


### PR DESCRIPTION
Fixes an issue where if a user had an apostrophe in their name the configuration_writer.yml file would get corrupted when using distributed configurations.