### PR TITLE
[Config 1.6.0 rc3] Some DCC versions will not launch Shotgrid

### DIFF
--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -18,6 +18,7 @@ from __future__ import with_statement
 import os
 import copy
 import threading
+from tank_vendor import six
 
 from tank_vendor import yaml
 from ..errors import TankError, TankUnreadableFileError, TankFileDoesNotExistError
@@ -256,8 +257,15 @@ class YamlCache(object):
         """
         path = item.path
         try:
-            with open(path, "r", encoding="utf8") as fh:
-                raw_data = yaml.load(fh, Loader=yaml.FullLoader)
+            if six.PY2:
+                with open(path, "r") as fh:
+                    raw_data = yaml.load(fh, Loader=yaml.FullLoader)
+            else:
+                # For Python 3 or above use the 'utf8' encoding to avoid
+                # 'UnicodeDecodeError' when using non utf-8
+                # special encoding standards.
+                with open(path, "r", encoding="utf8") as fh:
+                    raw_data = yaml.load(fh, Loader=yaml.FullLoader)
         except IOError:
             raise TankFileDoesNotExistError("File does not exist: %s" % path)
         except Exception as e:


### PR DESCRIPTION
This PR keeps the support for Python 2 and fix the issue when launching Python 2 DCC's from SG Desktop.