### PR TITLE
SG-33587 Fix compatibility with PySide6 by patching QCoreApplication.flush()

### DIFF
--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -400,7 +400,7 @@ class PySide6Patcher(PySide2Patcher):
 
             @QtCore.Slot(int)
             def _emit_state_as_enum(self, state):
-                if isinstance(state, int):
+                if not isinstance(state, QtCore.Qt.CheckState):
                     state = QtCore.Qt.CheckState(state)
                 self.stateChanged.emit(state)
 

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -388,9 +388,7 @@ class PySide6Patcher(PySide2Patcher):
     @classmethod
     def _patch_QCheckBox_stateChanged(cls, QtGui, QtCore):
         """Patch the QCheckBox class to ensure the stateChanged signal emits Qt.CheckState."""
-
         class QCheckBox_stateChanged(QtGui.QCheckBox):
-            """Patch for QCheckBox stateChanged signal."""
             stateChanged = QtCore.Signal((QtCore.Qt.CheckState,), (int,))
 
             def __init__(self, *args, **kwargs):

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -386,13 +386,15 @@ class PySide6Patcher(PySide2Patcher):
         QtCore.QRegularExpression = QRegularExpression
 
     @classmethod
-    def _patch_QCheckBox_stateChanged(cls, QtGui, QtCore):
-        """Patch the QCheckBox class to ensure the stateChanged signal emits Qt.CheckState."""
-        class QCheckBox_stateChanged(QtGui.QCheckBox):
+    def _patch_QCheckBox(cls, QtCore, QtGui):
+        """
+        Patch the QCheckBox class to ensure the stateChanged signal emits Qt.CheckState.
+        """
+        class _QCheckBox(QtGui.QCheckBox):
             stateChanged = QtCore.Signal((QtCore.Qt.CheckState,), (int,))
 
             def __init__(self, *args, **kwargs):
-                super(QCheckBox_stateChanged, self).__init__(*args, **kwargs)
+                super(_QCheckBox, self).__init__(*args, **kwargs)
                 # Connect the original stateChanged signal to the private slot
                 self.stateChanged[int].connect(self._emit_state_as_enum)
 
@@ -567,6 +569,6 @@ class PySide6Patcher(PySide2Patcher):
         # For PySide6 compatibility, convert state to CheckState enum if not already
         # an instance. Patch the QCheckBox.stateChanged signal.
         # https://forum.qt.io/post/743017
-        cls._patch_QCheckBox_stateChanged(qt_gui_shim, qt_core_shim)
+        cls._patch_QCheckBox(qt_core_shim, qt_gui_shim)
 
         return qt_core_shim, qt_gui_shim, qt_web_engine_widgets_shim

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -386,27 +386,6 @@ class PySide6Patcher(PySide2Patcher):
         QtCore.QRegularExpression = QRegularExpression
 
     @classmethod
