### PR TITLE
SG-31554 no more external dependencies python 3

### DIFF
--- a/tests/authentication_tests/test_auth_settings.py
+++ b/tests/authentication_tests/test_auth_settings.py
@@ -13,9 +13,12 @@ Tests settings retrieval through the DefaultsManager
 """
 
 from __future__ import with_statement
-from mock import patch, Mock, PropertyMock
 
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
 from tank_test.tank_test_base import setUpModule  # noqa
 
 from tank.authentication import CoreDefaultsManager
@@ -48,11 +51,11 @@ class DefaultsManagerTest(ShotgunTestBase):
         ShotgunTestBase.setUp(self)
         UserSettings.clear_singleton()
 
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_current_host",
         return_value=_SESSION_CACHE_HOST,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_current_user",
         return_value=_SESSION_CACHE_USER,
     )
@@ -60,7 +63,7 @@ class DefaultsManagerTest(ShotgunTestBase):
         """
         Test the behaviour of the defaults manager when there are no settings.
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = None
         instance.default_site = self._CONFIG_HOST
         instance.default_login = self._CONFIG_USER
@@ -76,28 +79,28 @@ class DefaultsManagerTest(ShotgunTestBase):
         Test the behaviour of the defaults manager when there are no settings.
         """
         # Mock user settings singleton.
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = None
         instance.default_site = self._CONFIG_HOST
         instance.default_login = self._CONFIG_USER
         instance.app_store_proxy = None
 
-        with patch(
+        with mock.patch(
             "tank.util.system_settings.SystemSettings.http_proxy",
-            new_callable=PropertyMock,
+            new_callable=mock.PropertyMock,
             return_value="192.168.10.1",
         ):
             dm = DefaultsManager()
             self.assertIs(dm.get_http_proxy(), "192.168.10.1")
 
-    @patch("tank.authentication.session_cache.get_current_host", return_value=None)
-    @patch("tank.authentication.session_cache.get_current_user", return_value=None)
+    @mock.patch("tank.authentication.session_cache.get_current_host", return_value=None)
+    @mock.patch("tank.authentication.session_cache.get_current_user", return_value=None)
     def test_empty_session_cache(self, *unused_mocks):
         """
         Test the behaviour of the defaults manager when the cache is empty
         and the config file is set.
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = self._CONFIG_HTTP_PROXY
         instance.default_site = self._CONFIG_HOST
         instance.default_login = self._CONFIG_USER
@@ -107,7 +110,7 @@ class DefaultsManagerTest(ShotgunTestBase):
         self.assertEqual(dm.get_login(), self._CONFIG_USER)
         self.assertIs(dm.get_http_proxy(), self._CONFIG_HTTP_PROXY)
 
