### PR TITLE
SG-33968 Hide logs when user is typing https on login dialog

### DIFF
--- a/python/tank/authentication/site_info.py
+++ b/python/tank/authentication/site_info.py
@@ -92,35 +92,44 @@ class SiteInfo(object):
         :param url:            Url of the site to query.
         :param http_proxy:     HTTP proxy to use, if any.
         """
+        # Check for valid URL
+        url_items = utils.urlparse.urlparse(url)
+        if (
+            not url_items.netloc
+            or url_items.netloc in "https"
+            or url_items.scheme not in ["http", "https"]
+        ):
+            logger.debug("Invalid ShotGrid URL %s" % url)
+            return
+
         infos = {}
         try:
             infos = _get_site_infos(url, http_proxy)
         # pylint: disable=broad-except
         except Exception as exc:
             # Silently ignore exceptions
-            # Hide logs when user is typing `https://`
-            if utils.urlparse.urlparse(url).netloc not in "https":
-                logger.debug("Unable to connect with %s, got exception '%s'", url, exc)
-        else:
-            self._url = url
-            self._infos = infos
+            logger.debug("Unable to connect with %s, got exception '%s'", url, exc)
+            return
 
-            logger.debug("Site info for {url}".format(url=self._url))
-            logger.debug(
-                "  user_authentication_method: {value}".format(
-                    value=self.user_authentication_method,
-                )
+        self._url = url
+        self._infos = infos
+
+        logger.debug("Site info for {url}".format(url=self._url))
+        logger.debug(
+            "  user_authentication_method: {value}".format(
+                value=self.user_authentication_method,
             )
-            logger.debug(
-                "  unified_login_flow_enabled: {value}".format(
-                    value=self.unified_login_flow_enabled,
-                )
+        )
+        logger.debug(
+            "  unified_login_flow_enabled: {value}".format(
+                value=self.unified_login_flow_enabled,
             )
-            logger.debug(
-                "  authentication_app_session_launcher_enabled: {value}".format(
-                    value=self.app_session_launcher_enabled,
-                )
+        )
+        logger.debug(
+            "  authentication_app_session_launcher_enabled: {value}".format(
+                value=self.app_session_launcher_enabled,
             )
+        )
 
     @property
     def user_authentication_method(self):
@@ -178,6 +187,4 @@ class SiteInfo(object):
                     or not.
         """
 
-        return self._infos.get(
-            "authentication_app_session_launcher_enabled", False
-        )
+        return self._infos.get("authentication_app_session_launcher_enabled", False)

--- a/python/tank/authentication/site_info.py
+++ b/python/tank/authentication/site_info.py
@@ -98,27 +98,29 @@ class SiteInfo(object):
         # pylint: disable=broad-except
         except Exception as exc:
             # Silently ignore exceptions
-            logger.debug("Unable to connect with %s, got exception '%s'", url, exc)
+            # Hide logs when user is typing `https://`
+            if utils.urlparse.urlparse(url).netloc not in "https":
+                logger.debug("Unable to connect with %s, got exception '%s'", url, exc)
+        else:
+            self._url = url
+            self._infos = infos
 
-        self._url = url
-        self._infos = infos
-
-        logger.debug("Site info for {url}".format(url=self._url))
-        logger.debug(
-            "  user_authentication_method: {value}".format(
-                value=self.user_authentication_method,
+            logger.debug("Site info for {url}".format(url=self._url))
+            logger.debug(
+                "  user_authentication_method: {value}".format(
+                    value=self.user_authentication_method,
+                )
             )
-        )
-        logger.debug(
-            "  unified_login_flow_enabled: {value}".format(
-                value=self.unified_login_flow_enabled,
+            logger.debug(
+                "  unified_login_flow_enabled: {value}".format(
+                    value=self.unified_login_flow_enabled,
+                )
             )
-        )
-        logger.debug(
-            "  authentication_app_session_launcher_enabled: {value}".format(
-                value=self.app_session_launcher_enabled,
+            logger.debug(
+                "  authentication_app_session_launcher_enabled: {value}".format(
+                    value=self.app_session_launcher_enabled,
+                )
             )
-        )
 
     @property
     def user_authentication_method(self):

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -1361,7 +1361,7 @@ class LoadInformationInfoTests(ShotgunTestBase):
                 self.assertEqual(site_i._url, None)
                 self.assertEqual(site_i._infos, {})
                 self.assertEqual(len(cm.output), 1)
-                self.assertIn("Infos for site 'https' not in cache or expired", cm.output[0])
+                self.assertIn("Invalid ShotGrid URL https", cm.output[0])
 
     def test_reload_wrong_site(self, *unused_mocks):
         with self.assertLogs("sgtk.core.authentication.site_info", level="DEBUG") as cm:

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -16,7 +16,6 @@ from __future__ import with_statement, print_function
 
 import contextlib
 
-import os
 import sys
 
 from tank_test.tank_test_base import setUpModule  # noqa

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -16,6 +16,7 @@ from __future__ import with_statement, print_function
 
 import contextlib
 
+import os
 import sys
 
 from tank_test.tank_test_base import setUpModule  # noqa
@@ -35,6 +36,7 @@ from tank.authentication import (
     interactive_authentication,
     invoker,
     user_impl,
+    site_info,
 )
 
 import tank
@@ -1345,3 +1347,34 @@ class InteractiveTests(ShotgunTestBase):
 
         self.assertIsInstance(asl_task.exception, errors.AuthenticationError)
         self.assertEqual(asl_task.exception.args[0], "Unknown authentication error")
+
+
+class LoadInformationInfoTests(ShotgunTestBase):
+    def test_reload_wrong_url(self, *unused_mocks):
+        with self.assertLogs("sgtk.core.authentication.site_info", level="DEBUG") as cm:
+            with mock.patch.object(
+                tank_vendor.shotgun_api3.Shotgun,
+                "info",
+                side_effect=Exception()
+            ):
+                site_i = site_info.SiteInfo()
+                site_i.reload(url="https")
+                self.assertEqual(site_i._url, None)
+                self.assertEqual(site_i._infos, {})
+                self.assertEqual(len(cm.output), 1)
+                self.assertIn("Infos for site 'https' not in cache or expired", cm.output[0])
+
+    def test_reload_wrong_site(self, *unused_mocks):
+        with self.assertLogs("sgtk.core.authentication.site_info", level="DEBUG") as cm:
+            with mock.patch.object(
+                tank_vendor.shotgun_api3.Shotgun,
+                "info",
+                side_effect=Exception()
+            ):
+                site_i = site_info.SiteInfo()
+                site_i.reload(url="https://foo")
+                self.assertEqual(site_i._url, None)
+                self.assertEqual(site_i._infos, {})
+                self.assertEqual(len(cm.output), 2)
+                self.assertIn("Infos for site 'https://foo' not in cache or expired", cm.output[0])
+                self.assertIn("Unable to connect with https://foo, got exception", cm.output[1])


### PR DESCRIPTION
Some logs are now ignored when the user is starting to type `https` on the login dialog to have a cleaner tk-desktop.log file.