### PR TITLE
SG-33787 & SG-34012 Fix session token exception

### DIFF
--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -270,7 +270,7 @@ def _insert_or_update_user(users_file, login, session_token, session_metadata):
         if _is_same_user(user, login):
             result = False
             # Update and return True only if something changed.
-            if user[_SESSION_TOKEN] != session_token:
+            if user.get(_SESSION_TOKEN) != session_token:
                 user[_SESSION_TOKEN] = session_token
                 result = True
             if (
@@ -349,6 +349,9 @@ def get_session_data(base_url, login):
         for user in users_file[_USERS]:
             # Search for the user in the users dictionary.
             if not _is_same_user(user, login):
+                continue
+
+            if not user.get(_SESSION_TOKEN):
                 continue
 
             session_data = {

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -348,17 +348,21 @@ def get_session_data(base_url, login):
         users_file = _try_load_site_authentication_file(info_path)
         for user in users_file[_USERS]:
             # Search for the user in the users dictionary.
-            if _is_same_user(user, login):
-                session_data = {
-                    _LOGIN: user[_LOGIN],
-                    _SESSION_TOKEN: user[_SESSION_TOKEN],
-                }
-                # We want to keep session_metadata out of the session data if there
-                # is none. This is to ensure backward compatibility for older
-                # version of tk-core reading the authentication.yml
-                if user.get(_SESSION_METADATA):
-                    session_data[_SESSION_METADATA] = user[_SESSION_METADATA]
-                return session_data
+            if not _is_same_user(user, login):
+                continue
+
+            session_data = {
+                _LOGIN: user[_LOGIN],
+                _SESSION_TOKEN: user[_SESSION_TOKEN],
+            }
+
+            # We want to keep session_metadata out of the session data if there
+            # is none. This is to ensure backward compatibility for older
+            # version of tk-core reading the authentication.yml
+            if user.get(_SESSION_METADATA):
+                session_data[_SESSION_METADATA] = user[_SESSION_METADATA]
+
+            return session_data
         logger.debug("No cached user found for %s" % login)
     except Exception:
         logger.exception("Exception thrown while loading cached session info.")


### PR DESCRIPTION
Prevent ShotGrid Desktop from crashing when the current user's session_token key is missing from the session_cache.