### PR TITLE
Automation helpers

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -111,25 +111,21 @@ Exception Classes
 
 .. autoclass:: ShotgunAuthenticationError
     :show-inheritance:
-    :inherited-members:
-    :members:
 
 .. autoclass:: AuthenticationError
     :show-inheritance:
-    :inherited-members:
-    :members:
 
 .. autoclass:: IncompleteCredentials
     :show-inheritance:
-    :inherited-members:
-    :members:
 
 .. autoclass:: AuthenticationCancelled
     :show-inheritance:
-    :inherited-members:
-    :members:
 
 .. autoclass:: ConsoleLoginNotSupportedError
     :show-inheritance:
-    :inherited-members:
-    :members:
+
+.. autoclass:: UnresolvableHumanUser
+    :show-inheritance:
+
+.. autoclass:: UnresolvableScriptUser
+    :show-inheritance:

--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -25,6 +25,8 @@ from .errors import (  # noqa
     ConsoleLoginNotSupportedError,
     IncompleteCredentials,
     ShotgunAuthenticationError,
+    UnresolvableHumanUser,
+    UnresolvableScriptUser,
 )
 from .web_login_support import (
     get_shotgun_authenticator_support_web_login,

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -53,6 +53,45 @@ class AuthenticationCancelled(ShotgunAuthenticationError):
         )
 
 
+class UnresolvableUser(ShotgunAuthenticationError):
+    """
+    Thrown when Toolkit is not able to resolve a user.
+    """
+
+    def __init__(self, nice_user_type, user_type, key_name, key_value):
+        """
+        Constructor.
+        """
+        super(UnresolvableUser, self).__init__(
+            "The {0} named '{3}' could not be resolved. Check if the "
+            "permissions for the current user are hiding the field '{1}.{2}'.".format(
+                nice_user_type, user_type, key_name, key_value
+            )
+        )
+
+
+class UnresolvableHumanUser(UnresolvableUser):
+    """
+    Thrown when Toolkit is not able to resolve a human user.
+    """
+
+    def __init__(self, login):
+        super(UnresolvableHumanUser, self).__init__(
+            "person", "HumanUser", "login", login
+        )
+
+
+class UnresolvableScriptUser(UnresolvableUser):
+    """
+    Thrown when Toolkit is not able to resolve a human user.
+    """
+
+    def __init__(self, script_name):
+        super(UnresolvableScriptUser, self).__init__(
+            "script", "ApiUser", "firstname", script_name
+        )
+
+
 class ConsoleLoginNotSupportedError(ShotgunAuthenticationError):
     """
     Thrown when attempting to use Username/Password pair to login onto

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -45,9 +45,6 @@ class AuthenticationCancelled(ShotgunAuthenticationError):
     """
 
     def __init__(self):
-        """
-        Constructor.
-        """
         ShotgunAuthenticationError.__init__(
             self, "Authentication was cancelled by the user."
         )
@@ -59,9 +56,6 @@ class UnresolvableUser(ShotgunAuthenticationError):
     """
 
     def __init__(self, nice_user_type, user_type, key_name, key_value):
-        """
-        Constructor.
-        """
         super(UnresolvableUser, self).__init__(
             "The {0} named '{3}' could not be resolved. Check if the "
             "permissions for the current user are hiding the field '{1}.{2}'.".format(
@@ -76,6 +70,9 @@ class UnresolvableHumanUser(UnresolvableUser):
     """
 
     def __init__(self, login):
+        """
+        :param str login: ``login`` field value of the ``HumanUser`` that could not be resolved.
+        """
         super(UnresolvableHumanUser, self).__init__(
             "person", "HumanUser", "login", login
         )
@@ -87,6 +84,9 @@ class UnresolvableScriptUser(UnresolvableUser):
     """
 
     def __init__(self, script_name):
+        """
+        :param str script_name: ``firstname`` field value of the ``ApiUser`` that could not be resolved.
+        """
         super(UnresolvableScriptUser, self).__init__(
             "script", "ApiUser", "firstname", script_name
         )

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -79,6 +79,15 @@ class ShotgunUser(object):
         """
         return self._impl.get_login()
 