-    @patch(
+    @mock.patch(
         "tank.util.shotgun.get_associated_sg_config_data",
         return_value={"host": _SHOTGUN_YML_HOST, "http_proxy": _SHOTGUN_YML_PROXY},
     )
@@ -115,7 +118,7 @@ class DefaultsManagerTest(ShotgunTestBase):
         """
         Make sure that shotgun.yml always overrides toolkit.ini
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = self._CONFIG_HTTP_PROXY
         instance.default_site = self._CONFIG_HOST
         instance.default_login = self._CONFIG_USER
@@ -125,7 +128,7 @@ class DefaultsManagerTest(ShotgunTestBase):
         self.assertEqual(dm.get_login(), self._CONFIG_USER)
         self.assertIs(dm.get_http_proxy(), self._SHOTGUN_YML_PROXY)
 
-    @patch(
+    @mock.patch(
         "tank.util.shotgun.get_associated_sg_config_data",
         return_value={"host": _SHOTGUN_YML_HOST},
     )
@@ -133,43 +136,43 @@ class DefaultsManagerTest(ShotgunTestBase):
         """
         Make sure that no proxy in shogun.yml means proxy in shotgun.yml will be picked.
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = self._CONFIG_HTTP_PROXY
 
         dm = CoreDefaultsManager()
         self.assertIs(dm.get_http_proxy(), self._CONFIG_HTTP_PROXY)
 
-    @patch(
+    @mock.patch(
         "tank.util.system_settings.SystemSettings.http_proxy",
-        new_callable=PropertyMock,
+        new_callable=mock.PropertyMock,
         return_value="192.168.10.1",
     )
-    @patch("tank.util.shotgun.get_associated_sg_config_data", return_value={})
+    @mock.patch("tank.util.shotgun.get_associated_sg_config_data", return_value={})
     def test_toolkit_ini_disabling_global_proxy(self, *_):
         """
         Make sure that toolkit.ini can disable the system level proxy.
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = ""
 
         dm = CoreDefaultsManager()
 
         self.assertEqual(dm.get_http_proxy(), "")
 
-    @patch(
+    @mock.patch(
         "tank.util.shotgun.get_associated_sg_config_data",
         return_value={"http_proxy": ""},
     )
-    @patch(
+    @mock.patch(
         "tank.util.system_settings.SystemSettings.http_proxy",
-        new_callable=PropertyMock,
+        new_callable=mock.PropertyMock,
         return_value="192.168.10.1",
     )
     def test_shotgun_yml_empty_string_can_override_global_proxy(self, *_):
         """
         Make sure that shotgun.yml can disable the system level proxy.
         """
-        instance = UserSettings._instance = Mock()
+        instance = UserSettings._instance = mock.Mock()
         instance.shotgun_proxy = None
 
         dm = CoreDefaultsManager()
@@ -183,7 +186,7 @@ class DefaultsManagerTest(ShotgunTestBase):
             sgtk.authentication.CoreDefaultsManager, sgtk.util.CoreDefaultsManager
         )
 
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_current_host",
         return_value=_SESSION_CACHE_HOST,
     )

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -23,9 +23,9 @@ from tank_test.tank_test_base import (
     ShotgunTestBase,
     skip_if_pyside_missing,
     interactive,
+    mock,
     suppress_generated_code_qt_warnings,
 )
-from mock import patch
 from tank.authentication import (
     console_authentication,
     ConsoleLoginNotSupportedError,
@@ -102,7 +102,7 @@ class InteractiveTests(ShotgunTestBase):
 
         # Patch out the SsoSaml2Toolkit class to avoid threads being created, which cause
         # issues with tests.
-        with patch("tank.authentication.login_dialog.SsoSaml2Toolkit"):
+        with mock.patch("tank.authentication.login_dialog.SsoSaml2Toolkit"):
             with contextlib.closing(MyLoginDialog(is_session_renewal, **kwargs)) as ld:
                 try:
                     self._prepare_window(ld)
@@ -152,7 +152,7 @@ class InteractiveTests(ShotgunTestBase):
         """
         self._test_login(console=False)
 
-    @patch("tank.authentication.interactive_authentication._get_ui_state")
+    @mock.patch("tank.authentication.interactive_authentication._get_ui_state")
     @interactive
     @suppress_generated_code_qt_warnings
     def test_login_console(self, _get_ui_state_mock):
@@ -218,7 +218,7 @@ class InteractiveTests(ShotgunTestBase):
         """
         self._test_session_renewal(test_console=False)
 
-    @patch("tank.authentication.interactive_authentication._get_ui_state")
+    @mock.patch("tank.authentication.interactive_authentication._get_ui_state")
     @interactive
     @suppress_generated_code_qt_warnings
     def test_session_renewal_console(self, _get_ui_state_mock):
@@ -323,7 +323,7 @@ class InteractiveTests(ShotgunTestBase):
         with self.assertRaises(FromMainThreadException):
             bg.wait()
 
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.input",
         side_effect=[
             "  https://test.shotgunstudio.com ",
@@ -331,7 +331,7 @@ class InteractiveTests(ShotgunTestBase):
             " 2fa code ",
         ],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.ConsoleLoginHandler._get_password",
         return_value=" password ",
     )
@@ -350,29 +350,29 @@ class InteractiveTests(ShotgunTestBase):
         )
         self.assertEqual(handler._get_2fa_code(), "2fa code")
 
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.is_sso_enabled_on_site",
         return_value=False,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
         return_value=False,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.generate_session_token",
         side_effect=[
             tank_vendor.shotgun_api3.MissingTwoFactorAuthenticationFault(),
             "my_session_token_39",
         ],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.input",
         side_effect=[
             "",  # Select default login
             "2fa code",
         ],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.ConsoleLoginHandler._get_password",
         return_value="password",
     )
@@ -383,20 +383,20 @@ class InteractiveTests(ShotgunTestBase):
             ("https://test.shotgunstudio.com", "username", "my_session_token_39", None),
         )
 
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={
             "unified_login_flow2_enabled": False,
         },
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.ConsoleRenewSessionHandler._get_password",
         side_effect=[
             "password",
             EOFError(),  # Simulate an error
         ],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.generate_session_token",
         return_value="my_session_token_97",
     )
@@ -411,15 +411,15 @@ class InteractiveTests(ShotgunTestBase):
         with self.assertRaises(errors.AuthenticationCancelled):
             handler.authenticate("https://test.shotgunstudio.com", "username", None)
 
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.input",
         side_effect=["  https://test-sso.shotgunstudio.com "],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.is_sso_enabled_on_site",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
         return_value=False,
     )
@@ -434,7 +434,7 @@ class InteractiveTests(ShotgunTestBase):
         with self.assertRaises(ConsoleLoginWithSSONotSupportedError):
             handler.authenticate(None, None, None)
 
-    @patch(
+    @mock.patch(
         "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
         return_value=False,
     )
@@ -446,10 +446,10 @@ class InteractiveTests(ShotgunTestBase):
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=True)
         for option in [(True, True), (True, False), (False, True)]:
-            with patch(
+            with mock.patch(
                 "tank.authentication.console_authentication.is_sso_enabled_on_site",
                 return_value=option[0],
-            ), patch(
+            ), mock.patch(
                 "tank.authentication.console_authentication.is_autodesk_identity_enabled_on_site",
                 return_value=option[1],
             ):
@@ -486,11 +486,11 @@ class InteractiveTests(ShotgunTestBase):
                     self.assertEqual(widget.currentText(), "text")
 
     @suppress_generated_code_qt_warnings
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={},
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.login_dialog._is_running_in_desktop",
         return_value=True,
     )
@@ -538,7 +538,7 @@ class InteractiveTests(ShotgunTestBase):
             )
 
         # Link Activated - browser error - mainly for coverage
-        with patch(
+        with mock.patch(
             "tank.authentication.login_dialog.QtGui.QDesktopServices.openUrl",
             return_value=False,
         ), self._login_dialog(
@@ -580,7 +580,7 @@ class InteractiveTests(ShotgunTestBase):
             self.assertEqual(ld.isVisible(), False)
 
         # Test escape key event
-        with patch(
+        with mock.patch(
             "tank.authentication.login_dialog.ULF2_AuthTask.start",
             return_value=False,
         ), self._login_dialog(False) as ld:
@@ -609,21 +609,21 @@ class InteractiveTests(ShotgunTestBase):
             self.assertEqual(ld.isVisible(), False)
 
     @suppress_generated_code_qt_warnings
-    @patch(
+    @mock.patch(
         "tank.authentication.login_dialog._is_running_in_desktop",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.web_login_support.get_shotgun_authenticator_support_web_login",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_preferred_method",
         return_value=None,
     )
     def test_login_dialog_method_selected(self, *unused_mocks):
         # First - basic
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={},
         ), self._login_dialog(
@@ -635,7 +635,7 @@ class InteractiveTests(ShotgunTestBase):
             self.assertFalse(ld._use_local_browser)
 
         # Then Web login
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={
                 "user_authentication_method": "oxygen",
@@ -647,7 +647,7 @@ class InteractiveTests(ShotgunTestBase):
             self.assertFalse(ld._use_local_browser)
 
         # Then Web login but env override
-        with patch("os.environ.get", return_value="1"), patch(
+        with mock.patch("os.environ.get", return_value="1"), mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={
                 "user_authentication_method": "oxygen",
@@ -659,15 +659,15 @@ class InteractiveTests(ShotgunTestBase):
             self.assertFalse(ld._use_local_browser)
 
     @suppress_generated_code_qt_warnings
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={},
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_recent_users",
         return_value=["john"],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.generate_session_token",
         side_effect=[
             tank_vendor.shotgun_api3.MissingTwoFactorAuthenticationFault(),
@@ -678,7 +678,7 @@ class InteractiveTests(ShotgunTestBase):
     def test_ui_auth_2fa(self, *mocks):
         from tank.authentication.ui.qt_abstraction import QtGui
 
-        with patch.object(
+        with mock.patch.object(
             QtGui.QDialog,
             "exec_",
             return_value=QtGui.QDialog.Accepted,
@@ -747,26 +747,26 @@ class InteractiveTests(ShotgunTestBase):
             )
 
     @suppress_generated_code_qt_warnings
-    @patch(
+    @mock.patch(
         "tank.authentication.login_dialog._is_running_in_desktop",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={
             "user_authentication_method": "oxygen",
             "unified_login_flow_enabled": True,
         },
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_recent_users",
         return_value=["john"],
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.sso_saml2.SsoSaml2.login_attempt",
         return_value=False,
     )
@@ -777,7 +777,7 @@ class InteractiveTests(ShotgunTestBase):
 
         from tank.authentication.ui.qt_abstraction import QtGui
 
-        with patch.object(
+        with mock.patch.object(
             QtGui.QDialog,
             "exec_",
             return_value=QtGui.QDialog.Accepted,
@@ -798,16 +798,16 @@ class InteractiveTests(ShotgunTestBase):
             self.assertIsNone(ld.result())
 
     @suppress_generated_code_qt_warnings
-    @patch("tank.authentication.login_dialog.ULF2_AuthTask.start")
-    @patch(
+    @mock.patch("tank.authentication.login_dialog.ULF2_AuthTask.start")
+    @mock.patch(
         "tank.authentication.login_dialog._is_running_in_desktop",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
         return_value=True,
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.unified_login_flow2.authentication.process",
         return_value=(
             "https://host.shotgunstudio.com",
@@ -816,11 +816,11 @@ class InteractiveTests(ShotgunTestBase):
             None,
         ),
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_preferred_method",
         return_value=None,
     )
-    @patch(  # Only for coverage purposes
+    @mock.patch(  # Only for coverage purposes
         "tank.authentication.session_cache.get_recent_users",
         return_value=["john", "bob"],
     )
@@ -828,12 +828,12 @@ class InteractiveTests(ShotgunTestBase):
         from tank.authentication.ui.qt_abstraction import QtGui
 
         # First basic and ULF2 methods
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={
                 "unified_login_flow2_enabled": True,
             },
-        ), patch.object(
+        ), mock.patch.object(
             QtGui.QDialog,
             "exec_",
             return_value=QtGui.QDialog.Accepted,
@@ -905,12 +905,15 @@ class InteractiveTests(ShotgunTestBase):
             )
 
         # Test SGTK_FORCE_STANDARD_LOGIN_DIALOG override
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={
                 "unified_login_flow2_enabled": True,
             },
-        ), patch("os.environ.get", return_value="1",), self._login_dialog(
+        ), mock.patch(
+            "os.environ.get",
+            return_value="1",
+        ), self._login_dialog(
             True,
             hostname="https://host.shotgunstudio.com",
         ) as ld:
@@ -919,7 +922,7 @@ class InteractiveTests(ShotgunTestBase):
             self.assertFalse(ld._use_local_browser)
 
         # Then Web login vs ULF2
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_site_infos",
             return_value={
                 "user_authentication_method": "oxygen",
@@ -981,16 +984,16 @@ class InteractiveTests(ShotgunTestBase):
                 ),
             )
 
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={
             "unified_login_flow2_enabled": True,
         },
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.generate_session_token", return_value=None
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_recent_hosts",
         return_value=[
             "https://site1.shotgunstudio.com",
@@ -1002,14 +1005,14 @@ class InteractiveTests(ShotgunTestBase):
         handler = console_authentication.ConsoleLoginHandler(fixed_host=False)
 
         # First select the legacy method
-        with patch(
+        with mock.patch(
             "tank.authentication.console_authentication.input",
             side_effect=[
                 "\n",  # Select default SG site (site1)
                 "2",  # Select "legacy" auth method
                 "username",
             ],
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.ConsoleLoginHandler._get_password",
             return_value="password",
         ):
@@ -1019,14 +1022,14 @@ class InteractiveTests(ShotgunTestBase):
             )
 
         # Then repeat the operation but select the ULF2 method
-        with patch(
+        with mock.patch(
             "tank.authentication.console_authentication.input",
             side_effect=[
                 "",  # Select default site -> site4
                 "1",  # Select "ULF2" auth method
                 "",  # OK to continue
             ],
-        ), patch(
+        ), mock.patch(
             "tank.authentication.unified_login_flow2.authentication.process",
             return_value=("https://site4.shotgunstudio.com", "ULF2!", None, None),
         ):
@@ -1039,16 +1042,16 @@ class InteractiveTests(ShotgunTestBase):
         handler = console_authentication.ConsoleLoginHandler(fixed_host=True)
 
         # Then repeat the operation having the site configured with Oxygen
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_user_authentication_method",
             return_value="oxygen",
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.input",
             side_effect=[
                 # No method to select as there is only one option
                 "",  # OK to continue
             ],
-        ), patch(
+        ), mock.patch(
             "tank.authentication.unified_login_flow2.authentication.process",
             return_value="ULF2 result 9867",
         ):
@@ -1058,15 +1061,15 @@ class InteractiveTests(ShotgunTestBase):
             )
 
         # Then, one more small test for coverage
-        with patch(
+        with mock.patch(
             "tank.authentication.sso_saml2.utils._get_user_authentication_method",
             return_value="oxygen",
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.input",
             side_effect=[
                 "",  # OK to continue
             ],
-        ), patch(
+        ), mock.patch(
             "tank.authentication.unified_login_flow2.authentication.process",
             return_value=None,  # Simulate an authentication error
         ):
@@ -1077,16 +1080,16 @@ class InteractiveTests(ShotgunTestBase):
 
         # Finally, disable ULF2 method and ensure legacy cred methods is
         # automatically selected
-        with patch(
+        with mock.patch(
             "tank.authentication.console_authentication.is_unified_login_flow2_enabled_on_site",
             return_value=False,
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.input",
             side_effect=[
                 # No method to select as there is only one option
                 "username",
             ],
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.ConsoleLoginHandler._get_password",
             return_value="password",
         ):
@@ -1095,20 +1098,20 @@ class InteractiveTests(ShotgunTestBase):
                 ("https://site3.shotgunstudio.com", "username", None, None),
             )
 
-    @patch(
+    @mock.patch(
         "tank.authentication.sso_saml2.utils._get_site_infos",
         return_value={
             "unified_login_flow2_enabled": True,
         },
     )
-    @patch(
+    @mock.patch(
         "tank.authentication.session_cache.get_preferred_method",
         return_value=None,
     )
     def test_console_get_auth_method(self, *unused_mocks):
         handler = console_authentication.ConsoleLoginHandler(fixed_host=True)
 
-        with patch(
+        with mock.patch(
             "tank.authentication.console_authentication.input",
             return_value="1",
         ):
@@ -1117,7 +1120,7 @@ class InteractiveTests(ShotgunTestBase):
                 handler._authenticate_unified_login_flow2,
             )
 
-        with patch(
+        with mock.patch(
             "tank.authentication.console_authentication.input",
             return_value="2",
         ):
@@ -1126,10 +1129,10 @@ class InteractiveTests(ShotgunTestBase):
                 handler._authenticate_legacy,
             )
 
-        with patch(
+        with mock.patch(
             "tank.authentication.session_cache.get_preferred_method",
             return_value=auth_constants.METHOD_BASIC,
-        ), patch(
+        ), mock.patch(
             "tank.authentication.console_authentication.input",
             return_value="",
         ):
@@ -1139,7 +1142,7 @@ class InteractiveTests(ShotgunTestBase):
             )
 
         for wrong_value in ["0", "3", "-1", "42", "wrong"]:
-            with patch(
+            with mock.patch(
                 "tank.authentication.console_authentication.input",
                 return_value=wrong_value,
             ):

--- a/tests/authentication_tests/test_session_cache.py
+++ b/tests/authentication_tests/test_session_cache.py
@@ -11,9 +11,12 @@
 from __future__ import with_statement
 
 import os
-from mock import patch
 
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
 from tank_test.tank_test_base import setUpModule  # noqa
 
 from tank.authentication import session_cache
@@ -214,7 +217,7 @@ class SessionCacheTests(ShotgunTestBase):
     def test_url_cleanup(self):
 
         # Make sure that if a file has the url saved incorrectly...
-        with patch("sgtk.util.shotgun.connection.sanitize_url", wraps=lambda x: x):
+        with mock.patch("sgtk.util.shotgun.connection.sanitize_url", wraps=lambda x: x):
             session_cache.set_current_host("https://host.cleaned.up.on.read/")
             # ... then sure we indeed disabled cleanup and that the malformed value was written to disk...
             self.assertEqual(

--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -9,13 +9,16 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from __future__ import with_statement
-from mock import patch
 import os
 import base64
 
 from tank_vendor import six
 
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
 from tank_test.tank_test_base import setUpModule  # noqa
 
 from tank.authentication import (
@@ -44,9 +47,9 @@ class CustomDefaultManager(DefaultsManager):
 
 
 class ShotgunAuthenticatorTests(ShotgunTestBase):
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank.authentication.session_cache.generate_session_token")
-    @patch("tank.util.LocalFileStorageManager.get_global_root")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank.authentication.session_cache.generate_session_token")
+    @mock.patch("tank.util.LocalFileStorageManager.get_global_root")
     def test_create_session_user(
         self, get_global_root, generate_session_token_mock, server_caps_mock
     ):
@@ -126,7 +129,7 @@ class ShotgunAuthenticatorTests(ShotgunTestBase):
         connection = session_user.create_sg_connection()
         self.assertEqual(connection.config.session_token, "session_token")
 
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
     def test_create_script_user(self, server_caps_mock):
         """
         Makes sure that create_script_user does correct input validation.
@@ -151,14 +154,14 @@ class ShotgunAuthenticatorTests(ShotgunTestBase):
         self.assertEqual(connection.config.script_name, "api_script")
         self.assertEqual(connection.config.api_key, "api_key")
 
-    @patch("tank.authentication.session_cache.get_current_host", return_value=None)
+    @mock.patch("tank.authentication.session_cache.get_current_host", return_value=None)
     def test_no_current_host(self, _):
         """
         Makes sure the login is None when there is no host.
         """
         self.assertIsNone(DefaultsManager().get_login())
 
-    @patch("tank.authentication.session_cache.generate_session_token")
+    @mock.patch("tank.authentication.session_cache.generate_session_token")
     def test_get_default_user(self, generate_session_token_mock):
         """
         Makes sure get_default_user handles all the edge cases.

--- a/tests/authentication_tests/test_shotgun_wrapper.py
+++ b/tests/authentication_tests/test_shotgun_wrapper.py
@@ -9,9 +9,12 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from __future__ import with_statement
-from mock import patch
 
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
 from tank_test.tank_test_base import setUpModule  # noqa
 
 
@@ -24,9 +27,9 @@ class ShotgunWrapperTests(ShotgunTestBase):
     Tests the user_impl module.
     """
 
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
     def test_create_connection_with_session_renewal(
         self, renew_session_mock, server_caps_mock, _call_rpc_mock
     ):
@@ -59,9 +62,9 @@ class ShotgunWrapperTests(ShotgunTestBase):
         self.assertEqual(_call_rpc_mock.call_count, 2)
         self.assertEqual(id(mocked_result), id(test_result))
 
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
     def test_create_connection_with_session_renewal_failure(
         self, renew_session_mock, server_caps_mock, _call_rpc_mock
     ):
@@ -90,10 +93,10 @@ class ShotgunWrapperTests(ShotgunTestBase):
         self.assertTrue(renew_session_mock.called)
         self.assertEqual(_call_rpc_mock.call_count, 1)
 
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank.authentication.interactive_authentication.renew_session")
-    @patch("tank.authentication.session_cache.get_session_data")
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank.authentication.session_cache.get_session_data")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
     def test_successfull_session_cache_snooping(
         self,
         _call_rpc_mock,
@@ -138,10 +141,10 @@ class ShotgunWrapperTests(ShotgunTestBase):
         # We should have talked to the server twice.
         self.assertEqual(_call_rpc_mock.call_count, 2)
 
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank.authentication.interactive_authentication.renew_session")
-    @patch("tank.authentication.session_cache.get_session_data")
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank.authentication.session_cache.get_session_data")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
     def test_failed_session_cache_snooping(
         self,
         _call_rpc_mock,

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -15,9 +15,10 @@ import base64
 import pytest
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase
-
-from mock import patch
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 from tank.authentication import user, user_impl, errors
 from tank_vendor.shotgun_api3 import AuthenticationFault
@@ -207,9 +208,9 @@ class UserTests(ShotgunTestBase):
             }
             user_impl.ScriptUser.from_dict(script_user_with_unknown_data)
 
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
-    @patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
     def test_refresh_credentials_failure(
         self, renew_session_mock, call_rpc_mock, server_caps_mock
     ):
@@ -228,9 +229,9 @@ class UserTests(ShotgunTestBase):
         with self.assertRaises(AuthenticationFault):
             sg._call_rpc()
 
-    @patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
-    @patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
-    @patch("tank.authentication.interactive_authentication.renew_session")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun._call_rpc")
+    @mock.patch("tank.authentication.interactive_authentication.renew_session")
     def test_refresh_credentials_on_old_connection(
         self, renew_session_mock, call_rpc_mock, server_caps_mock
     ):
@@ -301,7 +302,7 @@ class UserTests(ShotgunTestBase):
     def _test_resolve_entity(
         self, class_name, entity_type, field_name, field_value, factory, error_type
     ):
-        with patch(
+        with mock.patch(
             "tank.authentication.user_impl.%s.create_sg_connection" % class_name,
             return_value=self.mockgun,
         ):

--- a/tests/bootstrap_tests/test_backups.py
+++ b/tests/bootstrap_tests/test_backups.py
@@ -13,15 +13,17 @@ from __future__ import with_statement
 import os
 import fnmatch
 import stat
-from mock import patch
 import sgtk
 from sgtk.pipelineconfig_utils import get_metadata
 from tank.util import is_windows
 from shutil import copytree
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import temp_env_var
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    temp_env_var,
+)
 
 
 # Copied from Python 2.7's source code.
@@ -127,7 +129,7 @@ class TestBackups(ShotgunTestBase):
                 self.core_backup_folder_path = core
 
             # Update the configuration, but don't clean up backups
-            with patch.object(
+            with mock.patch.object(
                 sgtk.bootstrap.resolver.CachedConfiguration,
                 "_cleanup_backup_folders",
                 new=dont_cleanup_backup_folders,
@@ -201,7 +203,7 @@ class TestBackups(ShotgunTestBase):
                 self.config_backup_folder_path = config
                 self.core_backup_folder_path = core
 
-            with patch.object(
+            with mock.patch.object(
                 sgtk.bootstrap.resolver.CachedConfiguration,
                 "_cleanup_backup_folders",
                 new=dont_cleanup_backup_folders,

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -13,10 +13,13 @@ from __future__ import with_statement
 import uuid
 import os
 import sys
-from mock import patch, Mock
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, temp_env_var
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    TankTestBase,
+)
 
 from tank.bootstrap import constants
 from sgtk.bootstrap.cached_configuration import CachedConfiguration
@@ -76,7 +79,7 @@ class TestConfiguration(TestConfigurationBase):
         configuration = Configuration(None, None)
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=default_user,
         ):
@@ -102,12 +105,12 @@ class TestConfiguration(TestConfigurationBase):
         default_user = self._create_session_user("default_user")
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=default_user,
         ):
             # Python 2.6 doesn't support multi-expression with statement, so nest the calls instead.
-            with patch(
+            with mock.patch(
                 "tank_vendor.shotgun_authentication.deserialize_user",
                 wraps=tank_vendor.shotgun_authentication.deserialize_user,
             ) as deserialize_wrapper:
@@ -135,7 +138,7 @@ class TestConfiguration(TestConfigurationBase):
         script_user = self._create_script_user("api_script")
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=script_user,
         ):
@@ -160,7 +163,7 @@ class TestConfiguration(TestConfigurationBase):
             "default_user", "https://test-2.shotgunstudio.com"
         )
 
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=project_user,
         ):
@@ -184,7 +187,7 @@ class TestConfiguration(TestConfigurationBase):
         script_user_for_project = self._create_script_user("api_script_for_project")
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=script_user_for_project,
         ):
@@ -211,7 +214,7 @@ class TestConfiguration(TestConfigurationBase):
         user_for_project = self._create_session_user("project_user")
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=user_for_project,
         ):
