### PR TITLE
Refactor git descriptors

### DIFF
--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -74,11 +74,11 @@ class _IODescriptorGitCache(type):
         else:
             version =  descriptor_dict['version']
 
-        id_ = f"{descriptor_dict['type']}-{descriptor_dict['path']}-{version}"
+        id_ = "{}-{}-{}".format(descriptor_dict['type'], descriptor_dict['path'], version)
 
         cached_time, self = cls._instances.get(id_, (-1, None))
         if cached_time < floored_time:
-            log.debug(f"{cached_time}, {floored_time}, {id_}")
+            log.debug("{} {} cache expired: cachedTime:{}".format(self, id_, cached_time))
             self = super().__call__(descriptor_dict, sg_connection, bundle_type)
             cls._instances[id_] = (floored_time, self)
 
@@ -286,9 +286,9 @@ class IODescriptorGit(IODescriptorDownloadable, metaclass=_IODescriptorGitCache)
         if self._descriptor_dict.get("type") == "git_branch" and not is_latest_commit:
             depth = ""
         else:
-            depth = f"--depth {depth}" if depth else ""
+            depth = "--depth {}".format(depth) if depth else ""
 
-        ref = f"-b {ref}" if ref else ""
-        cmd = f'git clone --no-hardlinks -q "{self._path}" {ref} "{target_path}" {depth}'
+        ref = "-b {}".format(ref) if ref else ""
+        cmd = 'git clone --no-hardlinks -q "{}" {} "{}" {}'.format(self._path, ref, target_path, depth)
 
         return cmd

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -109,7 +109,10 @@ class IODescriptorGit(IODescriptorDownloadable):
         # first probe to check that git exists in our PATH
         self.is_git_available()
 
-        str_cmd = " ".join(commands)
+        if not isinstance(commands, str):
+            str_cmd = " ".join(commands)
+        else:
+            str_cmd = commands
 
         log.debug("Executing command '%s' using subprocess module." % str_cmd)
 

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -209,7 +209,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         can_connect = True
         try:
             log.debug("%r: Probing if a connection to git can be established..." % self)
-            self._execute_git_commands(["git", "ls-remote", shlex.quote(self._path)])
+            self._execute_git_commands(["git", "ls-remote", "--heads", self._path])
             log.debug("...connection established")
         except (OSError, SubprocessCalledProcessError) as e:
             log.debug("...could not establish connection: %s" % e)

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -121,8 +121,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         # I would have expected Windows to give an error about stdin being close and
         # aborting the git command but at least on Windows 10 that is not the case.
         environ = os.environ.copy()
-        if _can_hide_terminal():
-            environ["GIT_TERMINAL_PROMPT"] = "0"
+        environ["GIT_TERMINAL_PROMPT"] = "0"
 
         try:
             output = _check_output(commands, env=environ)

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -32,7 +32,8 @@ def _can_hide_terminal():
         subprocess.STARTF_USESHOWWINDOW
         subprocess.SW_HIDE
         return True
-    except Exception:
+    except AttributeError as e:
+        log.debug("Terminal cant be hidden: %s" % e)
         return False
 
 
@@ -202,7 +203,7 @@ class IODescriptorGit(IODescriptorDownloadable):
             log.debug("%r: Probing if a connection to git can be established..." % self)
             self._execute_git_commands(["git", "ls-remote", shlex.quote(self._path)])
             log.debug("...connection established")
-        except Exception as e:
+        except (OSError, SubprocessCalledProcessError) as e:
             log.debug("...could not establish connection: %s" % e)
             can_connect = False
         return can_connect

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -88,10 +88,15 @@ class IODescriptorGit(IODescriptorDownloadable):
 
     def is_git_available(self):
         log.debug("Checking that git exists and can be executed...")
+
+        if IS_WINDOWS:
+            cmd = "where"
+        else:
+            cmd = "which"
+
         try:
-            output = _check_output(["git", "--version"])
+            output = _check_output([cmd, "git"])
         except SubprocessCalledProcessError:
