### PR TITLE
Ticket/sg 17810 fix issue with simple cookie

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -379,12 +379,15 @@ class SsoSaml2Core(object):
         cookie_jar = self._view.page().networkAccessManager().cookieJar()
 
         # Here, the cookie jar is a dictionary of key/values
-        cookies = SimpleCookie()
+        # cookies = SimpleCookie()
+        cookies = []
 
         for cookie in cookie_jar.allCookies():
-            cookies.load(str(cookie.toRawForm()))
+            self._logger.debug("-> %s", str(cookie.toRawForm()))
+            # cookies.load(str(cookie.toRawForm()))
+            cookies.append("Set-Cookie: %s" % str(cookie.toRawForm()))
 
-        encoded_cookies = _encode_cookies(cookies)
+        encoded_cookies = _encode_cookies("\r\n".join(cookies))
         content = {
             "session_expiration": get_saml_claims_expiration(encoded_cookies),
             "session_id": get_session_id(encoded_cookies),
@@ -432,9 +435,11 @@ class SsoSaml2Core(object):
                 )
                 QtNetwork.QNetworkProxy.setApplicationProxy(proxy)
 
-            cookies = _decode_cookies(self._session.cookies)
+            cookies = _decode_cookies(self._session.cookies).replace("Set-Cookie: ", "")
+            self._logger.debug("Cookies: %s", cookies)
             qt_cookies = QtNetwork.QNetworkCookie.parseCookies(
-                cookies.output(header="")
+                # cookies.output(header="")
+                cookies
             )
 
         self._view.page().networkAccessManager().cookieJar().setAllCookies(qt_cookies)

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -370,8 +370,15 @@ class SsoSaml2Core(object):
 
         cookie_jar = self._view.page().networkAccessManager().cookieJar()
 
-        # Serializing the cookies in a format compatible with SimpleCookie
-        # to maintain backward compatibility.
+        # WARNING: Serializing the cookies in a format compatible with SimpleCookie
+        # to maintain backward compatibility:
+        #
+        # In the past, we used SimpleCookie as an interim storage for cookies.
+        # This turned out to be a bad decision, since SimpleCookie does not
+        # discriminate based on the Domain. With two cookies with the same name
+        # but different domains, the second overwrites the first.
+        # But the SimpleCookie format is used for storage, thus the need for
+        # backward/forward compatibility
         cookies = []
         for cookie in cookie_jar.allCookies():
             cookies.append("Set-Cookie: %s" % str(cookie.toRawForm()))
@@ -424,8 +431,9 @@ class SsoSaml2Core(object):
                 )
                 QtNetwork.QNetworkProxy.setApplicationProxy(proxy)
 
-            # The session cookies are serialized using a format that must
-            # be readable by SimpleCookie for backward compatibility.
+            # WARNING: The session cookies are serialized using a format that
+            # must be readable by SimpleCookie for backward compatibility.
+            # See comment in method update_session_from_browser for details.
             cookies = _decode_cookies(self._session.cookies).replace("Set-Cookie: ", "")
             qt_cookies = QtNetwork.QNetworkCookie.parseCookies(cookies)
 

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -63,9 +63,8 @@ def _decode_cookies(encoded_cookies):
 
     :param encoded_cookies: An encoded string representing the cookie jar.
 
-    :returns: A SimpleCookie containing all the cookies.
+    :returns: A string containing all the cookies.
     """
-    # cookies = SimpleCookie()
     decoded_cookies = ""
     if encoded_cookies:
         try:
@@ -74,7 +73,6 @@ def _decode_cookies(encoded_cookies):
                 # If decoded_cookies is not a string, it's likely we're on
                 # Python3, and decoded_cookies is binary.  Try to decode it.
                 decoded_cookies = decoded_cookies.decode()
-            # cookies.load(decoded_cookies)
         except (TypeError, binascii.Error) as e:
             # In Python 2 this raises a TypeError, while in 3 it will raise a
             # binascii.Error.  Catch either and handle them the same.
@@ -86,12 +84,11 @@ def _encode_cookies(cookies):
     """
     Extract the cookies from a base64 encoded string.
 
-    :param cookies: A Cookie.SimpleCookie instance representing the cookie jar.
+    :param cookies: A string representing the serialized cookie jar.
 
     :returns: An encoded string representing the cookie jar.
     """
     PY3 = sys.version_info[0] == 3
-    # output = cookies.output()
     if PY3 and isinstance(cookies, str):
         # On Python 3, encode str to binary before passing it to b64encode.
         cookies = cookies.encode()

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -65,7 +65,8 @@ def _decode_cookies(encoded_cookies):
 
     :returns: A SimpleCookie containing all the cookies.
     """
