### PR TITLE
SG-17191 Added the ability to flag certain includes as optional

### DIFF
--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -36,7 +36,7 @@ from ..log import LogManager
 from . import constants
 
 from ..util.yaml_cache import g_yaml_cache
-from ..util.includes import _get_includes
+from ..util.includes import get_includes
 from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
@@ -126,7 +126,7 @@ def _process_includes_r(file_name, data, context):
                         they were loaded from.
     """
     # first build our big fat lookup dict
-    include_files = _get_includes(file_name, data)
+    include_files = get_includes(file_name, data)
 
     lookup_dict = {}
     fw_lookup = {}
@@ -247,7 +247,7 @@ def find_reference(file_name, context, token, absolute_location=False):
     data = g_yaml_cache.get(file_name) or {}
 
     # first build our big fat lookup dict
-    include_files = _get_includes(file_name, data)
+    include_files = get_includes(file_name, data)
     found_file = None
     found_token = token
 

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -64,11 +64,13 @@ def _resolve_includes(file_name, data, context):
 
     for include in includes:
 
+        path = None
+
         # Convert string includes into dictionaries with default values
         if isinstance(include, six.string_types):
             include = {
                 "path": include,
-                "optional": False,
+                "required": True,
             }
 
         # Validate
@@ -77,9 +79,9 @@ def _resolve_includes(file_name, data, context):
                 'Failed to process an include in %s. Misisng required "path" key. %s'
                 % (file_name, include)
             )
-        if "optional" in include and not isinstance(include["optional"], bool):
+        if "required" in include and not isinstance(include["required"], bool):
             raise TankError(
-                'Invalid "optional" value for the include %s in %s. Expected a boolean'
+                'Invalid "required" value for the include %s in %s. Expected a boolean'
                 % (include["path"], file_name)
             )
 
@@ -139,7 +141,7 @@ def _resolve_includes(file_name, data, context):
             try:
                 path = resolve_include(file_name, include["path"])
             except TankError as e:
-                if not include.get("optional", False):
+                if include.get("required", True):
                     raise
                 log.warning("Skipping optional include. %s" % e.message)
 

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -143,7 +143,7 @@ def _resolve_includes(file_name, data, context):
             except TankError as e:
                 if include.get("required", True):
                     raise
-                log.warning("Skipping optional include. %s" % e.message)
+                log.warning("Skipping optional include. %s" % str(e))
 
         if path and path not in resolved_includes:
             resolved_includes.append(path)

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -33,35 +33,8 @@ import os
 from .errors import TankError
 from . import constants
 from .util import yaml_cache
-from .util.includes import resolve_include
+from .util.includes import _get_includes
 from tank_vendor import six
-
-
-def _get_includes(file_name, data):
-    """
-    Parse the includes section and return a list of valid paths
-
-    :param str file_name: Name of the file to parse.
-    :param aray or str data: Include path or array of include paths to evaluate.
-    """
-    includes = []
-
-    resolved_includes = list()
-
-    if constants.SINGLE_INCLUDE_SECTION in data:
-        # single include section
-        includes.append(data[constants.SINGLE_INCLUDE_SECTION])
-
-    if constants.MULTI_INCLUDE_SECTION in data:
-        # multi include section
-        includes.extend(data[constants.MULTI_INCLUDE_SECTION])
-
-    for include in includes:
-        resolved = resolve_include(file_name, include)
-        if resolved and resolved not in resolved_includes:
-            resolved_includes.append(resolved)
-
-    return resolved_includes
 
 
 def _process_template_includes_r(file_name, data):

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -33,7 +33,7 @@ import os
 from .errors import TankError
 from . import constants
 from .util import yaml_cache
-from .util.includes import _get_includes
+from .util.includes import get_includes
 from tank_vendor import six
 
 
@@ -55,7 +55,7 @@ def _process_template_includes_r(file_name, data):
         return output_data
 
     # process includes
-    included_paths = _get_includes(file_name, data)
+    included_paths = get_includes(file_name, data)
 
     for included_path in included_paths:
         included_data = (

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -80,12 +80,12 @@ def _get_includes(file_name, data):
         # Validate
         if "path" not in include:
             raise TankError(
-                'Failed to process an include in %s. Misisng required "path" key. %s'
+                "Failed to process an include in '%s'. Misisng required 'path' key. %s"
                 % (file_name, include)
             )
         if "required" in include and not isinstance(include["required"], bool):
             raise TankError(
-                'Invalid "required" value for the include %s in %s. Expected a boolean'
+                "Invalid 'required' value for the include '%s' in '%s'. Expected a boolean"
                 % (include["path"], file_name)
             )
 

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -50,7 +50,7 @@ def _is_current_platform_abspath(path):
         return posixpath.isabs(path)
 
 
-def _get_includes(file_name, data):
+def get_includes(file_name, data):
     """
     Parse the includes section and return a list of valid paths
 
