### PR TITLE
SG-30915 Detect the application name sent to ShotGrid

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -164,7 +164,6 @@ class ConsoleAuthenticationHandlerBase(object):
         session_info = unified_login_flow2.process(
             hostname,
             http_proxy=http_proxy,
-            product="toolkit",  # Same as "PRODUCT_IDENTIFIER" from LoginDialog
             browser_open_callback=webbrowser.open,
         )
 

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -164,7 +164,6 @@ class ConsoleAuthenticationHandlerBase(object):
         session_info = unified_login_flow2.process(
             hostname,
             http_proxy=http_proxy,
-            product=unified_login_flow2.get_product_name(),
             browser_open_callback=webbrowser.open,
         )
 

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -164,6 +164,7 @@ class ConsoleAuthenticationHandlerBase(object):
         session_info = unified_login_flow2.process(
             hostname,
             http_proxy=http_proxy,
+            product=unified_login_flow2.get_product_name(),
             browser_open_callback=webbrowser.open,
         )
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -857,6 +857,7 @@ class LoginDialog(QtGui.QDialog):
             self,
             site,
             http_proxy=self._http_proxy,
+            product=unified_login_flow2.get_product_name(),
         )
         self._ulf2_task.finished.connect(self._ulf2_task_finished)
         self._ulf2_task.start()
@@ -905,12 +906,13 @@ class LoginDialog(QtGui.QDialog):
 class ULF2_AuthTask(QtCore.QThread):
     progressing = QtCore.Signal(str)
 
-    def __init__(self, parent, sg_url, http_proxy=None):
+    def __init__(self, parent, sg_url, http_proxy=None, product=None):
         super(ULF2_AuthTask, self).__init__(parent)
         self.should_stop = False
 
         self._sg_url = sg_url
         self._http_proxy = http_proxy
+        self._product = product
 
         # Result object
         self.session_info = None
@@ -921,6 +923,7 @@ class ULF2_AuthTask(QtCore.QThread):
             self.session_info = unified_login_flow2.process(
                 self._sg_url,
                 http_proxy=self._http_proxy,
+                product=self._product,
                 browser_open_callback=lambda u: QtGui.QDesktopServices.openUrl(u),
                 keep_waiting_callback=self.should_continue,
             )

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -857,7 +857,6 @@ class LoginDialog(QtGui.QDialog):
             self,
             site,
             http_proxy=self._http_proxy,
-            product=PRODUCT_IDENTIFIER,
         )
         self._ulf2_task.finished.connect(self._ulf2_task_finished)
         self._ulf2_task.start()
@@ -906,13 +905,12 @@ class LoginDialog(QtGui.QDialog):
 class ULF2_AuthTask(QtCore.QThread):
     progressing = QtCore.Signal(str)
 
-    def __init__(self, parent, sg_url, http_proxy=None, product=None):
+    def __init__(self, parent, sg_url, http_proxy=None):
         super(ULF2_AuthTask, self).__init__(parent)
         self.should_stop = False
 
         self._sg_url = sg_url
         self._http_proxy = http_proxy
-        self._product = product
 
         # Result object
         self.session_info = None
@@ -923,7 +921,6 @@ class ULF2_AuthTask(QtCore.QThread):
             self.session_info = unified_login_flow2.process(
                 self._sg_url,
                 http_proxy=self._http_proxy,
-                product=self._product,
                 browser_open_callback=lambda u: QtGui.QDesktopServices.openUrl(u),
                 keep_waiting_callback=self.should_continue,
             )

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -857,7 +857,6 @@ class LoginDialog(QtGui.QDialog):
             self,
             site,
             http_proxy=self._http_proxy,
-            product=unified_login_flow2.get_product_name(),
         )
         self._ulf2_task.finished.connect(self._ulf2_task_finished)
         self._ulf2_task.start()
@@ -906,13 +905,20 @@ class LoginDialog(QtGui.QDialog):
 class ULF2_AuthTask(QtCore.QThread):
     progressing = QtCore.Signal(str)
 
-    def __init__(self, parent, sg_url, http_proxy=None, product=None):
+    def __init__(self, parent, sg_url, http_proxy=None):
         super(ULF2_AuthTask, self).__init__(parent)
         self.should_stop = False
 
         self._sg_url = sg_url
         self._http_proxy = http_proxy
