### PR TITLE
SG-30916 Log Metrics regarding the authentication experience

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -108,9 +108,13 @@ class ConsoleAuthenticationHandlerBase(object):
                 "Logged In",
                 properties={
                     "authentication_method": site_i.user_authentication_method,
-                    "Method": constants.method_resolve.get(method_selected),
-                    "mode": "console",
-                    "Action": isinstance(self, ConsoleRenewSessionHandler),
+                    "authentication_experience": constants.method_resolve.get(
+                        method_selected
+                    ),
+                    "authentication_interface": "console",
+                    "authentication_renewal": isinstance(
+                        self, ConsoleRenewSessionHandler
+                    ),
                 },
             )
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -668,9 +668,9 @@ class LoginDialog(QtGui.QDialog):
             "Logged In",
             properties={
                 "authentication_method": self.site_info.user_authentication_method,
-                "Method": auth_constants.method_resolve.get(self.method_selected),
-                "mode": "qt_dialog",
-                "Action": self._is_session_renewal,
+                "authentication_experience": auth_constants.method_resolve.get(self.method_selected),
+                "authentication_interface": "qt_dialog",
+                "authentication_renewal": self._is_session_renewal,
             },
         )
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -27,9 +27,11 @@ from .ui import resources_rc  # noqa
 from .ui import login_dialog
 from . import constants as auth_constants
 from . import session_cache
+from ..util.metrics import EventMetric
 from ..util.shotgun import connection
 from ..util import login
 from ..util import LocalFileStorageManager
+from ..util import metrics_cache
 from .errors import AuthenticationError
 from .ui.qt_abstraction import QtGui, QtCore, QtNetwork, QtWebKit, QtWebEngineWidgets
 from . import unified_login_flow2
@@ -660,6 +662,17 @@ class LoginDialog(QtGui.QDialog):
         res = self.exec_()
         if res != QtGui.QDialog.Accepted:
             return
+
+        metrics_cache.log(
+            EventMetric.GROUP_TOOLKIT,
+            "Logged In",
+            properties={
+                "authentication_method": self.site_info.user_authentication_method,
+                "Method": auth_constants.method_resolve.get(self.method_selected),
+                "mode": "qt_dialog",
+                "Action": self._is_session_renewal,
+            },
+        )
 
         if self.method_selected == auth_constants.METHOD_ULF2:
             if not self._ulf2_task:

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -41,6 +41,7 @@ from .errors import (
 from ..util import sgre as re
 from ..util.metrics import EventMetric
 from ..util.metrics import MetricsDispatcher
+from ..util import metrics_cache
 from ..log import LogManager
 
 from . import application
@@ -3202,6 +3203,8 @@ def _start_engine(engine_name, tk, old_context, new_context):
         # register this engine as the current engine
         set_current_engine(engine)
 
+    metrics_cache.consume()
+
     return engine
 
 
@@ -3337,6 +3340,8 @@ def start_shotgun_engine(tk, entity_type, context):
 
     # register this engine as the current engine
     set_current_engine(obj)
+
+    metrics_cache.consume()
 
     return obj
 

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -621,6 +621,7 @@ class EventMetric(object):
         EVENT_NAME_FORMAT % (GROUP_NAVIGATION, "Viewed Panel"),
         EVENT_NAME_FORMAT % (GROUP_PROJECTS, "Viewed Project Commands"),
         EVENT_NAME_FORMAT % (GROUP_TASKS, "Created Task"),
+        EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Logged In"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Launched Action"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Launched Command"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Launched Software"),

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+The Metrics logger thread is only launched once an engine is initialized.
+But we might want to log metrics event before Toolkit is fully initialized.
+
+For instance, when starting ShotGrid Desktop and authenticating, there is no
+engine set yet.
+
+This module provide a cache that can be filled prior to Toolkit initilization.
+Then, once the engine is set and the metric thread starts, the cache is consumed
+and send the items to the Metric instance.
+
+Unfortunatly, this cache can not live in a singleton in this module because,
+somehow, tk-core is fully unloaded off the python process between authentication
+and launch of an engine (desktopstartup).
+Instead, we store the records in the environment as JSON text
+"""
+
+import hashlib
+import json
+import os
+
+from . import metrics
+from .. import platform
+
+from .. import LogManager
+
+logger = LogManager.get_logger(__name__)
+
+
+def log(group, name, properties=None, log_once=False, bundle=None):
+    """
+    Same prototype as the log method from the metrics module.
+    """
+
+    args = (group, name)
+    kwargs = {}
+    if properties is not None:
+        kwargs["properties"] = properties
+    if log_once is not False:
+        kwargs["log_once"] = log_once
+    if bundle is not None:
+        kwargs["bundle"] = bundle
+
+    if platform.current_engine():
+        # We don't need to cache in this situation, Let's simply forward the
+        # order
+        return metrics.EventMetric.log(*args, **kwargs)
+
+    try:
+        cached_data = json.dumps((args, kwargs))
+    except TypeError:
+        logger.debug("Unable to cache metric. Can not be JSON encoded")
+        return
+
+    cache_key = "sgtk_metric_cache_{cid}".format(
+        cid=hashlib.sha1(cached_data.encode()).hexdigest()[:16],
+    )
+
+    os.environ[cache_key] = cached_data
+
+
+def consume():
+    """
+    Iterate the environment to find all the cached metrics
+    """
+
+    for cache_key in os.environ:
+        if not cache_key.startswith("sgtk_metric_cache_"):
+            continue
+
+        try:
+            cached_data = os.environ.pop(cache_key)
+        except KeyError:
+            # Might be due to parallel access
+            continue
+
+        try:
+            data = json.loads(cached_data)
+        except json.JSONDecodeError:
+            logger.debug("Unable to decode cached metric")
+            continue
+
+        if not isinstance(data, list) or len(data) != 2:
+            logger.debug("Invalid cached metric format")
+            continue
+
+        (args, kwargs) = data
+        if not isinstance(args, list) or not isinstance(kwargs, dict):
+            logger.debug("Invalid cached metric format")
+            continue
+
+        metrics.EventMetric.log(*args, **kwargs)

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -75,7 +75,7 @@ def consume():
     """
 
     for cache_key in os.environ:
