### PR TITLE
Use appropriate reload method for Py2 or Py3

### DIFF
--- a/setup/tank_api_proxy/sgtk/__init__.py
+++ b/setup/tank_api_proxy/sgtk/__init__.py
@@ -62,6 +62,15 @@ pipeline_config = os.path.join(current_folder, "..", "..", "..", "..")
 pipeline_config = os.path.abspath(pipeline_config)
 os.environ["TANK_CURRENT_PC"] = pipeline_config
 
+# From: https://stackoverflow.com/a/40119302
+try:
+    reload  # Python 2.7
+except NameError:
+    try:
+        from importlib import reload  # Python 3.4+
+    except ImportError:
+        from imp import reload  # Python 3.0 - 3.3
+
 # ok we got the parent location
 # prepend this to the python path and reload the module
 # this way we will load the 'real' tank!

--- a/setup/tank_api_proxy/tank/__init__.py
+++ b/setup/tank_api_proxy/tank/__init__.py
@@ -60,6 +60,15 @@ pipeline_config = os.path.join(current_folder, "..", "..", "..", "..")
 pipeline_config = os.path.abspath(pipeline_config)
 os.environ["TANK_CURRENT_PC"] = pipeline_config
 
+# From: https://stackoverflow.com/a/40119302
+try:
+    reload  # Python 2.7
+except NameError:
+    try:
+        from importlib import reload  # Python 3.4+
+    except ImportError:
+        from imp import reload  # Python 3.0 - 3.3
+
 # ok we got the parent location
 # prepend this to the python path and reload the module
 # this way we will load the 'real' tank!


### PR DESCRIPTION
We use a setup where the SGTK Pipeline Configuration is on disk, local to each Project.  We put `install/core/python` onto `$PYTHONPATH` to enable `import sgtk`.  In the process of transitioning to Python 3 we found these incompatible Python 2 `reload` calls.

The problem could be solved with `six.moves.reload_module` instead, but I don't know if you want to expect/force the user to have that library in their base environment since it is not part of the standard library.
