### PR TITLE
For SG-18321: redefine Array.prototype.splice as an alias to itself

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -72,10 +72,8 @@ SHOTGUN_SSO_RENEWAL_INTERVAL = 5000
 #     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind#Polyfill
 #
 # The redefinition of Array.prototype.splice was required following an update to
-# the Okta Sign-In Widget (version 4.2.0) in which Babel did not re-define splice
-# to be up to the latest definition. Not clear if it is a Babel bug or not. But
-# redefining the method the way we do triggers Babel to use the updated version.
-# Given our redefinition, we ensure that the original version is called if needed.
+# the Okta Sign-In Widget (version 4.2.0). When Babel checks to see if the method
+# needs to be polyfilled, it falls into an infinite loop.
 FUNCTION_PROTOTYPE_BIND_POLYFILL = """
     // Yes, it does work with `new funcA.bind(thisArg, args)`
     if (!Function.prototype.bind) (function(){
@@ -109,9 +107,8 @@ FUNCTION_PROTOTYPE_BIND_POLYFILL = """
       };
     })();
 
-    // Simply create an alias of splice. This will trigger Babel
-    // into polyfilling using a more recent version. Otherwise,
-    // the original Qt4 WebKit version is used.
+    // Simply create an alias of splice.
+    // This is to get around a Babel bug.
     Array.prototype.splice_copy = Array.prototype.splice;
     Array.prototype.splice = function() {
         return this.splice_copy.apply(this, arguments);


### PR DESCRIPTION
By creating an alias to the original function definition, we triggers Babel (if used) to NOT to polyfill with its own version.
That check to see if the method needs to be polyfilled cause the virtual machine to go into an infinite loop.
