### PR TITLE
SG-25374 Weblogin does not show up in Nuke 11 and makes Nuke 12 and 13 to crash,

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -1021,7 +1021,7 @@ class SsoSaml2Core(object):
                 if self._is_executable_nuke:
                     """
                     https://jira.autodesk.com/browse/SG-25374
-                    Weblogin does not show up in Nuke 11 and makes Nuke 12 and 
+                    Weblogin does not show up in Nuke 11 and makes Nuke 12 and
                     13 to crash
                     """
                     self._display_nuke_messagebox()


### PR DESCRIPTION
When ShotGrid session expires and you have Nuke DCC open, this crashes doing the web login dialog open (exec_). 

This crash is silent, so there's not exception that we can trap. This PR adds a messagebox that warns user that ShotGrid integration won't work until you restart the DCC.

![image](https://user-images.githubusercontent.com/2762494/199141913-c269c23c-32f6-4d71-b6b3-e566ca22e2ae.png)
