### PR TITLE
SHOT-4293: Fix PySide6 patch for QPalette.Background and PySide import ordering

### DIFF
--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -483,7 +483,7 @@ class PySide6Patcher(PySide2Patcher):
         # QHeaderView method rename
         qt_gui_shim.QHeaderView.setResizeMode = qt_gui_shim.QHeaderView.setSectionResizeMode
 
-        # QPainter HighQualityAntialiasing is obsolet. Use Antiasliasing instead.
+        # QPainter HighQualityAntialiasing is obsolete. Use Antiasliasing instead.
         # https://doc.qt.io/qt-5/qpainter.html#RenderHint-enum
         qt_gui_shim.QPainter.HighQualityAntialiasing = qt_gui_shim.QPainter.Antialiasing
 

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -487,4 +487,8 @@ class PySide6Patcher(PySide2Patcher):
         # https://doc.qt.io/qt-5/qpainter.html#RenderHint-enum
         qt_gui_shim.QPainter.HighQualityAntialiasing = qt_gui_shim.QPainter.Antialiasing
 
+        # QPaelette Background is obsolete. Use Window instead.
+        # https://doc.qt.io/qt-5/qpalette.html#ColorRole-enum
+        qt_gui_shim.QPalette.Background = qt_gui_shim.QPalette.Window
+
         return qt_core_shim, qt_gui_shim

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -399,10 +399,14 @@ class QtImporter(object):
     def _import_modules(self, interface_version_requested):
         """
         Tries to import different Qt binding implementation in the following order:
-            - PySide6
             - PySide2
             - PySide
             - PyQt4
+            - PySide6
+        
+        PySide6 is attempted to be imported last at the moment because it is is not yet fully
+        supported. If a DCC requires PySide6, it can run with the current level of support,
+        but be warned that you may encounter issues.
 
         :returns: The (binding name, binding version, modules) tuple or (None, None, None) if
             no binding is avaialble.

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -415,23 +415,7 @@ class QtImporter(object):
         }.get(interface_version_requested)
         logger.debug("Requesting %s-like interface", interface)
 
-        # First try PySide6.
-        if interface_version_requested == self.QT4:
-            try:
-                pyside6 = self._import_pyside6_as_pyside()
-                logger.debug("Imported PySide6 as PySide.")
-                return pyside6
-            except ImportError:
-                pass
-        elif interface_version_requested == self.QT6:
-            try:
-                pyside6 = self._import_pyside6()
-                logger.debug("Imported PySide6.")
-                return pyside6
-            except ImportError:
-                pass
-
-        # Next, try PySide 2.
+        # First, try PySide 2 since Toolkit ships with PySide2.
         if interface_version_requested == self.QT4:
             try:
                 pyside2 = self._import_pyside2_as_pyside()
@@ -450,6 +434,22 @@ class QtImporter(object):
             # TODO migrate qt base from Qt4 interface to Qt6 will require patching Qt5 as Qt6
             logger.debug("Qt6 interface not implemented for Qt5")
             pass
+
+        # Next try PySide6. Allow using PySide6 if PySide2 not available.
+        if interface_version_requested == self.QT4:
+            try:
+                pyside6 = self._import_pyside6_as_pyside()
+                logger.debug("Imported PySide6 as PySide.")
+                return pyside6
+            except ImportError:
+                pass
+        elif interface_version_requested == self.QT6:
+            try:
+                pyside6 = self._import_pyside6()
+                logger.debug("Imported PySide6.")
+                return pyside6
+            except ImportError:
+                pass
 
         # We do not test for PyQt5 since it is supported on Python 3 only at the moment.
 

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -435,22 +435,6 @@ class QtImporter(object):
             logger.debug("Qt6 interface not implemented for Qt5")
             pass
 
-        # Next try PySide6. Allow using PySide6 if PySide2 not available.
-        if interface_version_requested == self.QT4:
-            try:
-                pyside6 = self._import_pyside6_as_pyside()
-                logger.debug("Imported PySide6 as PySide.")
-                return pyside6
-            except ImportError:
-                pass
-        elif interface_version_requested == self.QT6:
-            try:
-                pyside6 = self._import_pyside6()
-                logger.debug("Imported PySide6.")
-                return pyside6
-            except ImportError:
-                pass
-
         # We do not test for PyQt5 since it is supported on Python 3 only at the moment.
 
         # Now try PySide 1
@@ -468,6 +452,23 @@ class QtImporter(object):
                 pyqt = self._import_pyqt4()
                 logger.debug("Imported PyQt4.")
                 return pyqt
+            except ImportError:
+                pass
+
+        # Last attempt, try PySide6. PySide6 is not yet fully supported but allow DCCs that
+        # require PySide6 to run with the current support
+        if interface_version_requested == self.QT4:
+            try:
+                pyside6 = self._import_pyside6_as_pyside()
+                logger.debug("Imported PySide6 as PySide.")
+                return pyside6
+            except ImportError:
+                pass
+        elif interface_version_requested == self.QT6:
+            try:
+                pyside6 = self._import_pyside6()
+                logger.debug("Imported PySide6.")
+                return pyside6
             except ImportError:
                 pass
 

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -411,7 +411,7 @@ class QtImporter(object):
             - PySide
             - PyQt4
             - PySide6
-        
+
         PySide6 is attempted to be imported last at the moment because it is is not yet fully
         supported. If a DCC requires PySide6, it can run with the current level of support,
         but be warned that you may encounter issues.

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -178,7 +178,7 @@ def skip_if_pyside(found=True):
         found_pyside = _has_pyside()
         msg = "PySide found" if found else "PySide missing"
         return unittest.skipIf(found_pyside == found, msg)(func)
-    
+
     return _skip_if_pyside
 
 def _has_pyside2():
@@ -203,7 +203,7 @@ def skip_if_pyside2(found=True):
         found_pyside2 = _has_pyside2()
         msg = "PySide2 found" if found else "PySide2 missing"
         return unittest.skipIf(found_pyside2 == found, msg)(func)
-    
+
     return _skip_if_pyside2
 
 def _has_pyqt4():
@@ -253,7 +253,7 @@ def skip_if_pyside6(found=True):
         found_pyside6 = _has_pyside6()
         msg = "PySide6 found" if found else "PySide6 missing"
         return unittest.skipIf(found_pyside6 == found, msg)(func)
-    
+
     return _skip_if_pyside6
 
 def suppress_generated_code_qt_warnings(func):

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -25,6 +25,7 @@ import contextlib
 import atexit
 import uuid
 import datetime
+import importlib.util
 from functools import wraps
 
 from collections import defaultdict
@@ -49,6 +50,10 @@ __all__ = [
     "tank",
     "interactive",
     "skip_if_pyside_missing",
+    "skip_if_pyside",
+    "skip_if_pyside2",
+    "skip_if_pyside6",
+    "skip_if_pyqt4",
 ]
 
 
@@ -145,12 +150,111 @@ def _is_pyside_missing():
 
 def skip_if_pyside_missing(func):
     """
