### PR TITLE
SG-29193 [Cleaning] Update or remove the usage of six.ensure_str in the _format_context_property function

### DIFF
--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -299,11 +299,10 @@ class TankQDialog(TankDialogBase):
                 if p is None:
                     formatted = "Undefined"
                 elif show_type:
-                    formatted = "%s %s" % (p.get("type"), p.get("name"))
+                    formatted = "%s %s" % (six.ensure_str(p.get("type")),
+                                           six.ensure_str(p.get("name")))
                 else:
-                    formatted = "%s" % p.get("name")
-
-                formatted = six.ensure_str(formatted)
+                    formatted = "%s" % six.ensure_str(p.get("name"))
 
                 return formatted
 


### PR DESCRIPTION
Ensure string conversion before format the values