-    cookies = SimpleCookie()
+    # cookies = SimpleCookie()
+    decoded_cookies = ""
     if encoded_cookies:
         try:
             decoded_cookies = base64.b64decode(encoded_cookies)
@@ -73,12 +74,12 @@ def _decode_cookies(encoded_cookies):
                 # If decoded_cookies is not a string, it's likely we're on
                 # Python3, and decoded_cookies is binary.  Try to decode it.
                 decoded_cookies = decoded_cookies.decode()
-            cookies.load(decoded_cookies)
+            # cookies.load(decoded_cookies)
         except (TypeError, binascii.Error) as e:
             # In Python 2 this raises a TypeError, while in 3 it will raise a
             # binascii.Error.  Catch either and handle them the same.
             get_logger().error("Unable to decode the cookies: %s", str(e))
-    return cookies
+    return decoded_cookies
 
 
 def _encode_cookies(cookies):
@@ -90,11 +91,11 @@ def _encode_cookies(cookies):
     :returns: An encoded string representing the cookie jar.
     """
     PY3 = sys.version_info[0] == 3
-    output = cookies.output()
-    if PY3 and isinstance(output, str):
+    # output = cookies.output()
+    if PY3 and isinstance(cookies, str):
         # On Python 3, encode str to binary before passing it to b64encode.
-        output = output.encode()
-    encoded_cookies = base64.b64encode(output)
+        cookies = cookies.encode()
+    encoded_cookies = base64.b64encode(cookies)
     if PY3:
         # On Python 3, b64encode returns a bytes object that we'll want to
         # decode to a string for compatibility between Python 2 and 3.
@@ -144,7 +145,8 @@ def _get_cookie(encoded_cookies, cookie_name):
     :returns: A string of the cookie value, or None.
     """
     value = None
-    cookies = _decode_cookies(encoded_cookies)
+    cookies = SimpleCookie()
+    cookies.load(_decode_cookies(encoded_cookies))
     if cookie_name in cookies:
         value = cookies[cookie_name].value
     return value
@@ -160,7 +162,8 @@ def _get_cookie_from_prefix(encoded_cookies, cookie_prefix):
     :returns: A string of the cookie value, or None.
     """
     value = None
-    cookies = _decode_cookies(encoded_cookies)
+    cookies = SimpleCookie()
+    cookies.load(_decode_cookies(encoded_cookies))
     key = "%s%s" % (cookie_prefix, _get_shotgun_user_id(cookies))
     if key in cookies:
         value = cookies[key].value
@@ -258,7 +261,8 @@ def get_session_id(encoded_cookies):
     :returns: A string with the session id, or None
     """
     session_id = None
-    cookies = _decode_cookies(encoded_cookies)
+    cookies = SimpleCookie()
+    cookies.load(_decode_cookies(encoded_cookies))
     key = "_session_id"
     if key in cookies:
         session_id = cookies[key].value
@@ -286,7 +290,8 @@ def get_csrf_key(encoded_cookies):
 
     :returns: A string with the csrf token name
     """
-    cookies = _decode_cookies(encoded_cookies)
+    cookies = SimpleCookie()
+    cookies.load(_decode_cookies(encoded_cookies))
     # Shotgun appends the unique numerical ID of the user to the cookie name:
     # ex: csrf_token_u78
     return "csrf_token_u%s" % _get_shotgun_user_id(cookies)


### PR DESCRIPTION
Context: when using the Web to authenticate, we serialize/deserialize the browser cookies into the  `authentication.yml` file relevant to the Shotgun site visited. We do this for all the cookies, not just the Shotgun ones. This is done to allow automatic re-authentication against any SSO system being used.

At the root of the issue: SimpleCookie is not meant to mix cookies from multiple domains. E.g. setting a first cookie `xyz` for a domain `foo.com` will get overwritten should we then set cookie `xyz` but for domain `bar.com`.

This is causing issues when using some SSO backends, such as Google G Suite, and likely others. These will have multiple cookies with the same name but for different domains (in Google's case : `.google.ca` and `.google.com`).

This is NOT an issue for Shotgun itself, due to the way we isolate the serialized data per the Shotgun URLs.

The symptoms:
- the user will need to re-authenticate multiple times when the SG Desktop starts,
- the user will be asked to re-authenticate when the SSO Claims renewal happens.

This issue has been reported by Netflix and Orca (these are to my knowledge our only two clients using G Suite SSO), but other clients have also reported similar behaviour.

This has proven difficult to isolate and reproduce in our own environment. Luckily we now have a G Suite SAML test config (and we can create others)

The fix:
- serialize the full set of cookies as obtained from Qt Cookie Jar, and 
- not use `SimpleCookie` as an interim storage for non Shotgun cookies.