### PR TITLE
SG-34534 add shiboken module to tk core qtimporter class

### DIFF
--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -2164,8 +2164,7 @@ class Engine(TankBundle):
             else:
                 base["dialog_base"] = None
             base["wrapper"] = importer.binding
-            if importer.shiboken:
-                base["shiboken"] = importer.shiboken
+            base["shiboken"] = importer.shiboken
         except:
 
             self.log_exception(

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -176,6 +176,7 @@ class Engine(TankBundle):
         qt.QtCore = base_def.get("qt_core")
         qt.QtGui = base_def.get("qt_gui")
         qt.TankDialogBase = base_def.get("dialog_base")
+        qt.shiboken = base_def.get("shiboken")
 
         qt5_base = self.__define_qt5_base()
         self.__has_qt5 = len(qt5_base) > 0
@@ -2163,6 +2164,8 @@ class Engine(TankBundle):
             else:
                 base["dialog_base"] = None
             base["wrapper"] = importer.binding
+            if importer.shiboken:
+                base["shiboken"] = importer.shiboken
         except:
 
             self.log_exception(

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -393,9 +393,12 @@ class QtImporter(object):
         """
 
         import PySide6
+        import shiboken6
 
         sub_modules = pkgutil.iter_modules(PySide6.__path__)
         modules_dict = {}
+        # Add shiboken6 to the modules dict
+        modules_dict["shiboken"] = shiboken6
         for module in sub_modules:
             module_name = module.name
             try:

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -289,7 +289,7 @@ class QtImporter(object):
         """
         import PySide2
         from PySide2 import QtCore, QtGui, QtWidgets
-        import shiboken2 as shiboken
+        import shiboken2
         from .pyside2_patcher import PySide2Patcher
 
         QtCore, QtGui = PySide2Patcher.patch(QtCore, QtGui, QtWidgets, PySide2)
@@ -309,7 +309,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
-                "shiboken": shiboken,
+                "shiboken": shiboken2,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -359,7 +359,7 @@ class QtImporter(object):
         """
 
         import PySide6
-        import shiboken6 as shiboken
+        import shiboken6
         from .pyside6_patcher import PySide6Patcher
 
         QtCore, QtGui, QtWebEngineWidgets = PySide6Patcher.patch()
@@ -376,7 +376,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
-                "shiboken": shiboken,
+                "shiboken": shiboken6,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -216,6 +216,7 @@ class QtImporter(object):
         # imported even if the Qt binaries are missing, so it's better to try importing QtCore for
         # testing.
         from PySide2 import QtCore
+        import shiboken2
 
         # List of all Qt 5 modules.
         sub_modules = [
@@ -250,6 +251,9 @@ class QtImporter(object):
             sub_modules.append("QtWebEngineWidgets")
 
         modules_dict = {"QtCore": QtCore}
+
+        # Add shiboken2 to the modules dict
+        modules_dict["shiboken"] = shiboken2
 
         # Depending on the build of PySide 2 being used, more or less modules are supported. Instead
         # of assuming a base set of functionality, simply try every module one at a time.

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -144,6 +144,9 @@ class QtImporter(object):
 
     @property
     def shiboken(self):
+        """
+        :returns: The compatible shiboken module for the imported PySide version if available.
+        """
         return self._modules.get("shiboken") if self._modules else None
 
     def _import_module_by_name(self, parent_module_name, module_name):

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -142,6 +142,10 @@ class QtImporter(object):
     def qt_version_tuple(self):
         return self._qt_version_tuple
 
+    @property
+    def shiboken(self): # shiboken SG-31832
+        return self._modules.get("shiboken") if self._modules else None
+
     def _import_module_by_name(self, parent_module_name, module_name):
         """
         Import a module by its string name.
@@ -164,6 +168,7 @@ class QtImporter(object):
         :returns: The (binding name, binding version, modules) tuple.
         """
         from PySide import QtCore, QtGui
+        import shiboken  # shiboken SG-31832
 
         QtNetwork = self._import_module_by_name("PySide", "QtNetwork")
         QtWebKit = self._import_module_by_name("PySide", "QtWebKit")
@@ -192,6 +197,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": None,
+                "shiboken": shiboken,  # shiboken SG-31832
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -280,6 +286,7 @@ class QtImporter(object):
         """
         import PySide2
         from PySide2 import QtCore, QtGui, QtWidgets
+        import shiboken2 as shiboken  # shiboken SG-31832
         from .pyside2_patcher import PySide2Patcher
 
         QtCore, QtGui = PySide2Patcher.patch(QtCore, QtGui, QtWidgets, PySide2)
@@ -299,6 +306,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
+                "shiboken": shiboken,  # shiboken SG-31832
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -348,6 +356,7 @@ class QtImporter(object):
         """
 
         import PySide6
+        import shiboken6 as shiboken # shiboken SG-31832
         from .pyside6_patcher import PySide6Patcher
 
         QtCore, QtGui, QtWebEngineWidgets = PySide6Patcher.patch()
@@ -364,6 +373,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
+                "shiboken": shiboken,  # shiboken SG-31832
             },
             self._to_version_tuple(QtCore.qVersion()),
         )

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -143,7 +143,7 @@ class QtImporter(object):
         return self._qt_version_tuple
 
     @property
-    def shiboken(self): # shiboken SG-31832
+    def shiboken(self):
         return self._modules.get("shiboken") if self._modules else None
 
     def _import_module_by_name(self, parent_module_name, module_name):
@@ -168,7 +168,7 @@ class QtImporter(object):
         :returns: The (binding name, binding version, modules) tuple.
         """
         from PySide import QtCore, QtGui
-        import shiboken  # shiboken SG-31832
+        import shiboken
 
         QtNetwork = self._import_module_by_name("PySide", "QtNetwork")
         QtWebKit = self._import_module_by_name("PySide", "QtWebKit")
@@ -197,7 +197,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": None,
-                "shiboken": shiboken,  # shiboken SG-31832
+                "shiboken": shiboken,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -286,7 +286,7 @@ class QtImporter(object):
         """
         import PySide2
         from PySide2 import QtCore, QtGui, QtWidgets
-        import shiboken2 as shiboken  # shiboken SG-31832
+        import shiboken2 as shiboken
         from .pyside2_patcher import PySide2Patcher
 
         QtCore, QtGui = PySide2Patcher.patch(QtCore, QtGui, QtWidgets, PySide2)
@@ -306,7 +306,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
-                "shiboken": shiboken,  # shiboken SG-31832
+                "shiboken": shiboken,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )
@@ -356,7 +356,7 @@ class QtImporter(object):
         """
 
         import PySide6
-        import shiboken6 as shiboken # shiboken SG-31832
+        import shiboken6 as shiboken
         from .pyside6_patcher import PySide6Patcher
 
         QtCore, QtGui, QtWebEngineWidgets = PySide6Patcher.patch()
@@ -373,7 +373,7 @@ class QtImporter(object):
                 "QtNetwork": QtNetwork,
                 "QtWebKit": QtWebKit,
                 "QtWebEngineWidgets": QtWebEngineWidgets,
-                "shiboken": shiboken,  # shiboken SG-31832
+                "shiboken": shiboken,
             },
             self._to_version_tuple(QtCore.qVersion()),
         )

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -51,7 +51,7 @@ class QtImporterTests(TankTestBase):
     @skip_if_pyside2(found=False)
     def test_qt_importer_with_pyside2_interface_qt5(self):
         """
-        Test the QtImporter constructor with QT4 interface.
+        Test the QtImporter constructor with QT5 interface.
 
         This test only runs if PySide2 is available.
         """

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -37,6 +37,8 @@ class QtImporterTests(TankTestBase):
         assert qt.QtCore
         assert qt.QtGui
         assert qt.QtNetwork