-        self._product = product
+
+        self._product = unified_login_flow2.get_product_name()
+        # This is processed here, in the main thread, to prevent threading
+        # issues.
+        # One know problem is with Photoshop, the engine.host_info attribute is
+        # retrieved from PS in a WebSocket communication.
+        # The code is thread safe for Python threading but not designed to be
+        # used with QThreads. See SG-31490 for more information.
 
         # Result object
         self.session_info = None

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -41,21 +41,17 @@ class AuthenticationError(errors.AuthenticationError):
 
 def process(
     sg_url,
+    *,
     http_proxy=None,
     product=None,
-    browser_open_callback=None,
+    browser_open_callback,
     keep_waiting_callback=lambda: True,
 ):
-    """
-    :param product: **mandatory** - string
-      In most cases, the parameter should be the result of the get_product_name
-      function.
-      This is not provided as a default behavior to make developers aware of
-      threading issues. One example is with Photoshop, the engine.host_info attribute is retrieved from PS in a WebSocket communication. The code is thread safe for Python threading but not designed to be used with QThreads. See SG-31490 for more information.
-    """
-
     sg_url = connection.sanitize_url(sg_url)
     logger.debug("Trigger Authentication on {url}".format(url=sg_url))
+
+    if product is None:
+        product = get_product_name()
 
     assert product
     assert callable(browser_open_callback)

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -42,12 +42,22 @@ class AuthenticationError(errors.AuthenticationError):
 def process(
     sg_url,
     http_proxy=None,
+    product=None,
     browser_open_callback=None,
     keep_waiting_callback=lambda: True,
 ):
+    """
+    :param product: **mandatory** - string
+      In most cases, the parameter should be the result of the get_product_name
+      function.
+      This is not provided as a default behavior to make developers aware of
+      threading issues. One example is with Photoshop, the engine.host_info attribute is retrieved from PS in a WebSocket communication. The code is thread safe for Python threading but not designed to be used with QThreads. See SG-31490 for more information.
+    """
+
     sg_url = connection.sanitize_url(sg_url)
     logger.debug("Trigger Authentication on {url}".format(url=sg_url))
 
+    assert product
     assert callable(browser_open_callback)
     assert callable(keep_waiting_callback)
 
