### PR TITLE
Integration test hardening.

### DIFF
--- a/tests/integration_tests/bootstrap_hook.py
+++ b/tests/integration_tests/bootstrap_hook.py
@@ -68,13 +68,13 @@ class BootstrapHookTests(SgtkIntegrationTest):
                 "CustomNonProjectEntity01", {"sg_descriptor": descriptor}
             )
 
-        for i in range(5):
+        for _ in range(5):
             try:
                 # Upload the bundle to Shotgun.
                 cls.sg.upload(
                     "CustomNonProjectEntity01", item["id"], temp_zipfile, "sg_content"
                 )
-            except Exception as e:
+            except Exception:
                 logger.exception(
                     "An unexpected exception was raised using the upload of the configuration:"
                 )

--- a/tests/integration_tests/bootstrap_hook.py
+++ b/tests/integration_tests/bootstrap_hook.py
@@ -68,10 +68,20 @@ class BootstrapHookTests(SgtkIntegrationTest):
                 "CustomNonProjectEntity01", {"sg_descriptor": descriptor}
             )
 
-        # Upload the bundle to Shotgun.
-        cls.sg.upload(
-            "CustomNonProjectEntity01", item["id"], temp_zipfile, "sg_content"
-        )
+        for i in range(5):
+            try:
+                # Upload the bundle to Shotgun.
+                cls.sg.upload(
+                    "CustomNonProjectEntity01", item["id"], temp_zipfile, "sg_content"
+                )
+            except Exception as e:
+                logger.exception(
+                    "An unexpected exception was raised using the upload of the configuration:"
+                )
+            else:
+                return
+        else:
+            raise RuntimeError("Failed uploading media after 5 retries.")
 
     @classmethod
     def _find_bundle_in_sg(cls, descriptor):


### PR DESCRIPTION
We often get connection reset by peer during this test on Azure Pipelines during the upload. This should harden the test against upload failures.