### PR TITLE
SG-28499 - Fix sso_saml2 login error when login contain a space

### DIFF
--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -566,7 +566,7 @@ class SsoSaml2Core(object):
 
     def update_session_from_browser(self):
         """
-        Updtate our session from the browser cookies.
+        Update our session from the browser cookies.
         """
         self._logger.debug("Updating session cookies from browser")
 

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -24,10 +24,10 @@ import urllib
 # fail.
 try:
     import urlparse
-    from urllib import unquote
+    from urllib import unquote_plus
 except ImportError:
     import urllib.parse as urlparse
-    from urllib.parse import unquote
+    from urllib.parse import unquote_plus
 try:
     from http.cookies import SimpleCookie
 except ImportError:
@@ -252,7 +252,7 @@ def get_user_name(encoded_cookies):
         encoded_cookies, "shotgun_current_user_login"
     ) or _get_cookie_from_prefix(encoded_cookies, "shotgun_sso_session_userid_u")
     if user_name is not None:
-        user_name = unquote(user_name)
+        user_name = unquote_plus(user_name)
     return user_name
 
 

--- a/tests/authentication_tests/test_saml_sso_core_utils.py
+++ b/tests/authentication_tests/test_saml_sso_core_utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from __future__ import with_statement
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
+
+from tank.authentication.sso_saml2.core.utils import get_user_name, _encode_cookies
+
+
+class SamlSsoCoreUtilsTests(ShotgunTestBase):
+
+    def test_username_valid(self):
+        login_cookies = {
+            'user+name': 'shotgun_current_user_login=user%2Bname; domain=shotgrid.autodesk.com; path=/',
+            'user name': 'shotgun_current_user_login=user+name; domain=shotgrid.autodesk.com; path=/'
+        }
+        for login in login_cookies:
+            self.assertEqual(login, get_user_name(_encode_cookies(login_cookies[login])))


### PR DESCRIPTION
I validate that unquote_plus exist both in python 2 and 3...
https://docs.python.org/2/library/urllib.html#urllib.unquote_plus
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.unquote_plus

I also fix a small typo...