-    Decorated that allows to skips a test if PySide is missing.
+    Decorator that allows to skip tests if no version of PySide is found.
     :param func: Function to be decorated.
     :returns: The decorated function.
     """
     return unittest.skipIf(_is_pyside_missing(), "PySide is missing")(func)
 
+def _has_pyside():
+    """
+    Tests if PySide is avalable.
+    :returns: True if PySide is available, False otherwise.
+    """
+    pyside_spec = importlib.util.find_spec("PySide")
+    found = pyside_spec is not None
+    return found
+
+def skip_if_pyside(found=True):
+    """
+    Decorator that allows to skip tests based on if PySide module found or not.
+    :param func: Function to be decorated.
+    :param found: True will skip if PySide is found, else will skip if PySide not found
+        (e.g. missing). Default to skip if PySide found.
+    :returns: The decorated function.
+    """
+
+    def _skip_if_pyside(func):
+        found_pyside = _has_pyside()
+        msg = "PySide found" if found else "PySide missing"
+        return unittest.skipIf(found_pyside == found, msg)(func)
+    
+    return _skip_if_pyside
+
+def _has_pyside2():
+    """
+    Tests if PySide2 is avalable.
+    :returns: True if PySide2 is available, False otherwise.
+    """
+    pyside2_spec = importlib.util.find_spec("PySide2")
+    found = pyside2_spec is not None
+    return found
+
+def skip_if_pyside2(found=True):
+    """
+    Decorator that allows to skip tests based on if PySide2 module found or not.
+    :param func: Function to be decorated.
+    :param found: True will skip if PySide2 is found, else will skip if PySide2 not found
+        (e.g. missing). Default to skip if PySide2 found.
+    :returns: The decorated function.
+    """
+
+    def _skip_if_pyside2(func):
+        found_pyside2 = _has_pyside2()
+        msg = "PySide2 found" if found else "PySide2 missing"
+        return unittest.skipIf(found_pyside2 == found, msg)(func)
+    
+    return _skip_if_pyside2
+
+def _has_pyqt4():
+    """
+    Tests if PyQt4 is avalable.
+    :returns: True if PyQt4 is available, False otherwise.
+    """
+    pyqt4_spec = importlib.util.find_spec("PyQt4")
+    found = pyqt4_spec is not None
+    return found
+
+def skip_if_pyqt4(found=True):
+    """
+    Decorator that allows to skip tests based on if PyQt4 module found or not.
+    :param func: Function to be decorated.
+    :param found: True will skip if PyQt4 is found, else will skip if PyQt4 not found
+        (e.g. missing). Default to skip if PyQt4 found.
+    :returns: The decorated function.
+    """
+
+    def _skip_if_pyqt4(func):
+        found_pyqt4= _has_pyqt4()
+        msg = "PyQt4 found" if found else "PyQt4 missing"
+        return unittest.skipIf(found_pyqt4 == found, msg)(func)
+
+    return _skip_if_pyqt4
+
+def _has_pyside6():
+    """
+    Tests if PySide6 is avalable.
+    :returns: True if PySide6 is available, False otherwise.
+    """
+    pyside6_spec = importlib.util.find_spec("PySide6")
+    found = pyside6_spec is not None
+    return found
+
+def skip_if_pyside6(found=True):
+    """
+    Decorator that allows to skip tests if PySide6 is missing.
+    :param func: Function to be decorated.
+    :param found: True will skip if PySide2 is found, else will skip if PySide2 not found
+        (e.g. missing). Default to skip if PySide2 found.
+    :returns: The decorated function.
+    """
+
+    def _skip_if_pyside6(func):
+        found_pyside6 = _has_pyside6()
+        msg = "PySide6 found" if found else "PySide6 missing"
+        return unittest.skipIf(found_pyside6 == found, msg)(func)
+    
+    return _skip_if_pyside6
 
 def suppress_generated_code_qt_warnings(func):
     """

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -8,42 +8,42 @@
 # agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk.
 
