### PR TITLE
SG-30914 Implement the App Session Launcher authentication UX in the console handler

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -361,4 +361,4 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
 
         login = self._get_keyboard_input("Login", login)
         password = self._get_password()
-        return sanitize_url(hostname), login, password
+        return hostname, login, password

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -140,25 +140,27 @@ class ConsoleAuthenticationHandlerBase(object):
     def _authenticate_unified_login_flow2(self, hostname, login, http_proxy):
         print()
         print(
-            "The authentication to {sg_url} requires to use your web browser.\n"
+            "Authenticating to {sg_url} requires your web browser.\n"
             "\n"
-            'After pressing "continue", your web browser will open shortly '
-            "targeting your selected ShotGrid site.\n"
+            'After selecting "continue", your default web browser will open '
+            "and prompt you to authenticate to {sg_url} if you are not already "
+            "authenticated to this site in the browser.\n"
             "\n"
-            "If you are not already authenticated to {sg_url} in the browser,"
-            "you will first need to authenticate.\n"
+            "Then, you will be prompted to approve the authentication request "
+            "and return to this application.\n"
             "\n"
-            "Then, you will be prompted to review the access request.\n"
             'Select "Approve" and come back to this application.'
             "\n".format(sg_url=hostname)
         )
 
-        self._read_clean_input("Press enter when you are ready to continue")
+        self._read_clean_input("Press enter when you are ready to continue.")
         print("\n")  # Always have 2 empty lines after a prompt
         print(
-            "Your browser will open shortly.\n"
-            "Once you approved the access request, come back to this "
-            "application"
+            "Stand by... your default browser will open shortly for you to "
+            "approve the authentication request.\n"
+            "\n"
+            "After approving the authentication request, return to this "
+            "application."
         )
         print()
         session_info = ulf2_authentication.process(
@@ -172,7 +174,10 @@ class ConsoleAuthenticationHandlerBase(object):
         if not session_info:
             raise AuthenticationError("The web authentication failed.")
 
-        print("The web authentication succeed, now processing.")
+        print(
+            "Success! The web authentication has been approved and your "
+            "application is ready to use."
+        )
         return session_info
 
     def _get_auth_method(self, hostname, http_proxy):
@@ -356,12 +361,15 @@ class ConsoleLoginHandler(ConsoleAuthenticationHandlerBase):
             recent_hosts.insert(0, hostname)
 
         if len(recent_hosts) > 1:
-            print("List of you recent ShotGrid sites:")
+            print("Recent ShotGrid sites:")
             for sg_url in recent_hosts:
                 print("  *", sg_url)
             print()
 
-        return self._get_keyboard_input("Enter a SG site URL", hostname)
+        return self._get_keyboard_input(
+            "Enter the ShotGrid site URL for authentication",
+            hostname,
+        )
 
     def _get_user_credentials(self, hostname, login, http_proxy):
         """

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -164,7 +164,7 @@ class ConsoleAuthenticationHandlerBase(object):
             hostname,
             http_proxy=http_proxy,
             product="toolkit",  # Same as "PRODUCT_IDENTIFIER" from LoginDialog
-            browser_open_callback=lambda u: webbrowser.open(u),
+            browser_open_callback=webbrowser.open,
         )
 
         print()

--- a/python/tank/authentication/constants.py
+++ b/python/tank/authentication/constants.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Shotgun Software Inc.
+# Copyright (c) 2023 Autodesk.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -7,8 +7,6 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
-
-# Authentication method constants
 
 METHOD_BASIC = 0x01
 METHOD_WEB_LOGIN = 0x02

--- a/python/tank/authentication/constants.py
+++ b/python/tank/authentication/constants.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# Authentication method constants
+
+METHOD_BASIC = 0x01
+METHOD_WEB_LOGIN = 0x02
+METHOD_ULF2 = 0x03
+
+method_resolve = {
+    METHOD_BASIC: "credentials",
+    METHOD_WEB_LOGIN: "web_legacy",
+    METHOD_ULF2: "unified_login_flow2",
+}
+
+
+def method_resolve_reverse(m):
+    global method_resolve
+
+    for (k, v) in method_resolve.items():
+        if v == m:
+            return k

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -25,6 +25,7 @@ from .. import constants
 from .web_login_support import get_shotgun_authenticator_support_web_login
 from .ui import resources_rc  # noqa
 from .ui import login_dialog
+from . import constants as auth_constants
 from . import session_cache
 from ..util.shotgun import connection
 from ..util import login
@@ -478,7 +479,7 @@ class LoginDialog(QtGui.QDialog):
                 self.ui.message, "Can't open '%s'." % forgot_password
             )
 
-    def _toggle_web(self, menu_action=None):
+    def _toggle_web(self, method_selected=None):
         """
         Sets up the dialog GUI according to the use of web login or not.
         """
@@ -506,18 +507,18 @@ class LoginDialog(QtGui.QDialog):
         if self._query_task.unified_login_flow2_enabled:
             site = self._query_task.url_to_test
 
-            if menu_action:
+            if method_selected:
                 # Selecting requested mode (credentials, web_legacy or unified_login_flow2)
-                if menu_action == "unified_login_flow2":
+                if method_selected == auth_constants.METHOD_ULF2:
                     use_local_browser = True
 
-                session_cache.set_preferred_method(site, menu_action)
+                session_cache.set_preferred_method(site, method_selected)
             elif os.environ.get("SGTK_FORCE_STANDARD_LOGIN_DIALOG"):
                 # Selecting legacy auth by default
                 pass
             else:
                 method = session_cache.get_preferred_method(site)
-                if not method or method == "unified_login_flow2":
+                if not method or method == auth_constants.METHOD_ULF2:
                     # Select Unified Login Flow 2
                     use_local_browser = True
 
@@ -590,13 +591,13 @@ class LoginDialog(QtGui.QDialog):
         self.menu_action_legacy.setEnabled(self._use_local_browser)
 
     def _menu_activated_action_ulf2(self):
-        self._toggle_web(menu_action="unified_login_flow2")
+        self._toggle_web(method_selected=auth_constants.METHOD_ULF2)
 
     def _menu_activated_action_web_legacy(self):
-        self._toggle_web(menu_action="web_legacy")
+        self._toggle_web(method_selected=auth_constants.METHOD_WEB_LOGIN)
 
     def _menu_activated_action_login_creds(self):
-        self._toggle_web(menu_action="credentials")
+        self._toggle_web(method_selected=auth_constants.METHOD_BASIC)
 
     def _current_page_changed(self, index):
         """

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -30,6 +30,7 @@ from tank_vendor.shotgun_api3 import (
 )
 from tank_vendor.shotgun_api3.lib import httplib2
 from tank_vendor import yaml
+from . import constants
 from .errors import AuthenticationError
 from .. import LogManager
 from ..util.shotgun import connection
@@ -544,8 +545,11 @@ def get_preferred_method(host):
     # Retrieve the cached info file location from the host
     info_path = _get_site_authentication_file_location(host)
     document = _try_load_site_authentication_file(info_path)
-    method = document[_PREFERRED_METHOD]
-    return method.strip() if method else method
+    method_name = document[_PREFERRED_METHOD]
+    if not method_name:
+        return
+
+    return constants.method_resolve_reverse(method_name.strip())
 
 
 def set_preferred_method(host, method):
@@ -556,16 +560,19 @@ def set_preferred_method(host, method):
     :param method: The prefered authentication method for specified host.
     """
     host = host.strip()
-    method = method.strip()
+
+    method_name = constants.method_resolve.get(method)
+    if not method_name:
+        return
 
     file_path = _get_site_authentication_file_location(host)
     _ensure_folder_for_file(file_path)
 
     current_user_file = _try_load_site_authentication_file(file_path)
-    if current_user_file[_PREFERRED_METHOD] == method:
+    if current_user_file[_PREFERRED_METHOD] == method_name:
         return
 
-    current_user_file[_PREFERRED_METHOD] = method
+    current_user_file[_PREFERRED_METHOD] = method_name
     _write_yaml_file(file_path, current_user_file)
 
 

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -341,8 +341,12 @@ class InteractiveTests(ShotgunTestBase):
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
         self.assertEqual(
+            handler._get_sg_url(None, None),
+            "https://test.shotgunstudio.com",
+        )
+        self.assertEqual(
             handler._get_user_credentials(None, None, None),
-            ("https://test.shotgunstudio.com", "username", " password "),
+            (None, "username", " password "),
         )
         self.assertEqual(handler._get_2fa_code(), "2fa code")
 
@@ -354,6 +358,10 @@ class InteractiveTests(ShotgunTestBase):
         "tank.authentication.console_authentication.is_sso_enabled_on_site",
         return_value=True,
     )
+    @patch(
+        "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
+        return_value=False,
+    )
     @suppress_generated_code_qt_warnings
     def test_sso_enabled_site_with_legacy_exception_name(self, *mocks):
         """
@@ -363,7 +371,7 @@ class InteractiveTests(ShotgunTestBase):
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
         with self.assertRaises(ConsoleLoginWithSSONotSupportedError):
-            handler._get_user_credentials(None, None, None)
+            handler.authenticate(None, None, None)
 
     @patch(
         "tank.authentication.console_authentication.input",
@@ -373,6 +381,10 @@ class InteractiveTests(ShotgunTestBase):
         "tank.authentication.console_authentication.is_sso_enabled_on_site",
         return_value=True,
     )
+    @patch(
+        "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
+        return_value=False,
+    )
     @suppress_generated_code_qt_warnings
     def test_sso_enabled_site(self, *mocks):
         """
@@ -381,7 +393,7 @@ class InteractiveTests(ShotgunTestBase):
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
         with self.assertRaises(ConsoleLoginNotSupportedError):
-            handler._get_user_credentials(None, None, None)
+            handler.authenticate(None, None, None)
 
     @suppress_generated_code_qt_warnings
     def test_ui_auth_with_whitespace(self):

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -554,6 +554,10 @@ class InteractiveTests(ShotgunTestBase):
             None,
         ),
     )
+    @patch(
+        "tank.authentication.session_cache.get_preferred_method",
+        return_value=None,
+    )
     def test_login_dialog_unified_login_flow2(self, *unused_mocks):
         with self._login_dialog(
             True,
@@ -730,6 +734,10 @@ class InteractiveTests(ShotgunTestBase):
         return_value={
             "unified_login_flow_enabled2": True,
         },
+    )
+    @patch(
+        "tank.authentication.session_cache.get_preferred_method",
+        return_value=None,
     )
     def test_console_get_auth_method(self, *unused_mocks):
         handler = console_authentication.ConsoleLoginHandler(fixed_host=True)


### PR DESCRIPTION

Code refactoring to make the `ConsoleAuthenticationHandler` class support more than one "method/UX".
Before that, the class only supported legacy login/password authentication. The "embedded web browser" (unified login flow) method was not supported and remains so. This is not possible because the console handler does not have QT available so can not raise the QT-based web browser.

Insert a command line dialog to have the user select its authentication UX between login/password and ULF2 when both options are available. When this is the case, the user's choice is saved in the session cache using the same setting as the QT login dialog.

When the user selects the ULF2 method, instructions are displayed in the terminal first. Then, after the user press [enter], the web browser is launched the ULF2 process runs as usual.



