### PR TITLE
Update dump_config.py

### DIFF
--- a/python/tank/commands/dump_config.py
+++ b/python/tank/commands/dump_config.py
@@ -250,7 +250,7 @@ class DumpConfigAction(Action):
                 )
         else:
             # get an in-memory file handle
-            fh = StringIO.StringIO()
+            fh = StringIO()
 
         return fh
 


### PR DESCRIPTION
Removing excess `StringIO` attribute which led to breaking the dump config --sparse