+# import sys
+# sys.path.append("C:\\python_libs")
+# import ptvsd
+# ptvsd.enable_attach()
+# ptvsd.wait_for_attach()
+
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,
+    skip_if_pyside6,
 )
 
 from tank.util import pyside6_patcher
 
-
+@skip_if_pyside6(found=False)
 class PySide6PatcherTests(TankTestBase):
     """Tests PySide6 patcher functionality."""
 
     def test_patch(self):
         """Test the PySide6Patcher patch method that patches PySide6 as PySide."""
 
-        core, gui = None, None
-        try:
-            core, gui = pyside6_patcher.PySide6Patcher.patch()
-            # Assert the core ang gui modules are created and returned
-            assert core
-            assert gui
-            # Assert QtCore attributes
-            assert core.Qt.MidButton == core.Qt.MiddleButton
-            assert core.QRegExp == core.QRegularExpression
-            # Assert QtGui attributes
-            assert gui.QApplication.desktop
-            assert gui.QAbstractButton.animateClick
-            assert gui.QSortFilterProxyModel.filterRegExp == gui.QSortFilterProxyModel.filterRegularExpression
-            assert gui.QSortFilterProxyModel.setFilterRegExp == gui.QSortFilterProxyModel.setFilterRegularExpression
-            assert gui.QDesktopWidget == gui.QScreen
-            assert gui.QFontMetrics.width == gui.QFontMetrics.horizontalAdvance
-            assert gui.QFont.setWeight == gui.QFont.setLegacyWeight
-            assert gui.QHeaderView.setResizeMode == gui.QHeaderView.setSectionResizeMode
-            assert gui.QPainter.HighQualityAntialiasing == gui.QPainter.Antialiasing
-            assert gui.QPalette.Background == gui.QPalette.Window
-        except ImportError:
-            # PySide6 not available. Until unit tests fully support PySide6, we cannot use a
-            # decorator to skip this test when PySide6 is not available
-            assert core is None
-            assert gui is None
+        core, gui = pyside6_patcher.PySide6Patcher.patch()
+        # Assert the core ang gui modules are created and returned
+        assert core
+        assert gui
+        # Assert QtCore attributes
+        assert core.Qt.MidButton == core.Qt.MiddleButton
+        assert core.QRegExp == core.QRegularExpression
+        # Assert QtGui attributes
+        assert gui.QApplication.desktop
+        assert gui.QAbstractButton.animateClick
+        assert gui.QSortFilterProxyModel.filterRegExp == gui.QSortFilterProxyModel.filterRegularExpression
+        assert gui.QSortFilterProxyModel.setFilterRegExp == gui.QSortFilterProxyModel.setFilterRegularExpression
+        assert gui.QDesktopWidget == gui.QScreen
+        assert gui.QFontMetrics.width == gui.QFontMetrics.horizontalAdvance
+        assert gui.QFont.setWeight == gui.QFont.setLegacyWeight
+        assert gui.QHeaderView.setResizeMode == gui.QHeaderView.setSectionResizeMode
+        assert gui.QPainter.HighQualityAntialiasing == gui.QPainter.Antialiasing
+        assert gui.QPalette.Background == gui.QPalette.Window

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    TankTestBase,
+)
+
+from tank.util import pyside6_patcher
+
+
+class PySide6PatcherTests(TankTestBase):
+    """Tests PySide6 patcher functionality."""
+
+    def test_patch(self):
+        """Test the PySide6Patcher patch method that patches PySide6 as PySide."""
+
+        core, gui = None, None
+        try:
+            core, gui = pyside6_patcher.PySide6Patcher.patch()
+            # Assert the core ang gui modules are created and returned
+            assert core
+            assert gui
+            # Assert QtCore attributes
+            assert core.Qt.MidButton == core.Qt.MiddleButton
+            assert core.QRegExp == core.QRegularExpression
+            # Assert QtGui attributes
+            assert gui.QApplication.desktop
+            assert gui.QAbstractButton.animateClick
+            assert gui.QSortFilterProxyModel.filterRegExp == gui.QSortFilterProxyModel.filterRegularExpression
+            assert gui.QSortFilterProxyModel.setFilterRegExp == gui.QSortFilterProxyModel.setFilterRegularExpression
+            assert gui.QDesktopWidget == gui.QScreen
+            assert gui.QFontMetrics.width == gui.QFontMetrics.horizontalAdvance
+            assert gui.QFont.setWeight == gui.QFont.setLegacyWeight
+            assert gui.QHeaderView.setResizeMode == gui.QHeaderView.setSectionResizeMode
+            assert gui.QPainter.HighQualityAntialiasing == gui.QPainter.Antialiasing
+            assert gui.QPalette.Background == gui.QPalette.Window
+        except ImportError:
+            # PySide6 not available. Until unit tests fully support PySide6, we cannot use a
+            # decorator to skip this test when PySide6 is not available
+            assert core is None
+            assert gui is None

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -8,12 +8,6 @@
 # agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk.
 
