### PR TITLE
SG-38210 Add RV Live Review metrics

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -629,6 +629,7 @@ class EventMetric(object):
     GROUP_MEDIA = "Media"
     GROUP_NAVIGATION = "Navigation"
     GROUP_PROJECTS = "Projects"
+    GROUP_RV = "RV"
     GROUP_TASKS = "Tasks"
     GROUP_TOOLKIT = "Toolkit"
 
@@ -645,6 +646,17 @@ class EventMetric(object):
         EVENT_NAME_FORMAT % (GROUP_NAVIGATION, "Viewed Projects"),
         EVENT_NAME_FORMAT % (GROUP_NAVIGATION, "Viewed Panel"),
         EVENT_NAME_FORMAT % (GROUP_PROJECTS, "Viewed Project Commands"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Assign Presenter"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Feedback Form Opened"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Feedback Form Submitted"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Join Session"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Join Session Failed"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Leave Session"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Link Copied"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Panel Toggled"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session Created"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session ID Copied from menu"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session Joined"),
         EVENT_NAME_FORMAT % (GROUP_TASKS, "Created Task"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Logged In"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Launched Action"),


### PR DESCRIPTION
SG-38210 Add RV Live Review metrics

This commit adds RV Live Review events to the allowlist in metrics.py

**Context:**
Note that prior to the RV 2024 release which was based off OpenRV as a submodule, RV had its own Amplitude secret to report Amplitude events. Since that we did not want to make this secret public when we open sourced RV, this secret was removed and we lost the capability of reporting Amplitude analytics events in RV.
That being said, the RV Code was only reporting Live Review related events. 
This commit restores this functionality in RV.

This is just a proposal, please feel free to refuse this PR or ask me to rework it.

Thanks