### PR TITLE
SG-33462 Feature: Add support for multiple sites on shotgun entity descriptors

### DIFF
--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -135,19 +135,19 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
 
         # ensure version is an int if specified
         try:
-            
+
             if "version" in descriptor_dict:
                 version_data = descriptor_dict["version"]
 
                 if isinstance(version_data, dict):
                     # support for multiple sites with different version for each
-                    # 
+                    #
                     # bundle-name:
                     #   location:
                     #     type: shotgun
                     #     entity_type: EntityType
                     #     name: the-name
-                    #     version: 
+                    #     version:
                     #       studio.shotgunstudio.com: 321987
                     #       studio.shotgrid.autodesk.com: 123456
                     #     field: field_name

--- a/tests/descriptor_tests/test_shotgun.py
+++ b/tests/descriptor_tests/test_shotgun.py
@@ -94,6 +94,29 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             }
         )
 
+
+        # test version id dict not keyed by site
+        _test_raises_error(
+            {
+                "type": "shotgun",
+                "version": {"not.a.site": 123},
+                "entity_type": "Shot",
+                "field": "sg_field",
+                "id": "123",
+            }
+        )
+
+        # test version id dict not int
+        _test_raises_error(
+            {
+                "type": "shotgun",
+                "version": {"not.a.site": "nan"},
+                "entity_type": "Shot",
+                "field": "sg_field",
+                "id": "123",
+            }
+        )
+
         # cannot specify both id and name
         _test_raises_error(
             {
@@ -146,6 +169,20 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             {
                 "type": "shotgun",
                 "version": "123",
+                "entity_type": "Shot",
+                "field": "sg_field",
+                "name": "aaa111",
+            }
+        )
+
+        self.assertEqual(name_desc.system_name, "aaa111")
+        self.assertEqual(name_desc.version, "v123")
+
+
+        name_desc = self._create_desc(
+            {
+                "type": "shotgun",
+                "version": {"unit_test_mock_sg": 123},
                 "entity_type": "Shot",
                 "field": "sg_field",
                 "name": "aaa111",

--- a/tests/descriptor_tests/test_shotgun.py
+++ b/tests/descriptor_tests/test_shotgun.py
@@ -94,7 +94,6 @@ class TestShotgunIODescriptor(ShotgunTestBase):
             }
         )
 
-
         # test version id dict not keyed by site
         _test_raises_error(
             {
@@ -110,7 +109,7 @@ class TestShotgunIODescriptor(ShotgunTestBase):
         _test_raises_error(
             {
                 "type": "shotgun",
-                "version": {"not.a.site": "nan"},
+                "version": {"unit_test_mock_sg": "nan"},
                 "entity_type": "Shot",
                 "field": "sg_field",
                 "id": "123",
@@ -177,7 +176,6 @@ class TestShotgunIODescriptor(ShotgunTestBase):
 
         self.assertEqual(name_desc.system_name, "aaa111")
         self.assertEqual(name_desc.version, "v123")
-
 
         name_desc = self._create_desc(
             {


### PR DESCRIPTION
The change implements some data validation and a proposed dictionary structure for the version key, where keys can be the ShotGrid site url, that will be matched with current used one to get the appropriate id 

This allows for an easier management of centralized configs for Studios with different sites, and that rely on the uploaded bundles to ShotGrid when using the distributed functionality.

En example descriptor would be:
```
bundle-name:
    location:
    type: shotgun
    entity_type: EntityType
    name: the-name
    version: 
        studio.shotgunstudio.com: 321987
        studio.shotgrid.autodesk.com: 123456
    field: field_name
```

The other only option I think might work is to provide a core hook that allows to preprocess the descriptor dict before passing it to the Descriptor class, ut couldn't find a way to call the execute_core_hook method from there