+    def resolve_entity(self):
+        """
+        Resolves the Shotgun entity associated with this user.
+
+        :returns: A dictionary with ``type`` and ``id`` values.
+        :rtype: dict
+        """
+        return self._impl.resolve_entity()
+
     def create_sg_connection(self):
         """
         Creates a Shotgun connection using the credentials for this user.

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -25,7 +25,7 @@ from tank_vendor import six
 from tank_vendor.six.moves import http_client
 
 from . import session_cache
-from .errors import IncompleteCredentials
+from .errors import IncompleteCredentials, UnresolvableHumanUser, UnresolvableScriptUser
 from .. import LogManager
 from ..util import pickle
 from ..util import json as sgjson
@@ -63,6 +63,11 @@ class ShotgunUserImpl(object):
 
         self._host = host
         self._http_proxy = http_proxy
+
+        # This is the cached result of resolve_entity.
+        # One resolve_entity() has been called once,
+        # the cached entity will always be returned afterwards
+        self._cached_entity = None
 
     def get_host(self):
         """
@@ -283,6 +288,22 @@ class SessionUser(ShotgunUserImpl):
             connect=False,
         )
 
+    def resolve_entity(self):
+        """
+        Resolves the Shotgun entity associated with this user.
+
+        :returns: A dictionary with ``type`` and ``id`` values.
+        :rtype: dict
+        """
+        # We cache the entity to avoid fetching it multiple times.
+        if self._cached_entity is None:
+            self._cached_entity = self.create_sg_connection().find_one(
+                "HumanUser", [["login", "is", self._login]]
+            )
+            if self._cached_entity is None:
+                raise UnresolvableHumanUser(self._login)
+        return self._cached_entity
+
     @LogManager.log_timing
     def are_credentials_expired(self):
         """
@@ -434,6 +455,22 @@ class ScriptUser(ShotgunUserImpl):
             http_proxy=self._http_proxy,
             connect=False,
         )
+
+    def resolve_entity(self):
+        """
+        Resolves the Shotgun entity associated with this user.
+
+        :returns: A dictionary with ``type`` and ``id`` values.
+        :rtype: dict
+        """
+        # We cache the entity to avoid fetching it multiple times.
+        if self._cached_entity is None:
+            self._cached_entity = self.create_sg_connection().find_one(
+                "ApiUser", [["firstname", "is", self._api_script]]
+            )
+            if self._cached_entity is None:
+                raise UnresolvableScriptUser(self._api_script)
+        return self._cached_entity
 
     def refresh_credentials(self):
         """

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -54,16 +54,6 @@ class UserTests(ShotgunTestBase):
             )
         )
 
