### PR TITLE
Ticket/sg 9861 add support for py side2 for unified login flow

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -26,7 +26,7 @@ from . import session_cache
 from ..util.shotgun import connection
 from ..util import login
 from .errors import AuthenticationError
-from .ui.qt_abstraction import QtGui, QtCore, QtNetwork, QtWebKit
+from .ui.qt_abstraction import QtGui, QtCore, QtNetwork, QtWebKit, QtWebEngineWidgets
 from .sso_saml2 import (
     SsoSaml2Toolkit,
     SsoSaml2MissingQtModuleError,
@@ -144,6 +144,7 @@ class LoginDialog(QtGui.QDialog):
             "QtGui": QtGui,
             "QtNetwork": QtNetwork,
             "QtWebKit": QtWebKit,
+            "QtWebEngineWidgets": QtWebEngineWidgets,
         }
         try:
             self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -147,12 +147,11 @@ class LoginDialog(QtGui.QDialog):
             "QtWebKit": QtWebKit,
             "QtWebEngineWidgets": QtWebEngineWidgets,
         }
-        # try:
-        #     self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)
-        # except SsoSaml2MissingQtModuleError as e:
-        #     logger.info("Web login not supported due to missing Qt module: %s" % e)
-        #     self._sso_saml2 = None
-        self._sso_saml2 = None
+        try:
+            self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)
+        except SsoSaml2MissingQtModuleError as e:
+            logger.info("Web login not supported due to missing Qt module: %s" % e)
+            self._sso_saml2 = None
 
         hostname = hostname or ""
         login = login or ""

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -147,11 +147,12 @@ class LoginDialog(QtGui.QDialog):
             "QtWebKit": QtWebKit,
             "QtWebEngineWidgets": QtWebEngineWidgets,
         }
-        try:
-            self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)
-        except SsoSaml2MissingQtModuleError as e:
-            logger.info("Web login not supported due to missing Qt module: %s" % e)
-            self._sso_saml2 = None
+        # try:
+        #     self._sso_saml2 = SsoSaml2Toolkit("Web Login", qt_modules=qt_modules)
+        # except SsoSaml2MissingQtModuleError as e:
+        #     logger.info("Web login not supported due to missing Qt module: %s" % e)
+        #     self._sso_saml2 = None
+        self._sso_saml2 = None
 
         hostname = hostname or ""
         login = login or ""

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -25,6 +25,7 @@ from .ui import login_dialog
 from . import session_cache
 from ..util.shotgun import connection
 from ..util import login
