### PR TITLE
SG-33048 Update dev and path descriptor docs

### DIFF
--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -379,7 +379,8 @@ When using a ``path`` descriptor in production, you can include paths to multipl
 
     sgtk:descriptor:path?linux_path=/path/to/app&mac_path=/path/to/app&windows_path=c:\path\to\app
 
-Environment variables can be included in paths:
+Environment variables can be included in paths, they will be expanded using :py:func:`os.path.expandvars` and :py:func:`os.path.expanduser`.
+This is only supported in ``dev`` and ``path`` descriptors.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Preview:
![image](https://github.com/shotgunsoftware/tk-core/assets/123113322/9fac1a77-565c-4403-a08b-27dc781987b8)

Both functions points to the standard Python docs: 
- https://docs.python.org/3.9/library/os.path.html#os.path.expanduser
- https://docs.python.org/3.9/library/os.path.html#os.path.expandvars