### PR TITLE
Fix Memory Growth Issue

### DIFF
--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -242,9 +242,9 @@ def copy_folder(src, dst, folder_permissions=0o775, skip_list=None):
     # because we want users to be able to pass in
     # skip_list=[] in order to clear the default skip list.
     if skip_list is None:
-        actual_skip_list = SKIP_LIST_DEFAULT
+        actual_skip_list = SKIP_LIST_DEFAULT.copy()
     else:
-        actual_skip_list = skip_list
+        actual_skip_list = skip_list.copy()
 
     # add the items we always want to skip
     actual_skip_list.extend(SKIP_LIST_ALWAYS)


### PR DESCRIPTION
The copy_folder function calls extend() on a list to add some additional file names to skip. However this modifies the list that SKIP_LIST_DEFAULT is referencing. As a result, SKIP_LIST_DEFAULT's list grows for every call of the function. Ensure that the list gets copied before calling extend().