@@ -73,7 +83,7 @@ def process(
         # method="POST", # see bellow
         data=urllib.parse.urlencode(
             {
-                "appName": get_product_name(),
+                "appName": product,
                 "machineId": platform.node(),
             }
         ).encode(),
@@ -439,6 +449,7 @@ if __name__ == "__main__":
 
     result = process(
         args.sg_url,
+        product="Test Script",
         browser_open_callback=lambda u: webbrowser.open(u),
     )
     if not result:

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -439,7 +439,6 @@ if __name__ == "__main__":
 
     result = process(
         args.sg_url,
-        product="Test Script",
         browser_open_callback=lambda u: webbrowser.open(u),
     )
     if not result:

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -12,6 +12,7 @@ import json
 import os
 import platform
 import random
+import sys
 import time
 
 import tank
@@ -272,6 +273,10 @@ def get_product_name():
 
         return product
 
+    # current_engine is not set in SGD at login time...
+    if os.path.splitext(os.path.basename(sys.argv[0]))[0].lower() == "shotgun":
+        return "ShotGrid Desktop"
+
     # Fallback to default/worst case value
     return "ShotGrid Toolkit"
 
@@ -416,7 +421,6 @@ def build_user_agent():
 
 if __name__ == "__main__":
     import argparse
-    import sys
     import webbrowser
 
     parser = argparse.ArgumentParser()

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -275,7 +275,8 @@ def get_product_name():
     try:
         engine = sgtk_platform.current_engine()
         product = engine.host_info["name"]
-    except (AttributeError, TypeError, KeyError):
+        assert product and isinstance(product, str)
+    except (AttributeError, TypeError, KeyError, AssertionError):
         logger.debug("Unable to retrieve the host_info from the current_engine")
         # Most likely because the engine is not initialized yet
     else:

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -280,6 +280,13 @@ def get_product_name():
     if os.path.splitext(os.path.basename(sys.argv[0]))[0].lower() == "shotgun":
         return PRODUCT_DESKTOP
 
+    # Flame
+    if (
+        "SHOTGUN_FLAME_CONFIGPATH" in os.environ
+        and "SHOTGUN_FLAME_VERSION" in os.environ
+    ):
+        return "Flame {SHOTGUN_FLAME_VERSION}".format(**os.environ)
+
     # Fallback to default/worst case value
     return PRODUCT_DEFAULT
 

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -19,6 +19,7 @@ from tank_vendor import six
 from tank_vendor.six.moves import http_client, urllib
 
 from . import errors
+from .. import platform as sgtk_platform
 from ..util.shotgun import connection
 
 from .. import LogManager
@@ -37,18 +38,12 @@ class AuthenticationError(errors.AuthenticationError):
 def process(
     sg_url,
     http_proxy=None,
-    product=None,
     browser_open_callback=None,
     keep_waiting_callback=lambda: True,
 ):
     sg_url = connection.sanitize_url(sg_url)
-
-    if not product and "TK_AUTH_PRODUCT" in os.environ:
-        product = os.environ["TK_AUTH_PRODUCT"]
-
     logger.debug("Trigger Authentication on {url}".format(url=sg_url))
 
-    assert product
     assert callable(browser_open_callback)
     assert callable(keep_waiting_callback)
 
@@ -74,7 +69,7 @@ def process(
         # method="POST", # see bellow
         data=urllib.parse.urlencode(
             {
-                "appName": product,
+                "appName": get_product_name(),
                 "machineId": platform.node(),
             }
         ).encode(),
@@ -257,6 +252,28 @@ def process(
         response.json["sessionToken"],
         None,  # Extra metadata - useless here
     )
+
+
+def get_product_name():
+    if "TK_AUTH_PRODUCT" in os.environ:
+        return os.environ["TK_AUTH_PRODUCT"]
+
+    try:
+        engine = sgtk_platform.current_engine()
+        product = engine.host_info["name"]
+    except (AttributeError, TypeError, KeyError):
+        pass
+    else:
+        if product.lower() == "desktop":
+            product = "ShotGrid Desktop"
+
+        if engine.host_info.get("version", "unknown") != "unknown":
+            product += " {version}".format(**engine.host_info)
+
+        return product
+
+    # Fallback to default/worst case value
+    return "ShotGrid Toolkit"
 
 
 def _get_content_type(headers):

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -276,7 +276,8 @@ def get_product_name():
         engine = sgtk_platform.current_engine()
         product = engine.host_info["name"]
     except (AttributeError, TypeError, KeyError):
-        pass
+        logger.debug("Unable to retrieve the host_info from the current_engine")
+        # Most likely because the engine is not initialized yet
     else:
         if product.lower() == "desktop":
             product = PRODUCT_DESKTOP

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -27,6 +27,9 @@ from .. import LogManager
 
 logger = LogManager.get_logger(__name__)
 
+PRODUCT_DEFAULT = "ShotGrid Toolkit"
+PRODUCT_DESKTOP = "ShotGrid Desktop"
+
 
 class AuthenticationError(errors.AuthenticationError):
     def __init__(self, msg, ulf2_errno=None, payload=None, parent_exception=None):
@@ -266,7 +269,7 @@ def get_product_name():
         pass
     else:
         if product.lower() == "desktop":
-            product = "ShotGrid Desktop"
+            product = PRODUCT_DESKTOP
 
         if engine.host_info.get("version", "unknown") != "unknown":
             product += " {version}".format(**engine.host_info)
@@ -275,10 +278,10 @@ def get_product_name():
 
     # current_engine is not set in SGD at login time...
     if os.path.splitext(os.path.basename(sys.argv[0]))[0].lower() == "shotgun":
-        return "ShotGrid Desktop"
+        return PRODUCT_DESKTOP
 
     # Fallback to default/worst case value
-    return "ShotGrid Toolkit"
+    return PRODUCT_DEFAULT
 
 
 def _get_content_type(headers):

--- a/tests/authentication_tests/test_ulf2.py
+++ b/tests/authentication_tests/test_ulf2.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import random
+import sys
 import threading
 
 
@@ -39,27 +40,23 @@ class ULF2Tests(ShotgunTestBase):
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback="Test",
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback=lambda: True,
                 keep_waiting_callback=None,
             )
@@ -124,7 +121,6 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=url_opener,
                 http_proxy="{fqdn}:{port}".format(  # For code coverage
                     fqdn=self.httpd.server_address[0],
@@ -148,7 +144,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -212,7 +207,6 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             ),
             (self.api_url, "john", "to123", None),
@@ -224,7 +218,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -239,7 +232,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -256,7 +248,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -276,7 +267,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -291,7 +281,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -307,7 +296,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -324,7 +312,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -341,7 +328,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -358,7 +344,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -398,7 +383,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -418,7 +402,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: False,
             )
 
