### PR TITLE
Fix Code Style Validation Job by Upgrading Black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       exclude: "scripts\/tank_cmd.bat|setup\/root_binaries\/tank.bat"
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/developer/bake_config.py
+++ b/developer/bake_config.py
@@ -120,7 +120,11 @@ def bake_config(sg_connection, config_uri, target_path, do_zip, skip_bundles_typ
     # configuration descriptor and version.
     target_path = os.path.join(
         target_path,
-        "%s-%s" % (config_descriptor.system_name, config_descriptor.version,),
+        "%s-%s"
+        % (
+            config_descriptor.system_name,
+            config_descriptor.version,
+        ),
     )
 
     # Check that target path doesn't exist
@@ -313,7 +317,11 @@ http://developer.shotgridsoftware.com/tk-core/descriptor
 
     # we are all set.
     bake_config(
-        sg_connection, config_descriptor, target_path, options.zip, skip_bundle_types,
+        sg_connection,
+        config_descriptor,
+        target_path,
+        options.zip,
+        skip_bundle_types,
     )
 
     # all good!

--- a/python/tank/commands/install.py
+++ b/python/tank/commands/install.py
@@ -539,8 +539,8 @@ class InstallEngineAction(Action):
             # run descriptor factory method
             log.info("Connecting to git...")
             location = {"type": "git", "path": engine_name}
-            engine_descriptor = self.tk.pipeline_configuration.get_latest_engine_descriptor(
-                location
+            engine_descriptor = (
+                self.tk.pipeline_configuration.get_latest_engine_descriptor(location)
             )
             log.info(
                 "Latest tag in repository '%s' is %s."
@@ -559,8 +559,8 @@ class InstallEngineAction(Action):
             # this is an app store app!
             log.info("Connecting to the Toolkit App Store...")
             location = {"type": "app_store", "name": engine_name}
-            engine_descriptor = self.tk.pipeline_configuration.get_latest_engine_descriptor(
-                location
+            engine_descriptor = (
+                self.tk.pipeline_configuration.get_latest_engine_descriptor(location)
             )
             log.info(
                 "Latest approved App Store Version is %s." % engine_descriptor.version

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -1728,7 +1728,7 @@ def context_yaml_representer(dumper, context):
     # pipeline config path as part of the dict
     context_dict["_pc_path"] = context.tank.pipeline_configuration.get_path()
 
-    return dumper.represent_mapping(u"!TankContext", context_dict)
+    return dumper.represent_mapping("!TankContext", context_dict)
 
 
 def context_yaml_constructor(loader, node):
@@ -1759,7 +1759,7 @@ def context_yaml_constructor(loader, node):
 
 
 yaml.add_representer(Context, context_yaml_representer)
-yaml.add_constructor(u"!TankContext", context_yaml_constructor)
+yaml.add_constructor("!TankContext", context_yaml_constructor)
 
 ################################################################################################
 # utility methods

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -601,7 +601,7 @@ class LogManager(object):
 
     @property
     def log_file(self):
-        """ Full path to the current log file or None if logging is not active. """
+        """Full path to the current log file or None if logging is not active."""
         return self._std_file_handler_log_file
 
     @property

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -69,8 +69,7 @@ class Environment(object):
         return "Environment %s" % os.path.basename(self._env_path)
 
     def _refresh(self):
-        """Refreshes the environment data from disk
-        """
+        """Refreshes the environment data from disk"""
         data = self.__load_environment_data()
 
         self._env_data = environment_includes.process_includes(
@@ -1013,20 +1012,20 @@ class WritableEnvironment(InstalledEnvironment):
         # it isn't correct to have one.
         #
         # It is the difference between the following:
-        #
-        # common.engines.tk-maya.location:
-        #   type: app_store
-        #   name: tk-maya
-        #   version: v0.8.1
-        #
-        # And:
-        #
-        # common.apps.tk-multi-shotgunpanel:
-        #   location:
-        #     type: app_store
-        #     name: tk-multi-shotgunpanel
-        #     version: v1.4.3
-        #
+        """
+        common.engines.tk-maya.location:
+          type: app_store
+          name: tk-maya
+          version: v0.8.1
+
+        And:
+
+        common.apps.tk-multi-shotgunpanel:
+          location:
+            type: app_store
+            name: tk-multi-shotgunpanel
+            version: v1.4.3
+        """
         # In the former, the new location information is replaced at
         # the top level of the data dictionary. For the latter, the
         # location key's contents is replaced.

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -521,7 +521,7 @@ class StringKey(TemplateKey):
             if match is None:
                 # no match. return empty string
                 # validate should prevent this from happening
-                resolved_value = u""
+                resolved_value = ""
 
             elif self._subset_format:
                 # we have an explicit format string we want to apply to the

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -429,7 +429,7 @@ class EntityExpression(object):
         match = regex_obj.match(value_to_convert)
         if match is None:
             # no match. return empty string
-            resolved_value = u""
+            resolved_value = ""
         else:
             # we have a match object. concatenate the groups
             resolved_value = "".join(match.groups())

--- a/tests/commands_tests/test_core_update.py
+++ b/tests/commands_tests/test_core_update.py
@@ -37,9 +37,13 @@ from tank_test.mock_appstore import patch_app_store
 )
 # We're mocking _install_core so that it does nothing. We are only
 # testing that it can update the core_api.yml.
-@patch("tank.commands.core_upgrade.TankCoreUpdater._install_core",)
+@patch(
+    "tank.commands.core_upgrade.TankCoreUpdater._install_core",
+)
 # Need to set the path to the cache config, this is done in the method.
-@patch("tank.pipelineconfig_utils.get_path_to_current_core",)
+@patch(
+    "tank.pipelineconfig_utils.get_path_to_current_core",
+)
 class TestCoreUpdate(TankTestBase):
     """
     Makes sure environment code works with the app store mocker.
@@ -86,7 +90,8 @@ class TestCoreUpdate(TankTestBase):
         self.assertEqual(descriptor.version, "v0.19.5")
 
     @patch(
-        "tank.descriptor.descriptor.Descriptor.is_immutable", return_value=True,
+        "tank.descriptor.descriptor.Descriptor.is_immutable",
+        return_value=True,
     )
     def test_immutable_config_core_update_core_api_yaml(
         self, _mock_is_immutable, mock_config_path, *_
@@ -108,7 +113,8 @@ class TestCoreUpdate(TankTestBase):
         self.assertEqual(descriptor.version, "v0.18.91")
 
     @patch(
-        "tank.descriptor.descriptor.Descriptor.is_dev", return_value=True,
+        "tank.descriptor.descriptor.Descriptor.is_dev",
+        return_value=True,
     )
     @patch("tank.descriptor.descriptor.Descriptor.get_path")
     def test_dev_config_core_update_core_api_yaml(

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -301,8 +301,8 @@ class TestPipelineConfigUtils(ShotgunTestBase):
             )
 
         # Test with a core location that is invalid.
-        config_with_invalid_core_location = self._create_unlocalized_pipeline_configuration(
-            "config_with_invalid_core"
+        config_with_invalid_core_location = (
+            self._create_unlocalized_pipeline_configuration("config_with_invalid_core")
         )
 
         self._create_core_file(
@@ -315,8 +315,8 @@ class TestPipelineConfigUtils(ShotgunTestBase):
             )
 
         # Test when the core file is missing.
-        config_with_no_core_file_location = self._create_unlocalized_pipeline_configuration(
-            "config_with_no_core_file"
+        config_with_no_core_file_location = (
+            self._create_unlocalized_pipeline_configuration("config_with_no_core_file")
         )
 
         with self.assertRaisesRegex(

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -319,8 +319,8 @@ class TestStringKey(ShotgunTestBase):
         )
         tests.append(
             {
-                "short": u"foo",
-                "full": u"foobar",
+                "short": "foo",
+                "full": "foobar",
                 "template": StringKey("field_name", subset="(.{3}).*"),
             }
         )
@@ -328,8 +328,8 @@ class TestStringKey(ShotgunTestBase):
         # unicode
         tests.append(
             {
-                "short": u"\u3042\u308a\u304c",
-                "full": u"\u3042\u308a\u304c\u3068",
+                "short": "\u3042\u308a\u304c",
+                "full": "\u3042\u308a\u304c\u3068",
                 "template": StringKey("field_name", subset="(.{3}).*"),
             }
         )
@@ -402,8 +402,8 @@ class TestStringKey(ShotgunTestBase):
         # unicode
         tests.append(
             {
-                "short": u"\u3042\u308a\u304c ",
-                "full": u"\u3042\u308a\u304c\u3068",
+                "short": "\u3042\u308a\u304c ",
+                "full": "\u3042\u308a\u304c\u3068",
                 "template": StringKey(
                     "field_name", subset="(.{3}).*", subset_format="{0} "
                 ),

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -12,7 +12,7 @@
 Tests for templatefield module.
 """
 
-from __future__ import with_statement, print_function
+from __future__ import with_statement, print_function, unicode_literals
 
 from tank import TankError
 import copy

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -487,14 +487,16 @@ class TestDescriptorSupport(TankTestBase):
             with patch(
                 "tank.descriptor.io_descriptor.appstore.log.debug"
             ) as log_debug_mock:
-                descriptor = sgtk.descriptor.io_descriptor.appstore.IODescriptorAppStore(
-                    {
-                        "name": "tk-config-basic",
-                        "version": "v1.0.0",
-                        "type": "app_store",
-                    },
-                    self.mockgun,
-                    sgtk.descriptor.Descriptor.CONFIG,
+                descriptor = (
+                    sgtk.descriptor.io_descriptor.appstore.IODescriptorAppStore(
+                        {
+                            "name": "tk-config-basic",
+                            "version": "v1.0.0",
+                            "type": "app_store",
+                        },
+                        self.mockgun,
+                        sgtk.descriptor.Descriptor.CONFIG,
+                    )
                 )
                 self.assertEqual(descriptor.has_remote_access(), False)
 
@@ -660,12 +662,20 @@ class TestDescriptorSupport(TankTestBase):
                 target_path, depth=1, ref="master"
             ),
             'git clone --no-hardlinks -q "%s" %s "%s" '
-            % (self.git_repo_uri, "-b master", target_path,),
+            % (
+                self.git_repo_uri,
+                "-b master",
+                target_path,
+            ),
         )
         self.assertEqual(
             desc._io_descriptor._validate_git_commands(target_path, ref="master"),
             'git clone --no-hardlinks -q "%s" %s "%s" '
-            % (self.git_repo_uri, "-b master", target_path,),
+            % (
+                self.git_repo_uri,
+                "-b master",
+                target_path,
+            ),
         )
 
 

--- a/tests/descriptor_tests/test_io_descriptors.py
+++ b/tests/descriptor_tests/test_io_descriptors.py
@@ -232,7 +232,9 @@ class TestIODescriptors(ShotgunTestBase):
             "path": self.git_repo_uri,
         }
         d = sgtk.descriptor.create_descriptor(
-            sg, sgtk.descriptor.Descriptor.APP, location,
+            sg,
+            sgtk.descriptor.Descriptor.APP,
+            location,
         )
 
         self.assertEqual(

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -611,8 +611,7 @@ class TestCreateFilesystemStructure(TankTestBase):
         self.assertTrue(os.path.exists(expected))
 
     def test_wrong_type_entity_ids(self):
-        """Test passing in type other than list, int or tuple as value for entity_ids parameter.
-        """
+        """Test passing in type other than list, int or tuple as value for entity_ids parameter."""
         for bad_entity_ids in ["abab", self.shot, object()]:
             self.assertRaises(
                 ValueError,

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -384,7 +384,7 @@ class TestUpdateEnvironment(TankTestBase):
         prev_settings = self.env.get_engine_settings("test_engine")
 
         self.env.update_engine_settings(
-            "test_engine", {"foo": u"bar"}, {"type": "dev", "path": "foo"}
+            "test_engine", {"foo": "bar"}, {"type": "dev", "path": "foo"}
         )
 
         # get raw environment after

--- a/tests/util_tests/test_login.py
+++ b/tests/util_tests/test_login.py
@@ -32,8 +32,13 @@ class LoginTests(TankTestBase):
         session.
         """
         find_one_mock.return_value = {"login": "tk-user"}
-        get_authenticated_user_mock.return_value = ShotgunAuthenticator().create_session_user(
-            host="host", login="tk-user", session_token="session_token", http_proxy=None
+        get_authenticated_user_mock.return_value = (
+            ShotgunAuthenticator().create_session_user(
+                host="host",
+                login="tk-user",
+                session_token="session_token",
+                http_proxy=None,
+            )
         )
         try:
             # Clear the cache so that get_current_user can work. Path cache is being updated by

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -58,13 +58,13 @@ class TestEventMetric(ShotgunTestBase):
         self.assertTrue("event_properties" in metric)
 
     def test_init_with_invalid_parameters(self):
-        """ Simply assert that the constructor is exception free and is
-            able to deal with invalid parameters and various type of extra
-            properties.
+        """Simply assert that the constructor is exception free and is
+        able to deal with invalid parameters and various type of extra
+        properties.
 
-            Also tests the '_add_system_info_properties' method which
-            gets called in constructor
-            """
+        Also tests the '_add_system_info_properties' method which
+        gets called in constructor
+        """
 
         try:
             EventMetric(None, "Testing No event group"),
@@ -80,11 +80,11 @@ class TestEventMetric(ShotgunTestBase):
             )
 
     def test_init_with_valid_parameters(self):
-        """ Simply assert that the constructor is exception free.
+        """Simply assert that the constructor is exception free.
 
-            Also tests the '_add_system_info_properties' method which
-            gets called in constructor
-            """
+        Also tests the '_add_system_info_properties' method which
+        gets called in constructor
+        """
         try:
 
             EventMetric("App", "Test Log Metric without additional properties")
@@ -106,7 +106,7 @@ class TestEventMetric(ShotgunTestBase):
             )
 
     def test_usage_of_extra_properties(self):
-        """ Simply assert usage of the properties parameter is exception free. """
+        """Simply assert usage of the properties parameter is exception free."""
         EventMetric("App", "Test add_event_properties", None)
 
         EventMetric(
@@ -898,15 +898,15 @@ class TestMetricsQueueSingleton(unittest2.TestCase):
 
 
 class TestMetricsDeprecatedFunctions(ShotgunTestBase):
-    """ Cases testing tank.util.metrics of deprecated functions
+    """Cases testing tank.util.metrics of deprecated functions
 
-        Test that the `log_metric`, `log_user_activity_metric` and
-        `log_user_attribute_metric` methods are deprecated by creating a
-        mock of the `MetricsQueueSingleton.log` method and then
-        verifiying whether or not it was called.
+    Test that the `log_metric`, `log_user_activity_metric` and
+    `log_user_attribute_metric` methods are deprecated by creating a
+    mock of the `MetricsQueueSingleton.log` method and then
+    verifiying whether or not it was called.
 
-        Also test that method still exist for retro-compatibility although
-        there're basically empty no-op methods.
+    Also test that method still exist for retro-compatibility although
+    there're basically empty no-op methods.
     """
 
     def setUp(self):

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -9,10 +9,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from __future__ import unicode_literals
 from unittest2 import TestCase
 import re
 from tank.util import sgre
-from __future__ import unicode_literals
 
 
 class TestSgre(TestCase):

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -14,6 +14,7 @@ import re
 from tank.util import sgre
 from __future__ import unicode_literals
 
+
 class TestSgre(TestCase):
     def test_wrap(self):
         r"""

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -20,7 +20,7 @@ class TestSgre(TestCase):
         Ensure that sgre injects the re.ASCII flag appropriately, and that
         unicode characters do not match `\w` in Python 2 or 3.
         """
-        char = u"漢字"
+        char = "漢字"
         expr = r"\w+"
 
         # test all wrapped methods
@@ -37,7 +37,7 @@ class TestSgre(TestCase):
         also passed positonally, and that unicode characters do not match `\w`
         in Python 2 or 3.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods
@@ -54,7 +54,7 @@ class TestSgre(TestCase):
         also passed as keyword arguments, and that unicode characters do not
         match `\w` in Python 2 or 3.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods
@@ -69,7 +69,7 @@ class TestSgre(TestCase):
         """
         Ensure that the unicode flag overrides the flag insertion behavior.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -12,7 +12,7 @@
 from unittest2 import TestCase
 import re
 from tank.util import sgre
-
+from __future__ import unicode_literals
 
 class TestSgre(TestCase):
     def test_wrap(self):

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -307,7 +307,13 @@ class TestShotgunFindPublish(TankTestBase):
         # Create a new project and pipeline configuration, and set the new project
         # as the current project of the new pipeline configuraiton
         other_proj, other_proj_root = self.create_project({"name": "other project"})
-        (_, _, _, _, other_tk,) = self.create_pipeline_configuration(other_proj)
+        (
+            _,
+            _,
+            _,
+            _,
+            other_tk,
+        ) = self.create_pipeline_configuration(other_proj)
         other_proj_name = os.path.basename(other_proj_root)
         other_pub = {
             "type": "PublishedFile",


### PR DESCRIPTION
Upgrade Black version to v22.3.0 to prevent the Pipeline Code Style Validation job from failing.