### PR TITLE
SG_7624 Review client PR Shallow git clones using git descriptors

### DIFF
--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -89,7 +89,7 @@ class IODescriptorGit(IODescriptorDownloadable):
 
     @LogManager.log_timing
     def _clone_then_execute_git_commands(
-            self, target_path, commands, depth=None, ref=None
+        self, target_path, commands, depth=None, ref=None
     ):
         """
         Clones the git repository into the given location and

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -88,7 +88,9 @@ class IODescriptorGit(IODescriptorDownloadable):
             self._path = self._path[:-1]
 
     @LogManager.log_timing
-    def _clone_then_execute_git_commands(self, target_path, commands):
+    def _clone_then_execute_git_commands(
+            self, target_path, commands, depth=None, ref=None
+    ):
         """
         Clones the git repository into the given location and
         executes the given list of git commands::
@@ -115,6 +117,8 @@ class IODescriptorGit(IODescriptorDownloadable):
 
         :param target_path: path to clone into
         :param commands: list git commands to execute, e.g. ['checkout x']
+        :param depth: depth of the clone, allows shallow clone
+        :param ref: git ref to checkout - it can be commit, tag or branch
         :returns: stdout and stderr of the last command executed as a string
         :raises: TankGitError on git failure
         """
@@ -133,6 +137,7 @@ class IODescriptorGit(IODescriptorDownloadable):
                 "Cannot execute the 'git' command. Please make sure that git is "
                 "installed on your system and that the git executable has been added to the PATH."
             )
+
         log.debug("Git installed: %s" % output)
 
         # Note: git doesn't like paths in single quotes when running on
@@ -144,7 +149,14 @@ class IODescriptorGit(IODescriptorDownloadable):
         # complications in cleanup scenarios and with file copying. We want
         # each repo that we clone to be completely independent on a filesystem level.
         log.debug("Git Cloning %r into %s" % (self, target_path))
-        cmd = 'git clone --no-hardlinks -q "%s" "%s"' % (self._path, target_path)
+        depth = "--depth %s" % depth if depth else ""
+        ref = "-b %s" % ref if ref else ""
+        cmd = 'git clone --no-hardlinks -q "%s" %s "%s" %s' % (
+            self._path,
+            ref,
+            target_path,
+            depth,
+        )
 
         run_with_os_system = True
 
@@ -245,7 +257,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         # return the last returned stdout/stderr
         return output
 
-    def _tmp_clone_then_execute_git_commands(self, commands):
+    def _tmp_clone_then_execute_git_commands(self, commands, depth=None, ref=None):
         """
         Clone into a temp location and executes the given
         list of git commands.
@@ -260,7 +272,9 @@ class IODescriptorGit(IODescriptorDownloadable):
         )
         filesystem.ensure_folder_exists(clone_tmp)
         try:
-            return self._clone_then_execute_git_commands(clone_tmp, commands)
+            return self._clone_then_execute_git_commands(
+                clone_tmp, commands, depth, ref
+            )
         finally:
             log.debug("Cleaning up temp location '%s'" % clone_tmp)
             shutil.rmtree(clone_tmp, ignore_errors=True)
@@ -288,7 +302,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         try:
             log.debug("%r: Probing if a connection to git can be established..." % self)
             # clone repo into temp folder
-            self._tmp_clone_then_execute_git_commands([])
+            self._tmp_clone_then_execute_git_commands([], depth=1)
             log.debug("...connection established")
         except Exception as e:
             log.debug("...could not establish connection: %s" % e)

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -126,11 +126,10 @@ class IODescriptorGitBranch(IODescriptorGit):
         try:
             # clone the repo, switch to the given branch
             # then reset to the given commit
-            commands = [
-                'checkout -q "%s"' % self._branch,
-                'reset --hard -q "%s"' % self._version,
-            ]
-            self._clone_then_execute_git_commands(destination_path, commands)
+            commands = ['checkout -q "%s"' % self._version]
+            self._clone_then_execute_git_commands(
+                destination_path, commands, depth=1, ref=self._branch
+            )
         except Exception as e:
             raise TankDescriptorError(
                 "Could not download %s, branch %s, "

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -165,25 +165,29 @@ def _compare_versions(a, b):
         for version in version_a:
             if isinstance(version, (int)):
                 version_num_a.append(version)
-            elif version == '-':
+            elif version == "-":
                 break
         for version in version_b:
             if isinstance(version, (int)):
                 version_num_b.append(version)
-            elif version == '-':
+            elif version == "-":
                 break
 
         # Comparing equal number versions with with one of them with '-' appended, if a version
         # has '-' appended it's older than the same version with '-' at the end
         if version_num_a == version_num_b:
-            if '-' in a and '-' not in b:
+            if "-" in a and "-" not in b:
                 return False  # False, version a is older than b
-            elif '-' in b and '-' not in a:
+            elif "-" in b and "-" not in a:
                 return True  # True, version a is older than b
             else:
-                return LooseVersion(a) > LooseVersion(b)  # If both has '-' compare '-rcx' versions
+                return LooseVersion(a) > LooseVersion(
+                    b
+                )  # If both has '-' compare '-rcx' versions
         else:
-            return LooseVersion(a) > LooseVersion(b)  # If they are different numeric versions
+            return LooseVersion(a) > LooseVersion(
+                b
+            )  # If they are different numeric versions
     except TypeError:
         # To mimick the behavior in Python 2.7 as closely as possible, we will
         # If LooseVersion comparison didn't work, try to extract a numeric

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -157,7 +157,33 @@ def _compare_versions(a, b):
     # First, try to use LooseVersion for comparison.  This should work in
     # most cases.
     try:
-        return LooseVersion(a) > LooseVersion(b)
+        version_a = LooseVersion(a).version
+        version_b = LooseVersion(b).version
+        version_num_a = []
+        version_num_b = []
+        # taking only the integers of the version to make comparison
+        for version in version_a:
+            if isinstance(version, (int)):
+                version_num_a.append(version)
+            elif version == '-':
+                break
+        for version in version_b:
+            if isinstance(version, (int)):
+                version_num_b.append(version)
+            elif version == '-':
+                break
+
+        # Comparing equal number versions with with one of them with '-' appended, if a version
+        # has '-' appended it's older than the same version with '-' at the end
+        if version_num_a == version_num_b:
+            if '-' in a and '-' not in b:
+                return False  # False, version a is older than b
+            elif '-' in b and '-' not in a:
+                return True  # True, version a is older than b
+            else:
+                return LooseVersion(a) > LooseVersion(b)  # If both has '-' compare '-rcx' versions
+        else:
+            return LooseVersion(a) > LooseVersion(b)  # If they are different numeric versions
     except TypeError:
         # To mimick the behavior in Python 2.7 as closely as possible, we will
         # If LooseVersion comparison didn't work, try to extract a numeric

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -225,7 +225,7 @@ class TankCommands(SgtkIntegrationTest):
 
     def test_07_install_app(self):
         """
-        Runs tank install_app on the project..
+        Runs tank install_app on the project.
         """
         output = self.run_tank_cmd(
             self.pipeline_location,

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -225,7 +225,7 @@ class TankCommands(SgtkIntegrationTest):
 
     def test_07_install_app(self):
         """
-        Runs tank install_app on the project.
+        Runs tank install_app on the project..
         """
         output = self.run_tank_cmd(
             self.pipeline_location,


### PR DESCRIPTION
Reviewing the client PR about shallow git clones using git descriptors because it was not properly sorting the git tag versions with dashes appended.