### PR TITLE
For SG-23187: Fixed authentication for Autodesk Identity

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -28,7 +28,7 @@ from .errors import (
     ConsoleLoginNotSupportedError,
 )
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
-from .sso_saml2 import is_autodesk_identity_enabled_on_site, is_sso_enabled_on_site
+from .sso_saml2 import is_sso_enabled_on_site
 from ..util.shotgun.connection import sanitize_url
 
 from getpass import getpass
@@ -45,8 +45,6 @@ def _assert_console_session_is_supported(hostname, http_proxy):
     """
     if is_sso_enabled_on_site(hostname, http_proxy):
         raise ConsoleLoginNotSupportedError(hostname, "Single Sign-On")
-    if is_autodesk_identity_enabled_on_site(hostname, http_proxy):
-        raise ConsoleLoginNotSupportedError(hostname, "Autodesk Identity")
 
 
 class ConsoleAuthenticationHandlerBase(object):

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -103,10 +103,10 @@ class ConsoleAuthenticationHandlerBase(object):
                         ),
                         None,
                     )
-            except AuthenticationError:
+            except AuthenticationError as error:
                 # If any combination of credentials are invalid (user + invalid pass or
                 # user + valid pass + invalid 2da code) we'll end up here.
-                print("Login failed.")
+                print("Login failed: %s" % error)
                 print()
 
     def _get_user_credentials(self, hostname, login, http_proxy):

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -63,7 +63,7 @@ def _is_running_in_desktop():
     target site is using Autodesk Identity.
     """
     executable_name = os.path.splitext(os.path.basename(sys.executable))[0].lower()
-    return executable_name == "shotgun"
+    return executable_name in ["shotgun", "shotgrid"]
 
 
 class QuerySiteAndUpdateUITask(QtCore.QThread):

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -371,7 +371,7 @@ class LoginDialog(QtGui.QDialog):
         # We only update the GUI if there was a change between to mode we
         # are showing and what was detected on the potential target site.
         use_web = (
-            self._query_task.sso_enabled or self._query_task.autodesk_identity_enabled
+            self._query_task.sso_enabled
         )
 
         # If we have full support for Web-based login, or if we enable it in our

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -17,6 +17,8 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
+import os
+import sys
 from tank_vendor import shotgun_api3
 from tank_vendor import six
 from .web_login_support import get_shotgun_authenticator_support_web_login
@@ -50,6 +52,18 @@ USER_INPUT_DELAY_BEFORE_SSO_CHECK = 300
 
 # Let's put at 5 seconds the maximum time we might wait for a SSO check thread.
 THREAD_WAIT_TIMEOUT_MS = 5000
+
+
+def _is_context_desktop():
+    """
+    Indicate if we are in the context of the ShotGrid Desktop.
+
+    When the ShotGrid Desktop is used, we want to disregard the value returned
+    by the call to `get_shotgun_authenticator_support_web_login()` when the
+    target site is using Autodesk Identity.
+    """
+    executable_name = os.path.splitext(os.path.basename(sys.executable))[0].lower()
+    return executable_name == "shotgun"
 
 
 class QuerySiteAndUpdateUITask(QtCore.QThread):
@@ -371,6 +385,10 @@ class LoginDialog(QtGui.QDialog):
         # We only update the GUI if there was a change between to mode we
         # are showing and what was detected on the potential target site.
         use_web = self._query_task.sso_enabled
+
+        if _is_context_desktop():
+            logger.info("Using the Web Login with the ShotGrid Desktop")
+            use_web = use_web or self._query_task.autodesk_identity_enabled
 
         # If we have full support for Web-based login, or if we enable it in our
         # environment, use the Unified Login Flow for all authentication modes.

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -370,9 +370,7 @@ class LoginDialog(QtGui.QDialog):
         """
         # We only update the GUI if there was a change between to mode we
         # are showing and what was detected on the potential target site.
-        use_web = (
-            self._query_task.sso_enabled
-        )
+        use_web = self._query_task.sso_enabled
 
         # If we have full support for Web-based login, or if we enable it in our
         # environment, use the Unified Login Flow for all authentication modes.

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -54,7 +54,7 @@ USER_INPUT_DELAY_BEFORE_SSO_CHECK = 300
 THREAD_WAIT_TIMEOUT_MS = 5000
 
 
-def _is_context_desktop():
+def _is_running_in_desktop():
     """
     Indicate if we are in the context of the ShotGrid Desktop.
 