+        assert qt.shiboken
+        assert qt.shiboken.__name__ == "shiboken2"
         # We need one or the other
         assert qt.QtWebKit or qt.QtWebEngineWidgets
 
@@ -60,6 +62,8 @@ class QtImporterTests(TankTestBase):
         assert qt.QtCore
         assert qt.QtGui
         assert qt.QtNetwork
+        assert qt.shiboken
+        assert qt.shiboken.__name__ == "shiboken2"
         try:
             qt_web_kit = qt.QtWebKit
         except KeyError:
@@ -92,6 +96,8 @@ class QtImporterTests(TankTestBase):
         assert qt.QtCore
         assert qt.QtGui
         assert qt.QtNetwork
+        assert qt.shiboken
+        assert qt.shiboken.__name__ == "shiboken"
         # We need one or the other
         assert qt.QtWebKit or qt.QtWebEngineWidgets
 
@@ -142,6 +148,8 @@ class QtImporterTests(TankTestBase):
         assert qt.QtCore
         assert qt.QtGui
         assert qt.QtNetwork
+        assert qt.shiboken
+        assert qt.shiboken.__name__ == "shiboken6"
         # We need one or the other
         assert qt.QtWebKit or qt.QtWebEngineWidgets
 
@@ -168,6 +176,8 @@ class QtImporterTests(TankTestBase):
         assert qt.QtCore
         assert qt.QtGui
         assert qt.QtNetwork
+        assert qt.shiboken
+        assert qt.shiboken.__name__ == "shiboken6"
         try:
             qt_web_kit = qt.QtWebKit
         except KeyError:


### PR DESCRIPTION
This PR enhances the `sgtk.platform.qt` module by enabling direct access to the appropriate `shiboken` module based on the PySide version in use.

