### PR TITLE
SG-34181 Allow http:// sites with an opt-in environment variable

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -40,6 +40,12 @@ Note: this variable does not override the session cache. If a valid method has
 been recorded in the session cache, this method will be prioritized over the
 one provided by `SGTK_DEFAULT_AUTH_METHOD`.
 
+``SGTK_AUTH_ALLOW_NO_HTTPS``
+----------------------------
+Allows the user to bypass the HTTPS requirement for the ``credentials`` and
+``qt_web_login`` authentication methods. This is not recommended and should only
+be used for the legacy offerings of ShotGrid local installations.
+
 ``SGTK_FORCE_STANDARD_LOGIN_DIALOG``
 ------------------------------------
 Always display the traditional authentication (login and password fields) in the

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -42,9 +42,9 @@ one provided by `SGTK_DEFAULT_AUTH_METHOD`.
 
 ``SGTK_AUTH_ALLOW_NO_HTTPS``
 ----------------------------
-Allows the user to bypass the HTTPS requirement for the ``credentials`` and
-``qt_web_login`` authentication methods. This is not recommended and should only
-be used for the legacy offerings of ShotGrid local installations.
+Allows the user to bypass the HTTPS requirement for the authentication methods.
+This is not recommended and should only be used for the legacy offerings of
+ShotGrid local installations.
 
 ``SGTK_FORCE_STANDARD_LOGIN_DIALOG``
 ------------------------------------

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -762,7 +762,7 @@ class LoginDialog(QtGui.QDialog):
 
         # Cleanup the URL and update the GUI.
         if self.method_selected != auth_constants.METHOD_BASIC:
-            if site.startswith("http://") and "SHOTGUN_AUTH_ALLOW_NO_HTTPS" not in os.environ:
+            if site.startswith("http://") and "SGTK_AUTH_ALLOW_NO_HTTPS" not in os.environ:
                 site = "https" + site[4:]
             self.ui.site.setEditText(site)
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -762,7 +762,7 @@ class LoginDialog(QtGui.QDialog):
 
         # Cleanup the URL and update the GUI.
         if self.method_selected != auth_constants.METHOD_BASIC:
-            if site.startswith("http://"):
+            if site.startswith("http://") and "SHOTGUN_AUTH_ALLOW_NO_HTTPS" not in os.environ:
                 site = "https" + site[4:]
             self.ui.site.setEditText(site)
 


### PR DESCRIPTION
On RV, we have the RV_SHOTGUN_AUTH_NO_HTTPS environment variable. We lost that functionality while moving to a login based on SGTK.