### PR TITLE
App store downloads by URL and not ID.

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -425,11 +425,11 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         #  'type': 'Attachment',
         #  'id': 139,
         #  'link_type': 'upload'}
-        attachment_id = version[constants.TANK_CODE_PAYLOAD_FIELD]["id"]
+        attachment_url = version[constants.TANK_CODE_PAYLOAD_FIELD]["url"]
 
         # download and unzip
         try:
-            shotgun.download_and_unpack_attachment(sg, attachment_id, destination_path)
+            shotgun.download_and_unpack_url(sg, attachment_url, destination_path)
         except ShotgunAttachmentDownloadError as e:
             raise TankAppStoreError("Failed to download %s. Error: %s" % (self, e))
 
@@ -753,12 +753,14 @@ class IODescriptorAppStore(IODescriptorDownloadable):
                 else:
                     raise
 
-            log.debug("Connecting to %s..." % constants.SGTK_APP_STORE)
+            app_store = os.environ.get("SGTK_APP_STORE", constants.SGTK_APP_STORE)
+
+            log.debug("Connecting to %s..." % app_store)
             # Connect to the app store and resolve the script user id we are connecting with.
             # Set the timeout explicitly so we ensure the connection won't hang in cases where
             # a response is not returned in a reasonable amount of time.
             app_store_sg = shotgun_api3.Shotgun(
-                constants.SGTK_APP_STORE,
+                app_store,
                 script_name=script_name,
                 api_key=script_key,
                 http_proxy=self.__get_app_store_proxy_setting(),

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -425,11 +425,11 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         #  'type': 'Attachment',
         #  'id': 139,
         #  'link_type': 'upload'}
-        attachment_url = version[constants.TANK_CODE_PAYLOAD_FIELD]["url"]
+        attachment_id = version[constants.TANK_CODE_PAYLOAD_FIELD]["id"]
 
         # download and unzip
         try:
-            shotgun.download_and_unpack_url(sg, attachment_url, destination_path)
+            shotgun.download_and_unpack_attachment(sg, attachment_id, destination_path)
         except ShotgunAttachmentDownloadError as e:
             raise TankAppStoreError("Failed to download %s. Error: %s" % (self, e))
 

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -425,11 +425,11 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         #  'type': 'Attachment',
         #  'id': 139,
         #  'link_type': 'upload'}
-        attachment_id = version[constants.TANK_CODE_PAYLOAD_FIELD]["id"]
+        attachment_url = version[constants.TANK_CODE_PAYLOAD_FIELD]["url"]
 
         # download and unzip
         try:
-            shotgun.download_and_unpack_attachment(sg, attachment_id, destination_path)
+            shotgun.download_and_unpack_url(sg, attachment_url, destination_path)
         except ShotgunAttachmentDownloadError as e:
             raise TankAppStoreError("Failed to download %s. Error: %s" % (self, e))
 

--- a/python/tank/util/shotgun/download.py
+++ b/python/tank/util/shotgun/download.py
@@ -175,6 +175,8 @@ def download_and_unpack_attachment(
         the bundle in a subfolder, this should be correctly unfolded.
     :raises: ShotgunAttachmentDownloadError on failure
     """
+    # NOTE Downloading by attachment ID is deprecated in the Shotgun API.
+    # We should avoid using this where possible.
     return _download_and_unpack(
         sg, target, retries, auto_detect_bundle, attachment_id=attachment_id
     )


### PR DESCRIPTION
This PR makes it so that the app store download code, downloads via URL rather than by ID.
Downloading by attachment ID is deprecated in the Shotgun API.

This also gives us the added benefit of seeing the download url in the logs.