### PR TITLE
[SHOT-3594] Windows platform shutil buffer override to increase performance for file copying

### DIFF
--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -172,11 +172,14 @@ def copy_file(src, dst, permissions=0o666):
                         be readable and writable for all users.
     """
     if is_windows():
-        windows_src = open(src, mode="rb")
-        windows_dst = open(dst, mode="wb")
-        shutil.copyfileobj(windows_src, windows_dst, length=16 * 1024 * 1024)
-        windows_src.close()
-        windows_dst.close()
+        # Check if the dst is a directory and change it to a filename if it is
+        if os.path.isdir(dst):
+            basename = os.path.basename(src)
+            dst = os.path.join(dst, basename)
+        # Use larger copy buffer in the shutil.copyfileobj operation
+        with open(src, mode="rb") as windows_src:
+            with open(dst, mode="wb") as windows_dst:
+                shutil.copyfileobj(windows_src, windows_dst, length=16 * 1024 * 1024)
         log.debug("Used shutil override on Windows")
     else:
         shutil.copy(src, dst)

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -174,7 +174,7 @@ def copy_file(src, dst, permissions=0o666):
     if is_windows():
         windows_src = open(src, mode="rb")
         windows_dst = open(dst, mode="wb")
-        shutil.copyfileobj(windows_src, windows_dst, length=16*1024*1024)
+        shutil.copyfileobj(windows_src, windows_dst, length=16 * 1024 * 1024)
         windows_src.close()
         windows_dst.close()
         log.debug("Used shutil override on Windows")

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -171,7 +171,15 @@ def copy_file(src, dst, permissions=0o666):
     :param permissions: Permissions to use for target file. Default permissions will
                         be readable and writable for all users.
     """
-    shutil.copy(src, dst)
+    if is_windows():
+        windows_src = open(src, mode="rb")
+        windows_dst = open(dst, mode="wb")
+        shutil.copyfileobj(windows_src, windows_dst, length=16*1024*1024)
+        windows_src.close()
+        windows_dst.close()
+        log.debug("Used shutil override on Windows")
+    else:
+        shutil.copy(src, dst)
     os.chmod(dst, permissions)
 
 


### PR DESCRIPTION
There were multiple complaints from ACD customers about poor performance during Shotgun Publishing in Alias and VRED which led to this backlog ticket. After investigating, this tweak to the copy operation greatly improves the performance.