### PR TITLE
SG-38301 App Session Launcher to use `SHOTGUN_API_CACERTS` just like python-api

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -10,6 +10,17 @@ A number of different environment variables exist to help control the behavior o
 General
 =======
 
+``SHOTGUN_API_CACERTS``
+-----------------------
+This variable can be used to override the default Trusted Root Certification
+Authorities Certificate Store bundled with Toolkit.
+By default, Toolkit relies on `certifi <https://pypi.org/project/certifi/>`_ as
+Root CA store.
+
+For an example on how to use this variable, see the
+`SSLHandshakeError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed <https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_qa_troubleshooting_qa_sslhandshakeerror_ssl_certificate_verify_failed_html>`_
+article.
+
 ``SHOTGUN_HOME``
 ----------------
 Overrides the location where Toolkit stores data, which includes bootstrap data as well as bundle cache, cached thumbnails and other temp files.

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -12,13 +12,13 @@ General
 
 ``SHOTGUN_API_CACERTS``
 -----------------------
-This variable can be used to override the default Trusted Root Certification
-Authorities Certificate Store bundled with Toolkit.
+Use this variable to override the default Trusted Root Certification Authorities
+Certificate Store bundled with Toolkit.
 By default, Toolkit relies on `certifi <https://pypi.org/project/certifi/>`_ as
-Root CA store.
+its Root CA store.
 
-For an example on how to use this variable, see the
-`SSLHandshakeError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed <https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_qa_troubleshooting_qa_sslhandshakeerror_ssl_certificate_verify_failed_html>`_
+For an example about using ``SHOTGUN_API_CACERTS`` to fix a certificate issue,
+see the `SSLHandshakeError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed <https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_qa_troubleshooting_qa_sslhandshakeerror_ssl_certificate_verify_failed_html>`_
 article.
 
 ``SHOTGUN_HOME``

--- a/python/tank/authentication/app_session_launcher.py
+++ b/python/tank/authentication/app_session_launcher.py
@@ -87,7 +87,7 @@ def process(
         logger.debug(f"Set CaCert handler to {ca_certs}")
 
         url_handlers.append(
-            shotgun_api3.CACertsHTTPSHandler(ca_certs),
+            shotgun_api3.shotgun.CACertsHTTPSHandler(ca_certs),
         )
 
     if http_proxy:

--- a/python/tank/authentication/app_session_launcher.py
+++ b/python/tank/authentication/app_session_launcher.py
@@ -12,6 +12,7 @@ import json
 import os
 import platform
 import random
+import ssl
 import sys
 import time
 
@@ -87,7 +88,11 @@ def process(
         logger.debug(f"Set CaCert handler to {ca_certs}")
 
         url_handlers.append(
-            shotgun_api3.shotgun.CACertsHTTPSHandler(ca_certs),
+            urllib.request.HTTPSHandler(
+                context = ssl.create_default_context(
+                    cafile=ca_certs,
+                ),
+            ),
         )
 
     if http_proxy:

--- a/python/tank/authentication/app_session_launcher.py
+++ b/python/tank/authentication/app_session_launcher.py
@@ -16,7 +16,10 @@ import sys
 import time
 
 import tank
-from tank_vendor import six
+from tank_vendor import (
+    shotgun_api3,
+    six,
+)
 from tank_vendor.six.moves import http_client, urllib
 
 from . import errors
@@ -78,6 +81,15 @@ def process(
     assert callable(keep_waiting_callback)
 
     url_handlers = [urllib.request.HTTPHandler]
+
+    ca_certs = shotgun_api3.Shotgun._get_certs_file(None)
+    if ca_certs:
+        logger.debug(f"Set CaCert handler to {ca_certs}")
+
+        url_handlers.append(
+            shotgun_api3.CACertsHTTPSHandler(ca_certs),
+        )
+
     if http_proxy:
         proxy_addr = _build_proxy_addr(http_proxy)
         sg_url_parsed = urllib.parse.urlparse(sg_url)


### PR DESCRIPTION
Python API can use a custom CA Cert store using the `SHOTGUN_API_CACERTS` variable

https://developers.shotgridsoftware.com/python-api/reference.html#shotgun-api-cacerts

App Session Launcher uses a different API and was using a different CA Cert store. It is now aligned with python-api (certifi).


Related to shotgunsoftware/python-api#373