@@ -427,6 +410,7 @@ class ULF2APITests(ShotgunTestBase):
             "Unable to open local browser",
         )
 
+    @mock.patch.dict(os.environ)
     def test_param_product(self):
         def api_handler1(request):
             os.environ["test_96272fea51"] = request["args"][b"appName"][0].decode()
@@ -440,10 +424,10 @@ class ULF2APITests(ShotgunTestBase):
         # Install a proper POST request handler
         self.httpd.router["[POST]/internal_api/app_session_request"] = api_handler1
 
+        # Validate the default product name
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="app_2a37c59",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,
             )
@@ -452,12 +436,80 @@ class ULF2APITests(ShotgunTestBase):
 
         self.assertEqual(
             os.environ["test_96272fea51"],
-            "app_2a37c59",
+            unified_login_flow2.PRODUCT_DEFAULT,
         )
 
         # Cleanup for next test
         del os.environ["test_96272fea51"]
 
+        # Validate the FLAME product name
+        os.environ["SHOTGUN_FLAME_CONFIGPATH"] = "/flame"
+        os.environ["SHOTGUN_FLAME_VERSION"] = "1.2.3"
+        with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
+            unified_login_flow2.process(
+                self.api_url,
+                browser_open_callback=lambda url: True,
+                keep_waiting_callback=lambda: False,
+            )
+
+        self.assertEqual(cm.exception.args[0], "The request has never been approved")
+
+        self.assertEqual(
+            os.environ["test_96272fea51"],
+            "Flame 1.2.3",
+        )
+
+        # Cleanup for next test
+        del os.environ["test_96272fea51"]
+
+        # Validate ShotGrid Desktop
+        with mock.patch.object(
+            sys,
+            "argv",
+            [os.path.join("Applications", "ShotGun.exe")],
+        ), self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
+            unified_login_flow2.process(
+                self.api_url,
+                browser_open_callback=lambda url: True,
+                keep_waiting_callback=lambda: False,
+            )
+
+        self.assertEqual(cm.exception.args[0], "The request has never been approved")
+
+        self.assertEqual(
+            os.environ["test_96272fea51"],
+            unified_login_flow2.PRODUCT_DESKTOP,
+        )
+
+        # Cleanup for next test
+        del os.environ["test_96272fea51"]
+
+        # Validate Engine host info
+        class MyEngine:
+            host_info = {
+                "name": "desktop",
+                "version": "3.2.1",
+            }
+
+        with mock.patch(
+            "tank.platform.current_engine", MyEngine,
+        ), self.assertRaises(
+            unified_login_flow2.AuthenticationError,
+        ) as cm:
+            unified_login_flow2.process(
+                self.api_url,
+                browser_open_callback=lambda url: True,
+                keep_waiting_callback=lambda: False,
+            )
+
+        self.assertEqual(cm.exception.args[0], "The request has never been approved")
+
+        self.assertEqual(
+            os.environ["test_96272fea51"],
+            "ShotGrid Desktop 3.2.1",
+        )
+
+        # Validate the TK_AUTH_PRODUCT environment variable
         os.environ["TK_AUTH_PRODUCT"] = "software_8b1a7bd"
 
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
@@ -498,7 +550,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=url_opener,
             )
 
@@ -524,7 +575,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )
@@ -538,7 +588,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )

