### PR TITLE
SG-31705 - The API now provide the URL so no need to format it ourselves

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -954,7 +954,7 @@ class ULF2_AuthTask(QtCore.QThread):
             )
         except AuthenticationError as err:
             self.exception = err
-        except Exception as err:
+        except Exception:
             logger.exception("Unknown error from unified_login_flow2")
             self.exception = AuthenticationError("Unknown authentication error")
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -954,6 +954,9 @@ class ULF2_AuthTask(QtCore.QThread):
             )
         except AuthenticationError as err:
             self.exception = err
+        except Exception as err:
+            logger.exception("Unknown error from unified_login_flow2")
+            self.exception = AuthenticationError("Unknown authentication error")
 
     def should_continue(self):
         return not self.should_stop

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -82,8 +82,8 @@ def _get_site_infos(url, http_proxy=None):
             sg.config.rpc_attempt_interval = 0
             infos = sg.info()
 
-            # Short term retro compatibility
             if "unified_login_flow_enabled2" in infos and "unified_login_flow2_enabled" not in infos:
+                # Retro compatibility with ShotGrid versions < 8.51.0.1628
                 infos["unified_login_flow2_enabled"] = infos["unified_login_flow_enabled2"]
 
             INFOS_CACHE[url] = (time.time(), infos)

--- a/python/tank/authentication/unified_login_flow2.py
+++ b/python/tank/authentication/unified_login_flow2.py
@@ -84,15 +84,19 @@ def process(
         raise errors.AuthenticationError("Proto error - token is empty")
 
     logger.debug("session ID: {session_id}".format(session_id=session_id))
-    try:
-        ret = browser_open_callback(
-            urllib.parse.urljoin(
-                sg_url,
-                "/app_session_request/{session_id}".format(
-                    session_id=session_id,
-                ),
+
+    browser_url = response.json.get("url", None)
+    if not browser_url:
+        # Retro compatibility with ShotGrid versions <v8.53.0.1993
+        browser_url = urllib.parse.urljoin(
+            sg_url,
+            "/app_session_request/{session_id}".format(
+                session_id=session_id,
             ),
         )
+
+    try:
+        ret = browser_open_callback(browser_url)
         if not ret:
             raise errors.AuthenticationError("Unable to open local browser")
 


### PR DESCRIPTION
ShotGrid version >=8.53.0.1993. now provide the browser URL so we no longer need to format it from the given information.