### PR TITLE
SG-33967 Avoid storing null default value in session cache for the authentication method

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -164,6 +164,7 @@ class LoginDialog(QtGui.QDialog):
 
         self.host_selected = None
         self.method_selected = auth_constants.METHOD_BASIC
+        self.method_selected_user = None
 
         self._asl_task = None
 
@@ -464,6 +465,7 @@ class LoginDialog(QtGui.QDialog):
         """
 
         site = self._query_task.url_to_test
+        self.method_selected_user = None
 
         # We only update the GUI if there was a change between to mode we
         # are showing and what was detected on the potential target site.
@@ -490,7 +492,7 @@ class LoginDialog(QtGui.QDialog):
         if can_use_asl:
             if method_selected:
                 # Selecting requested mode (credentials, qt_web_login or app_session_launcher)
-                session_cache.set_preferred_method(site, method_selected)
+                self.method_selected_user = method_selected
             elif os.environ.get("SGTK_FORCE_STANDARD_LOGIN_DIALOG"):
                 # Selecting legacy auth by default
                 method_selected = auth_constants.METHOD_BASIC
@@ -506,6 +508,7 @@ class LoginDialog(QtGui.QDialog):
             method_selected == auth_constants.METHOD_ASL and not can_use_asl
         ):
             method_selected = None
+            self.method_selected_user = None
 
         if not method_selected and os.environ.get("SGTK_DEFAULT_AUTH_METHOD"):
             method_selected = auth_constants.method_resolve_reverse(
@@ -777,6 +780,10 @@ class LoginDialog(QtGui.QDialog):
                 self._set_error_message(self.ui.message, "Please enter your password.")
                 self.ui.password.setFocus(QtCore.Qt.OtherFocusReason)
                 return
+
+        # Memorize the chosen method in session cache
+        if self.method_selected_user:
+            session_cache.set_preferred_method(site, self.method_selected_user)
 
         try:
             self._authenticate(self.ui.message, site, login, password)

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -221,7 +221,9 @@ def _try_load_site_authentication_file(file_path):
     content.setdefault(_USERS, [])
     content.setdefault(_CURRENT_USER, None)
     content.setdefault(_RECENT_USERS, [])
-    content.setdefault(_PREFERRED_METHOD, None)
+
+    if content.get(_PREFERRED_METHOD, "not null") is None:
+        del(content[_PREFERRED_METHOD])
 
     for user in content[_USERS]:
         user[_LOGIN] = user[_LOGIN].strip()
@@ -545,7 +547,7 @@ def get_preferred_method(host):
     # Retrieve the cached info file location from the host
     info_path = _get_site_authentication_file_location(host)
     document = _try_load_site_authentication_file(info_path)
-    method_name = document[_PREFERRED_METHOD]
+    method_name = document.get(_PREFERRED_METHOD)
     if not method_name:
         return
 
@@ -569,7 +571,7 @@ def set_preferred_method(host, method):
     _ensure_folder_for_file(file_path)
 
     current_user_file = _try_load_site_authentication_file(file_path)
-    if current_user_file[_PREFERRED_METHOD] == method_name:
+    if current_user_file.get(_PREFERRED_METHOD) == method_name:
         return
 
     current_user_file[_PREFERRED_METHOD] = method_name


### PR DESCRIPTION
The session_cache initializes default values for some keys. We don't want or need to have a null default value for the authentication method.