### PR TITLE
Allow Env Vars in Path Descriptor Version Spec

### DIFF
--- a/python/tank/descriptor/io_descriptor/path.py
+++ b/python/tank/descriptor/io_descriptor/path.py
@@ -92,6 +92,9 @@ class IODescriptorPath(IODescriptorBase):
         #  non-required for finding the code)
         self._version = descriptor_dict.get("version") or "Undefined"
 
+        # Resolve environment variables in the version
+        self._version = os.path.expandvars(self._version)
+
         # if there is a name defined in the descriptor dict then lets use
         # this, otherwise we'll fall back to the folder name:
         self._name = descriptor_dict.get("name")


### PR DESCRIPTION
This change allows the use of environment variables when specifying the version in a path descriptor. For example you could do the following:

```
base_configuration:
  type: path
  path: "${CONFIG_PATH}"
  version: "${CONFIG_VERSION}"
```

We don't explicitly use the `version` field in a path descriptor so this will not affect any regular descriptors. The only place this will be useful is when baking a configuration and we need to provide a descriptor to the bake script that includes an environment variable. 

**For testing:**
- Create a folder for your test plugin
- Inside the folder place an `info.yml` file that contains the following:
```
base_configuration:
  type: path
  path: "${CONFIG_PATH}"
  version: "${CONFIG_VERSION}"

plugin_id: "basic.test"
```
- Set the env var `CONFIG_PATH` in your environment to point to a valid pipeline configuration
- Set the env var `CONFIG_VERSION` to some arbitrary version number
- run the following:
```
python <path_to_tk-core>/developer/build_plugin.py --bake <path_to_your_plugin_folder> <output_path_for_baked_plugin>
```