### PR TITLE
Allow path dict for publish

### DIFF
--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -52,11 +52,14 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     number. This is used to group together publishes in Shotgun and various
     integrations.
 
-    If the path matches any local storage roots defined by the toolkit project,
-    it will be uploaded as a local file link to Shotgun. If not matching roots
-    are found, the method will retrieve the list of local storages from Shotgun
-    and try to locate a suitable storage. Failing that, it will fall back on a
-    register the path as a ``file://`` url. For more information on
+    The path can either be a string or, for advanced use cases, a dictionary with
+    `local_storage` and `relative_path` values explicitly set.
+
+    If the path is a string and matches any local storage roots defined by the
+    toolkit project, it will be uploaded as a local file link to Shotgun. If not
+    matching roots are found, the method will retrieve the list of local storages
+    from Shotgun and try to locate a suitable storage. Failing that, it will fall
+    back on a register the path as a ``file://`` url. For more information on
     this resolution logic, see our
     `Admin Guide <https://support.shotgunsoftware.com/hc/en-us/articles/115000067493#Configuring%20published%20file%20path%20resolution>`_.
 
@@ -161,6 +164,8 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
     :param path: The path to the file or sequence we want to publish. If the
                  path is a sequence path it will be abstracted so that
                  any sequence keys are replaced with their default values.
+                 The path can be a string or a dictionary with `local_storage` and
+                 `relative_path` values.
     :param name: A name, without version number, which helps distinguish
                this publish from other publishes. This is typically
                used for grouping inside of Shotgun so that all the
@@ -377,6 +382,8 @@ def _create_published_file(
     :param path: The path to the file or sequence we want to publish. If the
                  path is a sequence path it will be abstracted so that
                  any sequence keys are replaced with their default values.
+                 The path can be a string or a dictionary with `local_storage` and
+                 `relative_path` values.
     :param name: A name, without version number, which helps distinguish
                this publish from other publishes. This is typically
                used for grouping inside of Shotgun so that all the

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -302,6 +302,101 @@ class TestShotgunRegisterPublish(TankTestBase):
             self.assertEqual(sg_dict["path"], path_dict)
             self.assertTrue("pathcache" not in sg_dict)
 
+    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    def test_explicit_local_storage_publish(self, create_mock):
+        """
+        Tests handling publishes where the path is 'local_storage' and 'relative_path'
+        dictionary.
+        """
+        values = [
+            {
+                "local_storage": self.storage_2,
+                "relative_path": "path/to/file.txt"
+            },
+            {
+                "local_storage": self.storage_3,
+                "relative_path": "path/to/file.txt"
+            },
+
+        ]
+        # We should get a SG version error
+        with self.assertRaisesRegex(
+            tank.util.ShotgunPublishError,
+            "Your SG server version does not support storage and relative_path parameters",
+        ):
+            publish_data = tank.util.register_publish(
+                self.tk, self.context, values[0], self.name, self.version, dry_run=True
+            )
+
+        # Mock SG server capabilities
+        class server_capsMock:
+            def __init__(self, version):
+                self.version = version
+
+        # TODO: should we unset this?
+        self.mockgun.server_caps = server_capsMock(version=(7, 0, 1))
+
+        # Check missing values
+        with self.assertRaisesRegex(
+            tank.util.ShotgunPublishError,
+            "Both 'local_storage' and 'relative_path' values must be set",
+        ):
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                {"local_storage": self.storage_2},
+                self.name,
+                self.version,
+                dry_run=True
+            )
+        with self.assertRaisesRegex(
+            tank.util.ShotgunPublishError,
+            "Both 'local_storage' and 'relative_path' values must be set",
+        ):
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                {"relative_path": "path/to/file.txt"},
+                self.name,
+                self.version,
+                dry_run=True
+            )
+        # Check invalid path
+        with self.assertRaisesRegex(
+            tank.util.ShotgunPublishError,
+            "is an absolute path, not a relative path to a local storage",
+        ):
+            publish_data = tank.util.register_publish(
+                self.tk,
+                self.context,
+                {
+                    "relative_path": os.path.join(
+                        os.path.join(self.project_root, "path/to/file.txt")
+                    ),
+                    "local_storage": self.storage_2,
+                },
+                self.name,
+                self.version,
+                dry_run=True
+            )
+
+        # Test valid values and results
+        for local_path in values:
+            publish_data = tank.util.register_publish(
+                self.tk, self.context, local_path, self.name, self.version, dry_run=True
+            )
+            self.assertIsInstance(publish_data, dict)
+
+            tank.util.register_publish(
+                self.tk, self.context, local_path, self.name, self.version
+            )
+
+            create_data = create_mock.call_args
+            args, kwargs = create_data
+            sg_dict = args[1]
+            self.assertEqual(sg_dict["path"], local_path)
+            self.assertEqual(sg_dict["path_cache"], local_path["relative_path"])
+
     def test_publish_errors(self):
         """Tests exceptions raised on publish errors."""
 


### PR DESCRIPTION
SG TK does its best to retrieve a `LocalStorage` from a path for publishes, however there are many use cases where multiple storages could have the same root path on a platform, but different root paths for other platforms.

A typical case is just having a drive letter on Windows, but different mount points for the other platforms, for example:

```
project1:
    windows_path: P:\
    mac_path: /Volume/project1

project2
    windows_path: P:\
    mac_path: /Volume/project2
```

These changes allow to explicitly pass a `{ "local_storage", "relative_path"}` as the `path` parameter to `register_publish` for cases where these values are known in advance.
Unit tests were added to cover the added feature.
