### PR TITLE
Sg 23431 update core api tests to be compatible with identity

### DIFF
--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -14,8 +14,7 @@ There are also two optional environment variables:
 `SHOTGUN_TEST_TEMP`: When set, Toolkit will write all it's configuration files at this location and the data will not be erased after a test ends. This is useful for debugging.
 `SHOTGUN_TEST_COVERAGE`: When set, code coverage for tk-core will be generated and result into multiple `.coverage.<machine-name>.<uuid>` files containing coverage for each test run. Note that the test folder is not deleted so `coverage combine` can get line information properly.
 
-
-To run the tests you must first configure your Personal Access Token (PAT), if you have not yet configured your PAT you might not be able to run the tests. For more information on how to configure your Personal Access Token go to: https://knowledge.autodesk.com/support/shotgrid/learn-explore/caas/CloudHelp/cloudhelp/ENU/SG-Migration/files/mi-migration/SG-Migration-mi-migration-account-mi-end-user-account-html-html.html?us_oa=akn-us&us_si=e1612a29-78a6-4503-9349-2ec30fc72e28&us_st=Personal%20Access%20Tokens
+To run the tests you must first configure your Personal Access Token (PAT). If you have not yet configured your PAT you might not be able to run the tests. For more information on how to configure your Personal Access Token, please visit [this page](https://knowledge.autodesk.com/support/shotgrid/learn-explore/caas/CloudHelp/cloudhelp/ENU/SG-Migration/files/mi-migration/SG-Migration-mi-migration-account-mi-end-user-account-html-html.html?us_oa=akn-us&us_si=e1612a29-78a6-4503-9349-2ec30fc72e28&us_st=Personal%20Access%20Tokens).
 
 How to run an integration test
 ------------------------------


### PR DESCRIPTION
I modify the file README.md from the "Integration_tests" directory by adding the warning related to the "creation of the Personal Access Token (PAT)"  requesting to be reviewed.