@@ -95,7 +95,7 @@ def _get_includes(file_name, data):
         except TankError as e:
             if include.get("required", True):
                 raise
-            log.warning("Skipping optional include. %s" % str(e))
+            log.warning("Skipping optional include. %s" % e)
 
         if resolved and resolved not in resolved_includes:
             resolved_includes.append(resolved)

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -231,8 +231,8 @@ class TestIncludes(TankTestBase):
         )
         Environment(env_file)
         self.assertIsNotNone(
-            re.match(
-                "Skipping optional include .+ resolved to .+ which does not exist!",
+            re.search(
+                "Skipping optional include.+ resolved to '/not/a/valid/path\.yml' which does not exist!",
                 stream.getvalue(),
             )
         )

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -13,13 +13,18 @@ import os
 import itertools
 from mock import patch
 import re
-from StringIO import StringIO
 import logging
+
+# Import the correct StringIO module whether using python 2 or 3
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
 
 import tank
 from tank_test.tank_test_base import TankTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank.util.includes import _get_includes
+from tank.util.includes import get_includes
 from tank_vendor.shotgun_api3.lib import sgsix
 
 from tank.platform.environment import Environment
@@ -140,7 +145,7 @@ class TestIncludes(TankTestBase):
         """
         if isinstance(includes, str):
             includes = [includes]
-        return _get_includes(self._file_name, {"includes": includes})
+        return get_includes(self._file_name, {"includes": includes})
 
     def test_missing_file(self):
         """
@@ -167,7 +172,9 @@ class TestIncludes(TankTestBase):
             )
 
     def test_missing_include(self):
-
+        """
+        Test the behaviour and error message when an include file does not exist
+        """
         env_file = os.path.join(
             self.project_config, "env", "invalid_settings", "missing_include.yml"
         )
@@ -179,7 +186,9 @@ class TestIncludes(TankTestBase):
         )
 
     def test_missing_include_path(self):
-
+        """
+        Test the behaviour and error message when using a dictionary to define includes and the "path" key is missing
+        """
         env_file = os.path.join(
             self.project_config, "env", "invalid_settings", "missing_include_path.yml"
         )
@@ -191,7 +200,9 @@ class TestIncludes(TankTestBase):
         )
 
     def test_invalid_include_optional(self):
