### PR TITLE
Gracefully dealing with pick_environment returning None

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -1175,12 +1175,12 @@ class ToolkitManager(object):
                     "start_engine routine..."
                 )
                 engine = tank.platform.start_engine(engine_name, tk, ctx)
-            except Exception as exc:
+            except Exception as outer_exc:
                 log.debug(
                     "Shotgun engine failed to start using start_engine. An "
                     "attempt will now be made to start it using an legacy "
                     "shotgun_xxx.yml environment. The start_engine exception "
-                    "was the following: %r" % exc
+                    "was the following: %r" % outer_exc
                 )
                 try:
                     engine = self._legacy_start_shotgun_engine(
@@ -1189,6 +1189,23 @@ class ToolkitManager(object):
                     log.debug(
                         "Shotgun engine started using a legacy shotgun_xxx.yml environment."
                     )
+                except tank.platform.TankMissingEnvironmentFile as exc:
+                    # If the reason the new style bootstrap failed was that no environment was returned by the
+                    # pick_environment hook and the old style bootstrap failed because the env file is missing,
+                    # we're likely in a new style setup but trying to bootstrap using an entity that is not supported.
+                    if isinstance(
+                        outer_exc, tank.platform.TankUnresolvedEnvironmentError
+                    ):
+                        msg = (
+                            "No environment was found for the context {}. The pick_environment hook was "
+                            "unable to provide one, and the fallback was not successful. {}".format(
+                                ctx, exc
+                            )
+                        )
+                        log.warning(msg)
+                        raise tank.platform.TankUnresolvedEnvironmentError(msg)
+                    raise
+
                 except Exception as exc:
                     log.debug(
                         "Shotgun engine failed to start using the legacy "

--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -13,6 +13,7 @@
 from .engine import start_engine, current_engine, get_engine_path, find_app_settings
 from .errors import (
     TankEngineInitError,
+    TankUnresolvedEnvironmentError,
     TankContextChangeNotSupportedError,
     TankMissingEngineError,
     TankMissingEnvironmentFile,

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -32,6 +32,7 @@ from .. import hook
 from ..errors import TankError
 from .errors import (
     TankEngineInitError,
+    TankUnresolvedEnvironmentError,
     TankContextChangeNotSupportedError,
     TankEngineEventError,
     TankMissingEngineError,
@@ -3418,7 +3419,7 @@ def __pick_environment(engine_name, tk, context):
         # this may be because an incomplete Context was passed.
         # without an environment, engine creation cannot succeed.
         # raise an exception with a message
-        raise TankEngineInitError(
+        raise TankUnresolvedEnvironmentError(
             "Engine %s cannot initialize - the pick environment hook was not "
             "able to return an environment to use, given the context %s. "
             "Usually this is because the context contains insufficient information "

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -253,7 +253,7 @@ class Environment(object):
         """
         loads the main data from disk, raw form
         """
-        logger.debug("Loading environment data from path: %s", self._env_path)
+        logger.debug("Loading environment data from path: %s", path)
         return g_yaml_cache.get(path) or {}
 
     def __load_environment_data(self):
@@ -266,8 +266,10 @@ class Environment(object):
         """
         try:
             return self.__load_data(self._env_path)
-        except TankUnreadableFileError:
-            logger.exception("Missing environment file:")
+        except TankUnreadableFileError as e:
+            logger.debug(
+                "Failed to load environment file {}. {}".format(self._env_path, e)
+            )
             raise TankMissingEnvironmentFile(
                 "Missing environment file: %s" % self._env_path
             )

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -266,10 +266,8 @@ class Environment(object):
         """
         try:
             return self.__load_data(self._env_path)
-        except TankUnreadableFileError as e:
-            logger.debug(
-                "Failed to load environment file {}. {}".format(self._env_path, e)
-            )
+        except TankUnreadableFileError:
+            logger.exception("Missing environment file:")
             raise TankMissingEnvironmentFile(
                 "Missing environment file: %s" % self._env_path
             )

--- a/python/tank/platform/errors.py
+++ b/python/tank/platform/errors.py
@@ -34,6 +34,12 @@ class TankMissingEngineError(TankEngineInitError):
     """
 
 
+class TankUnresolvedEnvironmentError(TankEngineInitError):
+    """
+    Exception that indicates that the pick_environment hook did not return a valid environment
+    """
+
+
 class TankEngineEventError(errors.TankError):
     """
     Exception that is raised when there is a problem during engine event emission.


### PR DESCRIPTION
Distinguishes between generic engine bootstrap failure and getting None from the pick_environment hook.
Desktop server can then handle this case differently from other engine bootstrap failures. ([PR for desktopserver](https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/79))

