### PR TITLE
For SG-23615: provide override to use the old Qt authentication dialog

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -384,16 +384,24 @@ class LoginDialog(QtGui.QDialog):
         """
         # We only update the GUI if there was a change between to mode we
         # are showing and what was detected on the potential target site.
+        # With a SSO site, we have no choice but to use the web to login.
         use_web = self._query_task.sso_enabled
 
-        if _is_running_in_desktop():
-            logger.info("Using the Web Login with the ShotGrid Desktop")
-            use_web = use_web or self._query_task.autodesk_identity_enabled
+        # The user may decide to force the use of the old dialog:
+        # - due to graphical issues with Qt and its WebEngine
+        # - they need to use the legacy login / passphrase to use a PAT with
+        #   Autodesk Identity authentication
+        if os.environ.get("SGTK_FORCE_STANDARD_LOGIN_DIALOG"):
+            logger.info("Using the standard login dialog with the ShotGrid Desktop")
+        else:
+            if _is_running_in_desktop():
+                logger.info("Using the Web Login with the ShotGrid Desktop")
+                use_web = use_web or self._query_task.autodesk_identity_enabled
 
-        # If we have full support for Web-based login, or if we enable it in our
-        # environment, use the Unified Login Flow for all authentication modes.
-        if get_shotgun_authenticator_support_web_login():
-            use_web = use_web or self._query_task.unified_login_flow_enabled
+            # If we have full support for Web-based login, or if we enable it in our
+            # environment, use the Unified Login Flow for all authentication modes.
+            if get_shotgun_authenticator_support_web_login():
+                use_web = use_web or self._query_task.unified_login_flow_enabled
 
         # if we are switching from one mode (using the web) to another (not using
         # the web), or vice-versa, we need to update the GUI.


### PR DESCRIPTION
With SG-18096 we want to set the Web login mode as the default mode for all sites, no matter what their authentication mode is. Previously, only when login to a SSO or Autodesk Identity site would the Web login mode be used.

Some users will need to use the old Qt dialog, in order to:

circumvent graphical issues with Qt and the WebEngine
need to authenticate with the site using their Personal Access Token
desire a more controlled roll-out of the Web login mode for sites still using the default ShotGrid
By setting the environment variable `export SGTK_FORCE_STANDARD_LOGIN_DIALOG=1`, the toolkit will instead default to the old-style Qt dialog if connecting to a default or Autodesk Identity site.

Without environment variable:
![Screen Shot 2021-08-12 at 09 45 51](https://user-images.githubusercontent.com/8060460/129208863-21c7f75f-4b56-4045-afb4-6cdfdf125a3a.png)

With environment variable set:
![Screen Shot 2021-08-12 at 09 46 03](https://user-images.githubusercontent.com/8060460/129208913-f834b9dc-124a-4c29-b08f-1016a6f80871.png)
