### PR TITLE
SG-30639 fix: utf-8 in pickle dumps

### DIFF
--- a/python/tank/util/pickle.py
+++ b/python/tank/util/pickle.py
@@ -55,7 +55,7 @@ def dumps(data):
     except UnicodeError as e:
         # Fix unicode issue when ensuring string values
         # https://jira.autodesk.com/browse/SG-6588
-        if e.encoding == "utf-8" and e.reason == "invalid continuation byte":
+        if e.encoding == "utf-8" and e.reason in ("invalid continuation byte", "invalid start byte"):
             encoding = FALLBACK_ENCODING
             if isinstance(data, dict):
                 data[FALLBACK_ENCODING_KEY] = encoding

--- a/tests/util_tests/test_unicode.py
+++ b/tests/util_tests/test_unicode.py
@@ -96,6 +96,7 @@ class TestUnicode(TestCase):
             '이사이트에서는개발자가',
             'およびその他の教育リソース'
             '工作流技术总监或将要设置工作流并希望开发',
+            'Martin Tlustý',
         ]
 
         for login in logins:


### PR DESCRIPTION
```
File "/xxx/cfg/install/core/python/tank/util/pickle.py", line 54, in dumps
    return six.ensure_str(serialized)
  File "/xxx/cfg/install/core/python/tank_vendor/six.py", line 900, in ensure_str
    s = s.decode(encoding, errors)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 159: invalid start byte
```
There can be also 'invalid start byte" error in pickle.dumps!

Consider also removing the reason check
```
if e.encoding == "utf-8":
```