-            log.exception("Unexpected error:")
             raise TankGitError(
                 "Cannot execute the 'git' command. Please make sure that git is "
                 "installed on your system and that the git executable has been added to the PATH."

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
 import shlex
+import shutil
 import subprocess
 
 from .downloadable import IODescriptorDownloadable
@@ -16,7 +17,6 @@ from ... import LogManager
 from ...util.process import subprocess_check_output, SubprocessCalledProcessError
 
 from ..errors import TankError
-from ...util import filesystem
 from ...util import is_windows
 
 log = LogManager.get_logger(__name__)
@@ -172,8 +172,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         """
         # ensure *parent* folder exists
         parent_folder = os.path.dirname(target_path)
-
-        filesystem.ensure_folder_exists(parent_folder)
+        os.makedirs(parent_folder, exist_ok=True)
 
         # Make sure all git commands are correct according to the descriptor type
         cmd = self._get_git_clone_commands(
@@ -232,15 +231,8 @@ class IODescriptorGit(IODescriptorDownloadable):
         # make sure item exists locally
         self.ensure_local()
         # copy descriptor into target.
-        # the skip list contains .git folders by default, so pass in []
-        # to turn that restriction off. In the case of the git descriptor,
-        # we want to transfer this folder as well.
-        filesystem.copy_folder(
-            self.get_path(),
-            target_path,
-            # Make we do not pass none or we will be getting the default skip list.
-            skip_list=skip_list or [],
-        )
+        shutil.copytree(self.get_path(), target_path)
+
 
     def _get_git_clone_commands(
         self, target_path, depth=None, ref=None, is_latest_commit=None

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -256,23 +256,13 @@ class IODescriptorGit(IODescriptorDownloadable):
         # complications in cleanup scenarios and with file copying. We want
         # each repo that we clone to be completely independent on a filesystem level.
         log.debug("Git Cloning %r into %s" % (self, target_path))
-        depth = "--depth %s" % depth if depth else ""
-        ref = "-b %s" % ref if ref else ""
-        cmd = 'git clone --no-hardlinks -q "%s" %s "%s" %s' % (
-            self._path,
-            ref,
-            target_path,
-            depth,
-        )
-        if self._descriptor_dict.get("type") == "git_branch":
-            if not is_latest_commit:
-                if "--depth" in cmd:
-                    depth = ""
-                    cmd = 'git clone --no-hardlinks -q "%s" %s "%s" %s' % (
-                        self._path,
-                        ref,
-                        target_path,
-                        depth,
-                    )
+
+        if self._descriptor_dict.get("type") == "git_branch" and not is_latest_commit:
+            depth = ""
+        else:
+            depth = f"--depth {depth}" if depth else ""
+
+        ref = f"-b {ref}" if ref else ""
+        cmd = f'git clone --no-hardlinks -q "{self._path}" {ref} "{target_path}" {depth}'
 
         return cmd

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -181,10 +181,11 @@ class IODescriptorGit(IODescriptorDownloadable):
         )
         self._execute_git_commands(cmd)
 
-        full_commands = ["git", "-C", shlex.quote(target_path)]
-        full_commands.extend(commands)
+        if commands:
+            full_commands = ["git", "-C", os.path.normpath(target_path)]
+            full_commands.extend(commands)
 
-        return self._execute_git_commands(full_commands)
+            return self._execute_git_commands(full_commands)
 
     def get_system_name(self):
         """

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
-import shlex
+import platform
 import shutil
 import subprocess
 
@@ -20,6 +20,7 @@ from ..errors import TankError
 from ...util import is_windows
 
 log = LogManager.get_logger(__name__)
+IS_WINDOWS = platform.system() == "Windows"
 
 
 def _can_hide_terminal():

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -8,9 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
-import uuid
-import shutil
-import tempfile
+import shlex
 import subprocess
 
 from .downloadable import IODescriptorDownloadable
@@ -87,6 +85,48 @@ class IODescriptorGit(IODescriptorDownloadable):
         if self._path.endswith("/") or self._path.endswith("\\"):
             self._path = self._path[:-1]
 
+    def is_git_available(self):
+        log.debug("Checking that git exists and can be executed...")
+        try:
+            output = _check_output(["git", "--version"])
+        except SubprocessCalledProcessError:
+            log.exception("Unexpected error:")
+            raise TankGitError(
+                "Cannot execute the 'git' command. Please make sure that git is "
+                "installed on your system and that the git executable has been added to the PATH."
+            )
+        else:
+            log.debug("Git installed: %s" % output)
+            return True
+
+    def _execute_git_commands(self, commands):
+        # first probe to check that git exists in our PATH
+        self.is_git_available()
+
+        str_cmd = " ".join(commands)
+
+        log.debug("Executing command '%s' using subprocess module." % str_cmd)
+
+        # It's important to pass GIT_TERMINAL_PROMPT=0 or the git subprocess will
+        # just hang waiting for credentials to be entered on the missing terminal.
+        # I would have expected Windows to give an error about stdin being close and
+        # aborting the git command but at least on Windows 10 that is not the case.
+        environ = os.environ.copy()
+        if _can_hide_terminal():
+            environ["GIT_TERMINAL_PROMPT"] = "0"
+
+        try:
+            output = _check_output(commands, env=environ)
+        except SubprocessCalledProcessError as e:
+            raise TankGitError(
+                "Error executing git operation '%s': %s (Return code %s)"
+                % (str_cmd, e.output, e.returncode)
+            )
+        else:
+            output = output.strip().strip("'")
+            log.debug("Execution successful. stderr/stdout: '%s'" % output)
+            return output
+
     @LogManager.log_timing
     def _clone_then_execute_git_commands(
         self, target_path, commands, depth=None, ref=None, is_latest_commit=None
@@ -127,144 +167,16 @@ class IODescriptorGit(IODescriptorDownloadable):
 
         filesystem.ensure_folder_exists(parent_folder)
 
-        # first probe to check that git exists in our PATH
-        log.debug("Checking that git exists and can be executed...")
-        try:
-            output = _check_output(["git", "--version"])
-        except:
-            log.exception("Unexpected error:")
-            raise TankGitError(
-                "Cannot execute the 'git' command. Please make sure that git is "
-                "installed on your system and that the git executable has been added to the PATH."
-            )
-
-        log.debug("Git installed: %s" % output)
-
         # Make sure all git commands are correct according to the descriptor type
-        cmd = self._validate_git_commands(
+        cmd = self._get_git_clone_commands(
             target_path, depth=depth, ref=ref, is_latest_commit=is_latest_commit
         )
+        self._execute_git_commands(cmd)
 
-        run_with_os_system = True
+        full_commands = ["git", "-C", shlex.quote(target_path)]
+        full_commands.extend(commands)
 
-        # We used to call only os.system here. On macOS and Linux this behaved correctly,
-        # i.e. if stdin was open you would be prompted on the terminal and if not then an
-        # error would be raised. This is the best we could do.
-        #
-        # However, for Windows, os.system actually pops a terminal, which is annoying, especially
-        # if you don't require to authenticate. To avoid this popup, we will first launch
-        # git through the subprocess module and instruct it to not show a terminal for the
-        # subprocess.
-        #
-        # If that fails, then we'll assume that it failed because credentials were required.
-        # Unfortunately, we can't tell why it failed.
-        #
-        # Note: We only try this workflow if we can actually hide the terminal on Windows.
-        # If we can't there's no point doing all of this and we should just use
-        # os.system.
-        if is_windows() and _can_hide_terminal():
-            log.debug("Executing command '%s' using subprocess module." % cmd)
-            try:
-                # It's important to pass GIT_TERMINAL_PROMPT=0 or the git subprocess will
-                # just hang waiting for credentials to be entered on the missing terminal.
-                # I would have expected Windows to give an error about stdin being close and
-                # aborting the git command but at least on Windows 10 that is not the case.
-                environ = {}
-                environ.update(os.environ)
-                environ["GIT_TERMINAL_PROMPT"] = "0"
-                _check_output(cmd, env=environ)
-
-                # If that works, we're done and we don't need to use os.system.
-                run_with_os_system = False
-                status = 0
-            except SubprocessCalledProcessError:
-                log.debug("Subprocess call failed.")
-
-        if run_with_os_system:
-            # Make sure path and repo path are quoted.
-            log.debug("Executing command '%s' using os.system" % cmd)
-            log.debug(
-                "Note: in a terminal environment, this may prompt for authentication"
-            )
-            status = os.system(cmd)
-
-        log.debug("Command returned exit code %s" % status)
-        if status != 0:
-            raise TankGitError(
-                "Error executing git operation. The git command '%s' "
-                "returned error code %s." % (cmd, status)
-            )
-        log.debug("Git clone into '%s' successful." % target_path)
-
-        # clone worked ok! Now execute git commands on this repo
-
-        output = None
-
-        # note: for windows, we use git -C to point git to the right current
-        # working directory. This requires git 1.9+. This is to ensure that
-        # the solution handles UNC paths, which do not support os.getcwd() operations.
-        #
-        # for other platforms, we omit -C to ensure compatibility with older versions
-        # of git. Centos 7 still ships with 1.8.
-
-        cwd = os.getcwd()
-        try:
-            if not is_windows():
-                log.debug("Setting cwd to '%s'" % target_path)
-                os.chdir(target_path)
-
-            for command in commands:
-
-                if is_windows():
-                    # we use git -C to specify the working directory where to execute the command
-                    # this option was added in as part of git 1.9
-                    # and solves an issue with UNC paths on windows.
-                    full_command = 'git -C "%s" %s' % (target_path, command)
-                else:
-                    full_command = "git %s" % command
-
-                log.debug("Executing '%s'" % full_command)
-                try:
-                    output = _check_output(full_command, shell=True)
-
-                    # note: it seems on windows, the result is sometimes wrapped in single quotes.
-                    output = output.strip().strip("'")
-
-                except SubprocessCalledProcessError as e:
-                    raise TankGitError(
-                        "Error executing git operation '%s': %s (Return code %s)"
-                        % (full_command, e.output, e.returncode)
-                    )
-                log.debug("Execution successful. stderr/stdout: '%s'" % output)
-        finally:
-            if not is_windows():
-                log.debug("Restoring cwd (to '%s')" % cwd)
-                os.chdir(cwd)
-
-        # return the last returned stdout/stderr
-        return output
-
-    def _tmp_clone_then_execute_git_commands(self, commands, depth=None, ref=None):
-        """
-        Clone into a temp location and executes the given
-        list of git commands.
-
-        For more details, see :meth:`_clone_then_execute_git_commands`.
-
-        :param commands: list git commands to execute, e.g. ['checkout x']
-        :returns: stdout and stderr of the last command executed as a string
-        """
-        clone_tmp = os.path.join(
-            tempfile.gettempdir(), "sgtk_clone_%s" % uuid.uuid4().hex
-        )
-        filesystem.ensure_folder_exists(clone_tmp)
-        try:
-            return self._clone_then_execute_git_commands(
-                clone_tmp, commands, depth, ref
-            )
-        finally:
-            log.debug("Cleaning up temp location '%s'" % clone_tmp)
-            shutil.rmtree(clone_tmp, ignore_errors=True)
+        return self._execute_git_commands(full_commands)
 
     def get_system_name(self):
         """
@@ -288,8 +200,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         can_connect = True
         try:
             log.debug("%r: Probing if a connection to git can be established..." % self)
-            # clone repo into temp folder
-            self._tmp_clone_then_execute_git_commands([], depth=1)
+            self._execute_git_commands(["git", "ls-remote", shlex.quote(self._path)])
             log.debug("...connection established")
         except Exception as e:
             log.debug("...could not establish connection: %s" % e)
@@ -323,7 +234,7 @@ class IODescriptorGit(IODescriptorDownloadable):
             skip_list=skip_list or [],
         )
 
-    def _validate_git_commands(
+    def _get_git_clone_commands(
         self, target_path, depth=None, ref=None, is_latest_commit=None
     ):
         """

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -206,21 +206,6 @@ class IODescriptorGitBranch(IODescriptorGit):
                 "Latest version will be used." % self
             )
 
-        try:
-            # clone the repo, get the latest commit hash
-            # for the given branch
-            commands = [
-                'checkout -q "%s"' % self._branch,
-                "log -n 1 \"%s\" --pretty=format:'%%H'" % self._branch,
-            ]
-            git_hash = self._tmp_clone_then_execute_git_commands(commands)
-
-        except Exception as e:
-            raise TankDescriptorError(
-                "Could not get latest commit for %s, "
-                "branch %s: %s" % (self._path, self._branch, e)
-            )
-
         # make a new descriptor
         new_loc_dict = copy.deepcopy(self._descriptor_dict)
         new_loc_dict["version"] = six.ensure_str(git_hash)

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -111,25 +111,24 @@ class IODescriptorGitBranch(IODescriptorGit):
         """
         return self._version
 
-    def _is_latest_commit(self, version, branch):
+    def get_latest_commit(self):
+        output = self._execute_git_commands(["git", "ls-remote", self._path, self._branch])
+        latest_commit = output.split("\t")[0]
+        return six.ensure_str(latest_commit)
+
+    def get_latest_short_commit(self):
+        return self.get_latest_commit()[:7]
+
+    def _is_latest_commit(self):
         """
         Check if the git_branch descriptor is pointing to the
         latest commit version.
         """
         # first probe to check that git exists in our PATH
         log.debug("Checking if the version is pointing to the latest commit...")
-        try:
-            output = _check_output(["git", "ls-remote", self._path, branch])
-        except:
-            log.exception("Unexpected error:")
-            raise TankGitError(
-                "Cannot execute the 'git' command. Please make sure that git is "
-                "installed on your system and that the git executable has been added to the PATH."
-            )
-        latest_commit = output.split("\t")
-        short_latest_commit = latest_commit[0][:7]
+        short_latest_commit = self.get_latest_short_commit()
 
-        if short_latest_commit != version[:7]:
+        if short_latest_commit != self._version[:7]:
             return False
         log.debug(
             "This version is pointing to the latest commit %s, lets enable shallow clones"
@@ -155,7 +154,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         the git branch descriptor is to be downloaded to.
         """
         depth = None
-        is_latest_commit = self._is_latest_commit(self._version, self._branch)
+        is_latest_commit = self._is_latest_commit()
         if is_latest_commit:
             depth = 1
         try:
@@ -209,7 +208,7 @@ class IODescriptorGitBranch(IODescriptorGit):
 
         # make a new descriptor
         new_loc_dict = copy.deepcopy(self._descriptor_dict)
-        new_loc_dict["version"] = six.ensure_str(git_hash)
+        new_loc_dict["version"] = self.get_latest_commit()
         desc = IODescriptorGitBranch(
             new_loc_dict, self._sg_connection, self._bundle_type
         )

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -133,22 +133,13 @@ class IODescriptorGitBranch(IODescriptorGit):
 
         return True
 
-    def _download_local(self, destination_path):
+    def download_local(self):
         """
-        Retrieves this version to local repo.
-        Will exit early if app already exists local.
-
-        This will connect to remote git repositories.
-        Depending on how git is configured, https repositories
-        requiring credentials may result in a shell opening up
-        requesting username and password.
-
-        The git repo will be cloned into the local cache and
-        will then be adjusted to point at the relevant commit.
-
-        :param destination_path: The destination path on disk to which
-        the git branch descriptor is to be downloaded to.
+        Downloads the data represented by the descriptor into the primary bundle
+        cache path.
         """
+        log.info(f"Downloading {self.get_system_name()}:{self._version}")
+
         depth = None
         is_latest_commit = self._is_latest_commit()
         if is_latest_commit:
@@ -156,9 +147,9 @@ class IODescriptorGitBranch(IODescriptorGit):
         try:
             # clone the repo, switch to the given branch
             # then reset to the given commit
-            commands = ['checkout -q "%s"' % self._version]
+            commands = [f'checkout', '-q', self._version]
             self._clone_then_execute_git_commands(
-                destination_path,
+                self._get_primary_cache_path(),
                 commands,
                 depth=depth,
                 ref=self._branch,

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -62,7 +62,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         """
         # make sure all required fields are there
         self._validate_descriptor(
-            descriptor_dict, required=["type", "path", "version", "branch"], optional=[]
+            descriptor_dict, required=["type", "path", "branch"], optional=["version"]
         )
 
         # call base class
@@ -74,8 +74,8 @@ class IODescriptorGitBranch(IODescriptorGit):
         # have a path to a repo
         self._sg_connection = sg_connection
         self._bundle_type = bundle_type
-        self._version = descriptor_dict.get("version")
         self._branch = six.ensure_str(descriptor_dict.get("branch"))
+        self._version = descriptor_dict.get("version") or self.get_latest_commit()
 
     def __str__(self):
         """
@@ -112,6 +112,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         return self._version
 
     def get_latest_commit(self):
+        """Fetch the latest commit on a specific branch"""
         output = self._execute_git_commands(["git", "ls-remote", self._path, self._branch])
         latest_commit = output.split("\t")[0]
         return six.ensure_str(latest_commit)
@@ -128,7 +129,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         log.debug("Checking if the version is pointing to the latest commit...")
         short_latest_commit = self.get_latest_short_commit()
 
-        if short_latest_commit != self._version[:7]:
+        if short_latest_commit != self.get_short_version():
             return False
         log.debug(
             "This version is pointing to the latest commit %s, lets enable shallow clones"

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -92,24 +92,19 @@ class IODescriptorGitBranch(IODescriptorGit):
         :param bundle_cache_root: Bundle cache root path
         :return: Path to bundle cache location
         """
-        # If the descriptor is an integer change the version to a string type
-        if isinstance(self._version, int):
-            self._version = str(self._version)
-        # to be MAXPATH-friendly, we only use the first seven chars
-        short_hash = self._version[:7]
-
         # git@github.com:manneohrstrom/tk-hiero-publish.git -> tk-hiero-publish.git
         # /full/path/to/local/repo.git -> repo.git
         name = os.path.basename(self._path)
 
-        return os.path.join(bundle_cache_root, "gitbranch", name, short_hash)
+        return os.path.join(bundle_cache_root, "gitbranch", name, self.get_short_version())
 
     def get_version(self):
-        """
-        Returns the version number string for this item, .e.g 'v1.2.3'
-        or the branch name 'master'
-        """
+        """Returns the full commit sha."""
         return self._version
+
+    def get_short_version(self):
+        """Returns the short commit sha."""
+        return self._version[:7]
 
     def get_latest_commit(self):
         """Fetch the latest commit on a specific branch"""

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -138,7 +138,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         Downloads the data represented by the descriptor into the primary bundle
         cache path.
         """
-        log.info(f"Downloading {self.get_system_name()}:{self._version}")
+        log.info("Downloading {}:{}".format(self.get_system_name(), self._version))
 
         depth = None
         is_latest_commit = self._is_latest_commit()

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -10,11 +10,12 @@
 import os
 import copy
 
-from .git import IODescriptorGit, _check_output
+from .git import IODescriptorGit, TankGitError
 from ..errors import TankDescriptorError
 from ... import LogManager
 
 from tank_vendor import six
+from ...util.process import SubprocessCalledProcessError
 
 log = LogManager.get_logger(__name__)
 
@@ -168,7 +169,7 @@ class IODescriptorGitBranch(IODescriptorGit):
                 ref=self._branch,
                 is_latest_commit=is_latest_commit,
             )
-        except Exception as e:
+        except (TankGitError, OSError, SubprocessCalledProcessError) as e:
             raise TankDescriptorError(
                 "Could not download %s, branch %s, "
                 "commit %s: %s" % (self._path, self._branch, self._version, e)

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -20,6 +20,8 @@ from ...util.process import SubprocessCalledProcessError
 
 log = LogManager.get_logger(__name__)
 
+TAG_REGEX = re.compile(".*refs/tags/([^^/]+)$")
+
 
 class IODescriptorGitTag(IODescriptorGit):
     """
@@ -207,8 +209,6 @@ class IODescriptorGitTag(IODescriptorGit):
 
     def _fetch_tags(self):
         output = self._execute_git_commands(["git", "ls-remote", "--tags", self._path])
-
-        regex = re.compile(".*refs/tags/([^^/]+)$")
 
         git_tags = []
         for line in output.splitlines():

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -137,26 +137,17 @@ class IODescriptorGitTag(IODescriptorGit):
         """Returns the tag name."""
         return self._version
 
-    def _download_local(self, destination_path):
+    def download_local(self):
         """
-        Retrieves this version to local repo.
-        Will exit early if app already exists local.
-
-        This will connect to remote git repositories.
-        Depending on how git is configured, https repositories
-        requiring credentials may result in a shell opening up
-        requesting username and password.
-
-        The git repo will be cloned into the local cache and
-        will then be adjusted to point at the relevant tag.
-
-        :param destination_path: The destination path on disk to which
-        the git tag descriptor is to be downloaded to.
+        Downloads the data represented by the descriptor into the primary bundle
+        cache path.
         """
+        log.info(f"Downloading {self.get_system_name()}:{self._version}")
+
         try:
             # clone the repo, checkout the given tag
             self._clone_then_execute_git_commands(
-                destination_path, [], depth=1, ref=self._version
+                self._get_primary_cache_path(), [], depth=1, ref=self._version
             )
         except (TankGitError, OSError, SubprocessCalledProcessError) as e:
             raise TankDescriptorError(

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -74,7 +74,7 @@ class IODescriptorGitTag(IODescriptorGit):
                 self._version = self._get_latest_by_pattern(None)
             else:
                 self._version = self._get_latest_by_pattern(raw_version)
-            log.info(f"{self.get_system_name()}-{raw_version} resolved as {self._version}")
+            log.info("{}-{} resolved as {}".format(self.get_system_name(), raw_version, self._version))
         else:
             self._version = raw_version
 
@@ -142,7 +142,7 @@ class IODescriptorGitTag(IODescriptorGit):
         Downloads the data represented by the descriptor into the primary bundle
         cache path.
         """
-        log.info(f"Downloading {self.get_system_name()}:{self._version}")
+        log.info("Downloading {}:{}".format(self.get_system_name(), self._version))
 
         try:
             # clone the repo, checkout the given tag

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -62,9 +62,21 @@ class IODescriptorGitTag(IODescriptorGit):
 
         # path is handled by base class - all git descriptors
         # have a path to a repo
-        self._version = descriptor_dict.get("version")
         self._sg_connection = sg_connection
         self._bundle_type = bundle_type
+
+        raw_version = descriptor_dict.get("version")
+        raw_version_is_latest = raw_version == "latest"
+
+        if "x" in raw_version or raw_version_is_latest:
+            self._tags = self._fetch_tags()
+            if raw_version_is_latest:
+                self._version = self._get_latest_by_pattern(None)
+            else:
+                self._version = self._get_latest_by_pattern(raw_version)
+            log.info(f"{self.get_system_name()}-{raw_version} resolved as {self._version}")
+        else:
+            self._version = raw_version
 
     def __str__(self):
         """
@@ -122,9 +134,7 @@ class IODescriptorGitTag(IODescriptorGit):
         return paths
 
     def get_version(self):
-        """
-        Returns the version number string for this item, .e.g 'v1.2.3'
-        """
+        """Returns the tag name."""
         return self._version
 
     def _download_local(self, destination_path):
@@ -196,41 +206,39 @@ class IODescriptorGitTag(IODescriptorGit):
             - v1.2.3.x (will always return a forked version, eg. v1.2.3.2)
         :returns: IODescriptorGitTag object
         """
-        git_tags = self._fetch_tags()
-        latest_tag = self._find_latest_tag_by_pattern(git_tags, pattern)
-        if latest_tag is None:
-            raise TankDescriptorError(
-                "'%s' does not have a version matching the pattern '%s'. "
-                "Available versions are: %s"
-                % (self.get_system_name(), pattern, ", ".join(git_tags))
-            )
+        if not pattern:
+            latest_tag = self._get_latest_tag()
+        else:
+            latest_tag = self._find_latest_tag_by_pattern(self._tags, pattern)
+            if latest_tag is None:
+                raise TankDescriptorError(
+                    "'%s' does not have a version matching the pattern '%s'. "
+                    "Available versions are: %s"
+                    % (self.get_system_name(), pattern, ", ".join(self._tags))
+                )
 
         return latest_tag
 
     def _fetch_tags(self):
-        output = self._execute_git_commands(["git", "ls-remote", "--tags", self._path])
+        output = self._execute_git_commands(["git", "ls-remote", "-q", "--tags", self._path])
 
         git_tags = []
         for line in output.splitlines():
-            m = regex.match(six.ensure_str(line))
+            m = TAG_REGEX.match(six.ensure_str(line))
             if m:
                 git_tags.append(m.group(1))
 
         return git_tags
 
-    def _get_latest_version(self):
-        """
-        Returns a descriptor object that represents the latest version.
-        :returns: IODescriptorGitTag object
-        """
-        tags = self._fetch_tags()
-        if not tags:
+    def _get_latest_tag(self):
+        """Get latest tag name. Compare them as version numbers."""
+        if not self._tags:
             raise TankDescriptorError(
                 "Git repository %s doesn't have any tags!" % self._path
             )
 
         tupled_tags = []
-        for t in tags:
+        for t in self._tags:
             items = t.lstrip("v").split(".")
             tupled_tags.append(tuple(int(item) if item.isdigit() else item for item in items))
 

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -11,11 +11,12 @@ import os
 import copy
 import re
 
-from .git import IODescriptorGit
+from .git import IODescriptorGit, TankGitError
 from ..errors import TankDescriptorError
 from ... import LogManager
 
 from tank_vendor import six
+from ...util.process import SubprocessCalledProcessError
 
 log = LogManager.get_logger(__name__)
 
@@ -145,7 +146,7 @@ class IODescriptorGitTag(IODescriptorGit):
             self._clone_then_execute_git_commands(
                 destination_path, [], depth=1, ref=self._version
             )
-        except Exception as e:
+        except (TankGitError, OSError, SubprocessCalledProcessError) as e:
             raise TankDescriptorError(
                 "Could not download %s, " "tag %s: %s" % (self._path, self._version, e)
             )

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -172,10 +172,7 @@ class IODescriptorGitTag(IODescriptorGit):
 
         :returns: IODescriptorGitTag object
         """
-        if constraint_pattern:
-            tag_name = self._get_latest_by_pattern(constraint_pattern)
-        else:
-            tag_name = self._get_latest_version()
+        tag_name = self._get_latest_by_pattern(constraint_pattern)
 
         new_loc_dict = copy.deepcopy(self._descriptor_dict)
         new_loc_dict["version"] = six.ensure_str(tag_name)

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -208,29 +208,15 @@ class IODescriptorGitTag(IODescriptorGit):
         return latest_tag
 
     def _fetch_tags(self):
-        try:
-            # clone the repo, list all tags
-            # for the repository, across all branches
-            commands = ["ls-remote -q --tags %s" % self._path]
-            tags = self._tmp_clone_then_execute_git_commands(commands, depth=1).split(
-                "\n"
-            )
-            regex = re.compile(".*refs/tags/([^^]*)$")
-            git_tags = []
-            for tag in tags:
-                m = regex.match(six.ensure_str(tag))
-                if m:
-                    git_tags.append(m.group(1))
+        output = self._execute_git_commands(["git", "ls-remote", "--tags", self._path])
 
-        except Exception as e:
-            raise TankDescriptorError(
-                "Could not get list of tags for %s: %s" % (self._path, e)
-            )
+        regex = re.compile(".*refs/tags/([^^/]+)$")
 
-        if len(git_tags) == 0:
-            raise TankDescriptorError(
-                "Git repository %s doesn't have any tags!" % self._path
-            )
+        git_tags = []
+        for line in output.splitlines():
+            m = regex.match(six.ensure_str(line))
+            if m:
+                git_tags.append(m.group(1))
 
         return git_tags
 
@@ -240,13 +226,17 @@ class IODescriptorGitTag(IODescriptorGit):
         :returns: IODescriptorGitTag object
         """
         tags = self._fetch_tags()
-        latest_tag = self._find_latest_tag_by_pattern(tags, pattern=None)
-        if latest_tag is None:
+        if not tags:
             raise TankDescriptorError(
                 "Git repository %s doesn't have any tags!" % self._path
             )
 
-        return latest_tag
+        tupled_tags = []
+        for t in tags:
+            items = t.lstrip("v").split(".")
+            tupled_tags.append(tuple(int(item) if item.isdigit() else item for item in items))
+
+        return sorted(tupled_tags)[-1]
 
     def get_latest_cached_version(self, constraint_pattern=None):
         """

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -660,14 +660,14 @@ class TestDescriptorSupport(TankTestBase):
             }
         )
         self.assertEqual(
-            desc._io_descriptor._validate_git_commands(
+            desc._io_descriptor._get_git_clone_commands(
                 target_path, depth=1, ref="master"
             ),
             'git clone --no-hardlinks -q "%s" %s "%s" '
             % (self.git_repo_uri, "-b master", target_path,),
         )
         self.assertEqual(
-            desc._io_descriptor._validate_git_commands(target_path, ref="master"),
+            desc._io_descriptor._get_git_clone_commands(target_path, ref="master"),
             'git clone --no-hardlinks -q "%s" %s "%s" '
             % (self.git_repo_uri, "-b master", target_path,),
         )


### PR DESCRIPTION
Hi there,

I was looking at my temp folder while doing some tests with the tk-core, and I saw that each time I reload an engine, a massive amount of temporary clone folders were created (associated with a big network load). By digging into the source code of git descriptors, I found that they clone repos each and every time they needs to execute a command in it.

So here is a PR with a big refactoring of the git, git_tag and git_branch descriptors:

- replace `git clone` with `git ls-remote` when fetching tags/commit values, checking remote access
- Add version pattern and `get_latest` support for git branch, and improve the logic for git tag
- Add caching system to avoid processing the same repo multiple times