@@ -290,7 +293,7 @@ class TestSSOClaims(TestConfigurationBase):
         self._configuration.update_configuration()
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=project_user,
         ):
@@ -312,7 +315,7 @@ class TestSSOClaims(TestConfigurationBase):
         bootstrap_user.is_claims_renewal_active = lambda: True
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=project_user,
         ):
@@ -336,7 +339,7 @@ class TestSSOClaims(TestConfigurationBase):
         bootstrap_user.is_claims_renewal_active = lambda: True
 
         # Create a default user.
-        with patch(
+        with mock.patch(
             "tank.authentication.ShotgunAuthenticator.get_default_user",
             return_value=script_user,
         ):
@@ -425,9 +428,9 @@ class TestBakedConfiguration(TestConfigurationBase):
         if sgtk.constants.ENV_VAR_EXTERNAL_PIPELINE_CONFIG_DATA in os.environ:
             del os.environ[sgtk.constants.ENV_VAR_EXTERNAL_PIPELINE_CONFIG_DATA]
 
-    @patch("tank.authentication.ShotgunAuthenticator.get_user")
-    @patch("sgtk.bootstrap.configuration_writer.ConfigurationWriter.install_core")
-    @patch(
+    @mock.patch("tank.authentication.ShotgunAuthenticator.get_user")
+    @mock.patch("sgtk.bootstrap.configuration_writer.ConfigurationWriter.install_core")
+    @mock.patch(
         "sgtk.bootstrap.configuration_writer.ConfigurationWriter.create_tank_command"
     )
     def test_build_and_use(

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -14,14 +14,16 @@ import os
 import sys
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 import sgtk
 from sgtk.bootstrap.configuration_writer import ConfigurationWriter
 from sgtk.util import ShotgunPath
 from tank.util import is_macos, is_windows
 from tank_vendor import yaml
-from mock import patch, MagicMock
 
 
 class TestConfigurationWriterBase(ShotgunTestBase):
@@ -191,7 +193,7 @@ class TestInterpreterFilesWriter(TestConfigurationWriterBase):
             fh.write(path)
 
         # We're going to pretend the interpreter location exists
-        with patch("os.path.exists", return_value=True):
+        with mock.patch("os.path.exists", return_value=True):
             # Check that our descriptors sees the value we just wrote to disk
             self.assertEqual(descriptor.python_interpreter, path)
         # Copy the descriptor to its location.

--- a/tests/bootstrap_tests/test_manager.py
+++ b/tests/bootstrap_tests/test_manager.py
@@ -12,13 +12,16 @@ from __future__ import with_statement
 import os
 
 import sgtk
-from mock import patch, Mock
 
 from sgtk.bootstrap import ToolkitManager
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
-from tank_test.tank_test_base import TankTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    TankTestBase,
+    temp_env_var,
+)
 
 
 class TestErrorHandling(ShotgunTestBase):
@@ -39,7 +42,10 @@ class TestErrorHandling(ShotgunTestBase):
 
 
 class TestFunctionality(ShotgunTestBase):
-    @patch("tank.authentication.ShotgunAuthenticator.get_user", return_value=Mock())
+    @mock.patch(
+        "tank.authentication.ShotgunAuthenticator.get_user",
+        return_value=mock.Mock(),
+    )
     def test_pipeline_config_id_env_var(self, _):
         """
         Tests the SHOTGUN_PIPELINE_CONFIGURATION_ID being picked up at init
@@ -55,7 +61,9 @@ class TestFunctionality(ShotgunTestBase):
             mgr = ToolkitManager()
             self.assertEqual(mgr.pipeline_configuration, None)
 
-    @patch("tank.authentication.ShotgunAuthenticator.get_user", return_value=Mock())
+    @mock.patch(
+        "tank.authentication.ShotgunAuthenticator.get_user", return_value=mock.Mock()
+    )
     def test_get_entity_from_environment(self, _):
         """
         Ensure the ToolkitManager can extract the entities from the environment
@@ -82,7 +90,9 @@ class TestFunctionality(ShotgunTestBase):
         with temp_env_var(SHOTGUN_ENTITY_TYPE="Shot", SHOTGUN_ENTITY_ID="invalid"):
             self.assertEqual(mgr.get_entity_from_environment(), None)
 
-    @patch("tank.authentication.ShotgunAuthenticator.get_user", return_value=Mock())
+    @mock.patch(
+        "tank.authentication.ShotgunAuthenticator.get_user", return_value=mock.Mock()
+    )
     def test_shotgun_bundle_cache(self, _):
         """
         Ensures ToolkitManager deals property with bundle cache from the user and from
@@ -128,7 +138,9 @@ class TestFunctionality(ShotgunTestBase):
             set(mgr._get_bundle_cache_fallback_paths()), set(["/a/b/c", "/d/e/f"])
         )
 
-    @patch("tank.authentication.ShotgunAuthenticator.get_user", return_value=Mock())
+    @mock.patch(
+        "tank.authentication.ShotgunAuthenticator.get_user", return_value=mock.Mock()
+    )
     def test_serialization(self, _):
         """
         Ensures we're serializing the manager properly.
@@ -339,9 +351,9 @@ class TestGetPipelineConfigs(TankTestBase):
         config = configs[0]
         self.assertEqual(config["name"], "Doe Dev")
 
-    @patch(
+    @mock.patch(
         "tank.bootstrap.resolver.ConfigurationResolver._create_config_descriptor",
-        return_value=Mock(),
+        return_value=mock.Mock(),
     )
     def test_latest_tracking_descriptor(self, _):
         """
@@ -367,7 +379,7 @@ class TestGetPipelineConfigs(TankTestBase):
         configs = mgr.get_pipeline_configurations(self._project)
 
         config = configs[0]
-        self.assertTrue(isinstance(config["descriptor"], Mock))
+        self.assertTrue(isinstance(config["descriptor"], mock.Mock))
         self.assertEqual(
             config["descriptor_source_uri"],
             "sgtk:descriptor:app_store?name=tk-config-basic",

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -13,13 +13,15 @@ from __future__ import with_statement
 import itertools
 import os
 import sys
-from mock import patch, Mock
 import sgtk
 from sgtk.util import ShotgunPath
 from tank_vendor.shotgun_api3.lib import sgsix
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import TankTestBase, temp_env_var
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 from tank.bootstrap import constants
 
 
@@ -248,7 +250,7 @@ class TestPluginMatching(TestResolverBase):
         self.assertFalse(_match_plugin_helper(None))
         self.assertFalse(_match_plugin_helper("foo.maya"))
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_single_matching_id(self, _):
         """
         Picks the sandbox with the right plugin id.
@@ -315,7 +317,7 @@ class TestFallbackHandling(TestResolverBase):
             "name": "tk-config-test",
         }
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_resolve_base_config(self, find_mock):
         """
         Tests the direct config resolve, which doesn't talk to Shotgun
@@ -327,7 +329,7 @@ class TestFallbackHandling(TestResolverBase):
         # make sure we didn't talk to shotgun
         self.assertEqual(find_mock.called, False)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_resolve_latest_base_config(self, find_mock):
         """
         Tests the direct config resolve for a descriptor with no version number set
@@ -351,8 +353,8 @@ class TestAutoUpdate(TestResolverBase):
         super(TestAutoUpdate, self).setUp()
         self.resolver._plugin_id = 'basic.desktop'
 
-    @patch("sys.version_info", return_value=Mock())
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("sys.version_info", return_value=mock.Mock())
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_autoupdate_config(self, find_mock, _):
         """
         Tests that the configuration resolved is the maximum tk-config-basic
@@ -472,7 +474,7 @@ class TestResolverPriority(TestResolverBase):
 
         :param str expected_path: Expected value for the current platform's path.
         """
-        with patch("os.path.isdir", return_value=True):
+        with mock.patch("os.path.isdir", return_value=True):
             config = self.resolver.resolve_shotgun_configuration(
                 pipeline_config_identifier=None,
                 fallback_config_descriptor=self.config_1,
@@ -577,7 +579,7 @@ class TestResolverPriority(TestResolverBase):
         self.assertEqual(primaries[0]["project"], self._project)
         self.assertEqual(primaries[0]["plugin_ids"], None)
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_more_recent_pipeline_is_shadowed(self, _):
         """
         When two pipeline configurations could have be chosen during resolve_shotgun_configuration
@@ -657,7 +659,7 @@ class TestPipelineLocationFieldPriority(TestResolverBase):
     Tests the field priority between descriptor, xxx_path and uploaded_config
     """
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_path_override(self, _):
         """
         If pipeline config paths are defined, these take precedence over the descriptor field.
@@ -876,7 +878,7 @@ class TestResolverSiteConfig(TestResolverBase):
             bundle_cache_fallback_paths=[self.install_root],
         )
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_resolve_installed_from_sg(self, _):
         """
         When a path is set, we have an installed configuration.
@@ -1033,7 +1035,7 @@ class TestResolvedLatestConfiguration(TankTestBase):
 
 
 class TestResolveWithFilter(TestResolverBase):
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_existing_pc_ic(self, _):
         """
         Resolve an existing pipeline configuration by id.
@@ -1051,7 +1053,7 @@ class TestResolveWithFilter(TestResolverBase):
 
         self.assertEqual(config._path.current_os, "sg_path")
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_non_existing_pc_ic(self, _):
         """
         Resolve a non-existent pipeline configuration by id should fail.
@@ -1066,7 +1068,7 @@ class TestResolveWithFilter(TestResolverBase):
                 current_login="john.smith",
             )
 
-    @patch("os.path.isdir", return_value=True)
+    @mock.patch("os.path.isdir", return_value=True)
     def test_resolve_by_name(self, _):
         """
         Ensure that specifying for pipeline by name works.
@@ -1184,7 +1186,7 @@ class TestErrorHandling(TestResolverBase):
             descriptor="sgtk:descriptor:app_store?name=tk-unknown-config",
         )
 
-        with patch(
+        with mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore.has_remote_access",
             return_value=False,
         ):

--- a/tests/commands_tests/test_core_update.py
+++ b/tests/commands_tests/test_core_update.py
@@ -15,31 +15,34 @@ from __future__ import with_statement
 
 import logging
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 from sgtk.pipelineconfig_utils import get_core_descriptor
-from mock import patch
 
 from tank_test.mock_appstore import patch_app_store
 
 
 # We need to patch the currently running core API version, as this will
 # likely be HEAD otherwise when running tests.
-@patch(
+@mock.patch(
     "tank.pipelineconfig_utils.get_currently_running_api_version",
     return_value="v0.18.91",
 )
 # Since we are mocking the app store core releases, there won't be any release notes,
 # so we should mock those as well, otherwise it will fail
-@patch(
+@mock.patch(
     "tank.commands.core_upgrade.TankCoreUpdater.get_release_notes",
     return_value=("description", "url"),
 )
 # We're mocking _install_core so that it does nothing. We are only
 # testing that it can update the core_api.yml.
-@patch("tank.commands.core_upgrade.TankCoreUpdater._install_core",)
+@mock.patch("tank.commands.core_upgrade.TankCoreUpdater._install_core")
 # Need to set the path to the cache config, this is done in the method.
-@patch("tank.pipelineconfig_utils.get_path_to_current_core",)
+@mock.patch("tank.pipelineconfig_utils.get_path_to_current_core")
 class TestCoreUpdate(TankTestBase):
     """
     Makes sure environment code works with the app store mocker.
@@ -85,7 +88,7 @@ class TestCoreUpdate(TankTestBase):
         descriptor = get_core_descriptor(self.pipeline_config_root, self.tk.shotgun)
         self.assertEqual(descriptor.version, "v0.19.5")
 
-    @patch(
+    @mock.patch(
         "tank.descriptor.descriptor.Descriptor.is_immutable", return_value=True,
     )
     def test_immutable_config_core_update_core_api_yaml(
@@ -107,10 +110,10 @@ class TestCoreUpdate(TankTestBase):
         descriptor = get_core_descriptor(self.pipeline_config_root, self.tk.shotgun)
         self.assertEqual(descriptor.version, "v0.18.91")
 
-    @patch(
+    @mock.patch(
         "tank.descriptor.descriptor.Descriptor.is_dev", return_value=True,
     )
-    @patch("tank.descriptor.descriptor.Descriptor.get_path")
+    @mock.patch("tank.descriptor.descriptor.Descriptor.get_path")
     def test_dev_config_core_update_core_api_yaml(
         self, mock_get_path, _mock_is_dev, mock_config_path, *_
     ):

--- a/tests/commands_tests/test_pipeconfig.py
+++ b/tests/commands_tests/test_pipeconfig.py
@@ -23,9 +23,12 @@ import sgtk
 from tank.errors import TankError
 from tank.util import is_windows
 
-from mock import patch
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 from tank_test.mock_appstore import patch_app_store
 
 
@@ -103,7 +106,7 @@ class TestPipelineConfig(TankTestBase):
                 raise OSError("os.rename is disabled")
             return unmocked_os_rename(src, dst)
 
-        with patch("os.rename", side_effect=mocked_rename):
+        with mock.patch("os.rename", side_effect=mocked_rename):
             # And push again
             push_cmd.execute({"target_id": cloned_pc_id})
             sgtk.sgtk_from_path(temp_pc_dir)

--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -17,12 +17,15 @@ from __future__ import with_statement
 import datetime
 import os
 import sgtk
-from mock import patch
 
 from sgtk.util import ShotgunPath
 
-from tank_test.tank_test_base import TankTestBase
+
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 
 class TestSetupProjectWizard(TankTestBase):
@@ -196,7 +199,8 @@ class TestSetupProjectWizard(TankTestBase):
         self._wizard.set_configuration_location(path.linux, path.windows, path.macosx)
 
         # Upload method not implemented on Mockgun yet, so skip that bit.
-        with patch("tank_vendor.shotgun_api3.lib.mockgun.mockgun.Shotgun.upload"):
-            with patch("tank.pipelineconfig_utils.get_core_api_version") as api_mock:
-                api_mock.return_value = "HEAD"
-                self._wizard.execute()
+        with mock.patch(
+            "tank_vendor.shotgun_api3.lib.mockgun.mockgun.Shotgun.upload"
+        ), mock.patch("tank.pipelineconfig_utils.get_core_api_version") as api_mock:
+            api_mock.return_value = "HEAD"
+            self._wizard.execute()

--- a/tests/commands_tests/test_setupproject.py
+++ b/tests/commands_tests/test_setupproject.py
@@ -18,10 +18,13 @@ import logging
 
 import tank
 from tank.util import is_linux, is_macos, is_windows
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 from tank_test.mock_appstore import patch_app_store
-from mock import patch
 
 
 class TestSetupProject(TankTestBase):
@@ -72,7 +75,7 @@ class TestSetupProject(TankTestBase):
             self.create_file(os.path.join(cfg_core, "interpreter_Linux.cfg"), "")
             self.create_file(os.path.join(cfg_core, "interpreter_Windows.cfg"), "")
 
-    @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
+    @mock.patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
     def test_setup_centralized_project(self, mocked=None):
         """
         Test setting up a Project.
@@ -122,8 +125,8 @@ class TestSetupProject(TankTestBase):
             )
         )
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload")
-    @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload")
+    @mock.patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
     def test_setup_distributed_project(
         self, resolve_all_os_paths_to_core_mock, upload_mock
     ):
@@ -188,8 +191,8 @@ class TestSetupProject(TankTestBase):
         self.assertEqual(pc_data["mac_path"], None)
         self.assertEqual(pc_data["id"], self.upload_associated_pipeline_config_id)
 
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_install_location")
-    @patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_install_location")
+    @mock.patch("tank.pipelineconfig_utils.resolve_all_os_paths_to_core")
     def test_setup_project_with_external_core(
         self, resolve_all_os_paths_to_core_mock, get_install_location_mock
     ):

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -10,15 +10,16 @@
 
 import os
 
-from mock import Mock, patch
-
-
 import tank
 from tank.api import Tank
 from tank.template import TemplatePath, TemplateString
 from tank.templatekey import StringKey, IntegerKey, SequenceKey
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 
 class TestInit(TankTestBase):
@@ -381,7 +382,7 @@ class TestPathsFromTemplateGlob(TankTestBase):
             "{Shot}/{version}/filename.{seq_num}", keys, root_path=self.project_root
         )
 
-    @patch("tank.api.glob.iglob")
+    @mock.patch("tank.api.glob.iglob")
     def assert_glob(self, fields, expected_glob, skip_keys, mock_glob):
         # want to ensure that value returned from glob is returned
         expected = [os.path.join(self.project_root, "shot_1", "001", "filename.00001")]

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -18,9 +18,11 @@ import datetime
 from sgtk.util import pickle
 import json
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
-
-from mock import patch, PropertyMock
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 import tank
 from tank import context
@@ -189,7 +191,7 @@ class TestEq(TestContext):
         # Assert that hashing function treats these as unequal
         self.assertNotEqual(hash(context_1), hash(not_context))
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_lazy_load_user(self, get_current_user):
 
         get_current_user.return_value = self.current_user
@@ -219,7 +221,7 @@ class TestUser(TestContext):
         kws1["step"] = self.step
         self.context = context.Context(**kws1)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_local_login(self, get_current_user):
         """
         Test that if user is not supplied, the human user matching the
@@ -241,7 +243,7 @@ class TestCreateEmpty(TestContext):
 
 
 class TestFromPath(TestContext):
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_shot(self, get_current_user):
 
         get_current_user.return_value = self.current_user
@@ -258,7 +260,7 @@ class TestFromPath(TestContext):
         self.assertIsNone(result.step)
         self.assertIsNone(result.task)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_external_path(self, get_current_user):
         get_current_user.return_value = self.current_user
         shot_path_abs = os.path.abspath(os.path.join(self.project_root, ".."))
@@ -289,7 +291,7 @@ class TestFromPath(TestContext):
 
 
 class TestFromPathWithPrevious(TestContext):
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_shot(self, get_current_user):
 
         get_current_user.return_value = self.current_user
@@ -451,7 +453,7 @@ class TestFromEntity(TestContext):
         self.add_to_sg_mock_db(self.task)
         self.add_to_sg_mock_db(self.publishedfile)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_from_linked_entity_types(self, get_current_user):
         get_current_user.return_value = self.current_user
 
@@ -481,7 +483,7 @@ class TestFromEntity(TestContext):
             check_name=False,
         )
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_entity_from_cache(self, get_current_user):
 
         get_current_user.return_value = self.current_user
@@ -501,7 +503,7 @@ class TestFromEntity(TestContext):
         self.check_entity(self.step, result.step)
         self.assertEqual(3, len(result.step))
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_step_higher_entity(self, get_current_user):
         """
         Case that step appears in path above entity.
@@ -520,7 +522,7 @@ class TestFromEntity(TestContext):
         self.check_entity(self.shot, result.entity)
         self.check_entity(self.current_user, result.user)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_task_from_sg(self, get_current_user):
         """
         Case that all data is found from shotgun query
@@ -564,7 +566,7 @@ class TestFromEntity(TestContext):
         num_finds_after = self.tk.shotgun.finds
         self.assertEqual((num_finds_after - num_finds_before), 1)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_data_missing_non_task(self, get_current_user):
         """
         Case that entity does not exist on local cache or in shotgun
@@ -599,8 +601,8 @@ class TestFromEntity(TestContext):
             TankError, context.from_entity, self.tk, task["type"], task["id"]
         )
 
-    @patch("tank.context.from_entity")
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.context.from_entity")
+    @mock.patch("tank.util.login.get_current_user")
     def test_from_entity_dictionary(self, get_current_user, from_entity):
         """
         Test context.from_entity_dictionary - this can contruct a context from
@@ -633,8 +635,8 @@ class TestFromEntity(TestContext):
 
         self.check_entity(self.current_user, result.user)
 
-    @patch("tank.context.from_entity")
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.context.from_entity")
+    @mock.patch("tank.util.login.get_current_user")
     def test_from_entity_dictionary_additional_entities(
         self, get_current_user, from_entity
     ):
@@ -856,13 +858,13 @@ class TestAsTemplateFields(TestContext):
     # It seems like Python 2.7.16+ is a bit less comfortable with paths with the wrong orientation
     # for the slashes, so we'll generate test data that is more conforming to the current platform.
     # This isn't an issue in the real world, as we always sanitize our inputs.
-    @patch(
+    @mock.patch(
         "tank.context.Context._get_project_roots",
         return_value=["{0}{0}foo{0}bar".format(os.path.sep)],
     )
-    @patch(
+    @mock.patch(
         "tank.context.Context.entity_locations",
-        new_callable=PropertyMock(
+        new_callable=mock.PropertyMock(
             return_value=["{0}{0}foo{0}bar{0}baz".format(os.path.sep)]
         ),
     )
@@ -1432,7 +1434,7 @@ class TestMultiRoot(TestContext):
         self.assertEqual(expected_step_name, result["Step"])
         self.assertEqual(expected_shot_name, result["Shot"])
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_non_primary_path(self, get_current_user):
         """Check that path which is not child of primary root create context."""
         get_current_user.return_value = self.current_user

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -13,14 +13,18 @@ import os
 import itertools
 
 import tank
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    temp_env_var,
+)
+
 from tank.template_includes import _get_includes as get_template_includes
 from tank.platform.environment_includes import (
     _resolve_includes as get_environment_includes,
 )
 from tank_vendor.shotgun_api3.lib import sgsix
-from mock import patch
 
 
 class Includes(object):
@@ -39,7 +43,7 @@ class Includes(object):
         _file_name = os.path.join(os.getcwd(), "test.yml")
         _file_dir = os.path.dirname(_file_name)
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_env_var_only(self, _):
             """
             Validate that a lone environment variable will resolve on all platforms.
@@ -51,7 +55,7 @@ class Includes(object):
                     self._resolve_includes("$INCLUDE_ENV_VAR"), [resolved_include]
                 )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_tilde(self, _):
             """
             Validate that a tilde will resolve on all platforms.
@@ -60,7 +64,7 @@ class Includes(object):
             resolved_include = os.path.expanduser(include)
             self.assertEqual(self._resolve_includes(include), [resolved_include])
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_relative_path(self, _):
             """
             Validate that relative path are processed correctly
@@ -71,7 +75,7 @@ class Includes(object):
                 [os.path.join(self._file_dir, "sub_folder", "include.yml")],
             )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_relative_path_with_env_var(self, _):
             """
             Validate that relative path with env vars are processed correctly
@@ -83,7 +87,7 @@ class Includes(object):
                     [os.path.join(os.getcwd(), "include.yml")],
                 )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_path_with_env_var_in_front(self, _):
             """
             Validate that relative path are processed correctly on all platforms.
@@ -95,7 +99,7 @@ class Includes(object):
                     [os.path.join(os.getcwd(), "include.yml")],
                 )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_path_with_env_var_in_middle(self, _):
             """
             Validate that relative path are processed correctly on all platforms.
@@ -106,7 +110,7 @@ class Includes(object):
                     self._resolve_includes(include), [os.path.expandvars(include)]
                 )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_path_with_multi_os_path(self, _):
             """
             Validate that relative path are processed correctly on all platforms.
@@ -122,7 +126,7 @@ class Includes(object):
                 [paths[sgsix.platform]],  # get the value for the current platform
             )
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_path_with_relative_env_var(self, _):
             """
             Validate that relative path are processed correctly on all platforms.
@@ -149,7 +153,7 @@ class Includes(object):
             with self.assertRaisesRegex(tank.TankError, "Include resolve error"):
                 self._resolve_includes("dead/path/to/a/file")
 
-        @patch("os.path.exists", return_value=True)
+        @mock.patch("os.path.exists", return_value=True)
         def test_includes_ordering(self, _):
             """
             Ensure include orders is preserved.

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -13,10 +13,12 @@ import os
 import copy
 
 import sgtk
-from mock import patch
 
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 
 class TestLogManager(ShotgunTestBase):
@@ -61,7 +63,7 @@ class TestLogManager(ShotgunTestBase):
         unicode_str = "司狼 神威"
 
         # When a logger's emit method fails, the handleError method is called.
-        with patch.object(
+        with mock.patch.object(
             manager.base_file_handler, "handleError"
         ) as handle_error_mock:
             # This used to not log.

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -19,10 +19,12 @@ import shutil
 import contextlib
 import logging
 
-from mock import Mock, patch, call
-
-from tank_test.tank_test_base import TankTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+    temp_env_var,
+)
 
 from tank import path_cache
 from tank import folder
@@ -129,7 +131,7 @@ class TestInit(TestPathCache):
             self.tk.pipeline_configuration.get_project_id(),
             self.tk.pipeline_configuration.get_shotgun_id(),
         )
-        with patch.object(
+        with mock.patch.object(
             self.tk.pipeline_configuration, "get_plugin_id", return_value="basic.maya"
         ):
             self.assertEqual(
@@ -139,7 +141,7 @@ class TestInit(TestPathCache):
                 ),
             )
 
-        with patch.object(
+        with mock.patch.object(
             self.tk.pipeline_configuration, "get_plugin_id", return_value=None
         ):
             self.assertEqual(
@@ -1128,11 +1130,11 @@ class TestPathCacheDelete(TankTestBase):
         add_item_to_cache(self._pc, self._asset_entity, self._asset_full_path)
 
         # Wrap some methods in a mock so we can track their usage.
-        self._pc._do_full_sync = Mock(wraps=self._pc._do_full_sync)
-        self._pc._import_filesystem_location_entry = Mock(
+        self._pc._do_full_sync = mock.Mock(wraps=self._pc._do_full_sync)
+        self._pc._import_filesystem_location_entry = mock.Mock(
             wraps=self._pc._import_filesystem_location_entry
         )
-        self._pc._remove_filesystem_location_entities = Mock(
+        self._pc._remove_filesystem_location_entities = mock.Mock(
             wraps=self._pc._remove_filesystem_location_entities
         )
 
@@ -1432,7 +1434,7 @@ class TestPathCacheBatchOperation(TankTestBase):
         record_count = list(cursor.execute("select count(*) from shotgun_status"))[0][0]
         self.assertEqual(record_count, 3)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_full_shotgun_retrieval(self, find_mock):
         """
         Tests that _get_filesystem_location_entities creates expected query structures
@@ -1481,7 +1483,7 @@ class TestPathCacheBatchOperation(TankTestBase):
 
         self.assertEqual(entities, find_return_payload)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_batched_shotgun_retrieval(self, find_mock):
         """
         Tests that _get_filesystem_location_entities creates expected query structures
@@ -1519,7 +1521,7 @@ class TestPathCacheBatchOperation(TankTestBase):
         expected_calls = []
         for x in range(8):
             expected_calls.append(
-                call(
+                mock.call(
                     "FilesystemLocation",
                     expected_ids[x],
                     [

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -12,10 +12,12 @@ import os
 import logging
 import shutil
 
-from mock import patch
-
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import TankTestBase, temp_env_var
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+    temp_env_var,
+)
 
 import tank
 from tank.commands import get_command
@@ -304,10 +306,10 @@ class TestConfigLocations(TankTestBase):
             self.assertEqual(tank.pipelineconfig_utils.is_localized(core_root), True)
 
         # We have to patch these methods because the core doesn't actually exist on disk for the tests.
-        with patch(
+        with mock.patch(
             "sgtk.pipelineconfig_utils.get_path_to_current_core", return_value=core_root
         ):
-            with patch(
+            with mock.patch(
                 "sgtk.pipelineconfig_utils.resolve_all_os_paths_to_core",
                 return_value={
                     "linux2": core_root if is_linux() else None,

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -16,8 +16,13 @@ from tank.api import Tank
 from tank.util import is_windows
 from tank.errors import TankInitError
 from sgtk.util import ShotgunPath
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule  # noqa
-from mock import patch
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    TankTestBase,
+)
+
 import tank_vendor.six.moves.cPickle as pickle
 from tank_vendor.shotgun_api3.lib import sgsix
 
@@ -514,18 +519,18 @@ class TestLookupCache(ShotgunTestBase):
         """
         The cache's schema has changed, ensure it stays backwards compatible.
         """
-        with patch(
+        with mock.patch(
             "tank.util.shotgun.get_sg_connection", return_value=self.mockgun
-        ) as mock:
+        ) as mock1:
             # Force read from Shotgun, a connection must be made to Shotgun.
-            mock.reset_mock()
+            mock1.reset_mock()
             sgtk.pipelineconfig_factory._get_pipeline_configs(True)
-            self.assertTrue(mock.called)
+            self.assertTrue(mock1.called)
 
             # Do not force read from Shotgun, there should be a cache hit.
-            mock.reset_mock()
+            mock1.reset_mock()
             sgtk.pipelineconfig_factory._get_pipeline_configs(False)
-            self.assertFalse(mock.called)
+            self.assertFalse(mock1.called)
 
             cache_data = sgtk.pipelineconfig_factory._load_lookup_cache()
             # The new paths_v2 sections should be in there.
@@ -539,9 +544,9 @@ class TestLookupCache(ShotgunTestBase):
 
             # Do not force read from Shotgun, but since the cache is not present
             # it should be loaded from Shotgun.
-            mock.reset_mock()
+            mock1.reset_mock()
             sgtk.pipelineconfig_factory._get_pipeline_configs(False)
-            self.assertTrue(mock.called)
+            self.assertTrue(mock1.called)
 
 
 class TestTankFromWithSiteConfig(TankTestBase):

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -12,8 +12,6 @@ import os
 import inspect
 import sys
 
-from mock import patch
-
 import sgtk
 import tank
 
@@ -26,16 +24,19 @@ from tank import (
 )
 from tank.util import ShotgunPath, is_windows
 
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
-
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    temp_env_var,
+)
 
 class TestGetConfigInstallLocationPathSlashes(ShotgunTestBase):
     """
     Tests the case where a Windows config location uses double slashes.
     """
 
-    @patch("tank.pipelineconfig_utils._get_install_locations")
+    @mock.patch("tank.pipelineconfig_utils._get_install_locations")
     def test_config_path_cleanup(self, get_install_locations_mock):
         """
         Check that any glitches in the path are correctly cleaned up.
@@ -171,7 +172,7 @@ class TestPipelineConfigUtils(ShotgunTestBase):
 
         # Patch os.path.exists since /i/wish/this/was/python3 is obviously not a real
         # file name.
-        with patch("os.path.exists", return_value=True):
+        with mock.patch("os.path.exists", return_value=True):
             with temp_env_var(SGTK_TEST_INTERPRETER="/i/wish/this/was/python3"):
                 self.assertEqual(
                     pipelineconfig_utils.get_python_interpreter_for_config(config_root),

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -18,9 +18,13 @@ from tank import TankError
 import copy
 import sys
 import datetime
-from mock import patch
-from tank_test.tank_test_base import ShotgunTestBase
+
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
 from tank.templatekey import StringKey, IntegerKey, SequenceKey, TimestampKey, make_keys
 from tank_vendor import six
 
@@ -1248,7 +1252,7 @@ class TestTimestampKey(ShotgunTestBase):
         with self.assertRaisesRegex(TankError, "Invalid type"):
             key.str_from_value(1)
 
-    @patch("tank.templatekey.TimestampKey._TimestampKey__get_current_time")
+    @mock.patch("tank.templatekey.TimestampKey._TimestampKey__get_current_time")
     def test_now_default_value(self, _get_time_mock):
         """
         Makes sure that a default value is proprely generated when the now default
@@ -1261,7 +1265,7 @@ class TestTimestampKey(ShotgunTestBase):
         # Convert to a string and compare the result.
         self.assertEqual(key.str_from_value(None), self._datetime_string)
 
-    @patch("tank.templatekey.TimestampKey._TimestampKey__get_current_utc_time")
+    @mock.patch("tank.templatekey.TimestampKey._TimestampKey__get_current_utc_time")
     def test_utc_now_default_value(self, _get_utc_time_mock):
         """
         Makes sure that a default value is proprely generated when the utc_now default

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -17,9 +17,11 @@ from __future__ import with_statement
 import os
 import json
 
-from mock import patch
-
-from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 import sgtk
 from sgtk.descriptor import Descriptor
@@ -43,15 +45,15 @@ class TestAppStoreLabels(ShotgunTestBase):
         super(TestAppStoreLabels, self).setUp()
 
         # work around the app store connection lookup loops to just use std mockgun instance to mock the app store
-        self._get_app_store_key_from_shotgun_mock = patch(
+        self._get_app_store_key_from_shotgun_mock = mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore._IODescriptorAppStore__create_sg_app_store_connection",
             return_value=(self.mockgun, None),
         )
         self._get_app_store_key_from_shotgun_mock.start()
         self.addCleanup(self._get_app_store_key_from_shotgun_mock.stop)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find_one")
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find_one")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_label_support(self, find_mock, find_one_mock):
         """
         Tests the label syntax and that it restricts versions correctly
@@ -323,8 +325,8 @@ class TestAppStoreConnectivity(ShotgunTestBase):
         mock.reset_mock()
         self.assertEqual(mock.call_count, 0)
 
-    @patch("tank_vendor.shotgun_api3.Shotgun")
-    @patch("tank_vendor.six.moves.urllib.request.urlopen")
+    @mock.patch("tank_vendor.shotgun_api3.Shotgun")
+    @mock.patch("tank_vendor.six.moves.urllib.request.urlopen")
     def test_disabling_access_to_app_store(self, urlopen_mock, shotgun_mock):
         """
         Tests that we can prevent connection to the app store based on usage

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -14,9 +14,15 @@ import sgtk
 
 import unittest
 
-from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, SealedMock
-
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    SealedMock,
+    ShotgunTestBase,
+    TankTestBase,
+)
+
+
 from tank.errors import TankError
 from tank.descriptor import (
     CheckVersionConstraintsError,
@@ -28,8 +34,6 @@ from tank.descriptor import (
     CoreDescriptor,
 )
 from tank.descriptor.descriptor_installed_config import InstalledConfigDescriptor
-
-from mock import Mock, patch
 
 from tank_vendor.shotgun_api3.lib.mockgun import Shotgun as Mockgun
 from tank_vendor import yaml
@@ -43,9 +47,9 @@ class TestCachedConfigDescriptor(ShotgunTestBase):
 
         class CoreConfigDescriptorWithoutFeatures(ConfigDescriptor):
             def resolve_core_descriptor(self):
-                io_desc = Mock()
+                io_desc = mock.Mock()
                 io_desc.get_manifest.return_value = dict()
-                sg_connection = Mock()
+                sg_connection = mock.Mock()
                 bundle_cache_root_override = None
                 fallback_roots = None
                 return CoreDescriptor(
@@ -60,9 +64,9 @@ class TestCachedConfigDescriptor(ShotgunTestBase):
 
         class CoreConfigDescriptorWithFeatures(ConfigDescriptor):
             def resolve_core_descriptor(self):
-                io_desc = Mock()
+                io_desc = mock.Mock()
                 io_desc.get_manifest.return_value = dict(features=dict(two="2"))
-                sg_connection = Mock()
+                sg_connection = mock.Mock()
                 bundle_cache_root_override = None
                 fallback_roots = None
                 return CoreDescriptor(
@@ -477,14 +481,14 @@ class TestDescriptorSupport(TankTestBase):
         """
         # Nested patches because Python 2.5 doesn't support multiple arguments to the `with`
         # keyword.
-        with patch(
+        with mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore"
             "._IODescriptorAppStore__create_sg_app_store_connection",
             side_effect=sgtk.descriptor.TankAppStoreError(
                 "This is my unit test exception."
             ),
         ):
-            with patch(
+            with mock.patch(
                 "tank.descriptor.io_descriptor.appstore.log.debug"
             ) as log_debug_mock:
                 descriptor = sgtk.descriptor.io_descriptor.appstore.IODescriptorAppStore(
@@ -708,7 +712,7 @@ class TestConstraintValidation(unittest.TestCase):
         )
 
         # Mock the get_manifest method so it uses our fake info.yml file.
-        desc._io_descriptor.get_manifest = Mock(
+        desc._io_descriptor.get_manifest = mock.Mock(
             return_value={
                 "requires_shotgun_version": version_constraints.get("min_sg"),
                 "requires_core_version": version_constraints.get("min_core"),
@@ -768,7 +772,7 @@ class TestConstraintValidation(unittest.TestCase):
             "Requires at least Core API .* but currently installed version is v6.6.5",
         )
 
-    @patch(
+    @mock.patch(
         "tank.pipelineconfig_utils.get_currently_running_api_version",
         return_value="v6.6.5",
     )
@@ -861,11 +865,11 @@ class TestConstraintValidation(unittest.TestCase):
             r"Requires at least SG Desktop.* but currently installed version is .*\.",
         )
 
-    @patch(
+    @mock.patch(
         "tank.descriptor.descriptor_bundle.BundleDescriptor._get_sg_version",
         return_value="6.6.5",
     )
-    @patch(
+    @mock.patch(
         "tank.pipelineconfig_utils.get_currently_running_api_version",
         return_value="v5.5.4",
     )
@@ -928,7 +932,7 @@ class TestFeaturesApi(unittest.TestCase):
         """
         Helper method which creates an io_descriptor
         """
-        sg_connection = Mock()
+        sg_connection = mock.Mock()
         bundle_cache_root_override = None
         fallback_roots = None
         return sgtk.descriptor.CoreDescriptor(
@@ -939,7 +943,7 @@ class TestFeaturesApi(unittest.TestCase):
         """
         Ensures a missing manifest is handled properly.
         """
-        io_desc = Mock()
+        io_desc = mock.Mock()
         io_desc.get_manifest.side_effect = TankMissingManifestError()
         desc = self._create_core_desc(io_desc)
 
@@ -951,7 +955,7 @@ class TestFeaturesApi(unittest.TestCase):
         """
         Ensures a missing features section is handled properly.
         """
-        io_desc = Mock()
+        io_desc = mock.Mock()
         io_desc.get_manifest.return_value = {}
         desc = self._create_core_desc(io_desc)
 
@@ -963,7 +967,7 @@ class TestFeaturesApi(unittest.TestCase):
         """
         Ensures a missing feature is handled properly.
         """
-        io_desc = Mock()
+        io_desc = mock.Mock()
         io_desc.get_manifest.return_value = dict(features={})
         desc = self._create_core_desc(io_desc)
 
@@ -976,7 +980,7 @@ class TestFeaturesApi(unittest.TestCase):
         Ensures an available feature is handled properly.
         """
         features = dict(two="2", foo="bar", zero=0)
-        io_desc = Mock()
+        io_desc = mock.Mock()
         io_desc.get_manifest.return_value = dict(features=features)
         desc = self._create_core_desc(io_desc)
 
@@ -1003,7 +1007,7 @@ class TestFeaturesApi(unittest.TestCase):
         ) as fh:
             info = yaml.safe_load(fh)
 
-        io_desc = Mock()
+        io_desc = mock.Mock()
         io_desc.get_manifest.return_value = info
         desc = self._create_core_desc(io_desc)
 

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -12,7 +12,6 @@ from __future__ import print_function
 from functools import reduce
 import multiprocessing
 import os
-from mock import patch
 import sys
 import tempfile
 import time
@@ -22,8 +21,13 @@ import zipfile
 import contextlib
 import pytest
 
-from tank_test.tank_test_base import ShotgunTestBase, skip_if_git_missing, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    skip_if_git_missing,
+    temp_env_var,
+)
 
 import sgtk
 import tank
@@ -293,16 +297,16 @@ class Implementation(object):
         io_descriptor_app_store = (
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore"
         )
-        with patch(
+        with mock.patch(
             "%s._IODescriptorAppStore__create_sg_app_store_connection"
             % io_descriptor_app_store,
             return_value=(self.mockgun, None),
         ):
-            with patch(
+            with mock.patch(
                 "%s._IODescriptorAppStore__refresh_metadata" % io_descriptor_app_store,
                 return_value=self._metadata,
             ):
-                with patch(
+                with mock.patch(
                     "tank.util.shotgun.download_and_unpack_attachment",
                     side_effect=self._download_and_unpack_attachment,
                 ):
@@ -326,7 +330,7 @@ class Implementation(object):
                 desc = self._create_desc(location)
         else:
             desc = self._create_desc(location)
-        with patch(
+        with mock.patch(
             "tank.util.shotgun.download_and_unpack_attachment",
             side_effect=self._download_and_unpack_attachment,
         ):
@@ -599,14 +603,14 @@ class Implementation(object):
 
         # ensure that an exception raised while downloading the descriptor to a
         # temporary folder will raise a TankDescriptorError
-        with patch(
+        with mock.patch(
             "tank.descriptor.io_descriptor.git_branch.IODescriptorGitBranch._download_local",
             side_effect=_raise_exception,
         ):
             with self.assertRaises(tank.descriptor.errors.TankDescriptorIOError):
                 self._download_git_branch_bundle()
 
-    @patch("os.rename", side_effect=_raise_exception)
+    @mock.patch("os.rename", side_effect=_raise_exception)
     def test_descriptor_rename_error_fallbacks(self, *_):
         """
         Tests that an error during the rename operation kicks in various fallbacks.
@@ -644,8 +648,8 @@ class Implementation(object):
         tmp_files_after = os.listdir(tmp_location)
         self.assertEqual(tmp_files_after, tmp_files_before)
 
-    @patch("tank.util.filesystem.move_folder")
-    @patch("os.rename", side_effect=_raise_exception)
+    @mock.patch("tank.util.filesystem.move_folder")
+    @mock.patch("os.rename", side_effect=_raise_exception)
     def test_descriptor_rename_fallback_failure(self, rename_mock, move_mock):
         """
         Tests the expected behaviour when a rename fails and then 'plan B' fallback also fails.

--- a/tests/descriptor_tests/test_shotgun.py
+++ b/tests/descriptor_tests/test_shotgun.py
@@ -11,8 +11,12 @@
 import os
 
 import sgtk
-from mock import patch
-from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 
 class TestShotgunIODescriptor(ShotgunTestBase):
@@ -165,7 +169,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         self.assertEqual(name_proj_desc.system_name, "p22_aaa111")
         self.assertEqual(name_proj_desc.version, "v123")
 
-    @patch("sgtk.util.shotgun.download_and_unpack_attachment")
+    @mock.patch("sgtk.util.shotgun.download_and_unpack_attachment")
     def test_resolve_id(self, _call_rpc_mock):
         """
         Test downloading shotgun descriptor based on id
@@ -198,7 +202,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         desc.ensure_local()
         self.assertEqual(desc.get_path(), expected_path)
 
-    @patch("sgtk.util.shotgun.download_and_unpack_attachment")
+    @mock.patch("sgtk.util.shotgun.download_and_unpack_attachment")
     def test_resolve_name_and_project(self, _call_rpc_mock):
         """
         Test downloading descriptor based on name
@@ -232,7 +236,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         desc.ensure_local()
         self.assertEqual(desc.get_path(), expected_path)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_get_latest_by_id(self, find_mock):
         """
         Tests resolving the latest descriptor based on id
@@ -284,7 +288,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         latest_desc = desc.find_latest_version()
         self.assertEqual(latest_desc.version, "v139")
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_get_latest_by_name(self, find_mock):
         """
         Tests resolving the latest descriptor based on name
@@ -336,7 +340,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         latest_desc = desc.find_latest_version()
         self.assertEqual(latest_desc.version, "v139")
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_get_latest_by_name_and_proj(self, find_mock):
         """
         Tests resolving the latest descriptor based on name and project
@@ -398,7 +402,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         latest_desc = desc.find_latest_version()
         self.assertEqual(latest_desc.version, "v139")
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_find_invalid_attachment(self, find_mock):
         """
         Tests resolving an attachment which doesn't have an uploaded attachment
@@ -438,7 +442,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         self.assertEqual(desc.version, "v0")
         self.assertRaises(sgtk.descriptor.TankDescriptorError, desc.find_latest_version)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find")
     def test_missing_record(self, find_mock):
         """
         Tests behavior when a shotgun record is missing

--- a/tests/folder_tests/__init__.py
+++ b/tests/folder_tests/__init__.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import shutil
-from mock import Mock, patch
+
 import tank
 from tank_vendor import yaml
 from tank import TankError

--- a/tests/folder_tests/test_configuration.py
+++ b/tests/folder_tests/test_configuration.py
@@ -11,13 +11,13 @@
 import os
 import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import setUpModule # noqa
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestFolderConfiguration(TankTestBase):

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -10,9 +10,7 @@
 
 import copy
 import os
-import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError

--- a/tests/folder_tests/test_deferred.py
+++ b/tests/folder_tests/test_deferred.py
@@ -9,9 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError

--- a/tests/folder_tests/test_optional_fields.py
+++ b/tests/folder_tests/test_optional_fields.py
@@ -10,9 +10,7 @@
 
 import copy
 import os
-import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError

--- a/tests/folder_tests/test_secondary_entity.py
+++ b/tests/folder_tests/test_secondary_entity.py
@@ -9,9 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError

--- a/tests/folder_tests/test_static_filter.py
+++ b/tests/folder_tests/test_static_filter.py
@@ -9,15 +9,13 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestStaticFolderFilters(TankTestBase):

--- a/tests/folder_tests/test_step_node.py
+++ b/tests/folder_tests/test_step_node.py
@@ -11,13 +11,15 @@
 import os
 import unittest
 import shutil
-from mock import Mock, patch
 import tank
 from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
@@ -444,7 +446,7 @@ class TestSchemaCreateFoldersStepAndUserSandbox(TankTestBase):
             self.FolderIOReceiverBackup
         )
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_shot(self, get_current_user):
         """Tests paths used in making a shot are as expected."""
 
@@ -466,7 +468,7 @@ class TestSchemaCreateFoldersStepAndUserSandbox(TankTestBase):
 
         assert_paths_to_create(expected_paths)
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_step_a(self, get_current_user):
         """Tests paths used in making a shot are as expected."""
 

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -11,13 +11,14 @@
 import os
 import unittest
 import shutil
-from mock import Mock
 import tank
 from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import (
+    TankTestBase,
+)
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_user_sandbox.py
+++ b/tests/folder_tests/test_user_sandbox.py
@@ -11,13 +11,15 @@
 import os
 import unittest
 import shutil
-from mock import Mock, patch
 import tank
 from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 
 class TestHumanUser(TankTestBase):
@@ -52,7 +54,7 @@ class TestHumanUser(TankTestBase):
         self.user_path = os.path.join(self.project_root, "foo", "shot_code")
         self.user_path2 = os.path.join(self.project_root, "bar", "shot_code")
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_not_made_default(self, get_current_user):
 
         self.assertFalse(os.path.exists(self.user_path))
@@ -62,7 +64,7 @@ class TestHumanUser(TankTestBase):
         )
         self.assertFalse(os.path.exists(self.user_path))
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_made_string(self, get_current_user):
         self.assertFalse(os.path.exists(self.user_path))
 
@@ -87,7 +89,7 @@ class TestHumanUser(TankTestBase):
         self.assertEqual(ctx_foo.filesystem_locations, [self.user_path])
         self.assertEqual(ctx_bar.filesystem_locations, [self.user_path2])
 
-    @patch("tank.util.login.get_current_user")
+    @mock.patch("tank.util.login.get_current_user")
     def test_login_not_in_shotgun(self, get_current_user):
         # make sure that if there is no loncal login matching, raise
         # an error when file system folders are created

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -20,11 +20,13 @@ import sys
 import shutil
 
 import unittest
-from mock import Mock, patch
 from tank.util import is_linux, is_macos, is_windows, filesystem
 from tank.util import yaml_cache, zip
 
 from sgtk_integration_test import SgtkIntegrationTest
+from tank_test.tank_test_base import (
+    mock,
+)
 
 import sgtk
 
@@ -83,7 +85,7 @@ class TankCommands(SgtkIntegrationTest):
         )
         os.makedirs(install_core_folder)
 
-        cw.write_shotgun_file(Mock(get_path=lambda: "does_not_exist"))
+        cw.write_shotgun_file(mock.Mock(get_path=lambda: "does_not_exist"))
         cw.write_install_location_file()
 
         sgtk.util.filesystem.copy_folder(
@@ -108,7 +110,7 @@ class TankCommands(SgtkIntegrationTest):
 
         sgtk.set_authenticated_user(self.user)
 
-        with patch(
+        with mock.patch(
             "tank.pipelineconfig_utils.resolve_all_os_paths_to_core",
             return_value=sgtk.util.ShotgunPath.from_current_os_path(
                 self.legacy_bootstrap_core

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -13,10 +13,11 @@ from __future__ import with_statement
 import logging
 import os
 
-from tank_test.tank_test_base import TankTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
-
-from mock import PropertyMock, patch
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
 from tank.platform import create_engine_launcher
 from tank.platform import SoftwareLauncher
@@ -178,7 +179,7 @@ class TestEngineLauncher(TankTestBase):
         min_version_method = (
             "sgtk.platform.software_launcher.SoftwareLauncher.minimum_supported_version"
         )
-        with patch(min_version_method, new_callable=PropertyMock) as min_version_mock:
+        with mock.patch(min_version_method, new_callable=mock.PropertyMock) as min_version_mock:
 
             min_version_mock.return_value = "2017.2"
 
@@ -225,7 +226,7 @@ class TestEngineLauncher(TankTestBase):
         min_version_method = (
             "sgtk.platform.software_launcher.SoftwareLauncher.minimum_supported_version"
         )
-        with patch(min_version_method, new_callable=PropertyMock) as min_version_mock:
+        with mock.patch(min_version_method, new_callable=mock.PropertyMock) as min_version_mock:
 
             min_version_mock.return_value = "2019"
 

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -16,11 +16,6 @@
 # Required for the --with-coverage option
 coverage==7.1.0
 
-# Use to temporarily replace part of the API or mock return vaues.
-mock==2.0.0; python_version < '3.3'
-
 # The Shotgun Desktop does not include setuptools, which comes with pip. Make
 # sure they are installed in case the tests are run with this python.
 setuptools==65.5.1
-
-unittest2; python_version < '3'

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -17,8 +17,10 @@
 coverage==7.1.0
 
 # Use to temporarily replace part of the API or mock return vaues.
-mock==2.0.0
+mock==2.0.0; python_version < '3.3'
 
 # The Shotgun Desktop does not include setuptools, which comes with pip. Make
 # sure they are installed in case the tests are run with this python.
 setuptools==65.5.1
+
+unittest2; python_version < '3'

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -31,8 +31,13 @@ from collections import defaultdict
 
 from tank_vendor.shotgun_api3.lib import mockgun
 
-import unittest
-import mock
+from tank_vendor import six
+if six.PY2:
+    import unittest2 as unittest
+    import mock
+else:
+    import unittest as unittest
+    from unittest import mock
 
 import sgtk
 import tank

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -31,13 +31,8 @@ from collections import defaultdict
 
 from tank_vendor.shotgun_api3.lib import mockgun
 
-from tank_vendor import six
-if six.PY2:
-    import unittest2 as unittest
-    import mock
-else:
-    import unittest as unittest
-    from unittest import mock
+import unittest
+from unittest import mock
 
 import sgtk
 import tank

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -45,12 +45,7 @@ test_python_path = os.path.join(test_python_path, "third_party")
 print("Adding tests/python/third_party location to python_path: %s" % test_python_path)
 sys.path = [test_python_path] + sys.path
 
-from tank_vendor import six
-
-if six.PY2:
-    import unittest2 as unittest
-else:
-    import unittest as unittest
+import unittest as unittest
 
 
 class TankTestRunner(object):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -45,7 +45,12 @@ test_python_path = os.path.join(test_python_path, "third_party")
 print("Adding tests/python/third_party location to python_path: %s" % test_python_path)
 sys.path = [test_python_path] + sys.path
 
-import unittest as unittest
+from tank_vendor import six
+
+if six.PY2:
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 
 
 class TankTestRunner(object):

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -12,11 +12,14 @@ from __future__ import with_statement
 
 import os
 from tank.util import is_linux, is_macos, is_windows
-from tank_test.tank_test_base import TankTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
+
 import tank.util.filesystem as fs
 
-from mock import patch
 import subprocess  # noqa
 import shutil
 import stat
@@ -251,7 +254,7 @@ class TestOpenInFileBrowser(TankTestBase):
         self.assertRaises(ValueError, fs.open_file_browser, "bad_path")
         self.assertRaises(ValueError, fs.open_file_browser, "")
 
-    @patch("subprocess.call", return_value=0)
+    @mock.patch("subprocess.call", return_value=0)
     def test_folder(self, subprocess_mock):
         """
         Tests opening a folder
@@ -268,14 +271,14 @@ class TestOpenInFileBrowser(TankTestBase):
         elif is_windows():
             self.assertEqual(args[0], ["cmd.exe", "/C", "start", self.test_folder])
 
-    @patch("subprocess.call", return_value=1234)
+    @mock.patch("subprocess.call", return_value=1234)
     def test_failed_folder(self, _):
         """
         Test failing opening folder
         """
         self.assertRaises(RuntimeError, fs.open_file_browser, self.test_folder)
 
-    @patch("subprocess.call", return_value=0)
+    @mock.patch("subprocess.call", return_value=0)
     def test_file(self, subprocess_mock):
         """
         Tests opening a file
@@ -292,7 +295,7 @@ class TestOpenInFileBrowser(TankTestBase):
         elif is_windows():
             self.assertEqual(args[0], ["explorer", "/select,", self.test_file])
 
-    @patch("subprocess.call", return_value=1234)
+    @mock.patch("subprocess.call", return_value=1234)
     def test_failed_file(self, _):
         """
         Test failing opening folder on mac/linux
@@ -300,7 +303,7 @@ class TestOpenInFileBrowser(TankTestBase):
         if not is_windows():
             self.assertRaises(RuntimeError, fs.open_file_browser, self.test_file)
 
-    @patch("subprocess.call", return_value=0)
+    @mock.patch("subprocess.call", return_value=0)
     def test_sequence(self, subprocess_mock):
         """
         Tests opening a folder

--- a/tests/util_tests/test_load_publish.py
+++ b/tests/util_tests/test_load_publish.py
@@ -12,8 +12,6 @@ from __future__ import with_statement
 import os
 import sys
 
-from mock import patch, call
-
 import sgtk
 from tank import context, errors
 from tank.util import is_linux, is_macos, is_windows

--- a/tests/util_tests/test_login.py
+++ b/tests/util_tests/test_login.py
@@ -9,10 +9,13 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from __future__ import with_statement
-from mock import patch
 
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+)
 
+import tank
 from tank.util import login
 from tank.authentication import ShotgunAuthenticator
 
@@ -22,8 +25,8 @@ class LoginTests(TankTestBase):
     Tests the login module.
     """
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find_one")
-    @patch("tank.api.get_authenticated_user")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.find_one")
+    @mock.patch("tank.api.get_authenticated_user")
     def test_get_current_user_uses_session(
         self, get_authenticated_user_mock, find_one_mock
     ):

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -11,8 +11,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
-from mock import patch
-
 from tank.util.metrics import (
     MetricsQueueSingleton,
     MetricsDispatchWorkerThread,
@@ -25,7 +23,12 @@ from tank.util.constants import TANK_LOG_METRICS_HOOK_NAME
 
 import tank
 from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    TankTestBase,
+)
+
 from tank.authentication import ShotgunAuthenticator
 
 import os
@@ -207,12 +210,12 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         tank.set_authenticated_user(None)
 
         # Prevents an actual connection to a Shotgun site.
-        self._server_caps_mock = patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+        self._server_caps_mock = mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
         self._server_caps_mock.start()
         self.addCleanup(self._server_caps_mock.stop)
 
         # Avoids crash because we're not in a pipeline configuration.
-        self._get_api_core_config_location_mock = patch(
+        self._get_api_core_config_location_mock = mock.patch(
             "tank.util.shotgun.connection.__get_api_core_config_location",
             return_value="unused_path_location",
         )
@@ -220,7 +223,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         self.addCleanup(self._get_api_core_config_location_mock.stop)
 
         # Mocks app store script user credentials retrieval
-        self._get_app_store_key_from_shotgun_mock = patch(
+        self._get_app_store_key_from_shotgun_mock = mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore._IODescriptorAppStore__get_app_store_key_from_shotgun",
             return_value=("abc", "123"),
         )
@@ -231,7 +234,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         self._create_engine()
 
         # Patch & Mock the `urlopen` method
-        self._urlopen_mock = patch("tank_vendor.six.moves.urllib.request.urlopen")
+        self._urlopen_mock = mock.patch("tank_vendor.six.moves.urllib.request.urlopen")
         self._mocked_method = self._urlopen_mock.start()
 
     def setUp(self):
@@ -780,7 +783,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         # For this test, we need to override that to something more specific.
         self._urlopen_mock.stop()
         self._urlopen_mock = None
-        self._urlopen_mock = patch(
+        self._urlopen_mock = mock.patch(
             "tank_vendor.six.moves.urllib.request.urlopen",
             side_effect=TestMetricsDispatchWorkerThread._mocked_urlopen_for_test_maximum_batch_size,
         )
@@ -844,7 +847,7 @@ class TestMetricsDispatchWorkerThread(TankTestBase):
         # For this test, we need to override that to something more specific.
         self._urlopen_mock.stop()
         self._urlopen_mock = None
-        self._urlopen_mock = patch(
+        self._urlopen_mock = mock.patch(
             "tank_vendor.six.moves.urllib.request.urlopen",
             side_effect=TestMetricsDispatchWorkerThread._mocked_urlopen_for_test_maximum_batch_size,
         )
@@ -913,7 +916,7 @@ class TestMetricsDeprecatedFunctions(ShotgunTestBase):
         super(TestMetricsDeprecatedFunctions, self).setUp()
 
         # Setting up the mocked method
-        self._metrics_queue_singleton_log_mock = patch(
+        self._metrics_queue_singleton_log_mock = mock.patch(
             "tank.util.metrics.MetricsQueueSingleton.log"
         )
         self._mocked_method = self._metrics_queue_singleton_log_mock.start()
@@ -1091,7 +1094,7 @@ class TestBundleMetrics(TankTestBase):
     def _de_authenticate(self):
         tank.set_authenticated_user(None)
 
-    @patch("tank.util.metrics.MetricsDispatcher.start")
+    @mock.patch("tank.util.metrics.MetricsDispatcher.start")
     def test_bundle_metrics(self, patched_start):
         """
         Test metrics logged by bundles.
@@ -1203,7 +1206,7 @@ class TestBundleMetrics(TankTestBase):
         # Make sure we tested at least one app with a framework
         self.assertTrue(able_to_test_a_framework)
 
-    @patch("urllib.open")
+    @mock.patch("urllib.open")
     def test_log_metrics_hook(self, patched):
         """
         Test the log_metric hook is fired when logging metrics
@@ -1225,7 +1228,7 @@ class TestBundleMetrics(TankTestBase):
             # Call the original hook
             return exec_core_hook(hook_name, hook_method, **kwargs)
 
-        with patch("tank.api.Sgtk.execute_core_hook_method") as mocked:
+        with mock.patch("tank.api.Sgtk.execute_core_hook_method") as mocked:
             mocked.side_effect = log_hook
             engine.log_metric("Hook test")
             # Make sure the dispatcher has some time to wake up
@@ -1248,8 +1251,8 @@ class TestPlatformInfo(unittest.TestCase):
         # reset un-cache PlatformInfo cached value
         PlatformInfo._PlatformInfo__cached_platform_info = None
 
-    @patch("platform.system", return_value="Windows")
-    @patch("platform.release", return_value="XP")
+    @mock.patch("platform.system", return_value="Windows")
+    @mock.patch("platform.release", return_value="XP")
     def test_as_windows(self, mocked_release, mocked_system):
         """
         Tests as a Windows XP system
@@ -1261,8 +1264,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_release.called)
 
-    @patch("platform.system", return_value="Darwin")
-    @patch("platform.mac_ver", return_value=("10.7.5", ("", "", ""), "i386"))
+    @mock.patch("platform.system", return_value="Darwin")
+    @mock.patch("platform.mac_ver", return_value=("10.7.5", ("", "", ""), "i386"))
     def test_as_osx(self, mocked_mac_ver, mocked_system):
         """
         Tests as some OSX Lion system
@@ -1274,8 +1277,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_mac_ver.called)
 
-    @patch("platform.system", return_value="Linux")
-    @patch(LINUX_DISTRIBUTION_FUNCTION, return_value=("debian", "7.7", ""))
+    @mock.patch("platform.system", return_value="Linux")
+    @mock.patch(LINUX_DISTRIBUTION_FUNCTION, return_value=("debian", "7.7", ""))
     def test_as_linux(self, mocked_system, mocked_linux_distribution):
         """
         Tests as a Linux Debian system
@@ -1287,8 +1290,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_linux_distribution.called)
 
-    @patch("platform.system", return_value="BSD")
-    @patch(LINUX_DISTRIBUTION_FUNCTION, side_effect=Exception)
+    @mock.patch("platform.system", return_value="BSD")
+    @mock.patch(LINUX_DISTRIBUTION_FUNCTION, side_effect=Exception)
     def test_as_unsupported_system(self, mocked_linux_distribution, mocked_system):
         """
         Tests a fake unsupported system
@@ -1301,8 +1304,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertFalse(mocked_linux_distribution.called)
 
-    @patch("platform.system", return_value="Linux")
-    @patch(LINUX_DISTRIBUTION_FUNCTION, side_effect=Exception)
+    @mock.patch("platform.system", return_value="Linux")
+    @mock.patch(LINUX_DISTRIBUTION_FUNCTION, side_effect=Exception)
     def test_as_linux_without_distribution(
         self, mocked_linux_distribution, mocked_system
     ):
@@ -1316,8 +1319,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_linux_distribution.called)
 
-    @patch("platform.system", return_value="Darwin")
-    @patch("platform.mac_ver", side_effect=Exception)
+    @mock.patch("platform.system", return_value="Darwin")
+    @mock.patch("platform.mac_ver", side_effect=Exception)
     def test_as_mac_without_mac_version(self, mocked_mac_ver, mocked_system):
         """
         Tests handling of an exception caused by the 'mac_ver' method.
@@ -1329,8 +1332,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_mac_ver.called)
 
-    @patch("platform.system", return_value="Windows")
-    @patch("platform.release", side_effect=Exception)
+    @mock.patch("platform.system", return_value="Windows")
+    @mock.patch("platform.release", side_effect=Exception)
     def test_as_mac_without_release(self, mocked_release, mocked_system):
         """
         Tests handling of an exception caused by the 'release' method.
@@ -1342,8 +1345,8 @@ class TestPlatformInfo(unittest.TestCase):
         self.assertTrue(mocked_system.called)
         self.assertTrue(mocked_release.called)
 
-    @patch("platform.system", side_effect=Exception)
-    @patch("platform.release", side_effect=Exception)
+    @mock.patch("platform.system", side_effect=Exception)
+    @mock.patch("platform.release", side_effect=Exception)
     def test_system(self, mocked_release, mocked_system):
         """
         Tests handling of an exception caused by the 'system' method.

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -11,12 +11,11 @@
 from __future__ import with_statement
 import os
 
-from mock import patch, call
-
 import tank
 from tank import context, errors
 from tank.util import is_windows
 from tank_test.tank_test_base import (
+    mock,
     TankTestBase,
     setUpModule,
     only_run_on_windows,
@@ -80,7 +79,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         Checks that if local storage is disabled that we raise a more user friendly error
         than a CRUD message.
         """
-        with patch.object(
+        with mock.patch.object(
             self.tk.shotgun,
             "create",
             side_effect=Exception("[Attachment.local_storage] does not exist"),
@@ -146,7 +145,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         self.assertEqual(expected_path, actual_path)
         self.assertEqual(expected_path_cache, actual_path_cache)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
     def test_url_paths(self, create_mock):
         """Tests the passing of urls via the path."""
 
@@ -181,7 +180,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         )
         self.assertEqual("pathcache" not in sg_dict, True)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
     def test_url_paths_host(self, create_mock):
         """Tests the passing of urls via the path."""
 
@@ -208,7 +207,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         )
         self.assertEqual("pathcache" not in sg_dict, True)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
     def test_local_storage_publish(self, create_mock):
         """
         Tests that we generate local file links when publishing to a known storage
@@ -242,7 +241,7 @@ class TestShotgunRegisterPublish(TankTestBase):
 
             self.assertTrue("pathcache" not in sg_dict)
 
-    @patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
+    @mock.patch("tank_vendor.shotgun_api3.lib.mockgun.Shotgun.create")
     def test_freeform_publish(self, create_mock):
         """
         Tests that we generate url file:// links for freeform paths
@@ -338,10 +337,10 @@ class TestShotgunRegisterPublish(TankTestBase):
         def raise_value_error(*arg, **kwargs):
             raise ValueError("Failed")
 
-        with patch(
+        with mock.patch(
             "tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload_thumbnail",
             new=raise_value_error,
-        ) as mock:
+        ):
             with self.assertRaises(tank.util.ShotgunPublishError) as cm:
 
                 publish_data = tank.util.register_publish(
@@ -373,10 +372,10 @@ class TestShotgunRegisterPublish(TankTestBase):
         def raise_io_error(*arg, **kwargs):
             open("/this/file/does/not/exist/or/we/are/very/unlucky.txt", "r")
 
-        with patch(
+        with mock.patch(
             "tank_vendor.shotgun_api3.lib.mockgun.Shotgun.upload_thumbnail",
             new=raise_io_error,
-        ) as mock:
+        ):
             with self.assertRaises(tank.util.ShotgunPublishError) as cm:
 
                 publish_data = tank.util.register_publish(
@@ -438,7 +437,7 @@ class TestMultiRoot(TankTestBase):
         self.mockgun.server_caps = server_capsMock()
 
         # Prevents an actual connection to a Shotgun site.
-        self._server_caps_mock = patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
+        self._server_caps_mock = mock.patch("tank_vendor.shotgun_api3.Shotgun.server_caps")
         self._server_caps_mock.start()
         self.addCleanup(self._server_caps_mock.stop)
 
@@ -468,7 +467,7 @@ class TestMultiRoot(TankTestBase):
 
 
 class TestCalcPathCache(TankTestBase):
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_case_difference(self, get_local_storage_roots):
         """
         Case that root case is different between input path and that in roots file.
@@ -490,7 +489,7 @@ class TestCalcPathCache(TankTestBase):
         assert path_cache == expected
 
     @only_run_on_windows
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_win_drive_letter(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
@@ -515,7 +514,7 @@ class TestCalcPathCache(TankTestBase):
             self.assertEqual("project_code/3d/Assets", path_cache)
 
     @only_run_on_windows
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_win_unc(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
@@ -538,7 +537,7 @@ class TestCalcPathCache(TankTestBase):
             self.assertEqual("project_code/3d/Assets", path_cache)
 
     @only_run_on_nix
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_path_normalization_nix(self, get_local_storage_roots):
         """
         Ensures that a variety of different slash syntaxes are valid when splitting
@@ -561,7 +560,7 @@ class TestCalcPathCache(TankTestBase):
             self.assertEqual("primary", root_name)
             self.assertEqual("project_code/3d/Assets", path_cache)
 
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_project_names_only_current_project(self, get_local_storage_roots):
         """
         Test _calc_path_cache with project_names as a single list containing the
@@ -590,7 +589,7 @@ class TestCalcPathCache(TankTestBase):
         assert root_name == "primary"
         assert path_cache == expected
 
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_project_names_multiple(self, get_local_storage_roots):
         """
         Test _calc_path_cache with project_names as a list of more than one.
@@ -658,7 +657,7 @@ class TestCalcPathCacheProjectWithSlash(TankTestBase):
             {"project_tank_name": "foo/bar"}
         )
 
-    @patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
+    @mock.patch("tank.pipelineconfig.PipelineConfiguration.get_local_storage_roots")
     def test_multi_project_root(self, get_local_storage_roots):
         """
         Testing path cache calculations for project names with slashes

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -14,11 +14,14 @@ import shutil
 import datetime
 from tank_vendor.six.moves import urllib
 
-from mock import patch, MagicMock
-
 import tank
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    TankTestBase,
+    ShotgunTestBase,
+)
+
 from tank.template import TemplatePath
 from tank.templatekey import SequenceKey
 
@@ -645,7 +648,7 @@ class TestShotgunDownloadAndUnpack(ShotgunTestBase):
         download_result = open(self.download_source, "rb").read()
         target_dir = os.path.join(self.download_destination, "attachment")
         attachment_id = 764876347
-        self.mockgun.download_attachment = MagicMock()
+        self.mockgun.download_attachment = mock.MagicMock()
         try:
             # fail forever, and ensure exception is raised.
             self.mockgun.download_attachment.side_effect = Exception("Test Exception")
@@ -677,7 +680,7 @@ class TestShotgunDownloadAndUnpack(ShotgunTestBase):
         """
         target_dir = os.path.join(self.download_destination, "url")
         try:
-            with patch("tank.util.shotgun.download.download_url") as download_url_mock:
+            with mock.patch("tank.util.shotgun.download.download_url") as download_url_mock:
                 # Fail forever, and ensure exception is raised.
                 download_url_mock.side_effect = Exception("Test Exception")
                 with self.assertRaises(tank.util.ShotgunAttachmentDownloadError):

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -12,13 +12,15 @@ from __future__ import with_statement
 import threading
 import unittest
 
-from mock import patch
-
 import tank
 from tank import errors
 
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+    temp_env_var,
+)
 from tank.authentication.user import ShotgunUser
 from tank.authentication.user_impl import SessionUser
 from tank.descriptor import Descriptor
@@ -26,7 +28,7 @@ from tank.descriptor.io_descriptor.appstore import IODescriptorAppStore
 from tank.util.shotgun.connection import sanitize_url
 
 
-@patch(
+@mock.patch(
     "tank.util.shotgun.connection.__get_api_core_config_location",
     return_value="unknown_path_location",
 )
@@ -235,14 +237,14 @@ class ConnectionSettingsTestCases:
             tank.set_authenticated_user(None)
 
             # Prevents from connecting to Shotgun.
-            self._server_caps_mock = patch(
+            self._server_caps_mock = mock.patch(
                 "tank_vendor.shotgun_api3.Shotgun.server_caps"
             )
             self._server_caps_mock.start()
             self.addCleanup(self._server_caps_mock.stop)
 
             # Avoids crash because we're not in a pipeline configuration.
-            self._get_api_core_config_location_mock = patch(
+            self._get_api_core_config_location_mock = mock.patch(
                 "tank.util.shotgun.connection.__get_api_core_config_location",
                 return_value="unused_path_location",
             )
@@ -250,7 +252,7 @@ class ConnectionSettingsTestCases:
             self.addCleanup(self._get_api_core_config_location_mock.stop)
 
             # Mocks app store script user credentials retrieval
-            self._get_app_store_key_from_shotgun_mock = patch(
+            self._get_app_store_key_from_shotgun_mock = mock.patch(
                 "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore."
                 "_IODescriptorAppStore__get_app_store_key_from_shotgun",
                 return_value=("abc", "123"),
@@ -358,9 +360,9 @@ class LegacyAuthConnectionSettings(ConnectionSettingsTestCases.Impl):
         """
         Mock information coming from shotgun.yml for pre-authentication framework authentication.
         """
-        with patch("tank.util.shotgun.connection.__get_sg_config_data") as mock:
+        with mock.patch("tank.util.shotgun.connection.__get_sg_config_data") as mock1:
             # Mocks shotgun.yml content, which we use for authentication.
-            mock.return_value = {
+            mock1.return_value = {
                 "host": site,
                 "api_script": "1234",
                 "api_key": "1234",
@@ -371,7 +373,7 @@ class LegacyAuthConnectionSettings(ConnectionSettingsTestCases.Impl):
                 source_store_proxy
                 != ConnectionSettingsTestCases.FOLLOW_HTTP_PROXY_SETTING
             ):
-                mock.return_value["app_store_http_proxy"] = source_store_proxy
+                mock1.return_value["app_store_http_proxy"] = source_store_proxy
 
             ConnectionSettingsTestCases.Impl._run_test(
                 self,
@@ -397,9 +399,9 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
         """
         Mock information coming from the Shotgun user and shotgun.yml for authentication.
         """
-        with patch("tank.util.shotgun.connection.__get_sg_config_data") as mock:
+        with mock.patch("tank.util.shotgun.connection.__get_sg_config_data") as mock1:
             # Mocks shotgun.yml content
-            mock.return_value = {
+            mock1.return_value = {
                 # We're supposed to read only the proxy settings for the appstore
                 "host": "https://this_should_not_be_read.shotgunstudio.com",
                 "api_script": "1234",
@@ -411,7 +413,7 @@ class AuthConnectionSettings(ConnectionSettingsTestCases.Impl):
                 source_store_proxy
                 != ConnectionSettingsTestCases.FOLLOW_HTTP_PROXY_SETTING
             ):
-                mock.return_value["app_store_http_proxy"] = source_store_proxy
+                mock1.return_value["app_store_http_proxy"] = source_store_proxy
 
             # Mocks a user being authenticated.
             user = ShotgunUser(

--- a/tests/util_tests/test_system_settings.py
+++ b/tests/util_tests/test_system_settings.py
@@ -12,10 +12,11 @@ from __future__ import with_statement
 
 import os
 
-from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
-
-from mock import patch
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 from tank.util.system_settings import SystemSettings
 
@@ -31,6 +32,6 @@ class SystemSettingsTests(ShotgunTestBase):
         """
         http_proxy = "foo:bar@74.50.63.111:80"  # IP address of shotgunstudio.com
 
-        with patch.dict(os.environ, {"http_proxy": "http://" + http_proxy}):
+        with mock.patch.dict(os.environ, {"http_proxy": "http://" + http_proxy}):
             settings = SystemSettings()
             self.assertEqual(settings.http_proxy, http_proxy)

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -12,10 +12,11 @@ from __future__ import with_statement
 
 import os
 
-from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
-
-from mock import patch
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
 
 from tank.util import EnvironmentVariableFileLookupError
 from tank.util.user_settings import UserSettings
@@ -146,7 +147,7 @@ class UserSettingsTests(ShotgunTestBase):
                 "default_site": "https://${SGTK_TEST_SHOTGUN_SITE}.shotgunstudio.com"
             }
         )
-        with patch.dict(os.environ, {"SGTK_TEST_SHOTGUN_SITE": "shotgun_site"}):
+        with mock.patch.dict(os.environ, {"SGTK_TEST_SHOTGUN_SITE": "shotgun_site"}):
             settings = UserSettings()
             self.assertEqual(
                 settings.default_site, "https://shotgun_site.shotgunstudio.com"
@@ -156,10 +157,10 @@ class UserSettingsTests(ShotgunTestBase):
         """
         Test environment variables being set to files that don't exist.
         """
-        with patch.dict(os.environ, {"SGTK_PREFERENCES_LOCATION": "/a/b/c"}):
+        with mock.patch.dict(os.environ, {"SGTK_PREFERENCES_LOCATION": "/a/b/c"}):
             with self.assertRaisesRegex(EnvironmentVariableFileLookupError, "/a/b/c"):
                 UserSettings()
 
-        with patch.dict(os.environ, {"SGTK_DESKTOP_CONFIG_LOCATION": "/d/e/f"}):
+        with mock.patch.dict(os.environ, {"SGTK_DESKTOP_CONFIG_LOCATION": "/d/e/f"}):
             with self.assertRaisesRegex(EnvironmentVariableFileLookupError, "/d/e/f"):
                 UserSettings()


### PR DESCRIPTION
unittest2 and mock are backport packages from Py 3 to Py 2. We should use them as an exception for Py 2 only.