### PR TITLE
[SHOT-2756] Allow Tank Dialog window title "Shotgun"

### DIFF
--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -209,7 +209,11 @@ class TankQDialog(TankDialogBase):
         else:
             self.ui.label.setText(title)
 
-        self.setWindowTitle("Shotgun: %s" % title)
+        if title.startswith("Shotgun"):
+            self.setWindowTitle(title)
+        else:
+            self.setWindowTitle("Shotgun: %s" % title)
+
         if os.path.exists(bundle.icon_256):
             self._window_icon = QtGui.QIcon(bundle.icon_256)
             self.setWindowIcon(self._window_icon)


### PR DESCRIPTION
For non-docked Shotgun Panel (e.g. in Alias), we want the window title to just be "Shotgun" but the Tank Dialog will always prepend "Shotgun: {title}".

Proposing a change to not prepend "Shotgun:" to the window title if it already starts with "Shotgun".