### PR TITLE
SG-31939 Remove warnings raised by CI tests

### DIFF
--- a/python/tank_vendor/ruamel_yaml/comments.py
+++ b/python/tank_vendor/ruamel_yaml/comments.py
@@ -12,7 +12,7 @@ these are not really related, formatting could be factored out as
 a separate base
 """
 
-from collections import MutableSet
+from collections.abc import MutableSet
 
 from .compat import ordereddict
 

--- a/python/tank_vendor/ruamel_yaml/constructor.py
+++ b/python/tank_vendor/ruamel_yaml/constructor.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',
            'ConstructorError', 'RoundTripConstructor']
 
-import collections
+import collections.abc
 import datetime
 import base64
 import binascii
@@ -143,7 +143,7 @@ class BaseConstructor(object):
             # keys can be list -> deep
             key = self.construct_object(key_node, deep=True)
             # lists are not hashable, but tuples are
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, collections.abc.Hashable):
                 if isinstance(key, list):
                     key = tuple(key)
             if PY2:
@@ -155,7 +155,7 @@ class BaseConstructor(object):
                         "found unacceptable key (%s)" %
                         exc, key_node.start_mark)
             else:
-                if not isinstance(key, collections.Hashable):
+                if not isinstance(key, collections.abc.Hashable):
                     raise ConstructorError(
                         "while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
@@ -932,7 +932,7 @@ class RoundTripConstructor(SafeConstructor):
             # keys can be list -> deep
             key = self.construct_object(key_node, deep=True)
             # lists are not hashable, but tuples are
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, collections.abc.Hashable):
                 if isinstance(key, list):
                     key = tuple(key)
             if PY2:
@@ -944,7 +944,7 @@ class RoundTripConstructor(SafeConstructor):
                         "found unacceptable key (%s)" %
                         exc, key_node.start_mark)
             else:
-                if not isinstance(key, collections.Hashable):
+                if not isinstance(key, collections.abc.Hashable):
                     raise ConstructorError(
                         "while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
@@ -976,7 +976,7 @@ class RoundTripConstructor(SafeConstructor):
             # keys can be list -> deep
             key = self.construct_object(key_node, deep=True)
             # lists are not hashable, but tuples are
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, collections.abc.Hashable):
                 if isinstance(key, list):
                     key = tuple(key)
             if PY2:
@@ -988,7 +988,7 @@ class RoundTripConstructor(SafeConstructor):
                         "found unacceptable key (%s)" %
                         exc, key_node.start_mark)
             else:
-                if not isinstance(key, collections.Hashable):
+                if not isinstance(key, collections.abc.Hashable):
                     raise ConstructorError(
                         "while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)

--- a/tests/descriptor_tests/test_github.py
+++ b/tests/descriptor_tests/test_github.py
@@ -72,6 +72,21 @@ class MockResponse(object):
         self.msg = status_message
         self.headers = headers
 
+    def close(self):
+        """
+        This method is called by tempfile.__del__ starting in Python 3.9.
+        We create if here to avoid an exception and warning message
+        ##[warning]Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x10be9f310>
+
+        Traceback (most recent call last):
+        File "/Users/runner/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/tempfile.py", line 445, in __del__
+            self.close()
+        File "/Users/runner/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/tempfile.py", line 438, in close
+            self.file.close()
+        AttributeError: 'MockResponse' object has no attribute 'close'
+        """
+        pass
+
     def read(self):
         """
         Return the body of the page, mimicking the response object's behavior.

--- a/tests/descriptor_tests/test_github.py
+++ b/tests/descriptor_tests/test_github.py
@@ -74,16 +74,9 @@ class MockResponse(object):
 
     def close(self):
         """
-        This method is called by tempfile.__del__ starting in Python 3.9.
-        We create if here to avoid an exception and warning message
-        ##[warning]Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x10be9f310>
-
-        Traceback (most recent call last):
-        File "/Users/runner/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/tempfile.py", line 445, in __del__
-            self.close()
-        File "/Users/runner/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/tempfile.py", line 438, in close
-            self.file.close()
-        AttributeError: 'MockResponse' object has no attribute 'close'
+        This method needs to be defined starting with Python 3.9 to prevent a
+        warning message:
+          [warning]Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x10be9f310>
         """
         pass
 


### PR DESCRIPTION

- Python 3.10 deprecation notice
  ```
  ##[warning]Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  ```

- Python 3.9 tempfile mocker class
  ```
  ##[warning]Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x10e04b310>
  ```