### PR TITLE
SG-31206 Fixup crash with Nuke

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -355,7 +355,7 @@ class LoginDialog(QtGui.QDialog):
             #  #2. Pass the QDialog stylesheet to the QMessageBox since I did
             #      not see any other consequence by not passing the parent
             #      parameter.
-            # I chose solution #1, se bellow.
+            # I chose solution #1, se below.
         )
 
         self.confirm_box.setInformativeText(

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -347,13 +347,15 @@ class LoginDialog(QtGui.QDialog):
             "ShotGrid Login",  # title
             "Would you like to cancel your request?",  # text
             buttons=QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-            ## parent=self,
-            # Could not be done in the constructor because of the parent
-            # parameter.
-            # When using Nuke, passing the parent parameter in the
-            # constructor made Nuke crash.
-            # We need the parent reference to have the message box re-using
-            # this dialog's style.
+            # parent=self,
+            # Passing the parent parameter here, in the constructor, makes
+            # Nuke versions<=13 crash.
+            # Two ways to resolve that:
+            #  #1. Create the QMessageBox later (not in the constructor)
+            #  #2. Pass the QDialog stylesheet to the QMessageBox since I did
+            #      not see any other consequence by not passing the parent
+            #      parameter.
+            # I chose solution #1, se bellow.
         )
 
         self.confirm_box.setInformativeText(
@@ -362,7 +364,6 @@ class LoginDialog(QtGui.QDialog):
         )
 
         self.confirm_box.setStyleSheet(self.styleSheet())
-
 
     def __del__(self):
         """

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -341,19 +341,10 @@ class LoginDialog(QtGui.QDialog):
                 % self._get_current_site()
             )
 
-        # Initialize exit confirm message box
-        self.confirm_box = QtGui.QMessageBox(
-            QtGui.QMessageBox.Question,
-            "ShotGrid Login",  # title
-            "Would you like to cancel your request?",  # text
-            buttons=QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-            parent=self,
-        )
+        # Initialize an empty confirm message box; see the _confirm_exit method
+        # for details
+        self.confirm_box = None
 
-        self.confirm_box.setInformativeText(
-            "The authentication is still in progress and closing this window "
-            "will result in canceling your request."
-        )
 
     def __del__(self):
         """
@@ -363,6 +354,27 @@ class LoginDialog(QtGui.QDialog):
         self._query_task.wait()
 
     def _confirm_exit(self):
+        if not self.confirm_box:
+            # Initialize exit confirm message box
+            self.confirm_box = QtGui.QMessageBox(
+                QtGui.QMessageBox.Question,
+                "ShotGrid Login",  # title
+                "Would you like to cancel your request?",  # text
+                buttons=QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
+                parent=self,
+                # Could not be done in the constructor because of the parent
+                # parameter.
+                # When using Nuke, passing the parent parameter in the
+                # constructor made Nuke crash.
+                # We need the parent reference to have the message box re-using
+                # this dialog's style.
+            )
+
+            self.confirm_box.setInformativeText(
+                "The authentication is still in progress and closing this window "
+                "will result in canceling your request."
+            )
+
         return self.confirm_box.exec_() == QtGui.QMessageBox.StandardButton.Yes
         # PySide uses "exec_" instead of "exec" because "exec" is a reserved
         # keyword in Python 2.

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -341,9 +341,27 @@ class LoginDialog(QtGui.QDialog):
                 % self._get_current_site()
             )
 
-        # Initialize an empty confirm message box; see the _confirm_exit method
-        # for details
-        self.confirm_box = None
+        # Initialize exit confirm message box
+        self.confirm_box = QtGui.QMessageBox(
+            QtGui.QMessageBox.Question,
+            "ShotGrid Login",  # title
+            "Would you like to cancel your request?",  # text
+            buttons=QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
+            ## parent=self,
+            # Could not be done in the constructor because of the parent
+            # parameter.
+            # When using Nuke, passing the parent parameter in the
+            # constructor made Nuke crash.
+            # We need the parent reference to have the message box re-using
+            # this dialog's style.
+        )
+
+        self.confirm_box.setInformativeText(
+            "The authentication is still in progress and closing this window "
+            "will result in canceling your request."
+        )
+
+        self.confirm_box.setStyleSheet(self.styleSheet())
 
 
     def __del__(self):
@@ -354,27 +372,6 @@ class LoginDialog(QtGui.QDialog):
         self._query_task.wait()
 
     def _confirm_exit(self):
-        if not self.confirm_box:
-            # Initialize exit confirm message box
-            self.confirm_box = QtGui.QMessageBox(
-                QtGui.QMessageBox.Question,
-                "ShotGrid Login",  # title
-                "Would you like to cancel your request?",  # text
-                buttons=QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-                parent=self,
-                # Could not be done in the constructor because of the parent
-                # parameter.
-                # When using Nuke, passing the parent parameter in the
-                # constructor made Nuke crash.
-                # We need the parent reference to have the message box re-using
-                # this dialog's style.
-            )
-
-            self.confirm_box.setInformativeText(
-                "The authentication is still in progress and closing this window "
-                "will result in canceling your request."
-            )
-
         return self.confirm_box.exec_() == QtGui.QMessageBox.StandardButton.Yes
         # PySide uses "exec_" instead of "exec" because "exec" is a reserved
         # keyword in Python 2.


### PR DESCRIPTION
Passing the parent parameter in the constructor created a crash when using Nuke.