### PR TITLE
SG-19670 Fixes the integration tests by using a simple test config.

### DIFF
--- a/tests/integration_tests/data/simple_config/env/project.yml
+++ b/tests/integration_tests/data/simple_config/env/project.yml
@@ -25,15 +25,15 @@ engines:
         location:
           type: app_store
           name: tk-multi-launchapp
-          version: v0.9.15
+          version: v0.11.1
     location:
       type: app_store
       name: tk-shell
-      version: v0.6.0
+      version: v0.8.0
 
 frameworks:
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.3.4
+      version: v5.7.6
       type: app_store
       name: tk-framework-shotgunutils

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -155,7 +155,7 @@ class TankCommands(SgtkIntegrationTest):
 
         self.tank_setup_project(
             self.shared_core_location,
-            "tk-config-basic",
+            "tk-config-testing",
             None,
             self.project["id"],
             "tankcommandtest",
@@ -171,7 +171,7 @@ class TankCommands(SgtkIntegrationTest):
 
         self.tank_setup_project(
             self.shared_core_location,
-            "https://github.com/shotgunsoftware/tk-config-basic.git",
+            "https://github.com/shotgunsoftware/tk-config-testing.git",
             None,
             self.project["id"],
             "tankcommandtest",
@@ -195,9 +195,6 @@ class TankCommands(SgtkIntegrationTest):
             force=True,
         )
 
-    @unittest2.skipIf(
-        sys.version_info[0] > 2, "shell engine is not Python 3 compatible."
-    )
     def test_04_list_actions_for_project_with_shared_core(self):
         """
         Ensures that running the tank command when there is a site-wide Primary


### PR DESCRIPTION
App store and git setup project tests now use a new dedicated simple testing config, which means testing time is a lot faster due to less dependancies.
https://github.com/shotgunsoftware/tk-config-testing

Previously the tests were failing because the size of one of the basic config components was very large and it timed out waiting for the setup project to complete due to the download time.

Also removes a skip, now that tk-shell is Python 3 compatible.

Updates the test config components, but not to the latest so that the update test can still run.