--- a/tests/authentication_tests/test_ulf2.py
+++ b/tests/authentication_tests/test_ulf2.py
@@ -40,23 +40,27 @@ class ULF2Tests(ShotgunTestBase):
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
+                product=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
+                product="my_app",
                 browser_open_callback=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
+                product="my_app",
                 browser_open_callback="Test",
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
+                product="my_app",
                 browser_open_callback=lambda: True,
                 keep_waiting_callback=None,
             )
@@ -78,6 +82,55 @@ class ULF2Tests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2._build_proxy_addr("u:p@10.20.30.40"),
             "http://u:p@10.20.30.40:8080",
+        )
+
+    @mock.patch.dict(os.environ)
+    def test_get_product_name(self):
+        # Validate the default product name
+        self.assertEqual(
+            unified_login_flow2.get_product_name(),
+            unified_login_flow2.PRODUCT_DEFAULT,
+        )
+
+        # Validate the FLAME product name
+        os.environ["SHOTGUN_FLAME_CONFIGPATH"] = "/flame"
+        os.environ["SHOTGUN_FLAME_VERSION"] = "1.2.3"
+        self.assertEqual(
+            unified_login_flow2.get_product_name(),
+            "Flame 1.2.3",
+        )
+
+        # Validate ShotGrid Desktop
+        with mock.patch.object(
+            sys,
+            "argv",
+            [os.path.join("Applications", "ShotGun.exe")],
+        ):
+            self.assertEqual(
+                unified_login_flow2.get_product_name(),
+                unified_login_flow2.PRODUCT_DESKTOP,
+            )
+
+        # Validate Engine host info
+        class MyEngine:
+            host_info = {
+                "name": "desktop",
+                "version": "3.2.1",
+            }
+
+        with mock.patch(
+            "tank.platform.current_engine", MyEngine,
+        ):
+            self.assertEqual(
+                unified_login_flow2.get_product_name(),
+                "ShotGrid Desktop 3.2.1",
+            )
+
+        # Validate the TK_AUTH_PRODUCT environment variable
+        os.environ["TK_AUTH_PRODUCT"] = "software_8b1a7bd"
+        self.assertEqual(
+            unified_login_flow2.get_product_name(),
+            "software_8b1a7bd",
         )
 
 
@@ -121,6 +174,7 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=url_opener,
                 http_proxy="{fqdn}:{port}".format(  # For code coverage
                     fqdn=self.httpd.server_address[0],
@@ -144,6 +198,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -207,6 +262,7 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             ),
             (self.api_url, "john", "to123", None),
@@ -218,6 +274,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -232,6 +289,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -248,6 +306,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -267,6 +326,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -281,6 +341,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -296,6 +357,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -312,6 +374,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -328,6 +391,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -344,6 +408,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -383,6 +448,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -402,6 +468,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: False,
             )
 
@@ -424,10 +491,10 @@ class ULF2APITests(ShotgunTestBase):
         # Install a proper POST request handler
         self.httpd.router["[POST]/internal_api/app_session_request"] = api_handler1
 
-        # Validate the default product name
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="app_2a37c59",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,
             )