-# import sys
-# sys.path.append("C:\\python_libs")
-# import ptvsd
-# ptvsd.enable_attach()
-# ptvsd.wait_for_attach()
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -22,6 +22,7 @@ from tank_test.tank_test_base import (
 
 from tank.util import pyside6_patcher
 
+
 @skip_if_pyside6(found=False)
 class PySide6PatcherTests(TankTestBase):
     """Tests PySide6 patcher functionality."""

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2023 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    TankTestBase,
+    skip_if_pyside,
+    skip_if_pyside2,
+    skip_if_pyside6,
+    skip_if_pyqt4,
+)
+from tank.util import qt_importer
+
+
+class QtImporterTests(TankTestBase):
+    """Tests QtImporter functionality."""
+
+    @skip_if_pyside2(found=False)
+    def test_qt_importer_with_pyside2_interface_qt4(self):
+        """
+        Test the QtImporter constructor with QT4 interface.
+
+        This test only runs if PySide2 is available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT4)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        # We need one or the other
+        assert qt.QtWebKit or qt.QtWebEngineWidgets
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PySide2"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version
+
+
+    @skip_if_pyside2(found=False)
+    def test_qt_importer_with_pyside2_interface_qt5(self):
+        """
+        Test the QtImporter constructor with QT4 interface.
+
+        This test only runs if PySide2 is available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT5)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        try:
+            qt_web_kit = qt.QtWebKit
+        except KeyError:
+            qt_web_kit = None
+        try:
+            qt_web_engine_widgets = qt.QtWebEngineWidgets
+        except KeyError:
+            qt_web_engine_widgets = None
+        # We need one or the other
+        assert qt_web_kit or qt_web_engine_widgets
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PySide2"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version
+
+
+    @skip_if_pyside(found=False)
+    @skip_if_pyside2(found=True)
+    def test_qt_importer_with_pyside_interface_qt4(self):
+        """
+        Test the QtImporter constructor with default interface version requested.
+
+        This test only runs if PySide is available and PySide2 is not available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT4)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        # We need one or the other
+        assert qt.QtWebKit or qt.QtWebEngineWidgets
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PySide"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version
+
+
+    @skip_if_pyqt4(found=False)
+    @skip_if_pyside(found=True)
+    @skip_if_pyside2(found=True)
+    def test_qt_importer_with_pyqt4_interface_qt4(self):
+        """
+        Test the QtImporter constructor with default interface version requested.
+
+        This test only runs if PyQt4 is available and PySide, PySide2 are not available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT4)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        assert qt.QtWebKit
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PyQt4"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version
+
+
+    @skip_if_pyside6(found=False)
+    @skip_if_pyqt4(found=True)
+    @skip_if_pyside(found=True)
+    @skip_if_pyside2(found=True)
+    def test_qt_importer_with_pyside6_interface_qt4(self):
+        """
+        Test the QtImporter constructor with default interface version requested.
+
+        This test only runs if PySide6 is available and PyQt4, PySide, PySide2 are not available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT4)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        # We need one or the other
+        assert qt.QtWebKit or qt.QtWebEngineWidgets
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PySide6"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version
+
+
+    @skip_if_pyside6(found=False)
+    @skip_if_pyqt4(found=True)
+    @skip_if_pyside(found=True)
+    @skip_if_pyside2(found=True)
+    def test_qt_importer_with_pyside6_interface_qt6(self):
+        """
+        Test the QtImporter constructor with default interface version requested.
+
+        This test only runs if PySide6 is available and PyQt4, PySide, PySide2 are not available.
+        """
+
+        qt = qt_importer.QtImporter(qt_importer.QtImporter.QT6)
+
+        # Check that the qt modules were initialized
+        assert qt.QtCore
+        assert qt.QtGui
+        assert qt.QtNetwork
+        try:
+            qt_web_kit = qt.QtWebKit
+        except KeyError:
+            qt_web_kit = None
+        try:
+            qt_web_engine_widgets = qt.QtWebEngineWidgets
+        except KeyError:
+            qt_web_engine_widgets = None
+        # We need one or the other
+        assert qt_web_kit or qt_web_engine_widgets
+
+        # Expect PySide2 as the binding
+        assert qt.binding_name == "PySide6"
+        assert qt.base
+        assert qt.base["__name__"] is qt.binding_name
+        assert qt.base["__version__"] is qt.binding_version

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -46,7 +46,6 @@ class QtImporterTests(TankTestBase):
         assert qt.base["__name__"] is qt.binding_name
         assert qt.base["__version__"] is qt.binding_version
 
-
     @skip_if_pyside2(found=False)
     def test_qt_importer_with_pyside2_interface_qt5(self):
         """
