### PR TITLE
[API] Get abstract paths with a different sequence key format

### DIFF
--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -681,12 +681,14 @@ class Sgtk(object):
         if skip_leaf_level:
             search_template = template.parent
 
-        # now carry out a regular search based on the template
-        found_files = self.paths_from_template(search_template, fields)
-
         st_abstract_key_names = [
             k.name for k in search_template.keys.values() if k.is_abstract
         ]
+
+        # now carry out a regular search based on the template
+        # skip abstract keys to fetch paths in case of special value
+        # like SequenceKey with "FORMAT:" value
+        found_files = self.paths_from_template(search_template, fields, skip_keys=st_abstract_key_names)
 
         # now collapse down the search matches for any abstract fields,
         # and add the leaf level if necessary

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -365,6 +365,15 @@ class TestAbstractPathsFromTemplate(TankTestBase):
         )
         self.assertEqual(set(expected), set(result))
 
+    def test_sequence_format(self):
+        expected = [
+            os.path.join(self.shot_a_path, "%V", "filename.$F4.exr"),
+            os.path.join(self.shot_b_path, "%V", "filename.$F4.exr"),
+        ]
+        result = self.tk.abstract_paths_from_template(
+            self.template, {"name": "filename", "SEQ": "FORMAT: $F"}
+        )
+        self.assertEqual(set(expected), set(result))
 
 class TestPathsFromTemplateGlob(TankTestBase):
     """Tests for Tank.paths_from_template method which check the string sent to glob.glob."""


### PR DESCRIPTION
# Goal
Add the ability to use a different format for `SequenceKey` token with `abstract_path_from_template`

# Use case
Find abstract paths from an houdini path template compatible for Nuke Sequence padding.

```python
# SEQ format_spec 4 with $F format
# Let's override the output format for nuke sequence padding format
fields['SEQ'] = 'FORMAT: %d'

# Before the PR: return is empty
tank.abstract_paths_from_template(template, fields)

# After the PR: abstract paths with %04d format
tank.abstract_paths_from_template(template, fields)
```