@@ -436,94 +503,7 @@ class ULF2APITests(ShotgunTestBase):
 
         self.assertEqual(
             os.environ["test_96272fea51"],
-            unified_login_flow2.PRODUCT_DEFAULT,
-        )
-
-        # Cleanup for next test
-        del os.environ["test_96272fea51"]
-
-        # Validate the FLAME product name
-        os.environ["SHOTGUN_FLAME_CONFIGPATH"] = "/flame"
-        os.environ["SHOTGUN_FLAME_VERSION"] = "1.2.3"
-        with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
-            unified_login_flow2.process(
-                self.api_url,
-                browser_open_callback=lambda url: True,
-                keep_waiting_callback=lambda: False,
-            )
-
-        self.assertEqual(cm.exception.args[0], "The request has never been approved")
-
-        self.assertEqual(
-            os.environ["test_96272fea51"],
-            "Flame 1.2.3",
-        )
-
-        # Cleanup for next test
-        del os.environ["test_96272fea51"]
-
-        # Validate ShotGrid Desktop
-        with mock.patch.object(
-            sys,
-            "argv",
-            [os.path.join("Applications", "ShotGun.exe")],
-        ), self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
-            unified_login_flow2.process(
-                self.api_url,
-                browser_open_callback=lambda url: True,
-                keep_waiting_callback=lambda: False,
-            )
-
-        self.assertEqual(cm.exception.args[0], "The request has never been approved")
-
-        self.assertEqual(
-            os.environ["test_96272fea51"],
-            unified_login_flow2.PRODUCT_DESKTOP,
-        )
-
-        # Cleanup for next test
-        del os.environ["test_96272fea51"]
-
-        # Validate Engine host info
-        class MyEngine:
-            host_info = {
-                "name": "desktop",
-                "version": "3.2.1",
-            }
-
-        with mock.patch(
-            "tank.platform.current_engine", MyEngine,
-        ), self.assertRaises(
-            unified_login_flow2.AuthenticationError,
-        ) as cm:
-            unified_login_flow2.process(
-                self.api_url,
-                browser_open_callback=lambda url: True,
-                keep_waiting_callback=lambda: False,
-            )
-
-        self.assertEqual(cm.exception.args[0], "The request has never been approved")
-
-        self.assertEqual(
-            os.environ["test_96272fea51"],
-            "ShotGrid Desktop 3.2.1",
-        )
-
-        # Validate the TK_AUTH_PRODUCT environment variable
-        os.environ["TK_AUTH_PRODUCT"] = "software_8b1a7bd"
-
-        with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
-            unified_login_flow2.process(
-                self.api_url,
-                browser_open_callback=lambda url: True,
-                keep_waiting_callback=lambda: False,
-            )
-
-        self.assertEqual(cm.exception.args[0], "The request has never been approved")
-
-        self.assertEqual(
-            os.environ["test_96272fea51"],
-            "software_8b1a7bd",
+            "app_2a37c59",
         )
 
     @mock.patch("time.sleep")
@@ -550,6 +530,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=url_opener,
             )
 
@@ -575,6 +556,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )
@@ -588,6 +570,7 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
+                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )

--- a/tests/authentication_tests/test_ulf2.py
+++ b/tests/authentication_tests/test_ulf2.py
@@ -37,30 +37,26 @@ import threading
 
 class ULF2Tests(ShotgunTestBase):
     def test_process_parameters(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback=None,
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback="Test",
             )
 
         with self.assertRaises(AssertionError):
             unified_login_flow2.process(
                 "https://test.shotgunstudio.com",
-                product="my_app",
                 browser_open_callback=lambda: True,
                 keep_waiting_callback=None,
             )
@@ -174,7 +170,6 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=url_opener,
                 http_proxy="{fqdn}:{port}".format(  # For code coverage
                     fqdn=self.httpd.server_address[0],
@@ -198,7 +193,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -262,7 +256,6 @@ class ULF2APITests(ShotgunTestBase):
         self.assertEqual(
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             ),
             (self.api_url, "john", "to123", None),
@@ -274,7 +267,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -289,7 +281,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -306,7 +297,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -326,7 +316,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -341,7 +330,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -357,7 +345,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -374,7 +361,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -391,7 +377,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -408,7 +393,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -427,7 +411,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -448,7 +431,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
             )
 
@@ -468,7 +450,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: False,
             )
 
@@ -530,7 +511,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=url_opener,
             )
 
@@ -556,7 +536,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )
@@ -570,7 +549,6 @@ class ULF2APITests(ShotgunTestBase):
         with self.assertRaises(unified_login_flow2.AuthenticationError) as cm:
             unified_login_flow2.process(
                 self.api_url,
-                product="my_app",
                 browser_open_callback=lambda url: True,
                 keep_waiting_callback=lambda: False,  # Avoid 5 minute timeout
             )


### PR DESCRIPTION
Updated the new **Unified Login Flow 2** process to detect and send an accurate _Application Name_ to ShotGrid instead of the hardcoded "Toolkit".

There are 4 alternatives for selecting the name (priority with the following as the first match returns):

1. pass by the environment with `TK_AUTH_PRODUCT`
2. use the current_engine if defined (with an exception for the "desktop" engine)
3. detect if ShotGrid Desktop by scanning `argv[0]`
4. default to `ShotGrid Toolkit` if can't find something better... 
