### PR TITLE
SG-37296 Add support to PySide6 for availableGeometry

### DIFF
--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -254,7 +254,7 @@ class PySide6Patcher(PySide2Patcher):
             try:
                 screen = widget.screen()
                 return QtGui.QGuiApplication.screens().index(screen)
-            except IndexError:
+            except (IndexError, AttributeError):
                 return -1
 
         def screenCount(self):

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -49,6 +49,22 @@ class PySide6Patcher(PySide2Patcher):
     )
 
     @classmethod
+    def _patch_QApplication(cls, QtGui):
+        """Patch QApplication."""
+
+        def desktop(*args):
+            """
+            QDesktopWidget removed along with QApplication.desktop, in favor or QScreen.
+            """
+            return QtGui.QApplication.primaryScreen()
+
+        # First apply the patch from PySide2 patcher
+        super()._patch_QApplication(QtGui)
+
+        # Now apply any PySide6 specific patches
+        QtGui.QApplication.desktop = desktop
+
+    @classmethod
     def _patch_QAbstractItemView(cls, QtGui):
         """Patch QAbstractItemView."""
 
@@ -210,27 +226,33 @@ class PySide6Patcher(PySide2Patcher):
 
 
         original_QScreen_availableGeometry = QtGui.QScreen.availableGeometry
-        def availableGeometry(self, widget=None):
-            """Patch QScreen to also act as QDesktopWidget."""
-            if widget is None:
+        def availableGeometry(self, arg__1=None):
+            """
+            Patch QScreen to also act as QDesktopWidget.
+
+            :param arg__1 Union(int, QtGui.QWidget, QtCore.QPoint): A widget, screen index or point.
+            """
+            if arg__1 is None:
                 return original_QScreen_availableGeometry(self)
 
-            if isinstance(widget, int):
+            if isinstance(arg__1, int):
                 screens = QtGui.QGuiApplication.screens()
                 try:
-                    screen = screens[widget]
+                    screen = screens[arg__1]
                 except IndexError:
                     return QtCore.QRect()
+            elif isinstance(arg__1, QtCore.QPoint):
+                return original_QScreen_availableGeometry(self)
             else:
-                screen = widget.screen()
+                screen = arg__1.screen()
 
             return screen.availableGeometry()
 
         def screenNumber(self, widget):
             """Provide QDesktopWidget method through QScreen."""
 
-            screen = widget.screen()
             try:
+                screen = widget.screen()
                 return QtGui.QGuiApplication.screens().index(screen)
             except IndexError:
                 return -1
@@ -534,12 +556,10 @@ class PySide6Patcher(PySide2Patcher):
         # https://doc.qt.io/qt-6/widgets-changes-qt6.html#the-qabstractitemview-class
         cls._patch_QAbstractItemView(qt_gui_shim)
 
-        # QDesktopWidget removed along with QApplication.desktop, in favor or QScreen. Patch
-        # QScreen such that it can be used as if it were a QDesktopWidget instance
+        # Patch QScreen such that it can be used as if it were a QDesktopWidget instance
         # https://doc.qt.io/qt-6/widgets-changes-qt6.html#qdesktopwidget-and-qapplication-desktop
         cls._patch_QScreen(qt_core_shim, qt_gui_shim)
         qt_gui_shim.QDesktopWidget = qt_gui_shim.QScreen
-        qt_gui_shim.QApplication.desktop = lambda: qt_gui_shim.QApplication.primaryScreen()
 
         # The default timeout parameter removed. This param, if given, will be ignored. It will
         # always timeout after 100 ms


### PR DESCRIPTION
## Context
[PySide6 deprecated](https://doc.qt.io/qt-6/widgets-changes-qt6.html#qdesktopwidget-and-qapplication-desktop) QDesktopWidget and QApplication.desktop we worked on #898.

## Problem

SGD is not able to start after the authentication step when the window has been pinned to the status bar

<img width="216" alt="Screenshot 2025-02-05 at 1 40 47 PM" src="https://github.com/user-attachments/assets/955b8e45-d2d4-4c17-b91c-1cc8deb01d43" />

This saves an internal registry (`com.shotgun-software.tk-desktop dialog_pinned` on Macos or `HKEY_CURRENT_USER\Software\ShotgunSoftware\tk-desktop\dialog_pinned` on Windows).

![image](https://github.com/user-attachments/assets/8b95033d-5a84-4257-b780-2c29b31f52c0)

## Solution to the PySide6 patcher

### `QApplication.desktop` monkey patch

Changed from a lambda to a named function inside an specific patcher `_patch_QApplication` that accepts dynamic arguments. This seemed to change on runtime for PySide6 although I couldn't find any documentation about it.

### `QtGui.QScreen.availableGeometry` monkey patch

Based on tests, the patched function `availableGeometry` cannot only receive a `QWidget` or `int` argument, [it can also receive](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QDesktopWidget.html#PySide2.QtWidgets.PySide2.QtWidgets.QDesktopWidget.availableGeometry) a `QPoint`. I've included a docstring to document this and proper support.

```
Union(int, QtGui.QWidget, QtCore.QPoint): A widget, screen index, or point.
```

### Bonus: `screenNumber`

I don't know when this function is used on a PySide6 environment. However, I've moved a `widget.screen()` call inside a `try` block to prevent an issue similar to the one described previously.