### PR TITLE
SG-35085 Make sure login/password authentication is available in console mode

### DIFF
--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -81,12 +81,10 @@ class ConsoleAuthenticationHandlerBase(object):
             if not site_i.app_session_launcher_enabled:
                 # Will raise an exception if using a username/password pair is
                 # not supported by the Flow Production Tracking server.
-                # Which is the case when using SSO or Autodesk Identity.
+                # Which is the case when using SSO.
 
                 if site_i.sso_enabled:
                     raise ConsoleLoginNotSupportedError(hostname, "Single Sign-On")
-                elif site_i.autodesk_identity_enabled:
-                    raise ConsoleLoginNotSupportedError(hostname, "Autodesk Identity")
 
             method_selected = self._get_auth_method(hostname, site_i)
             if method_selected == constants.METHOD_ASL:
@@ -200,9 +198,6 @@ class ConsoleAuthenticationHandlerBase(object):
     def _get_auth_method(self, hostname, site_i):
         if not site_i.app_session_launcher_enabled:
             return constants.METHOD_BASIC
-
-        if site_i.autodesk_identity_enabled or site_i.sso_enabled:
-            return constants.METHOD_ASL
 
         # We have 2 choices here
         methods = {

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -99,7 +99,7 @@ class ConsoleAuthenticationHandlerBase(object):
                 # user + valid pass + invalid 2da code) we'll end up here.
                 print("Login failed: %s" % error)
                 print()
-                return
+                raise error
 
             metrics_cache.log(
                 EventMetric.GROUP_TOOLKIT,

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -199,6 +199,9 @@ class ConsoleAuthenticationHandlerBase(object):
         if not site_i.app_session_launcher_enabled:
             return constants.METHOD_BASIC
 
+        if site_i.sso_enabled:
+            return constants.METHOD_ASL
+
         # We have 2 choices here
         methods = {
             "1": constants.METHOD_ASL,

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -201,8 +201,8 @@ class ConsoleAuthenticationHandlerBase(object):
 
         # We have 2 choices here
         methods = {
-            "1": constants.METHOD_BASIC,
-            "2": constants.METHOD_ASL,
+            "1": constants.METHOD_ASL,
+            "2": constants.METHOD_BASIC,
         }
 
         # Let's see which method the user chose previously for this site
@@ -217,8 +217,8 @@ class ConsoleAuthenticationHandlerBase(object):
         print(
             "\n"
             "The Flow Production Tracking site support two authentication methods:\n"
-            " 1. Authenticate with Legacy Flow Production Tracking Login Credentials\n"
-            " 2. Authenticate with the App Session Launcher using your default web browser\n"
+            " 1. Authenticate with the App Session Launcher using your default web browser\n"
+            " 2. Authenticate with Legacy Flow Production Tracking Login Credentials\n"
         )
 
         method_selected = self._get_keyboard_input(

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -1199,7 +1199,7 @@ class InteractiveTests(ShotgunTestBase):
             "tank.authentication.console_authentication.input",
             side_effect=[
                 "\n",  # Select default PTR site (site1)
-                "1",  # Select "legacy" auth method
+                "2",  # Select "legacy" auth method
                 "username",
             ],
         ), mock.patch(
@@ -1216,7 +1216,7 @@ class InteractiveTests(ShotgunTestBase):
             "tank.authentication.console_authentication.input",
             side_effect=[
                 "",  # Select default site -> site4
-                "2",  # Select App Session Launcher option
+                "1",  # Select App Session Launcher option
                 "",  # OK to continue
             ],
         ), mock.patch(
@@ -1322,7 +1322,7 @@ class InteractiveTests(ShotgunTestBase):
 
             with mock.patch(
                 "tank.authentication.console_authentication.input",
-                return_value="1",
+                return_value="2",
             ):
                 self.assertEqual(
                     handler._get_auth_method("https://host.shotgunstudio.com", site_i),
@@ -1331,7 +1331,7 @@ class InteractiveTests(ShotgunTestBase):
 
             with mock.patch(
                 "tank.authentication.console_authentication.input",
-                return_value="2",
+                return_value="1",
             ):
                 self.assertEqual(
                     handler._get_auth_method("https://host.shotgunstudio.com", site_i),

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -425,7 +425,6 @@ class InteractiveTests(ShotgunTestBase):
             "user_authentication_method": "saml2",
         },
     )
-    @suppress_generated_code_qt_warnings
     def test_sso_enabled_site_with_legacy_exception_name(self, *mocks):
         """
         Ensure that an exception is thrown should we attempt console authentication

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -452,9 +452,7 @@ class InteractiveTests(ShotgunTestBase):
         """
         handler = console_authentication.ConsoleLoginHandler(fixed_host=True)
         with self.assertRaises(ConsoleLoginNotSupportedError):
-            handler.authenticate(
-                "https://test-sso.shotgunstudio.com", None, None
-            )
+            handler.authenticate("https://test-sso.shotgunstudio.com", None, None)
 
     @suppress_generated_code_qt_warnings
     def test_ui_auth_with_whitespace(self):


### PR DESCRIPTION
* Fix regression: re-enable login/password authentication for oxygen/identity
  Regression introduced by #890
* Set ASL the default method for console - Should have been done in #948
* Fix an error when console authentication failed