### PR TITLE
SG-18533: Comparing a git hash with a version string raises an error in Python 3.

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -228,6 +228,17 @@ File Download Related
 .. autofunction:: download_and_unpack_attachment(sg, attachment_id, target, retries=5, auto_detect_bundle=False)
 .. autofunction:: download_and_unpack_url(sg, url, target, retries=5, auto_detect_bundle=False)
 
+
+Version Comparison Related
+=============================
+
+.. currentmodule:: sgtk.util
+
+.. autofunction:: is_version_older
+.. autofunction:: is_version_older_or_equal
+.. autofunction:: is_version_newer
+.. autofunction:: is_version_newer_or_equal
+
 Miscellaneous
 =============================
 

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -17,7 +17,12 @@ from .shotgun import create_event_log_entry
 from .shotgun import get_entity_type_display_name
 from .shotgun import get_published_file_entity_type
 
-from .version import is_version_newer, is_version_older
+from .version import (
+    is_version_older,
+    is_version_newer,
+    is_version_older_or_equal,
+    is_version_newer_or_equal,
+)
 
 from .shotgun_entity import get_sg_entity_name_field
 

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -17,6 +17,8 @@ from .shotgun import create_event_log_entry
 from .shotgun import get_entity_type_display_name
 from .shotgun import get_published_file_entity_type
 
+from .version import is_version_newer, is_version_older
+
 from .shotgun_entity import get_sg_entity_name_field
 
 from .environment import append_path_to_env_var

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -47,7 +47,7 @@ def is_version_newer(a, b):
     :raises TankError: Raised if the two versions are different git commit shas, as
         they can't be compared.
 
-    :returns: ``True``is ``a`` is newer than ``b`` but not equal, ``False`` otherwise.
+    :returns: ``True`` if ``a`` is newer than ``b`` but not equal, ``False`` otherwise.
     """
     return _compare_versions(a, b)
 
@@ -62,7 +62,7 @@ def is_version_older(a, b):
     :raises TankError: Raised if the two versions are different git commit shas, as
         they can't be compared.
 
-    :returns: ``True``is ``a`` is older than ``b`` but not equal, ``False`` otherwise.
+    :returns: ``True`` if ``a`` is older than ``b`` but not equal, ``False`` otherwise.
     """
     return _compare_versions(b, a)
 
@@ -77,7 +77,7 @@ def is_version_newer_or_equal(a, b):
     :raises TankError: Raised if the two versions are different git commit shas, as
         they can't be compared.
 
-    :returns: ``True``is ``a`` is newer than or equal to ``b``, ``False`` otherwise.
+    :returns: ``True`` if ``a`` is newer than or equal to ``b``, ``False`` otherwise.
     """
     return is_version_older(a, b) is False
 
@@ -92,7 +92,7 @@ def is_version_older_or_equal(a, b):
     :raises TankError: Raised if the two versions are different git commit shas, as
         they can't be compared.
 
-    :returns: ``True``is ``a`` is older than or equal to ``b``, ``False`` otherwise.
+    :returns: ``True`` if ``a`` is older than or equal to ``b``, ``False`` otherwise.
     """
     return is_version_newer(a, b) is False
 

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -50,6 +50,14 @@ def is_version_newer(a, b):
     return _compare_versions(a, b)
 
 
+def is_version_newer_or_equal(a, b):
+    return is_version_older(a, b) is False
+
+
+def is_version_older_or_equal(a, b):
+    return is_version_newer(a, b) is False
+
+
 def is_version_older(a, b):
     """
     Is the version number string a older than b?
@@ -93,6 +101,8 @@ def _compare_versions(a, b):
     if b is None:
         # a is always newer than None
         return True
+
+    print(a, b)
 
     if _is_git_commit(a) and not _is_git_commit(b):
         return True

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -102,8 +102,6 @@ def _compare_versions(a, b):
         # a is always newer than None
         return True
 
-    print(a, b)
-
     if _is_git_commit(a) and not _is_git_commit(b):
         return True
     elif _is_git_commit(b) and not _is_git_commit(a):

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -39,36 +39,62 @@ def _is_git_commit(version):
 
 def is_version_newer(a, b):
     """
-    Is the version number string a newer than b?
+    Is the version string ``a`` newer than ``b``?
 
-    a=v0.12.1 b=0.13.4 -- Returns False
-    a=v0.13.1 b=0.13.1 -- Returns True
-    a=HEAD b=0.13.4 -- Returns False
-    a=master b=0.13.4 -- Returns False
+    If one of the version is `master`, `head`, or formatted like a git commit sha,
+    it is considered more recent than the other version.
 
