### PR TITLE
SG-36857 Support PySide 6.5.7+commercial

### DIFF
--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -315,6 +315,7 @@ class QtImporter(object):
         """
 
         import PySide6
+        from PySide6 import QtCore
         import shiboken6
 
         sub_modules = pkgutil.iter_modules(PySide6.__path__)
@@ -336,7 +337,7 @@ class QtImporter(object):
             PySide6.__version__,
             PySide6,
             modules_dict,
-            self._to_version_tuple(PySide6.__version__),
+            self._to_version_tuple(QtCore.qVersion()),
         )
 
     def _to_version_tuple(self, version_str):


### PR DESCRIPTION
Using a PySide6 commercial version, the `__version__` method can bring unexpected characters:

```bash
>>> import PySide6
>>> PySide6.__version__
'6.5.7+commercial'
```

So we're changing to `QtCore.qVersion` output to prevent a crash.

```bash
>>> from PySide6 import QtCore
>>> QtCore.qVersion()
'6.5.7'
>>>
```