### PR TITLE
SG-31666 - Force the QMessageBox to be on top.

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -357,7 +357,8 @@ class LoginDialog(QtGui.QDialog):
             #      parameter.
             # I chose solution #1, se below.
         )
-
+        # force the QMessageBox to be on top of other dialogs.
+        self.confirm_box.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         self.confirm_box.setInformativeText(
             "The authentication is still in progress and closing this window "
             "will result in canceling your request."


### PR DESCRIPTION
This PR fixes the issue introduced in tk-core v0.20.21 happening on Windows where the QMessageBox confirmation dialog is hidden in the foreground behind the new SG Desktop login dialog, making it not visible and not actionable.

<img width="300" alt="QMessageBox" src="https://github.com/shotgunsoftware/tk-core/assets/42726133/88eddbe1-0791-4fbc-88bb-00a49df497c3">