+    :raises TankError: Raised if the two versions are different git commit shas, as
+        they can't be compared.
+
+    :returns: ``True``is ``a`` is newer than ``b`` but not equal, ``False`` otherwise.
     """
     return _compare_versions(a, b)
 
 
+def is_version_older(a, b):
+    """
+    Is the version string ``a`` older than ``b``?
+
+    If one of the version is `master`, `head`, or formatted like a git commit sha,
+    it is considered more recent than the other version.
+
+    :raises TankError: Raised if the two versions are different git commit shas, as
+        they can't be compared.
+
+    :returns: ``True``is ``a`` is older than ``b`` but not equal, ``False`` otherwise.
+    """
+    return _compare_versions(b, a)
+
+
 def is_version_newer_or_equal(a, b):
+    """
+    Is the version string ``a`` newer than or equal to ``b``?
+
+    If one of the version is `master`, `head`, or formatted like a git commit sha,
+    it is considered more recent than the other version.
+
+    :raises TankError: Raised if the two versions are different git commit shas, as
+        they can't be compared.
+
+    :returns: ``True``is ``a`` is newer than or equal to ``b``, ``False`` otherwise.
+    """
     return is_version_older(a, b) is False
 
 
 def is_version_older_or_equal(a, b):
+    """
+    Is the version string ``a`` older than or equal to ``b``?
+
+    If one of the version is `master`, `head`, or formatted like a git commit sha,
+    it is considered more recent than the other version.
+
+    :raises TankError: Raised if the two versions are different git commit shas, as
+        they can't be compared.
+
+    :returns: ``True``is ``a`` is older than or equal to ``b``, ``False`` otherwise.
+    """
     return is_version_newer(a, b) is False
-
-
-def is_version_older(a, b):
-    """
-    Is the version number string a older than b?
-
-    a=v0.12.1 b=0.13.4 -- Returns True
-    a=v0.13.1 b=0.13.1 -- Returns True
-    a=HEAD b=0.13.4 -- Returns False
-    a=master b=0.13.4 -- Returns False
-
-    """
-    return _compare_versions(b, a)
 
 
 def is_version_number(version):

--- a/tests/util_tests/test_version_compare.py
+++ b/tests/util_tests/test_version_compare.py
@@ -10,14 +10,51 @@
 
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
-import sgtk
+from sgtk.util import (
+    is_version_older,
+    is_version_newer,
+    is_version_newer_or_equal,
+    is_version_older_or_equal,
+)
+
+OLDER = "older"
+NEWER = "newer"
+EQUAL = "equal"
+
+git_sha = "b2cbcb9cefea668eb4ccf071e51cc650ebb27504"
 
 
 class TestVersionCompare(ShotgunTestBase):
     def setUp(self):
         super(TestVersionCompare, self).setUp()
 
+    versions = {
+        ("1.2.3", "1.2.3"): EQUAL,
+        ("1.2.3", "1.0.0"): NEWER,
+        ("v1.2.3", "v1.0.0"): NEWER,
+        ("v1.2.3", "1.0.0"): NEWER,
+        ("v1.200.3", "v1.12.345"): NEWER,
+        ("HEaD", "v1.12.345"): NEWER,
+        ("MAsTER", "v1.12.345"): NEWER,
+        ("HEaD", "1.12.345"): NEWER,
+        ("MAsTER", "1.12.345"): NEWER,
+        ("v0.12.3", "HEaD"): OLDER,
+        ("v0.12.3", "MAsTER"): OLDER,
+        ("0.12.3", "HEaD"): OLDER,
+        ("0.12.3", "MAsTER"): OLDER,
+        ("v0.12.3", "1.2.3"): OLDER,
+        ("v0.12.3", "0.12.4"): OLDER,
+        ("1.0.0", "1.0.0"): EQUAL,
+        ("1.2.3", "1.0.0"): NEWER,
+        (git_sha, "1.0.0"): NEWER,
+        ("1.0.0", git_sha): OLDER,
+        (git_sha, git_sha): EQUAL,
+    }
+
     def test_is_git_commit(self):
+        """
+        Test detection of git commits when passing in a version.
+        """
         from tank.util.version import _is_git_commit
 
         valid_commit = "b2cbcb9cefea668eb4ccf071e51cc650ebb27504"
@@ -42,96 +79,34 @@ class TestVersionCompare(ShotgunTestBase):
         # Too short
         assert _is_git_commit(too_short_commit) is False
 
-    def test_is_version_newer(self):
-
-        from tank.util.version import is_version_newer
-
-        self.assertTrue(is_version_newer("1.2.3", "1.0.0"))
-        self.assertTrue(is_version_newer("v1.2.3", "v1.0.0"))
-        self.assertTrue(is_version_newer("v1.2.3", "1.0.0"))
-
-        self.assertTrue(is_version_newer("v1.200.3", "v1.12.345"))
-
-        self.assertTrue(is_version_newer("HEaD", "v1.12.345"))
-        self.assertTrue(is_version_newer("MAsTER", "v1.12.345"))
-
-        self.assertTrue(is_version_newer("HEaD", "1.12.345"))
-        self.assertTrue(is_version_newer("MAsTER", "1.12.345"))
-
-        self.assertFalse(is_version_newer("v0.12.3", "HEaD"))
-        self.assertFalse(is_version_newer("v0.12.3", "MAsTER"))
-
-        self.assertFalse(is_version_newer("0.12.3", "HEaD"))
-        self.assertFalse(is_version_newer("0.12.3", "MAsTER"))
-
-        self.assertFalse(is_version_newer("v0.12.3", "1.2.3"))
-        self.assertFalse(is_version_newer("v0.12.3", "0.12.4"))
-
-        self.assertFalse(is_version_newer("1.0.0", "1.0.0"))
-
-        self.assertTrue(is_version_newer("1.2.3", "1.0.0"))
-
-        # Git hashes are always considered more recent that a version string.
-        self.assertFalse(
-            is_version_newer("1.2.3", "b2cbcb9cefea668eb4ccf071e51cc650ebb27504")
-        )
-        self.assertTrue(
-            is_version_newer("b2cbcb9cefea668eb4ccf071e51cc650ebb27504", "1.2.3")
-        )
-
-        # Commits are the same.
-        self.assertFalse(
-            is_version_newer(
-                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
-                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
+    def test_version_methods(self):
+        """
+        Test all version comparison methods and making sure they return
+        the expected result for all inputs.
+        """
+        for (left, right), expected in self.versions.items():
+            # We test for the expected result on the right hand-side, which
+            # allows us to know that result we should be getting from the
+            # function call.
+            assert is_version_older(left, right) == (expected == OLDER)
+            assert is_version_older_or_equal(left, right) == (
+                expected in [OLDER, EQUAL]
             )
-        )
+            assert is_version_newer(left, right) == (expected == NEWER)
+            assert is_version_newer_or_equal(left, right) == (
+                expected in [NEWER, EQUAL]
+            )
 
+    def test_version_error_conditions(self):
+        """
+        We can't compare two different git commit shas together and that should
+        return an error.
+        """
         with self.assertRaises(sgtk.TankError):
             is_version_newer("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
-
-    def test_is_version_older(self):
-
-        from tank.util.version import is_version_older
-
-        self.assertFalse(is_version_older("1.2.3", "1.0.0"))
-        self.assertFalse(is_version_older("v1.2.3", "v1.0.0"))
-        self.assertFalse(is_version_older("v1.2.3", "1.0.0"))
-
-        self.assertFalse(is_version_older("v1.200.3", "v1.12.345"))
-
-        self.assertFalse(is_version_older("HEaD", "v1.12.345"))
-        self.assertFalse(is_version_older("MAsTER", "v1.12.345"))
-
-        self.assertFalse(is_version_older("HEaD", "1.12.345"))
-        self.assertFalse(is_version_older("MAsTER", "1.12.345"))
-
-        self.assertTrue(is_version_older("v0.12.3", "HEaD"))
-        self.assertTrue(is_version_older("v0.12.3", "MAsTER"))
-
-        self.assertTrue(is_version_older("0.12.3", "HEaD"))
-        self.assertTrue(is_version_older("0.12.3", "MAsTER"))
-
-        self.assertTrue(is_version_older("v0.12.3", "1.2.3"))
-        self.assertTrue(is_version_older("v0.12.3", "0.12.4"))
-
-        self.assertFalse(is_version_older("1.0.0", "1.0.0"))
-
-        # Git hashes are always considered more recent that a version string.
-        self.assertTrue(
-            is_version_older("1.2.3", "b2cbcb9cefea668eb4ccf071e51cc650ebb27504")
-        )
-        self.assertFalse(
-            is_version_older("b2cbcb9cefea668eb4ccf071e51cc650ebb27504", "1.2.3")
-        )
-
-        # Commits are the same.
-        self.assertFalse(
-            is_version_older(
-                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
-                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
-            )
-        )
-
         with self.assertRaises(sgtk.TankError):
             is_version_older("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
+        with self.assertRaises(sgtk.TankError):
+            is_version_newer_or_equal("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
+        with self.assertRaises(sgtk.TankError):
+            is_version_newer_or_equal("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")

--- a/tests/util_tests/test_version_compare.py
+++ b/tests/util_tests/test_version_compare.py
@@ -16,6 +16,7 @@ from sgtk.util import (
     is_version_newer_or_equal,
     is_version_older_or_equal,
 )
+from sgtk import TankError
 
 OLDER = "older"
 NEWER = "newer"
@@ -102,11 +103,11 @@ class TestVersionCompare(ShotgunTestBase):
         We can't compare two different git commit shas together and that should
         return an error.
         """