+from ..util import LocalFileStorageManager
 from .errors import AuthenticationError
 from .ui.qt_abstraction import QtGui, QtCore, QtNetwork, QtWebKit, QtWebEngineWidgets
 from .sso_saml2 import (
@@ -446,12 +447,16 @@ class LoginDialog(QtGui.QDialog):
                   None if the user cancelled.
         """
         if self._session_metadata and self._sso_saml2:
+            profile_location = LocalFileStorageManager.get_site_root(
+                self._get_current_site(), LocalFileStorageManager.CACHE
+            )
             res = self._sso_saml2.login_attempt(
                 host=self._get_current_site(),
                 http_proxy=self._http_proxy,
                 cookies=self._session_metadata,
                 product=PRODUCT_IDENTIFIER,
                 use_watchdog=True,
+                profile_location=profile_location,
             )
             # If the offscreen session renewal failed, show the GUI as a failsafe
             if res == QtGui.QDialog.Accepted:
@@ -550,11 +555,15 @@ class LoginDialog(QtGui.QDialog):
         success = False
         try:
             if self._use_web and self._sso_saml2:
+                profile_location = LocalFileStorageManager.get_site_root(
+                    site, LocalFileStorageManager.CACHE
+                )
                 res = self._sso_saml2.login_attempt(
                     host=site,
                     http_proxy=self._http_proxy,
                     cookies=self._session_metadata,
                     product=PRODUCT_IDENTIFIER,
+                    profile_location=profile_location,
                 )
                 if res == QtGui.QDialog.Accepted:
                     self._new_session_token = self._sso_saml2.session_id

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -481,15 +481,15 @@ class SsoSaml2Core(object):
         """Destructor."""
         # We want to track destruction of the dialog in the logs.
         self._logger.debug("Destroying SSO dialog")
-        # self._sso_countdown_timer.stop()
-        # self._sso_renew_timer.stop()
-        # self._sso_renew_watchdog_timer.stop()
-        # if self._view:
-        #     self._view.urlChanged.disconnect(self._on_url_changed)
-        #     self._layout.removeWidget(self._view)
-        #     self._view = None
-        #     self._layout = None
-        #     self._dialog = None
+        self._sso_countdown_timer.stop()
+        self._sso_renew_timer.stop()
+        self._sso_renew_watchdog_timer.stop()
+        if self._view:
+            self._view.urlChanged.disconnect(self._on_url_changed)
+            self._layout.removeWidget(self._view)
+            self._view = None
+            self._layout = None
+            self._dialog = None
 
     @property
     def _session(self):

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -481,15 +481,16 @@ class SsoSaml2Core(object):
         """Destructor."""
         # We want to track destruction of the dialog in the logs.
         self._logger.debug("Destroying SSO dialog")
-        self._sso_countdown_timer.stop()
-        self._sso_renew_timer.stop()
-        self._sso_renew_watchdog_timer.stop()
-        if self._view:
-            self._view.urlChanged.disconnect(self._on_url_changed)
-            self._layout.removeWidget(self._view)
-            self._view = None
-            self._layout = None
-            self._dialog = None
+        # @TODO: Refactor these calls or figure out why they hang builds on Windows/3.7
+        # self._sso_countdown_timer.stop()
+        # self._sso_renew_timer.stop()
+        # self._sso_renew_watchdog_timer.stop()
+        # if self._view:
+        #     self._view.urlChanged.disconnect(self._on_url_changed)
+        #     self._layout.removeWidget(self._view)
+        #     self._view = None
+        #     self._layout = None
+        #     self._dialog = None
 
     @property
     def _session(self):

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -481,15 +481,15 @@ class SsoSaml2Core(object):
         """Destructor."""
         # We want to track destruction of the dialog in the logs.
         self._logger.debug("Destroying SSO dialog")
-        self._sso_countdown_timer.stop()
-        self._sso_renew_timer.stop()
-        self._sso_renew_watchdog_timer.stop()
-        if self._view:
-            self._view.urlChanged.disconnect(self._on_url_changed)
-            self._layout.removeWidget(self._view)
-            self._view = None
-            self._layout = None
-            self._dialog = None
+        # self._sso_countdown_timer.stop()
+        # self._sso_renew_timer.stop()
+        # self._sso_renew_watchdog_timer.stop()
+        # if self._view:
+        #     self._view.urlChanged.disconnect(self._on_url_changed)
+        #     self._layout.removeWidget(self._view)
+        #     self._view = None
+        #     self._layout = None
+        #     self._dialog = None
 
     @property
     def _session(self):

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -502,7 +502,7 @@ class SsoSaml2Core(object):
         # backward/forward compatibility
         cookies = []
         for cookie in self._cookie_jar.allCookies():
-            cookies.append("Set-Cookie: %s" % str(cookie.toRawForm()))
+            cookies.append("Set-Cookie: %s" % str(cookie.toRawForm(), "utf-8"))
         encoded_cookies = _encode_cookies("\r\n".join(cookies))
 
         content = {
@@ -556,7 +556,7 @@ class SsoSaml2Core(object):
             # must be readable by SimpleCookie for backward compatibility.
             # See comment in method update_session_from_browser for details.
             cookies = _decode_cookies(self._session.cookies).replace("Set-Cookie: ", "")
-            qt_cookies = QtNetwork.QNetworkCookie.parseCookies(cookies)
+            qt_cookies = QtNetwork.QNetworkCookie.parseCookies(cookies.encode())
 
         # Given that QWebEngineCookieStore.setCookie is not yet exposed to
         # PySide2, we need to rely on the profile for cookie persistency as

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -161,7 +161,6 @@ class SsoSaml2Core(object):
             raise SsoSaml2MissingQtNetwork("The QtNetwork module is unavailable")
 
         if QtWebKit is None and QtWebEngineWidgets is None:
-            # @TODO: change exception
             raise SsoSaml2MissingQtWebKit(
                 "The QtWebKit or QtWebEngineWidgets modules are unavailable"
             )
@@ -449,10 +448,6 @@ class SsoSaml2Core(object):
         # For debugging purposes
         if self._developer_mode:
             if QtWebKit:
-                self._logger.debug(
-                    "Using developer mode. Disabling strict SSL mode, enabling developer tools and local storage."
-                )
-
                 # Adds the Developer Tools option when right-clicking
                 QtWebKit.QWebSettings.globalSettings().setAttribute(
                     QtWebKit.QWebSettings.WebAttribute.DeveloperExtrasEnabled, True
@@ -833,7 +828,6 @@ class SsoSaml2Core(object):
 
         if not succeeded:
             self._logger.error('Loading of page "%s" generated an error.', url)
-            # @FIXME: Figure out proper way of handling error.
 
     def on_authentication_required(self, _reply, authenticator):
         """

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -24,8 +24,10 @@ import urllib
 # fail.
 try:
     import urlparse
+    from urllib import unquote
 except ImportError:
     import urllib.parse as urlparse
+    from urllib.parse import unquote
 try:
     from http.cookies import SimpleCookie
 except ImportError:
@@ -143,7 +145,7 @@ def _get_cookie(encoded_cookies, cookie_name):
     """
     value = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies))
+    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
     if cookie_name in cookies:
         value = cookies[cookie_name].value
     return value
@@ -160,7 +162,7 @@ def _get_cookie_from_prefix(encoded_cookies, cookie_prefix):
     """
     value = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies))
