### PR TITLE
For SG-24624: allow tk-core to improve the Autodesk Idenity login UX

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -26,6 +26,14 @@ Low level bypass to set the configuration desciptor URI that the bootstrap API s
 ------------
 Controls debug logging.
 
+``TK_SHOTGRID_DEFAULT_LOGIN``
+-----------------------------
+Indicates the default Autodesk Identity account to use to pre-fill the login window dialog. This is purely for the convenience of the user and has no other use or side-effects.
+
+``TK_SHOTGRID_SSO_DOMAIN``
+--------------------------
+When the user's Autodesk Identity account is on an email domain that uses SSO for authentication, setting this will allow the bypass of the initial Autodesk Identity window. This saves the user from entering their email twice. Has no other use or side-effects.
+
 .. _environment_variables_bundle_cache:
 
 Bundle cache

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -17,10 +17,10 @@ Module to support Web login via a web browser and automated session renewal.
 # pylint: disable=too-many-statements
 
 import base64
-import logging
 import os
 import sys
 import time
+import urllib
 
 from .authentication_session_data import AuthenticationSessionData
 from .errors import (
@@ -49,6 +49,12 @@ except ImportError:
     # environment.
     UsernamePasswordDialog = None
 
+try:
+    # Python2
+    from urllib import urlencode
+except ImportError:
+    # Python3
+    from urllib.parse import urlencode
 
 # Error messages for events.
 HTTP_CANT_CONNECT_TO_SHOTGUN = "Cannot Connect To SG site."
@@ -117,13 +123,33 @@ FUNCTION_PROTOTYPE_BIND_POLYFILL = """
     }
 """
 
+# login paths, used by the Unified Login Flow.
+URL_ULF_RENEW_PATH = "/auth/renew"
+URL_ULF_LANDING_PATH = "/auth/landing"
+
+
+def get_renew_path(session):
+    """Construct the renew path, leveraging existing environment variables"""
+    renew_path = session.host + URL_ULF_RENEW_PATH + "?"
+    renew_params = {"product": session.product}
+    # When this variable is set, it is passed to Autodesk Identity's login.
+    tk_shotgun_default_login = os.getenv("TK_SHOTGRID_DEFAULT_LOGIN")
+    # When this variable is set for a SSO domain, skip the initial login page.
+    tk_shotgun_sso_domain = os.getenv("TK_SHOTGRID_SSO_DOMAIN")
+
+    # ShotGrid's renew endpoint supports some useful
+    # Autodesk Identity params.
+    if tk_shotgun_default_login:
+        renew_params["email"] = tk_shotgun_default_login
+    if tk_shotgun_sso_domain:
+        renew_params["sso_domain"] = tk_shotgun_sso_domain
+
+    renew_path += urlencode(renew_params)
+    return renew_path
+
 
 class SsoSaml2Core(object):
     """Performs SG Web login and pre-emptive renewal for SSO sessions."""
-
-    # login paths, used by the Unified Login Flow.
-    renew_path = "/auth/renew"
-    landing_path = "/auth/landing"
 
     def __init__(self, window_title="Web Login", qt_modules=None):
         """
@@ -787,9 +813,7 @@ class SsoSaml2Core(object):
 
         # We do not update the page cookies, assuming that they have already
         # have been cleared/updated before.
-        url = (
-            self._session.host + self.renew_path + "?product=%s" % self._session.product
-        )
+        url = get_renew_path(self._session)
         self._logger.debug("Navigating to %s", url)
         self._view.page().mainFrame().load(url)
 
@@ -841,7 +865,7 @@ class SsoSaml2Core(object):
             self._dialog.setWindowTitle(url)
         self._logger.debug("_on_url_changed %s", url)
         if self._session is not None and url.startswith(
-            self._session.host + self.landing_path
+            self._session.host + URL_ULF_LANDING_PATH
         ):
             self._sso_renew_watchdog_timer.stop()
             self.update_session_from_browser()
@@ -966,9 +990,7 @@ class SsoSaml2Core(object):
         self._view.raise_()
 
         # We append the product code to the GET request.
-        url = (
-            self._session.host + self.renew_path + "?product=%s" % self._session.product
-        )
+        url = get_renew_path(self._session)
         self._logger.debug("Navigating to %s", url)
         self._view.page().mainFrame().load(url)
 

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -49,12 +49,7 @@ except ImportError:
     # environment.
     UsernamePasswordDialog = None
 
-try:
-    # Python2
-    from urllib import urlencode
-except ImportError:
-    # Python3
-    from urllib.parse import urlencode
+from tank_vendor.six.moves.urllib.parse import urlencode
 
 # Error messages for events.
 HTTP_CANT_CONNECT_TO_SHOTGUN = "Cannot Connect To SG site."


### PR DESCRIPTION
With Autodesk Identity being now used for hosted ShotGrid sites, we have added new environment variables to help improve the authentication flow.

The environment variable `TK_SHOTGRID_DEFAULT_LOGIN` can be used to set the Autodesk Identity username, an email. It will be used to pre-fill the email field.

Example: `export TK_SHOTGRID_DEFAULT_LOGIN=user@example.com`
![Feb-28-2022 17-09-08](https://user-images.githubusercontent.com/8060460/156066731-19597672-9eb0-44ba-afa8-16a88daa939d.gif)

The environment variable `TK_SHOTGRID_SSO_DOMAIN` can be used to indicate the email domain associated to Autodesk Identity for the SSO login (requires a Premier Subscription). This allows the user to bypass the initial Autodesk Identity login page and go directly to their company SSO system. If the domain set is NOT associated to SSO, then the normal Autodesk Identity flow will be used.

Example: `export TK_SHOTGRID_SSO_DOMAIN=adsktest.com`
![Feb-28-2022 17-06-20](https://user-images.githubusercontent.com/8060460/156066400-068f420b-f6a0-428a-a5cd-d3c3533ac27a.gif)
