### PR TITLE
Fix parent property of PathTemplate in case of optional key

### DIFF
--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -557,6 +557,17 @@ class TemplatePath(Template):
         """
         return self._prefix
 
+    def _dirname(self):
+        """
+        Returns the directory part of the template.
+
+        :returns: String
+        """
+        dirname, basename = os.path.split(self._repr_def)
+        if "[" in basename and "]" not in basename:
+            return dirname.split("[")[0]
+        return dirname
+
     @property
     def parent(self):
         """
@@ -566,7 +577,7 @@ class TemplatePath(Template):
 
         :returns: :class:`Template`
         """
-        parent_definition = os.path.dirname(self._repr_def)
+        parent_definition = self._dirname()
         if parent_definition and parent_definition != "/":
             return TemplatePath(
                 parent_definition,

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -566,8 +566,8 @@ class TemplatePath(Template):
 
         :returns: :class:`Template`
         """
-        parent_definition = os.path.dirname(self.definition)
-        if parent_definition:
+        parent_definition = os.path.dirname(self._repr_def)
+        if parent_definition and parent_definition != "/":
             return TemplatePath(
                 parent_definition,
                 self.keys,

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1184,3 +1184,16 @@ class TestParent(TestTemplatePath):
         template = TemplatePath(definition, keys, root_path=self.project_root)
         result = template.parent
         self.assertEqual("{new_name}", result.definition)
+
+    def test_parent_with_optional(self):
+        definition = "shots/{Sequence}[-{seq_num}]/{Shot}/{Step}/work"
+        parent_expected_definitions = [
+            "shots/{Sequence}-{seq_num}/{Shot}/{Step}",
+            "shots/{Sequence}/{Shot}/{Step}",
+        ]
+        parent_expected__repr_def = os.path.dirname(definition)
+
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        parent = template.parent
+        self.assertEqual(parent_expected_definitions, parent._definitions)
+        self.assertEqual(parent_expected__repr_def, parent._repr_def)

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1197,3 +1197,29 @@ class TestParent(TestTemplatePath):
         parent = template.parent
         self.assertEqual(parent_expected_definitions, parent._definitions)
         self.assertEqual(parent_expected__repr_def, parent._repr_def)
+
+class TestDirname(TestTemplatePath):
+    def test_dirname_with_word(self):
+        definition = "shots/{Sequence}/{Shot}/{Step}/work"
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}/{Step}", template.dirname)
+
+    def test_dirname_with_key(self):
+        definition = "shots/{Sequence}/{Shot}/{Step}"
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+
+    def test_dirname_with_optional(self):
+        definition = "shots/{Sequence}/{Shot}[/{Step}]"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+
+    def test_dirname_with_optional_word_and_key(self):
+        definition =  "shots/{Sequence}/{Shot}/[abc_{Step}]"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("", template.dirname)
+
+    def test_dirname_with_optional_key_and_key(self):
+        definition = "shots/{Sequence}/[{Shot}]-{Step}"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}", template.dirname)

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1198,6 +1198,7 @@ class TestParent(TestTemplatePath):
         self.assertEqual(parent_expected_definitions, parent._definitions)
         self.assertEqual(parent_expected__repr_def, parent._repr_def)
 
+
 class TestDirname(TestTemplatePath):
     def test_dirname_with_word(self):
         definition = "shots/{Sequence}/{Shot}/{Step}/work"
@@ -1215,7 +1216,7 @@ class TestDirname(TestTemplatePath):
         self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
 
     def test_dirname_with_optional_word_and_key(self):
-        definition =  "shots/{Sequence}/{Shot}/[abc_{Step}]"
+        definition = "shots/{Sequence}/{Shot}/[abc_{Step}]"
         template = TemplatePath(definition, {}, root_path=self.project_root)
         self.assertEqual("", template.dirname)
 


### PR DESCRIPTION
## Context

The [parent](https://github.com/shotgunsoftware/tk-core/blob/438a3fad3b8c7d282de12ebd03f2528b683194c2/python/tank/template.py#L561) property of [PathTemplate](https://github.com/shotgunsoftware/tk-core/blob/438a3fad3b8c7d282de12ebd03f2528b683194c2/python/tank/template.py#L517) doesn't  create a correct **PathTemplate** when optional keys are used. For example, if you create a template `shots/{Sequence}[-{seq_num}]/{Shot}/{Step}/work`, the **parent** property will return a **templatePath** without the optional `[-{seq_num}]` part.

## Problem

When creating a **PathTemplate** with optional keys, the **parent** property omits these keys in the generated path. This can result in incorrect or incomplete paths.

## Solution

To solve this issue, instead of passing **self.definition** to the **PathTemplate** constructor, we use **self._repr_def**, which contains the optional keys.

## Testing

A test has been added to verify that the **parent** property now correctly includes optional keys in the generated **PathTemplate**.