+    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
     key = "%s%s" % (cookie_prefix, _get_shotgun_user_id(cookies))
     if key in cookies:
         value = cookies[key].value
@@ -245,7 +247,7 @@ def get_user_name(encoded_cookies):
         encoded_cookies, "shotgun_current_user_login"
     ) or _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_userid_u")
     if user_name is not None:
-        user_name = urllib.unquote(user_name)
+        user_name = unquote(user_name)
     return user_name
 
 
@@ -259,7 +261,7 @@ def get_session_id(encoded_cookies):
     """
     session_id = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies))
+    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
     key = "_session_id"
     if key in cookies:
         session_id = cookies[key].value
@@ -288,7 +290,7 @@ def get_csrf_key(encoded_cookies):
     :returns: A string with the csrf token name
     """
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies))
+    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
     # Shotgun appends the unique numerical ID of the user to the cookie name:
     # ex: csrf_token_u78
     return "csrf_token_u%s" % _get_shotgun_user_id(cookies)

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -79,6 +79,11 @@ def _decode_cookies(encoded_cookies):
             # In Python 2 this raises a TypeError, while in 3 it will raise a
             # binascii.Error.  Catch either and handle them the same.
             get_logger().error("Unable to decode the cookies: %s", str(e))
+    # Should the decoded cookies be used with SimpleCookie, we strip out the
+    # 'Set-Cookie: ' prefix to maintain Python2 and Python3 compatibility.
+    # It turns out that the regex to parse cookies has change in SimpleCookie
+    # in Python3, causing problems when the prefix was present.
+    decoded_cookies = decoded_cookies.replace("Set-Cookie: ", "")
     return decoded_cookies
 
 
@@ -145,7 +150,7 @@ def _get_cookie(encoded_cookies, cookie_name):
     """
     value = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
+    cookies.load(_decode_cookies(encoded_cookies))
     if cookie_name in cookies:
         value = cookies[cookie_name].value
     return value
@@ -162,7 +167,7 @@ def _get_cookie_from_prefix(encoded_cookies, cookie_prefix):
     """
     value = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
+    cookies.load(_decode_cookies(encoded_cookies))
     key = "%s%s" % (cookie_prefix, _get_shotgun_user_id(cookies))
     if key in cookies:
         value = cookies[key].value
@@ -261,7 +266,7 @@ def get_session_id(encoded_cookies):
     """
     session_id = None
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
+    cookies.load(_decode_cookies(encoded_cookies))
     key = "_session_id"
     if key in cookies:
         session_id = cookies[key].value
@@ -290,7 +295,7 @@ def get_csrf_key(encoded_cookies):
     :returns: A string with the csrf token name
     """
     cookies = SimpleCookie()
