### PR TITLE
add engine as property on all TankBundle classes

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -364,6 +364,13 @@ class TankBundle(object):
         """
         return self.__log
 
+    @property
+    def engine(self):
+        """
+        The engine associated with this bundle.
+        """
+        raise NotImplementedError
+
     ##########################################################################################
     # public methods
 

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -539,6 +539,13 @@ class Engine(TankBundle):
         return self.tank.shotgun        
 
     @property
+    def engine(self):
+        """
+        The engine, returns self.
+        """
+        return self
+
+    @property
     def environment(self):
         """
         A dictionary with information about the environment.


### PR DESCRIPTION
The `Engine` class is currently the only `TankBundle` subclass to not implement the `.engine` property, but since it is itself an engine, adding the property and making all bundles have a consistent interface for retrieving the related engine seemed easy and appropriate.

The functional reason for this change originally was to be able to call `self.load_framework` within an engine hook.

Thanks!