### PR TITLE
SG-33500 Cleanup build_resources.sh scripts

### DIFF
--- a/python/tank/authentication/resources/build_resources.sh
+++ b/python/tank/authentication/resources/build_resources.sh
@@ -25,7 +25,7 @@ function build_qt {
     $1 $2 > $UI_PYTHON_PATH/$3.py
 
     # replace PySide imports with local imports and remove line containing Created by date
-    sed -i "" -e "s/from PySide import/from .qt_abstraction import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
+    sed -i"" -e "s/from PySide import/from .qt_abstraction import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
 }
 
 function build_ui {

--- a/python/tank/authentication/resources/build_resources.sh
+++ b/python/tank/authentication/resources/build_resources.sh
@@ -11,8 +11,6 @@ set -e
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# The path to output all built .py files to:
-UI_PYTHON_PATH=../ui
 if [ -z "${PYTHON_BASE}" ]; then
     PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
 fi
@@ -22,10 +20,10 @@ function build_qt {
     echo " > Building " $2
 
     # compile ui to python
-    $1 $2 > $UI_PYTHON_PATH/$3.py
+    $1 $2 > $3.py
 
     # replace PySide imports with local imports and remove line containing Created by date
-    sed -i"" -e "s/from PySide import/from .qt_abstraction import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
+    sed -i"" -e "s/from PySide import/from .qt_abstraction import/g" -e "/# Created:/d" $3.py
 }
 
 function build_ui {

--- a/python/tank/authentication/resources/build_resources.sh
+++ b/python/tank/authentication/resources/build_resources.sh
@@ -17,9 +17,6 @@ if [ -z "${PYTHON_BASE}" ]; then
     PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
 fi
 
-# Remove any problematic profiles from pngs.
-for f in *.png; do mogrify $f; done
-
 # Helper functions to build UI files
 function build_qt {
     echo " > Building " $2

--- a/python/tank/platform/qt/build_resources.sh
+++ b/python/tank/platform/qt/build_resources.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 #
 # Copyright (c) 2015 Shotgun Software Inc.
 #
@@ -10,8 +11,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# The path to where the PySide binaries are installed
-PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
+if [ -z "${PYTHON_BASE}" ]; then
+    # The path to where the PySide binaries are installed
+    PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
+fi
 
 # Remove any problematic profiles from pngs.
 for f in *.png; do mogrify $f; done

--- a/python/tank/platform/qt/build_resources.sh
+++ b/python/tank/platform/qt/build_resources.sh
@@ -16,9 +16,6 @@ if [ -z "${PYTHON_BASE}" ]; then
     PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
 fi
 
-# Remove any problematic profiles from pngs.
-for f in *.png; do mogrify $f; done
-
 # The path to output all built .py files to:
 UI_PYTHON_PATH=.
 

--- a/python/tank/platform/qt/build_resources.sh
+++ b/python/tank/platform/qt/build_resources.sh
@@ -16,18 +16,15 @@ if [ -z "${PYTHON_BASE}" ]; then
     PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
 fi
 
-# The path to output all built .py files to:
-UI_PYTHON_PATH=.
-
 # Helper functions to build UI files
 function build_qt {
     echo " > Building " $2
 
     # compile ui to python
-    $1 $2 > $UI_PYTHON_PATH/$3.py
+    $1 $2 > $3.py
 
     # replace PySide imports with local imports and remove line containing Created by date
-    sed -i"" -e "s/from PySide import/from . import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
+    sed -i"" -e "s/from PySide import/from . import/g" -e "/# Created:/d" $3.py
 }
 
 function build_ui {

--- a/python/tank/platform/qt/build_resources.sh
+++ b/python/tank/platform/qt/build_resources.sh
@@ -27,7 +27,7 @@ function build_qt {
     $1 $2 > $UI_PYTHON_PATH/$3.py
 
     # replace PySide imports with local imports and remove line containing Created by date
-    sed -i "" -e "s/from PySide import/from . import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
+    sed -i"" -e "s/from PySide import/from . import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
 }
 
 function build_ui {


### PR DESCRIPTION
- Replicate change from 8d116c7c
- Remove useless mogrify command since #984
- Make the sed command work with both GNU sed (Linux) and BSD sed (macOS)
- Remove useless UI_PYTHON_PATH variable


Related to #977. I'm not sure that we will merge this one but I wanted to point out what is wrong with the current script.