-    def _patch_QCheckBox(cls, QtCore, QtGui):
-        """
-        Patch the QCheckBox class to ensure the stateChanged signal emits Qt.CheckState.
-        """
-        class _QCheckBox(QtGui.QCheckBox):
-            stateChanged = QtCore.Signal((QtCore.Qt.CheckState,), (int,))
-
-            def __init__(self, *args, **kwargs):
-                super(_QCheckBox, self).__init__(*args, **kwargs)
-                # Connect the original stateChanged signal to the private slot
-                self.stateChanged[int].connect(self._emit_state_as_enum)
-
-            @QtCore.Slot(int)
-            def _emit_state_as_enum(self, state):
-                if not isinstance(state, QtCore.Qt.CheckState):
-                    state = QtCore.Qt.CheckState(state)
-                self.stateChanged.emit(state)
-
-        QtGui.QCheckBox = _QCheckBox
-
-    @classmethod
     def _patch_QCoreApplication_flush(cls, QtCore):
         """
         Patch QCoreApplication obsolete flush method for compatibility.
@@ -564,10 +543,5 @@ class PySide6Patcher(PySide2Patcher):
         # ----------------------------------------------------------------------
         qt_web_engine_widgets_shim.QWebEnginePage = QtWebEngineCore.QWebEnginePage
         qt_web_engine_widgets_shim.QWebEngineProfile = QtWebEngineCore.QWebEngineProfile
-
-        # For PySide6 compatibility, convert state to CheckState enum if not already
-        # an instance. Patch the QCheckBox.stateChanged signal.
-        # https://forum.qt.io/post/743017
-        cls._patch_QCheckBox(qt_core_shim, qt_gui_shim)
 
         return qt_core_shim, qt_gui_shim, qt_web_engine_widgets_shim

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -546,7 +546,9 @@ class PySide6Patcher(PySide2Patcher):
         qt_web_engine_widgets_shim.QWebEnginePage = QtWebEngineCore.QWebEnginePage
         qt_web_engine_widgets_shim.QWebEngineProfile = QtWebEngineCore.QWebEngineProfile
 
-        # Patch the QCheckBox.stateChanged signal
+        # For PySide6 compatibility, convert state to CheckState enum if not already
+        # an instance. Patch the QCheckBox.stateChanged signal.
+        # https://forum.qt.io/post/743017
         cls._patch_QCheckBox_stateChanged(qt_gui_shim, qt_core_shim)
 
         return qt_core_shim, qt_gui_shim, qt_web_engine_widgets_shim

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -406,6 +406,21 @@ class PySide6Patcher(PySide2Patcher):
         QtGui.QCheckBox.stateChanged = QCheckBox_stateChanged.stateChanged
 
     @classmethod
+    def _patch_QCoreApplication_flush(cls, QtCore):
+        """
+        Patch QCoreApplication obsolete flush method for compatibility.
+        """
+
+        def flush():
+            """
+            No-op function to serve as a placeholder for QCoreApplication.flush().
+            """
+            pass
+
+        # Add the no-op flush method to QCoreApplication
+        QtCore.QCoreApplication.flush = flush
+
+    @classmethod
     def patch(cls):
         """
         Patch the PySide6 modules, classes and function to conform to the PySide interface.
@@ -491,6 +506,11 @@ class PySide6Patcher(PySide2Patcher):
         # Rename RegExp functions to RegularExpression
         qt_gui_shim.QSortFilterProxyModel.filterRegExp = qt_gui_shim.QSortFilterProxyModel.filterRegularExpression
         qt_gui_shim.QSortFilterProxyModel.setFilterRegExp = qt_gui_shim.QSortFilterProxyModel.setFilterRegularExpression
+
+        # Patch the QCoreApplication.flush() method to ensure compatibility with code
+        # that expects this method, which is marked as obsolete.
+        # https://doc.qt.io/qt-5/qcoreapplication-obsolete.html#flush
+        cls._patch_QCoreApplication_flush(qt_core_shim)
 
         # QtGui
         # ------------------------------------------------------------------------------------

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -404,8 +404,7 @@ class PySide6Patcher(PySide2Patcher):
                     state = QtCore.Qt.CheckState(state)
                 self.stateChanged.emit(state)
 
-        QtGui.QCheckBox = QCheckBox_stateChanged
-        QtGui.QCheckBox.stateChanged = QCheckBox_stateChanged.stateChanged
+        QtGui.QCheckBox = _QCheckBox
 
     @classmethod
     def _patch_QCoreApplication_flush(cls, QtCore):


### PR DESCRIPTION
This PR fixes the issue that was affecting the ShotGrid Snapshot 'Take Screenshot' feature in Maya Beta 2025.

### Changes
- Adds a no-op patch for the obsolete PySide `QCoreApplication.flush()` method to maintain compatibility with older PySide references to the flush method, this ensures that calls to `flush()` do not cause errors when using PySide6.