-        if not cache_key.startswith("sgtk_metric_cache_"):
+        if not cache_key.lower().startswith("sgtk_metric_cache_"):
             continue
 
         try:

--- a/tests/util_tests/test_metrics_cache.py
+++ b/tests/util_tests/test_metrics_cache.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import unittest
+
+from unittest.mock import patch
+
+from tank.platform import (
+    engine,
+)
+
+from tank.util import (
+    metrics,
+    metrics_cache,
+)
+
+
+class MetricsCacheTests(unittest.TestCase):
+    def tearDown(self):
+        for k in os.environ:
+            if k.startswith("sgtk_metric_cache_"):
+                del os.environ[k]
+
+        super(MetricsCacheTests, self).tearDown()
+
+    def test_log(self, *mocks):
+        # not json_serializable
+        metrics_cache.log(object(), "name", log_once=True)
+        self.assertEqual(
+            len([k for k in os.environ if k.startswith("sgtk_metric_cache_")]),
+            0,
+        )
+
+        metrics_cache.log("group", "name", log_once=object())
+        self.assertEqual(
+            len([k for k in os.environ if k.startswith("sgtk_metric_cache_")]),
+            0,
+        )
+
+        metrics_cache.log("group", "name", properties={"k": "v"})
+        self.assertEqual(
+            os.environ["sgtk_metric_cache_cc567a4f3d676f29"],
+            '[["group", "name"], {"properties": {"k": "v"}}]',
+        )
+
+    @patch.object(metrics.EventMetric, "log")
+    def test_log_for_coverage(self, *mocks):
+        engine.set_current_engine(object())
+        try:
+            metrics_cache.log("group", "name", bundle=object())
+            self.assertFalse(
+                [k for k in os.environ if k.startswith("sgtk_metric_cache_")],
+            )
+        finally:
+            engine.set_current_engine(None)
+
+    @patch.object(
+        metrics.EventMetric,
+        "log",
+    )
+    def test_consume(self, *mocks):
+        """
+        No assert, just no exception and test coverage
+        """
+
+        os.environ["sgtk_metric_cache_1"] = "test"
+        metrics_cache.consume()
+
+        os.environ["sgtk_metric_cache_1"] = '"test"'
+        metrics_cache.consume()
+
+        os.environ["sgtk_metric_cache_1"] = '["i1", "i2"]'
+        metrics_cache.consume()
+
+        os.environ["sgtk_metric_cache_1"] = '[["args"], {"kwargs": {"k": "v"}}]'
+        metrics_cache.consume()
+
+        with patch.object(
+            os.environ,
+            "pop",
+            side_effect=KeyError("foo"),
+        ):
+            os.environ["sgtk_metric_cache_1"] = "test"
+            metrics_cache.consume()


### PR DESCRIPTION
Send metrics to ShotGrid regarding the authentication experience. This includes:

- user_authentication_method (default, oxygen, saml, ...)
- auth UX (basic login/password, web login, local browser)
- client UI (qt_dialog, console)
- renewal (true/false)

This way, we should be able to measure the adoption of the new authentication mechanism.