### PR TITLE
SG-33057 update pre commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Styles the code properly
 # Exclude the following file types
 # - third party modules (tank_vendor/third_party)
@@ -19,11 +22,10 @@ exclude: "tank_vendor|third_party|ui\/.*py$|\/.*png|\/.*pickle|test_post_update_
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -49,9 +51,8 @@ repos:
       # Same comment as the end-of-file-fixer
       exclude: "scripts\/tank_cmd.bat|setup\/root_binaries\/tank.bat"
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3
       exclude: "tests|python\/tank"

--- a/developer/build_plugin.py
+++ b/developer/build_plugin.py
@@ -348,7 +348,7 @@ def _bake_manifest(manifest_data, config_uri, core_descriptor, plugin_root):
 
             fh.write('base_configuration="%s"\n' % config_uri)
 
-            for (parameter, value) in manifest_data.items():
+            for parameter, value in manifest_data.items():
 
                 if parameter == "base_configuration":
                     continue

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -498,7 +498,7 @@ def _write_shotgun_cache(tk, entity_type, cache_file_name):
 
     # extract actions into cache file
     res = []
-    for (cmd_name, cmd_params) in engine_commands.items():
+    for cmd_name, cmd_params in engine_commands.items():
 
         # some apps provide a special deny_platforms entry
         if "deny_platforms" in cmd_params["properties"]:


### PR DESCRIPTION
Cleanup and update `.pre-commit-config.yaml` file:
- Update pre-commit-hooks to version `v5.0.0`
- Update black hook to version `25.1.0`
- Update black hook URL
- Use global `default_language_version` instead of individuals `language_version`

These changes are optional considering shotgunsoftware/tk-ci-tools#58. But we might want to cleanup/update the `.pre-commit-config.yaml` file every once in a while.