### PR TITLE
SG-35087 Stop masking exceptions

### DIFF
--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -796,7 +796,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
             # to give us a clue why the request failed.
             # The exception raised in this case is "ssl.SSLError: The read operation timed out"
             except httplib2.ssl.SSLError as e:
-                if "timed" in getattr(e, "message", ""):
+                if "timed" in str(e):
                     raise TankAppStoreConnectionError(
                         "Connection to %s timed out: %s"
                         % (app_store_sg.config.server, e)

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -796,7 +796,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
             # to give us a clue why the request failed.
             # The exception raised in this case is "ssl.SSLError: The read operation timed out"
             except httplib2.ssl.SSLError as e:
-                if "timed" in e.message:
+                if "timed" in getattr(e, "message", ""):
                     raise TankAppStoreConnectionError(
                         "Connection to %s timed out: %s"
                         % (app_store_sg.config.server, e)

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -1491,7 +1491,8 @@ def run_engine_cmd(pipeline_config_root, context_items, command, using_cwd, args
                     "%s If you want to unregister folders associated with this "
                     "entity, you can do so by calling the unregister_folders "
                     "command on the associated path instead: "
-                    '"tank unregister_folders /path/to/folder"' % exc.message
+                    '"tank unregister_folders /path/to/folder"'
+                    % getattr(exc, "message", "")
                 )
             raise
 

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -509,7 +509,7 @@ class TestDescriptorSupport(TankTestBase):
 
     def test_ssl_error(self):
         """
-        Catches SSL error
+        Catches SSLError
         """
         with mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore"

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -514,7 +514,7 @@ class TestDescriptorSupport(TankTestBase):
         with mock.patch(
             "tank.descriptor.io_descriptor.appstore.IODescriptorAppStore"
             "._IODescriptorAppStore__create_sg_app_store_connection",
-            side_effect=httplib2.ssl.SSLError("Some SSLError."),
+            side_effect=httplib2.ssl.SSLError("Read operation timed out"),
         ), mock.patch(
             "tank.descriptor.io_descriptor.appstore.log.debug"
         ) as log_debug_mock:
@@ -530,7 +530,7 @@ class TestDescriptorSupport(TankTestBase):
             self.assertEqual(descriptor.has_remote_access(), False)
 
             log_debug_mock.assert_called_with(
-                "...could not establish connection: ('Some SSLError.',)"
+                "...could not establish connection: ('Read operation timed out',)"
             )
 
     def test_git_version_logic(self):


### PR DESCRIPTION
Sometimes we have support cases with messages like:

```
[33532 DEBUG sgtk.core.descriptor.io_descriptor.appstore] ...could not establish connection: 'SSLCertVerificationError' object has no attribute 'message'
```

```
File "C:\Users\xxxxxxxx\cfg\install\core\scripts\tank_cmd.py", line 1494, in run_engine_cmd
'"tank unregister_folders /path/to/folder"' % exc.message
AttributeError: 'TankInitError' object has no attribute 'message'
```

Turns out tk-core is raising an error the moment the error is handled. 
This PR attempts to fix this by gracefully getting the error description.