-    cookies.load(_decode_cookies(encoded_cookies).replace("Set-Cookie: ", ""))
+    cookies.load(_decode_cookies(encoded_cookies))
     # Shotgun appends the unique numerical ID of the user to the cookie name:
     # ex: csrf_token_u78
     return "csrf_token_u%s" % _get_shotgun_user_id(cookies)

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -46,7 +46,13 @@ class SsoSaml2(object):
         self._core = SsoSaml2Core(window_title=window_title, qt_modules=qt_modules)
 
     def login_attempt(
-        self, host, cookies=None, product=None, http_proxy=None, use_watchdog=False
+        self,
+        host,
+        cookies=None,
+        product=None,
+        http_proxy=None,
+        use_watchdog=False,
+        profile_location=None,
     ):
         """
         Called to attempt a login process.
@@ -57,12 +63,14 @@ class SsoSaml2(object):
         If this fails, or there are no cookies, the user will be prompted for
         their credentials.
 
-        :param host:         URL of the Shotgun server.
-        :param cookies:      String of encoded cookies.
-        :param product:      String describing the application attempting to login.
-                             This string will appear in the Shotgun server logs.
-        :param http_proxy:   URL of the proxy.
+        :param host:                URL of the Shotgun server.
+        :param cookies:             String of encoded cookies.
+        :param product:             String describing the application attempting to login.
+                                    This string will appear in the Shotgun server logs.
+        :param http_proxy:          URL of the proxy.
         :param use_watchdog:
+        :param profile_location:    Location override for the WebEngine profile location.
+                                    This is only relevant when using Qt5/PySide2.
 
         :returns: True if the login was successful.
         """
@@ -76,6 +84,7 @@ class SsoSaml2(object):
                 "product": product,
             },
             use_watchdog,
+            profile_location,
         )
         return success == 1
 

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -72,7 +72,10 @@ def _get_site_infos(url, http_proxy=None):
         ):
             get_logger().info("Infos for site '%s' not in cache or expired", url)
             sg = shotgun_api3.Shotgun(
-                url, session_token="dummy", connect=False, http_proxy=http_proxy
+                url,
+                session_token="dummy",
+                connect=False,
+                http_proxy=http_proxy
             )
             # Remove delay between attempts at getting the site info.  Since
             # this is called in situations where blocking during multiple

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -148,6 +148,7 @@ def is_sso_enabled_on_site(url, http_proxy=None):
 
     :returns:   A boolean indicating if SSO has been enabled or not.
     """
+    # return True
     return _get_user_authentication_method(url, http_proxy) == "saml2"
 
 

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -72,10 +72,7 @@ def _get_site_infos(url, http_proxy=None):
         ):
             get_logger().info("Infos for site '%s' not in cache or expired", url)
             sg = shotgun_api3.Shotgun(
-                url,
-                session_token="dummy",
-                connect=False,
-                http_proxy=http_proxy
+                url, session_token="dummy", connect=False, http_proxy=http_proxy
             )
             # Remove delay between attempts at getting the site info.  Since
             # this is called in situations where blocking during multiple

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -148,7 +148,6 @@ def is_sso_enabled_on_site(url, http_proxy=None):
 
     :returns:   A boolean indicating if SSO has been enabled or not.
     """
-    # return True
     return _get_user_authentication_method(url, http_proxy) == "saml2"
 
 

--- a/python/tank/authentication/ui/qt_abstraction.py
+++ b/python/tank/authentication/ui/qt_abstraction.py
@@ -19,5 +19,6 @@ QtCore = _importer.QtCore
 QtGui = _importer.QtGui
 QtWebKit = _importer.QtWebKit
 QtNetwork = _importer.QtNetwork
+QtWebEngineWidgets = _importer.QtWebEngineWidgets
 qt_version_tuple = _importer.qt_version_tuple
 del _importer

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -79,6 +79,13 @@ class QtImporter(object):
         return self._modules["QtNetwork"] if self._modules else None
 
     @property