-
+        """
+        Test the behaviour and error message when the "required" parameter of an include is not set to a boolean
+        """
         env_file = os.path.join(
             self.project_config,
             "env",

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -232,7 +232,7 @@ class TestIncludes(TankTestBase):
         Environment(env_file)
         self.assertIsNotNone(
             re.search(
-                "Skipping optional include.+ resolved to '/not/a/valid/path\.yml' which does not exist!",
+                "Skipping optional include.+ resolved to '/not/a/valid/path.yml' which does not exist!",
                 stream.getvalue(),
             )
         )

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -18,7 +18,7 @@ import logging
 # Import the correct StringIO module whether using python 2 or 3
 try:
     from StringIO import StringIO
-except:
+except ModuleNotFoundError:
     from io import StringIO
 
 import tank

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -232,7 +232,7 @@ class TestIncludes(TankTestBase):
         Environment(env_file)
         self.assertIsNotNone(
             re.match(
-                "Skipping optional include. .+ resolved to '/not/a/valid/path.yml' which does not exist!",
+                "Skipping optional include .+ resolved to .+ which does not exist!",
                 stream.getvalue(),
             )
         )

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -15,168 +15,114 @@ import itertools
 import tank
 from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank.template_includes import _get_includes as get_template_includes
-from tank.platform.environment_includes import (
-    _resolve_includes as get_environment_includes,
-)
+from tank.util.includes import _get_includes
 from tank_vendor.shotgun_api3.lib import sgsix
 from mock import patch
 
 
-class Includes(object):
+class TestIncludes(ShotgunTestBase):
     """
-    Allows to nest the Imp class so that the unit test runner doesn't try to run it.
+    Note that these tests will only test the code for the current platform. They
+    need to be run on other platforms to get complete coverage.
     """
 
-    class Imp(ShotgunTestBase):
+    _file_name = os.path.join(os.getcwd(), "test.yml")
+    _file_dir = os.path.dirname(_file_name)
+
+    @patch("os.path.exists", return_value=True)
+    def test_env_var_only(self, _):
         """
-        Tests includes. _resolve_includes needs to be reimplemented by the derived class
-
-        Note that these tests will only test the code for the current platform. They
-        need to be run on other platforms to get complete coverage.
+        Validate that a lone environment variable will resolve on all platforms.
         """
+        resolved_include = os.path.join(os.getcwd(), "test.yml")
+        with temp_env_var(INCLUDE_ENV_VAR=resolved_include):
+            os.environ["INCLUDE_ENV_VAR"]
+            self.assertEqual(
+                self._resolve_includes("$INCLUDE_ENV_VAR"), [resolved_include]
+            )
 
-        _file_name = os.path.join(os.getcwd(), "test.yml")
-        _file_dir = os.path.dirname(_file_name)
+    @patch("os.path.exists", return_value=True)
+    def test_tilde(self, _):
+        """
+        Validate that a tilde will resolve on all platforms.
+        """
+        include = os.path.join("~", "test.yml")
+        resolved_include = os.path.expanduser(include)
+        self.assertEqual(self._resolve_includes(include), [resolved_include])
 
-        @patch("os.path.exists", return_value=True)
-        def test_env_var_only(self, _):
-            """
-            Validate that a lone environment variable will resolve on all platforms.
-            """
-            resolved_include = os.path.join(os.getcwd(), "test.yml")
-            with temp_env_var(INCLUDE_ENV_VAR=resolved_include):
-                os.environ["INCLUDE_ENV_VAR"]
-                self.assertEqual(
-                    self._resolve_includes("$INCLUDE_ENV_VAR"), [resolved_include]
-                )
+    @patch("os.path.exists", return_value=True)
+    def test_relative_path(self, _):
+        """
+        Validate that relative path are processed correctly
+        """
+        relative_include = "sub_folder/include.yml"
+        self.assertEqual(
+            self._resolve_includes(relative_include),
+            [os.path.join(self._file_dir, "sub_folder", "include.yml")],
+        )
 
-        @patch("os.path.exists", return_value=True)
-        def test_tilde(self, _):
-            """
-            Validate that a tilde will resolve on all platforms.
-            """
-            include = os.path.join("~", "test.yml")
-            resolved_include = os.path.expanduser(include)
-            self.assertEqual(self._resolve_includes(include), [resolved_include])
-
-        @patch("os.path.exists", return_value=True)
-        def test_relative_path(self, _):
-            """
-            Validate that relative path are processed correctly
-            """
-            relative_include = "sub_folder/include.yml"
+    @patch("os.path.exists", return_value=True)
+    def test_relative_path_with_env_var(self, _):
+        """
+        Validate that relative path with env vars are processed correctly
+        """
+        relative_include = "$INCLUDE_ENV_VAR/include.yml"
+        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
             self.assertEqual(
                 self._resolve_includes(relative_include),
-                [os.path.join(self._file_dir, "sub_folder", "include.yml")],
+                [os.path.join(os.getcwd(), "include.yml")],
             )
 
-        @patch("os.path.exists", return_value=True)
-        def test_relative_path_with_env_var(self, _):
-            """
-            Validate that relative path with env vars are processed correctly
-            """
-            relative_include = "$INCLUDE_ENV_VAR/include.yml"
-            with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
-                self.assertEqual(
-                    self._resolve_includes(relative_include),
-                    [os.path.join(os.getcwd(), "include.yml")],
-                )
-
-        @patch("os.path.exists", return_value=True)
-        def test_path_with_env_var_in_front(self, _):
-            """
-            Validate that relative path are processed correctly on all platforms.
-            """
-            include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
-            with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
-                self.assertEqual(
-                    self._resolve_includes(include),
-                    [os.path.join(os.getcwd(), "include.yml")],
-                )
-
-        @patch("os.path.exists", return_value=True)
-        def test_path_with_env_var_in_middle(self, _):
-            """
-            Validate that relative path are processed correctly on all platforms.
-            """
-            include = os.path.join(os.getcwd(), "$INCLUDE_ENV_VAR", "include.yml")
-            with temp_env_var(INCLUDE_ENV_VAR="includes"):
-                self.assertEqual(
-                    self._resolve_includes(include), [os.path.expandvars(include)]
-                )
-
-        @patch("os.path.exists", return_value=True)
-        def test_path_with_multi_os_path(self, _):
-            """
-            Validate that relative path are processed correctly on all platforms.
-            """
-            paths = {
-                "win32": "C:\\test.yml",
-                "darwin": "/test.yml",
-                "linux2": "/test.yml",
-            }
-            # Make sure that we are returning the include for the current platform.
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_env_var_in_front(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR=os.getcwd()):
             self.assertEqual(
-                self._resolve_includes(set(paths.values())),  # get unique values.
-                [paths[sgsix.platform]],  # get the value for the current platform
+                self._resolve_includes(include),
+                [os.path.join(os.getcwd(), "include.yml")],
             )
 
-        @patch("os.path.exists", return_value=True)
-        def test_path_with_relative_env_var(self, _):
-            """
-            Validate that relative path are processed correctly on all platforms.
-            """
-            include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
-            with temp_env_var(INCLUDE_ENV_VAR="sub_folder"):
-                self.assertEqual(
-                    self._resolve_includes(include),
-                    [os.path.join(os.getcwd(), "sub_folder", "include.yml")],
-                )
-
-        def _resolve_includes(self, includes):
-            """
-            Take the tedium out of calling _get_include
-            """
-            raise NotImplementedError(
-                "TestIncludes._resolve_includes is not implemented."
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_env_var_in_middle(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join(os.getcwd(), "$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR="includes"):
+            self.assertEqual(
+                self._resolve_includes(include), [os.path.expandvars(include)]
             )
 
-        def test_missing_file(self):
-            """
-            Make sure an exception is raised when the include doesn't exist.
-            """
-            with self.assertRaisesRegex(tank.TankError, "Include resolve error"):
-                self._resolve_includes("dead/path/to/a/file")
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_multi_os_path(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        paths = {
+            "win32": "C:\\test.yml",
+            "darwin": "/test.yml",
+            "linux2": "/test.yml",
+        }
+        # Make sure that we are returning the include for the current platform.
+        self.assertEqual(
+            self._resolve_includes(set(paths.values())),  # get unique values.
+            [paths[sgsix.platform]],  # get the value for the current platform
+        )
 
-        @patch("os.path.exists", return_value=True)
-        def test_includes_ordering(self, _):
-            """
-            Ensure include orders is preserved.
-            """
-            # Try different permutations of the same set of includes and they should
-            # always return in the same order. This is important as values found
-            # in later includes override earlier ones.
-
-            # We do permutations here because Python 2 and Python 3 handle
-            # set ordering differently.
-            for includes in itertools.permutations(["a.yml", "b.yml", "c.yml"]):
-                self.assertEqual(
-                    self._resolve_includes(includes),
-                    [os.path.join(os.getcwd(), include) for include in includes],
-                )
-
-
-# TODO: These tests should be moved within their respective test packages, but because they share
-# the same suite of tests there's no easy way to share the suite. However, once we finish the
-# refactoring of the include system, I suspect most of these tests will move to the refactored
-# framework location and this messiness will go away.
-
-
-class TestTemplateIncludes(Includes.Imp):
-    """
-    Tests template includes.
-    """
+    @patch("os.path.exists", return_value=True)
+    def test_path_with_relative_env_var(self, _):
+        """
+        Validate that relative path are processed correctly on all platforms.
+        """
+        include = os.path.join("$INCLUDE_ENV_VAR", "include.yml")
+        with temp_env_var(INCLUDE_ENV_VAR="sub_folder"):
+            self.assertEqual(
+                self._resolve_includes(include),
+                [os.path.join(os.getcwd(), "sub_folder", "include.yml")],
+            )
 
     def _resolve_includes(self, includes):
         """
@@ -184,18 +130,28 @@ class TestTemplateIncludes(Includes.Imp):
         """
         if isinstance(includes, str):
             includes = [includes]
-        return get_template_includes(self._file_name, {"includes": includes})
+        return _get_includes(self._file_name, {"includes": includes})
 
-
-class TestEnvironmentIncludes(Includes.Imp):
-    """
-    Tests environment includes.
-    """
-
-    def _resolve_includes(self, includes):
+    def test_missing_file(self):
         """
-        Resolve environment includes.
+        Make sure an exception is raised when the include doesn't exist.
         """
-        if isinstance(includes, str):
-            includes = [includes]
-        return get_environment_includes(self._file_name, {"includes": includes}, None)
+        with self.assertRaisesRegex(tank.TankError, "Include resolve error"):
+            self._resolve_includes("dead/path/to/a/file")
+
+    @patch("os.path.exists", return_value=True)
+    def test_includes_ordering(self, _):
+        """
+        Ensure include orders is preserved.
+        """
+        # Try different permutations of the same set of includes and they should
+        # always return in the same order. This is important as values found
+        # in later includes override earlier ones.
+
+        # We do permutations here because Python 2 and Python 3 handle
+        # set ordering differently.
+        for includes in itertools.permutations(["a.yml", "b.yml", "c.yml"]):
+            self.assertEqual(
+                self._resolve_includes(includes),
+                [os.path.join(os.getcwd(), include) for include in includes],
+            )

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -232,7 +232,7 @@ class TestIncludes(TankTestBase):
         Environment(env_file)
         self.assertIsNotNone(
             re.search(
-                "Skipping optional include.+ resolved to '/not/a/valid/path.yml' which does not exist!",
+                "Skipping optional include.+ resolved to '.+/not/a/valid/path.yml' which does not exist!",
                 stream.getvalue(),
             )
         )

--- a/tests/fixtures/config/env/invalid_settings/invalid_include_required.yml
+++ b/tests/fixtures/config/env/invalid_settings/invalid_include_required.yml
@@ -1,0 +1,2 @@
+includes:
+- { path: ./includes/bad_path.yml, required: "not boolean" }

--- a/tests/fixtures/config/env/invalid_settings/missing_include.yml
+++ b/tests/fixtures/config/env/invalid_settings/missing_include.yml
@@ -1,0 +1,2 @@
+includes:
+- ./includes/bad_path.yml

--- a/tests/fixtures/config/env/invalid_settings/missing_include_path.yml
+++ b/tests/fixtures/config/env/invalid_settings/missing_include_path.yml
@@ -1,0 +1,2 @@
+includes:
+- { pth: ./includes/bad_path.yml }

--- a/tests/fixtures/config/env/invalid_settings/optional_include.yml
+++ b/tests/fixtures/config/env/invalid_settings/optional_include.yml
@@ -1,4 +1,4 @@
 includes:
-- {path: /not/a/valid/path.yml, required: False}
+- {path: ./not/a/valid/path.yml, required: False}
 
 engines:

--- a/tests/fixtures/config/env/invalid_settings/optional_include.yml
+++ b/tests/fixtures/config/env/invalid_settings/optional_include.yml
@@ -1,0 +1,4 @@
+includes:
+- {path: /not/a/valid/path.yml, required: False}
+
+engines:

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -15,6 +15,7 @@ from tank.errors import TankError
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 from tank_vendor import yaml
+from tank.platform.environment import Environment
 
 import copy
 
@@ -104,6 +105,37 @@ class TestEnvironment(TankTestBase):
             self.env.get_app_descriptor("test_engine", "test_app").configuration_schema,
             self.raw_app_metadata["configuration"],
         )
+
+    def test_missing_include(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "missing_include.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_missing_include_path(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "missing_include_path.yml"
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_invalid_include_optional(self):
+
+        env_file = os.path.join(
+            self.project_config,
+            "env",
+            "invalid_settings",
+            "invalid_include_required.yml",
+        )
+        self.assertRaises(TankError, Environment, env_file)
+
+    def test_optional_include(self):
+
+        env_file = os.path.join(
+            self.project_config, "env", "invalid_settings", "optional_include.yml"
+        )
+        Environment(env_file)
 
 
 class TestDumpEnvironment(TankTestBase):

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -10,14 +10,12 @@
 
 import os
 import sys
+import copy
 
 from tank.errors import TankError
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 from tank_vendor import yaml
-from tank.platform.environment import Environment
-
-import copy
 
 
 class TestEnvironment(TankTestBase):
@@ -105,37 +103,6 @@ class TestEnvironment(TankTestBase):
             self.env.get_app_descriptor("test_engine", "test_app").configuration_schema,
             self.raw_app_metadata["configuration"],
         )
-
-    def test_missing_include(self):
-
-        env_file = os.path.join(
-            self.project_config, "env", "invalid_settings", "missing_include.yml"
-        )
-        self.assertRaises(TankError, Environment, env_file)
-
-    def test_missing_include_path(self):
-
-        env_file = os.path.join(
-            self.project_config, "env", "invalid_settings", "missing_include_path.yml"
-        )
-        self.assertRaises(TankError, Environment, env_file)
-
-    def test_invalid_include_optional(self):
-
-        env_file = os.path.join(
-            self.project_config,
-            "env",
-            "invalid_settings",
-            "invalid_include_required.yml",
-        )
-        self.assertRaises(TankError, Environment, env_file)
-
-    def test_optional_include(self):
-
-        env_file = os.path.join(
-            self.project_config, "env", "invalid_settings", "optional_include.yml"
-        )
-        Environment(env_file)
 
 
 class TestDumpEnvironment(TankTestBase):


### PR DESCRIPTION
Allows the user to flag an include as not required (optional). If an optional include resolves to a missing file, a warning is logged instead of raising an Exception.

Here's the new supported syntax (it still supports the old way too):

```
includes:
- {path: ./path/to/the_file.yml, required: false}
```