-        with self.assertRaises(sgtk.TankError):
+        with self.assertRaises(TankError):
             is_version_newer("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
-        with self.assertRaises(sgtk.TankError):
+        with self.assertRaises(TankError):
             is_version_older("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
-        with self.assertRaises(sgtk.TankError):
+        with self.assertRaises(TankError):
             is_version_newer_or_equal("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
-        with self.assertRaises(sgtk.TankError):
+        with self.assertRaises(TankError):
             is_version_newer_or_equal("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")

--- a/tests/util_tests/test_version_compare.py
+++ b/tests/util_tests/test_version_compare.py
@@ -10,11 +10,37 @@
 
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
+import sgtk
 
 
 class TestVersionCompare(ShotgunTestBase):
     def setUp(self):
         super(TestVersionCompare, self).setUp()
+
+    def test_is_git_commit(self):
+        from tank.util.version import _is_git_commit
+
+        valid_commit = "b2cbcb9cefea668eb4ccf071e51cc650ebb27504"
+        short_commit = valid_commit[0:7]
+        assert len(short_commit) == 7
+
+        too_short_commit = short_commit[:-1]
+        assert len(too_short_commit) == 6
+
+        # The regex accepts any letters between A-F upper/lower case
+        # and numbers, from 7 to 40 characters.
+        assert _is_git_commit(valid_commit) is True
+        assert _is_git_commit(valid_commit.upper()) is True
+        assert _is_git_commit(short_commit) is True
+
+        # Invalid character at the beginning
+        assert _is_git_commit("x" + short_commit) is False
+        # Invalid character at the end
+        assert _is_git_commit(short_commit + "x") is False
+        # Too long
+        assert _is_git_commit(valid_commit + "a") is False
+        # Too short
+        assert _is_git_commit(too_short_commit) is False
 
     def test_is_version_newer(self):
 
@@ -43,6 +69,27 @@ class TestVersionCompare(ShotgunTestBase):
 
         self.assertFalse(is_version_newer("1.0.0", "1.0.0"))
 
+        self.assertTrue(is_version_newer("1.2.3", "1.0.0"))
+
+        # Git hashes are always considered more recent that a version string.
+        self.assertFalse(
+            is_version_newer("1.2.3", "b2cbcb9cefea668eb4ccf071e51cc650ebb27504")
+        )
+        self.assertTrue(
+            is_version_newer("b2cbcb9cefea668eb4ccf071e51cc650ebb27504", "1.2.3")
+        )
+
+        # Commits are the same.
+        self.assertFalse(
+            is_version_newer(
+                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
+                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
+            )
+        )
+
+        with self.assertRaises(sgtk.TankError):
+            is_version_newer("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")
+
     def test_is_version_older(self):
 
         from tank.util.version import is_version_older
@@ -69,3 +116,22 @@ class TestVersionCompare(ShotgunTestBase):
         self.assertTrue(is_version_older("v0.12.3", "0.12.4"))
 
         self.assertFalse(is_version_older("1.0.0", "1.0.0"))
+
+        # Git hashes are always considered more recent that a version string.
+        self.assertTrue(
+            is_version_older("1.2.3", "b2cbcb9cefea668eb4ccf071e51cc650ebb27504")
+        )
+        self.assertFalse(
+            is_version_older("b2cbcb9cefea668eb4ccf071e51cc650ebb27504", "1.2.3")
+        )
+
+        # Commits are the same.
+        self.assertFalse(
+            is_version_older(
+                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
+                "b2cbcb9cefea668eb4ccf071e51cc650ebb27504",
+            )
+        )
+
+        with self.assertRaises(sgtk.TankError):
+            is_version_older("b2cbcb9cefea668eb4", "a2cbcb9cefea668eb4")


### PR DESCRIPTION
In some parts of the Toolkit platform, we compare the version of a bundle with a specific known version to know if a certain feature is available or not. This becomes an issue when the bundle is a git_branch descriptor, because the version is then a git hash.

Now, when a git-hash is detected in the `is_version_` methods, we consider them more recent than whatever was the other value passed in. More helpers were also added to simplify writing code.

Finally, those methods are now part of the official Toolkit API and can be used by anyone.

Here's what the doc looks like:
![image](https://user-images.githubusercontent.com/8126447/91219512-bca5b900-e6e8-11ea-8867-a4a5d227f466.png)

This is a pre-requisite for https://github.com/shotgunsoftware/tk-framework-desktopstartup/pull/61