+    def QtWebEngineWidgets(self):
+        """
+        :returns: QtWebEngineWidgets module, if available.
+        """
+        return self._modules["QtWebEngineWidgets"] if self._modules else None
+
+    @property
     def binding(self):
         """
         :returns: The PySide* or PyQt* root module.
@@ -176,6 +183,7 @@ class QtImporter(object):
                 "QtGui": QtGui,
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
+                "QtWebEngineWidgets": None,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -269,6 +277,9 @@ class QtImporter(object):
         QtCore, QtGui = PySide2Patcher.patch(QtCore, QtGui, QtWidgets, PySide2)
         QtNetwork = self._import_module_by_name("PySide2", "QtNetwork")
         QtWebKit = self._import_module_by_name("PySide2.QtWebKitWidgets", "QtWebKit")
+        QtWebEngineWidgets = self._import_module_by_name(
+            "PySide2.QtWebEngineWidgets", "QtWebEngineWidgets"
+        )
 
         return (
             "PySide2",
@@ -279,6 +290,7 @@ class QtImporter(object):
                 "QtGui": QtGui,
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
+                "QtWebEngineWidgets": QtWebEngineWidgets,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -90,13 +90,14 @@ class InteractiveTests(ShotgunTestBase):
         # Import locally since login_dialog has a dependency on Qt and it might be missing
         from tank.authentication import login_dialog
 
-        with contextlib.closing(
-            login_dialog.LoginDialog(is_session_renewal=is_session_renewal)
-        ) as ld:
-            # SSO module and threading causes issues with unit tests, so disable it.
-            ld._saml2_sso = None
-            self._prepare_window(ld)
-            yield ld
+        # Patch out the SsoSaml2Toolkit class to avoid threads being created, which cause
+        # issues with tests.
+        with patch("tank.authentication.login_dialog.SsoSaml2Toolkit"):
+            with contextlib.closing(
+                login_dialog.LoginDialog(is_session_renewal=is_session_renewal)
+            ) as ld:
+                self._prepare_window(ld)
+                yield ld
 
     @suppress_generated_code_qt_warnings
     def test_focus(self):


### PR DESCRIPTION
This branch brings in PySide2 support for the Web Login into Shotgun using the Unified Login Flow. This is, for the time being, used when connecting to a Shotgun site which uses SSO. In both of these cases, the use of a username/password pair is not allowed to initiate an API connection to Shotgun. A web browser environment must be used, which Qt provides.

The main difference between the Qt4 and Qt5 implementation revolves around the switch from QtWebKit to QtWebEngine/Chromium.

With QtWebKit, there is no browser-data (cookies, etc.) persistency. We are explicitly serializing all of the browser's cookies in to the authentication.yml on a Shotgun-site basis. When creating a WebView, we will inject any existing cookies we have serialized into it. Priming the pump in a way. This means that if the cookies are still valid for a SSO portal, the user will be able to authenticate without needed to enter their credentials. This is to resume a prior session. The same it is done using a Browser and saving its state when closing it, allowing to reconnect to that same session when restarted.

With QtWebEngine, persistency and location of the files, is controlled via the PySide2 API. One major difference with QtWebKit : the API to read or insert cookies into the Browser session has not been exposed to PySide2 yet. Meaning that we have had to find a way to circumvent this problem. Our solution leverages the availability signals being emitted by Qt5 when cookies are added and deleted in the browser session.

To allow for seamless switch between PySide and PySide2 using applications, we always persist the current cookies to the authentication.yml file, when using either QtWebKit or QtWebEngine. We have also settled on making cookies persistent across invocation of the Chromium browser, so that at the restart it can continue where things we left, based on its own serialized session data. As cookies are added and deleted to the session, we use callbacks we have registered to keep a synched copy of the current cookie jar.

We have decided not to share the same Chromium session between different Shotgun sites, as it would not map to the QtWebKit behaviour. By splitting the Chromium session on a per-Shotgun site basis, it makes it possible for us the clear all the cookies in the Chromium cookie jar when we detect that the user has signed out of the site (because there will be no cookies serialized in the authentication.yml).

One potential pitfall which may occur is that at startup the Chromium profile's cookie may be out of synch with the authentication.yml cookies (if the last application was PySide-based). This will stay until we have the required API to write cookies into the Chromium's profile, and cannot be avoided.

The major side effect would be: when quitting a PySide-using app, and the right away starting a PySide2-using app, the user will likely not be able to carry on the previous Qt4 session and may need to re-authenticate. This will generate a new Shotgun Session ID.