@@ -78,7 +77,6 @@ class QtImporterTests(TankTestBase):
         assert qt.base["__name__"] is qt.binding_name
         assert qt.base["__version__"] is qt.binding_version
 
-
     @skip_if_pyside(found=False)
     @skip_if_pyside2(found=True)
     def test_qt_importer_with_pyside_interface_qt4(self):
@@ -103,7 +101,6 @@ class QtImporterTests(TankTestBase):
         assert qt.base["__name__"] is qt.binding_name
         assert qt.base["__version__"] is qt.binding_version
 
-
     @skip_if_pyqt4(found=False)
     @skip_if_pyside(found=True)
     @skip_if_pyside2(found=True)
@@ -127,7 +124,6 @@ class QtImporterTests(TankTestBase):
         assert qt.base
         assert qt.base["__name__"] is qt.binding_name
         assert qt.base["__version__"] is qt.binding_version
-
 
     @skip_if_pyside6(found=False)
     @skip_if_pyqt4(found=True)
@@ -154,7 +150,6 @@ class QtImporterTests(TankTestBase):
         assert qt.base
         assert qt.base["__name__"] is qt.binding_name
         assert qt.base["__version__"] is qt.binding_version
-
 
     @skip_if_pyside6(found=False)
     @skip_if_pyqt4(found=True)


### PR DESCRIPTION
* QPalette.Background is now removed in Qt6. Use QPalette.Window instead (as per Qt doc)
* Revert PySide import ordering in QtImporter to try to import PySide2 first and PySide6 last