### PR TITLE
Bug Fix:  Import setuptools

### DIFF
--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -11,10 +11,14 @@ import warnings
 import contextlib
 import sys
 
-if sys.version_info[0:2] >= (3, 10):
-    from setuptools._distutils.version import LooseVersion
-else:
+if sys.version_info[0:2] < (3, 10):
     from distutils.version import LooseVersion
+else:
+    try:
+        from setuptools._distutils.version import LooseVersion
+    except ModuleNotFoundError:
+        # Known issue with VRED 16. Unable to load the setuptools module
+        from distutils.version import LooseVersion
 
 from . import sgre as re
 from ..errors import TankError

--- a/tests/util_tests/test_version_import.py
+++ b/tests/util_tests/test_version_import.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+
+import importlib
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    mock,
+    ShotgunTestBase,
+)
+
+
+class TestVersionImport(ShotgunTestBase):
+    """Test importing the tank.util.version module."""
+
+    def test_import_version(self):
+        """Test importing the tank.util.version module."""
+
+        # Import the version module
+        from tank.util import version
+        # Reload the module in case it was already imported
+        importlib.reload(version)
+        # Sanity check the setuptools was imported successfully
+        assert version.LooseVersion
+
+    def test_import_version_missing_setuptools_distutils(self):
+        """Test importing the tank.util.version module when setuptools is missing _distutils."""
+
+        # Mock the sys.modules so that the import for setuptools._distutils.vesrion raises a
+        # ModuleNotFound exception (to mock python environments where this module may not be
+        # available)
+        with mock.patch.dict('sys.modules', {"setuptools._distutils.version": None}):
+            # Import the version module
+            from tank.util import version
+            # Reload the module in case it was already imported
+            importlib.reload(version)
+            # Sanity check the setuptools was imported successfully
+            assert version.LooseVersion


### PR DESCRIPTION
* VRED cannot run ShotGrid because it fails on import for setuptools (see more details [here](https://jira.autodesk.com/browse/VRED-21235))
* Modify logic to try to import distutils from setuptools regardless of python version, with fallback to old import way if it fails