### PR TITLE
implement sudo_as_login for Toolkit

### DIFF
--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -184,7 +184,7 @@ class ShotgunAuthenticator(object):
             return user.ShotgunWebUser(impl)
         return user.ShotgunUser(impl)
 
-    def create_script_user(self, api_script, api_key, host=None, http_proxy=None):
+    def create_script_user(self, api_script, api_key, host=None, http_proxy=None, sudo_as_login=None):
         """
         Create an AuthenticatedUser given a set of script credentials.
 
@@ -194,6 +194,8 @@ class ShotgunAuthenticator(object):
                      be used.
         :param http_proxy: Shotgun proxy to use. If None, the default http proxy
                            will be used.
+        :param sudo_as_login: A Shotgun user login string for the user whose permissions will be applied
+            to all actions. If None, api_script permissions will be used.
 
         :returns: A :class:`ShotgunUser` derived instance.
         """
@@ -203,6 +205,7 @@ class ShotgunAuthenticator(object):
                 api_script,
                 api_key,
                 http_proxy or self._defaults_manager.get_http_proxy(),
+                sudo_as_login,
             )
         )
 
@@ -245,6 +248,7 @@ class ShotgunAuthenticator(object):
                 api_key=credentials.get("api_key"),
                 host=credentials.get("host"),
                 http_proxy=credentials.get("http_proxy"),
+                sudo_as_login=credentials.get("sudo_as_login"),
             )
         # If this looks like a session user, delegate to create_session_user.
         # If some of the arguments are missing, don't worry, create_session_user

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -79,6 +79,10 @@ class ShotgunUser(object):
         """
         return self._impl.get_login()
 
+    @property
+    def sudo_as_login(self):
+        return self._impl.get_sudo_as_login()
+
     def resolve_entity(self):
         """
         Resolves the Shotgun entity associated with this user.

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -111,6 +111,14 @@ class ShotgunUserImpl(object):
         """
         self.__class__._not_implemented("get_login")
 
+    def get_sudo_as_login(self):
+        """
+        Returns the sudo_as_login for this user.
+
+        :returns: The sudo_as_login string."
+        """
+        self.__class__._not_implemented("get_sudo_as_login")
+
     def get_session_metadata(self):
         """
         Returns the session metadata for this user.
@@ -235,6 +243,14 @@ class SessionUser(ShotgunUserImpl):
         :returns: The login name string.
         """
         return self._login
+
+    def get_sudo_as_login(self):
+        """
+        Returns the user used for sudo_as_login for this user.
+
+        :returns: The sudo_as_login user login string.
+        """
+        return None
 
     def get_session_token(self):
         """
@@ -421,7 +437,7 @@ class ScriptUser(ShotgunUserImpl):
     User that authenticates to the Shotgun server using a api name and api key.
     """
 
-    def __init__(self, host, api_script, api_key, http_proxy):
+    def __init__(self, host, api_script, api_key, http_proxy, sudo_as_login):
         """
         Constructor.
 
@@ -437,6 +453,7 @@ class ScriptUser(ShotgunUserImpl):
 
         self._api_script = api_script
         self._api_key = api_key
+        self._sudo_as_login = sudo_as_login
 
     def create_sg_connection(self):
         """
@@ -452,6 +469,7 @@ class ScriptUser(ShotgunUserImpl):
             self._host,
             script_name=self._api_script,
             api_key=self._api_key,
+            sudo_as_login=self._sudo_as_login,
             http_proxy=self._http_proxy,
             connect=False,
         )
@@ -509,7 +527,7 @@ class ScriptUser(ShotgunUserImpl):
         :returns: The login name string.
         """
         # Script user has no login.
-        return None
+        return self._sudo_as_login
 
     def get_session_metadata(self):
         """
@@ -520,6 +538,14 @@ class ScriptUser(ShotgunUserImpl):
         # Script user has no session_metadata.
         return None
 
+    def get_sudo_as_login(self):
+        """
+        Returns the user used for sudo_as_login for this user.
+
+        :returns: The sudo_as_login user login string.
+        """
+        return self._sudo_as_login
+
     def to_dict(self):
         """
         Converts the user into a dictionary object.
