### PR TITLE
Fix encoding issue in serialization

### DIFF
--- a/python/tank/util/pickle.py
+++ b/python/tank/util/pickle.py
@@ -18,7 +18,7 @@ from tank_vendor import six
 
 log = LogManager.get_logger(__name__)
 
-
+CODEC = "latin1"
 # kwargs for pickle.load* and pickle.dump* calls.
 LOAD_KWARGS = {"encoding": "bytes"} if six.PY3 else {}
 # Protocol 0 ensures ASCII encoding, which is required when writing
@@ -43,7 +43,7 @@ def dumps(data):
     # Force pickle protocol 0, since this is a non-binary pickle protocol.
     # See https://docs.python.org/2/library/pickle.html#pickle.HIGHEST_PROTOCOL
     # Decode the result to a str before returning.
-    return six.ensure_str(cPickle.dumps(data, **DUMP_KWARGS))
+    return six.ensure_str(cPickle.dumps(data, **DUMP_KWARGS), encoding=CODEC)
 
 
 def dump(data, fh):
@@ -72,7 +72,7 @@ def loads(data):
     :returns: The unpickled object.
     :rtype: object
     """
-    return ensure_contains_str(cPickle.loads(six.ensure_binary(data), **LOAD_KWARGS))
+    return ensure_contains_str(cPickle.loads(six.ensure_binary(data, encoding=CODEC), **LOAD_KWARGS))
 
 
 def load(fh):
@@ -108,8 +108,7 @@ def store_env_var_pickled(key, data):
     # Force pickle protocol 0, since this is a non-binary pickle protocol.
     # See https://docs.python.org/2/library/pickle.html#pickle.HIGHEST_PROTOCOL
     pickled_data = dumps(data)
-    encoded_data = six.ensure_str(pickled_data)
-    os.environ[key] = encoded_data
+    os.environ[key] = pickled_data
 
 
 def retrieve_env_var_pickled(key):
@@ -127,5 +126,5 @@ def retrieve_env_var_pickled(key):
     :param key: The name of the environment variable to retrieve data from.
     :returns: The original object that was stored.
     """
-    envvar_contents = six.ensure_binary(os.environ[key])
+    envvar_contents = six.ensure_binary(os.environ[key], encoding=CODEC)
     return loads(envvar_contents)

--- a/python/tank/util/pickle.py
+++ b/python/tank/util/pickle.py
@@ -98,10 +98,6 @@ def store_env_var_pickled(key, data):
     .. note::
         This method is part of Toolkit's internal API.
 
-    In Python 3 pickle.dumps() returns a binary object that can't be decoded to
-    a string for storage in an environment variable.  To work around this, we
-    encode the pickled data to base64, compress the result, and store that.
-
     :param key: The name of the environment variable to store the data in.
     :param data: The object to pickle and store.
     """
@@ -118,10 +114,6 @@ def retrieve_env_var_pickled(key):
 
     .. note::
         This method is part of Toolkit's internal API.
-
-    In Python 3 pickle.dumps() returns a binary object that can't be decoded to
-    a string for storage in an environment variable.  To work around this, we
-    encode the pickled data to base64, compress the result, and store that.
 
     :param key: The name of the environment variable to retrieve data from.
     :returns: The original object that was stored.

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# -*- coding: utf-8 -*-
+# # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -30,6 +30,9 @@ from tank_vendor import six
 from tank.authentication import ShotgunAuthenticator
 
 
+# Run tests with a "difficult" (non-ascii) user name
+USER_NAME = u"Üser Ñâme"
+
 class TestContext(TankTestBase):
     def setUp(self):
         super(TestContext, self).setUp()
@@ -66,7 +69,7 @@ class TestContext(TankTestBase):
         # One human user not matching the current login
         self.other_user = {
             "type": "HumanUser",
-            "name": "user_name",
+            "name": USER_NAME,
             "id": 1,
             "login": "user_login",
         }
@@ -74,7 +77,7 @@ class TestContext(TankTestBase):
         self.current_login = tank.util.login.get_login_name()
         self.current_user = {
             "type": "HumanUser",
-            "name": "user_name",
+            "name": USER_NAME,
             "id": 2,
             "login": self.current_login,
         }
@@ -1194,7 +1197,7 @@ class TestSerialize(TestContext):
             "Version", {"code": "version_code", "project": self.project}
         )
 
-        self.user = self.mockgun.create("HumanUser", {"name": "user_name"})
+        self.user = self.mockgun.create("HumanUser", {"name": USER_NAME})
 
         self.kws = {}
         self.kws["tk"] = self.tk
@@ -1263,7 +1266,7 @@ class TestSerialize(TestContext):
             "additional_entities": [
                 {"type": "Sequence", "name": "seq_name", "id": self.seq["id"]}
             ],
-            "user": {"type": "HumanUser", "id": self.user["id"], "name": "user_name"},
+            "user": {"type": "HumanUser", "id": self.user["id"], "name": USER_NAME},
         }
 
         ctx = context.Context(**self.kws)

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
@@ -30,8 +31,12 @@ from tank_vendor import six
 from tank.authentication import ShotgunAuthenticator
 
 
-# Run tests with a "difficult" (non-ascii) user name
-USER_NAME = u"Üser Ñâme"
+# Run tests with a "difficult" (non-latin1) user name
+if six.PY3:
+    USER_NAME = "Üser Ñâme"
+if six.PY2:
+    # In python2, the user name field is utf-8 encoded
+    USER_NAME = u"Üser Ñâme".encode("utf-8")
 
 class TestContext(TankTestBase):
     def setUp(self):

--- a/tests/core_tests/test_hook.py
+++ b/tests/core_tests/test_hook.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_root.py
+++ b/tests/core_tests/test_root.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_template.py
+++ b/tests/core_tests/test_template.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY

--- a/tests/core_tests/test_templatestring.py
+++ b/tests/core_tests/test_templatestring.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY


### PR DESCRIPTION
Some special characters in the user name have been causing issues in several of our sgtk engines.
We identified the issue to be with `tank.util.pickle.dumps` function, that feeds the result
of a `cPickle.dumps` call (encoded with `"raw-unicode-escape"`)
to `six.ensure_str` (expecting an `"utf-8"` encoding by default)

Note that this issue appears only for characters out of the `"latin1"` character set.

About the cPickle implementation source code:
https://github.com/python/cpython/blob/v3.7.13/Lib/pickle.py#L756
