### PR TITLE
SG-30649 Specify 'utf8' encoding when read YAML data from disk.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -58,4 +58,4 @@ exclude =
 # N806 Variables should be lower case. (clashes with Qt naming conventions)
 # E999 SyntaxError: invalid syntax (hack for hound CI which runs python 3.x)
 
-ignore = E203, E221, E261, E402, E501, W503, N802, N806, E999
+ignore = E203, E221, E261, E402, E501, W503, N802, N806, E999, BLK100

--- a/.flake8
+++ b/.flake8
@@ -58,4 +58,4 @@ exclude =
 # N806 Variables should be lower case. (clashes with Qt naming conventions)
 # E999 SyntaxError: invalid syntax (hack for hound CI which runs python 3.x)
 
-ignore = E203, E221, E261, E402, E501, W503, N802, N806, E999, BLK100
+ignore = E203, E221, E261, E402, E501, W503, N802, N806, E999

--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -256,7 +256,7 @@ class YamlCache(object):
         """
         path = item.path
         try:
-            with open(path, "r") as fh:
+            with open(path, "r", encoding='utf8') as fh:
                 raw_data = yaml.load(fh, Loader=yaml.FullLoader)
         except IOError:
             raise TankFileDoesNotExistError("File does not exist: %s" % path)

--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -256,7 +256,7 @@ class YamlCache(object):
         """
         path = item.path
         try:
-            with open(path, "r", encoding='utf8') as fh:
+            with open(path, "r", encoding="utf8") as fh:
                 raw_data = yaml.load(fh, Loader=yaml.FullLoader)
         except IOError:
             raise TankFileDoesNotExistError("File does not exist: %s" % path)


### PR DESCRIPTION
This pr fixes the 'UnicodeDecodeError' when using using non utf-8 special encoding standards.