-    def _create_test_user(self):
-        return user.ShotgunUser(
-            user_impl.SessionUser(
-                host="https://tank.shotgunstudio.com",
-                login="login",
-                session_token="session_token",
-                http_proxy="http_proxy",
-            )
-        )
-
     def _create_test_web_user(self):
         return user.ShotgunWebUser(
             user_impl.SessionUser(

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -10,13 +10,14 @@
 
 from __future__ import with_statement
 import base64
+import pytest
 
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
 
 from mock import patch
 
-from tank.authentication import user, user_impl
+from tank.authentication import user, user_impl, errors
 from tank_vendor.shotgun_api3 import AuthenticationFault
 from tank_vendor import six
 
@@ -33,6 +34,26 @@ valid_sso_session_metadata = base64.b64encode(
 
 
 class UserTests(ShotgunTestBase):
+    def _create_test_user(self):
+        return user.ShotgunUser(
+            user_impl.SessionUser(
+                host="https://tank.shotgunstudio.com",
+                login="login",
+                session_token="session_token",
+                http_proxy="http_proxy",
+            )
+        )
+
+    def _create_script_user(self):
+        return user.ShotgunUser(
+            user_impl.ScriptUser(
+                host="host",
+                api_script="api_script",
+                api_key="api_key",
+                http_proxy="http_proxy",
+            )
+        )
+
     def _create_test_user(self):
         return user.ShotgunUser(
             user_impl.SessionUser(
@@ -82,14 +103,7 @@ class UserTests(ShotgunTestBase):
         )
         self.assertEqual(session_user.login, "session_user")
 
-        script_user = user.ShotgunUser(
-            user_impl.ScriptUser(
-                host="host",
-                api_script="api_script",
-                api_key="api_key",
-                http_proxy="http_proxy",
-            )
-        )
+        script_user = self._create_script_user()
         self.assertIsNone(script_user.login)
 
         class CustomUser(user_impl.ShotgunUserImpl):
@@ -140,14 +154,7 @@ class UserTests(ShotgunTestBase):
         self.assertEqual(su.login, su_2.login)
         self.assertEqual(su.impl.get_session_token(), su_2.impl.get_session_token())
 
-        su = user.ShotgunUser(
-            user_impl.ScriptUser(
-                host="host",
-                api_script="api_script",
-                api_key="api_key",
-                http_proxy="http_proxy",
-            )
-        )
+        su = self._create_script_user()
 
         su_2 = user.deserialize_user(user.serialize_user(su))
         self.assertEqual(su.host, su_2.host)
@@ -224,3 +231,64 @@ class UserTests(ShotgunTestBase):
         # Trigger _call_rpc to make sure sure the ShotgunWrapper copied over the session_token.
         sg._call_rpc()
         self.assertEqual(sg._user.get_session_token(), "session_token_2")
+
+    def test_unresolvable_user(self):
+        """
+        Ensure the errors strings are properly formatted when we can't resolve a user's
+        entity dict.
+        """
+        assert str(errors.UnresolvableHumanUser("jf")) == (
+            "The person named 'jf' could not be resolved. Check if the "
+            "permissions for the current user are hiding the field "
+            "'HumanUser.login'."
+        )
+        assert str(errors.UnresolvableScriptUser("robot-jf")) == (
+            "The script named 'robot-jf' could not be resolved. Check if the "
+            "permissions for the current user are hiding the field "
+            "'ApiUser.firstname'."
+        )
+
+    def test_resolving_human_user(self):
+        """
+        Ensure HumanUser.resolve_entity behaves properly.
+        """
+        self._test_resolve_entity(
+            "SessionUser",
+            "HumanUser",
+            "login",
+            "login",
+            self._create_test_user,
+            errors.UnresolvableHumanUser,
+        )
+
+    def test_resolving_script_user(self):
+        """
+        Ensure ScriptUser.resolve_entity behaves properly.
+        """
+        self._test_resolve_entity(
+            "ScriptUser",
+            "ApiUser",
+            "firstname",
+            "api_script",
+            self._create_script_user,
+            errors.UnresolvableScriptUser,
+        )
+
+    def _test_resolve_entity(
+        self, class_name, entity_type, field_name, field_value, factory, error_type
+    ):
+        with patch(
+            "tank.authentication.user_impl.%s.create_sg_connection" % class_name,
+            return_value=self.mockgun,
+        ):
+            user = factory()
+            # When the user can't be found, an error should be raised.
+            with pytest.raises(error_type):
+                user.resolve_entity()
+
+            entity = self.mockgun.create(entity_type, {field_name: field_value})
+            # clean up the entity dict so we can easily compare it with the resolve_entity() result.
+            entity = {"type": entity["type"], "id": entity["id"]}
+            # When the user exists, it should be resolved properly.
+            resolved_entity = user.resolve_entity()
+            assert entity == resolved_entity


### PR DESCRIPTION
We can now resolve the Shotgun entity for a given `stgtk.authentication.ShotgunUser`. If we can't resolve the user, the `UnresolvableScriptUser` or `UnresolvableHumanUser` error is raised.

Here's what the new doc looks like.

In the ShotgunUser class:

![image](https://user-images.githubusercontent.com/8126447/94192266-b6883100-fe7c-11ea-9a63-032c080d91de.png)

The documentation for the exceptions was too verbose. They didn't have members and we shouldn't have displayed methods from the base class.

![image](https://user-images.githubusercontent.com/8126447/94192549-1c74b880-fe7d-11ea-9b1e-4c561ddf3ccc.png)