@@ -386,7 +386,7 @@ class LoginDialog(QtGui.QDialog):
         # are showing and what was detected on the potential target site.
         use_web = self._query_task.sso_enabled
 
-        if _is_context_desktop():
+        if _is_running_in_desktop():
             logger.info("Using the Web Login with the ShotGrid Desktop")
             use_web = use_web or self._query_task.autodesk_identity_enabled
 

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -562,8 +562,8 @@ def generate_session_token(hostname, login, password, http_proxy, auth_token=Non
         # .. and generate the session token. If it throws, we have invalid
         # credentials or invalid host/proxy settings.
         return sg.get_session_token()
-    except AuthenticationFault:
-        raise AuthenticationError("Authentication failed.")
+    except AuthenticationFault as error:
+        raise AuthenticationError("Authentication failed: %s" % error)
     except (ProtocolError, httplib2.ServerNotFoundError):
         raise AuthenticationError("Server %s was not found." % hostname)
     # In the following handlers, we are not rethrowing an AuthenticationError for

--- a/python/tank_vendor/shotgun_api3/shotgun.py
+++ b/python/tank_vendor/shotgun_api3/shotgun.py
@@ -176,6 +176,9 @@ class UserCredentialsNotAllowedForSSOAuthenticationFault(Fault):
 
 class UserCredentialsNotAllowedForOxygenAuthenticationFault(Fault):
     """
+    WARNING: This exception is no longer used, but has been left to avoid breaking
+             existing code.
+
     Exception when the server is configured to use Oxygen. It is not possible to use
     a username/password pair to authenticate on such server.
     """
@@ -2158,7 +2161,7 @@ class Shotgun(object):
         .. note::
             When sharing a filmstrip thumbnail, it is required to have a static thumbnail in
             place before the filmstrip will be displayed in the Shotgun web UI.
-            If the :ref:`thumbnail is still processing and is using a placeholder 
+            If the :ref:`thumbnail is still processing and is using a placeholder
             <interpreting_image_field_strings>`, this method will error.
 
         Simple use case:
@@ -2185,7 +2188,7 @@ class Shotgun(object):
             share the static thumbnail. Defaults to ``False``.
         :returns: ``id`` of the Attachment entity representing the source thumbnail that is shared.
         :rtype: int
-        :raises: :class:`ShotgunError` if not supported by server version or improperly called, 
+        :raises: :class:`ShotgunError` if not supported by server version or improperly called,
             or :class:`ShotgunThumbnailNotReady` if thumbnail is still pending.
         """
         if not self.server_caps.version or self.server_caps.version < (4, 0, 0):
@@ -2346,7 +2349,7 @@ class Shotgun(object):
         assign tags to the Attachment.
 
         .. note::
-          Make sure to have retries for file uploads. Failures when uploading will occasionally happen. 
+          Make sure to have retries for file uploads. Failures when uploading will occasionally happen.
           When it does, immediately retrying to upload usually works
 
         >>> mov_file = '/data/show/ne2/100_110/anim/01.mlk-02b.mov'
@@ -3617,8 +3620,6 @@ class Shotgun(object):
         ERR_2FA = 106
         # error code when SSO is activated on the site, preventing the use of username/password for authentication.
         ERR_SSO = 108
-        # error code when Oxygen is activated on the site, preventing the use of username/password for authentication.
-        ERR_OXYG = 110
 
         if isinstance(sg_response, dict) and sg_response.get("exception"):
             if sg_response.get("error_code") == ERR_AUTH:
@@ -3632,11 +3633,6 @@ class Shotgun(object):
                     sg_response.get("message",
                                     "Authentication using username/password is not "
                                     "allowed for an SSO-enabled ShotGrid site")
-                )
-            elif sg_response.get("error_code") == ERR_OXYG:
-                raise UserCredentialsNotAllowedForOxygenAuthenticationFault(
-                    sg_response.get("message", "Authentication using username/password is not "
-                                    "allowed for an Autodesk Identity enabled ShotGrid site")
                 )
             else:
                 # raise general Fault

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -372,24 +372,6 @@ class InteractiveTests(ShotgunTestBase):
         with self.assertRaises(ConsoleLoginNotSupportedError):
             handler._get_user_credentials(None, None, None)
 
-    @patch(
-        "tank.authentication.console_authentication.input",
-        side_effect=["  https://test-identity.shotgunstudio.com "],
-    )
-    @patch(
-        "tank.authentication.console_authentication.is_autodesk_identity_enabled_on_site",
-        return_value=True,
-    )
-    @suppress_generated_code_qt_warnings
-    def test_identity_enabled_site(self, *mocks):
-        """
-        Ensure that an exception is thrown should we attempt console authentication
-        on an Autodesk Identity-enabled site.
-        """
-        handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
-        with self.assertRaises(ConsoleLoginNotSupportedError):
-            handler._get_user_credentials(None, None, None)
-
     @suppress_generated_code_qt_warnings
     def test_ui_auth_with_whitespace(self):
         """


### PR DESCRIPTION
The tk-core code had unfortunately not been updated since the decision to add Personal Access Tokens has been made.

Previously, Autodesk Identity suffered the same constraint as logging in with a SSO-enabled site: you needed to use a  Browser-like environment to authenticate

But with the addition of PATs to Autodesk Identity, the old-style username / password (now known as Legacy Username / Passphrase) can also be used to authenticate. This allows existing code to handle Autodesk Identity authentication on sites that have migrated.

Screenshot showing the before/after for a console-based script:
![Screen Shot 2021-07-07 at 13 07 52](https://user-images.githubusercontent.com/8060460/124801366-c1501600-df24-11eb-9cbf-c99595ad731d.png)

As can be seen on the first attempt, just the fact that we detect that the site is using Identity is enough to stop the authentication process. The second attempt works, showing the list of projects on the site.

Screenshot showing the before/after for a GUI-based application:
![Screen Shot 2021-07-07 at 13 12 59](https://user-images.githubusercontent.com/8060460/124801656-13913700-df25-11eb-9c1b-7e255fcf5d95.png)

![Screen Shot 2021-07-07 at 13 09 32](https://user-images.githubusercontent.com/8060460/124801667-168c2780-df25-11eb-8a41-03300c7a28b4.png)

You can see on the first image that the user is forced to use the Web authentication.

In the second image, you see that the user is allowed to enter their legacy username and passphrase.

That second behaviour is the default one, unless:
a) you are accessing a Shotgrid-based SSO site (which can only use the Web)
b) you are accessing an Autodesk Identity site with the ShotGrid Desktop (we force the use of the Web login)
c) you call `sgtk.authentication.set_shotgun_authenticator_support_web_login(True)` prior to getting the user.

Took this opportunity to add details when authentication using the ShotGrid-based authentication is used. Notably to notify callers of a missing or incorrect Personal Access Token.

On the console:
![Screen Shot 2021-07-09 at 10 55 09](https://user-images.githubusercontent.com/8060460/125221560-5c831b80-e296-11eb-9cfe-3319562a9c5d.png)

And with the GUI:
![Screen Shot 2021-07-09 at 10 47 49](https://user-images.githubusercontent.com/8060460/125221580-67d64700-e296-11eb-8769-6d3ccda37d4d.png)
![Screen Shot 2021-07-09 at 10 48 01](https://user-images.githubusercontent.com/8060460/125221593-6c9afb00-e296-11eb-84ed-337ea2f69a7f.png)
![Screen Shot 2021-07-09 at 10 52 10](https://user-images.githubusercontent.com/8060460/125221603-70c71880-e296-11eb-90ef-465883788088.png)

NOTE: the error string is obtained directly from the ShotGrid server.