### PR TITLE
SG-27676 Fixup QT UI showing b'text' information

### DIFF
--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -299,11 +299,9 @@ class TankQDialog(TankDialogBase):
                 if p is None:
                     formatted = "Undefined"
                 elif show_type:
-                    formatted = "%s %s" % (p.get("type"), p.get("name"))
+                    formatted = "%s %s" % (six.ensure_str(p.get("type")), six.ensure_str(p.get("name")))
                 else:
-                    formatted = "%s" % p.get("name")
-
-                formatted = six.ensure_str(formatted)
+                    formatted = "%s" % six.ensure_str(p.get("name"))
 
                 return formatted
 


### PR DESCRIPTION
Convert byte/str data to str before any string formating to avoid the formated string to contain a byte converted data.


Introduced by 355728527816.