### PR TITLE
Test core with ci-tools Python 3.9 branch.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/master
+      ref: refs/heads/SG-24238_Add_Python_3.9_Coverage_To_Azure_Pipelines-Tests
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# Imports the shared Azure CI tools
+# Imports the shared Azure CI tools.
 resources:
   repositories:
     - repository: templates


### PR DESCRIPTION
Testing ci-tools tests with Python 3.9.