@@ -529,6 +555,7 @@ class ScriptUser(ShotgunUserImpl):
         data = super(ScriptUser, self).to_dict()
         data["api_script"] = self.get_script()
         data["api_key"] = self.get_key()
+        data["sudo_as_login"] = self.get_sudo_as_login()
         return data
 
     def __repr__(self):
@@ -537,7 +564,8 @@ class ScriptUser(ShotgunUserImpl):
 
         :returns: A string containing script name and site.
         """
-        return "<ScriptUser %s @ %s>" % (self._api_script, self._host)
+        sudo_as_login_repr = " (as %s)" % self._sudo_as_login if self._sudo_as_login else ""
+        return "<ScriptUser %s%s @ %s>" % (self._api_script, sudo_as_login_repr, self._host)
 
     def __str__(self):
         """
@@ -545,7 +573,10 @@ class ScriptUser(ShotgunUserImpl):
 
         :returns: A string.
         """
-        return self._api_script
+        value = self._api_script
+        if self._sudo_as_login:
+            value += " (as %s)" % self._sudo_as_login
+        return value
 
     @staticmethod
     def from_dict(payload):
@@ -560,6 +591,7 @@ class ScriptUser(ShotgunUserImpl):
             host=payload.get("host"),
             api_script=payload.get("api_script"),
             api_key=payload.get("api_key"),
+            sudo_as_login=payload.get("sudo_as_login"),
             http_proxy=payload.get("http_proxy"),
         )
 

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -283,14 +283,15 @@ class Configuration(object):
         project_user = None
 
         # If the project core's authentication code found a user...
-        # (Note that in the following code, a user with no login is a script user.)
+        # (Note that in the following code, a user with no login or a user with a sudo_as_login is a script user.)
+
         if default_user:
             # If the project uses a script user, we'll use that.
             if not default_user.login:
                 log.debug("User retrieved for the project is a script user.")
                 project_user = default_user
             # If the project didn't use a script, but the bootstrap did, we'll keep using it.
-            elif not bootstrap_user_login:
+            elif not bootstrap_user_login or bootstrap_user.sudo_as_login:
                 # We'll keep using the bootstrap user. This is because configurations like tk-
                 # config-basic or tk-config-default are meant to be used with whatever credentials
                 # were used during bootstrapping when used with a CachedDescriptor. The bootstrap

--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -151,6 +151,15 @@ class ShotgunAuthenticatorTests(ShotgunTestBase):
         self.assertEqual(connection.config.script_name, "api_script")
         self.assertEqual(connection.config.api_key, "api_key")
 
+        # Test using sudo_as_login
+        user = ShotgunAuthenticator(CustomDefaultManager()).create_script_user(
+            "api_script", "api_key", "https://host.shotgunstudio.com", None, "sudouser"
+        )
+        connection = user.create_sg_connection()
+        self.assertEqual(connection.config.script_name, "api_script")
+        self.assertEqual(connection.config.api_key, "api_key")
+        self.assertEqual(connection.config.sudo_as_login, "sudouser")
+
     @patch("tank.authentication.session_cache.get_current_host", return_value=None)
     def test_no_current_host(self, _):
         """


### PR DESCRIPTION
Hi,

Following this post on community.shotgunsoftware.com: https://community.shotgunsoftware.com/t/shotgunauthenticator-create-script-user-implement-sudo-as-login/10549

I submit this MR to see if it could be merged on your side.

Motivations:
 * When using ShotgunToolkit on the render farm the only way to do operations in the name of the user is to serialize the user session to the render farm. But the session will expire quickly.
 * This was only doable using the shotgun_api3 before and doing operations like opening a work scene updating references using breakdown and re publishing was not possible in the name of the user.

This MR contains:
 * Implement sudo_as_login argument to ShotgunAuthenticator.create_script_user with unit test
 * Change behavior of Configuration._set_authenticated_user to use bootstrap user if sudo_as_login is set.

Hope it can be useful to someone else!

DalteoCraft
