### PR TITLE
Refactor the skip_if_pyside_missing decorator to skip_if_pysideX

### DIFF
--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -22,7 +22,7 @@ import os
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,
-    skip_if_pyside_missing,
+    skip_if_pysideX,
     interactive,
     mock,
     suppress_generated_code_qt_warnings,
@@ -51,7 +51,7 @@ import tank
 import tank_vendor.shotgun_api3
 
 
-@skip_if_pyside_missing
+@skip_if_pysideX(found=False)
 class InteractiveTests(ShotgunTestBase):
     """
     Tests ui and console based authentication.

--- a/tests/authentication_tests/test_web_login.py
+++ b/tests/authentication_tests/test_web_login.py
@@ -14,14 +14,14 @@ from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,
     only_run_on_nix,
-    skip_if_pyside_missing,
+    skip_if_pysideX,
 )
 
 from tank.authentication.sso_saml2 import SsoSaml2Toolkit
 
 
 @only_run_on_nix  # This test issues a seg-fault on Windows
-@skip_if_pyside_missing
+@skip_if_pysideX(found=False)
 class WebLoginTests(ShotgunTestBase):
     """
     The main goal of these test is to add code coverage.

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -15,7 +15,7 @@ import os
 import shutil
 import logging
 import tempfile
-import mock
+from unittest import mock
 import inspect
 
 from tank_test.tank_test_base import *

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -22,7 +22,7 @@ import time
 
 from tank_test.tank_test_base import (
     TankTestBase,
-    skip_if_pyside_missing,
+    skip_if_pysideX,
     suppress_generated_code_qt_warnings,
 )
 from tank_test.tank_test_base import setUpModule  # noqa
@@ -101,7 +101,7 @@ class TestDialogCreation(TestEngineBase):
 
         sgtk.platform.start_engine("test_engine", self.tk, self.context)
 
-    @skip_if_pyside_missing
+    @skip_if_pysideX(found=False)
     def test_create_widget(self):
         """
         Ensures that the _create_widget method is exception safe.
@@ -116,7 +116,7 @@ class TestDialogCreation(TestEngineBase):
         # Ensure we don't bubble up an exception.
         sgtk.platform.current_engine()._create_widget(_test_widget)
 
-    @skip_if_pyside_missing
+    @skip_if_pysideX(found=False)
     def tearDown(self):
         """
         Tears down the current engine.
@@ -197,7 +197,7 @@ class TestLegacyStartShotgunEngine(TestEngineBase):
         )
 
 
-@skip_if_pyside_missing
+@skip_if_pysideX(found=False)
 class TestExecuteInMainThread(TestEngineBase):
     """
     Tests the execute_in_main_thread and async_execute_in_main_thread methods.
@@ -262,7 +262,7 @@ class TestExecuteInMainThread(TestEngineBase):
         )
         self._app.quit()
 
-    @skip_if_pyside_missing
+    @skip_if_pysideX(found=False)
     def test_exec_in_main_thread_deadlock(self):
         """
         Makes sure the main thread invoker doesn't deadlock when called from the main thread.
@@ -271,7 +271,7 @@ class TestExecuteInMainThread(TestEngineBase):
             self._assert_run_in_main_thread_and_quit
         )
 
-    @skip_if_pyside_missing
+    @skip_if_pysideX(found=False)
     def test_async_exec_in_main_thread_deadlock(self):
         """
         Makes sure the main thread async invoker doesn't deadlock when called from the main thread.
@@ -646,7 +646,7 @@ class TestCompatibility(TankTestBase):
         self.assertEqual(sgtk.platform.TankEngineInitError, sgtk.TankEngineInitError)
 
 
-@skip_if_pyside_missing
+@skip_if_pysideX(found=False)
 class TestShowDialog(TestEngineBase):
     """
     Tests the engine.show_dialog method.

--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -32,7 +32,7 @@ import tank
 import sgtk
 from sgtk.platform import engine
 from tank.errors import TankError
-import mock
+from unittest import mock
 
 
 class TestEngineBase(TankTestBase):

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -17,7 +17,7 @@ from __future__ import with_statement
 import functools
 import sys
 
-import mock
+from unittest import mock
 
 from sgtk.descriptor import Descriptor
 from sgtk.descriptor.io_descriptor.base import IODescriptorBase

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -49,7 +49,7 @@ __all__ = [
     "TankTestBase",
     "tank",
     "interactive",
-    "skip_if_pyside_missing",
+    "skip_if_pysideX",
     "skip_if_pyside2",
     "skip_if_pyside6",
 ]
@@ -124,36 +124,47 @@ def skip_if_git_missing(func):
     return unittest.skipIf(_is_git_missing(), "git is missing from PATH")(func)
 
 
-def _is_pyside_missing():
+def _has_pysideX():
     """
-    Tests is PySide is available.
-    :returns: True is PySide is available, False otherwise.
+    Tests if either PySide6 or PySide2 is avalable.
+    :returns: True if any is available, False otherwise.
     """
-
-    try:
-        # If PySide wasn't found, check for PySide2
-        import PySide2  # noqa
-
-        return False
-    except ImportError:
-        pass
 
     try:
         # Check for PySide6
         import PySide6  # noqa
 
-        return False
-    except ImportError:
         return True
+    except ImportError:
+        pass
 
+    try:
+        # If PySide wasn't found, check for PySide2
+        import PySide2  # noqa
 
-def skip_if_pyside_missing(func):
+        return True
+    except ImportError:
+        pass
+
+    return False
+
+def skip_if_pysideX(found=True):
     """
-    Decorator that allows to skip tests if no version of PySide is found.
+    Decorator that allows to skip tests based on if either PySide2 or PySide6
+    modules found or not.
     :param func: Function to be decorated.
+    :param found: True will skip if either PySide2 or PySide6 is found, else
+        will skip if PySide2 not found
+        (e.g. missing). Default to skip if found.
     :returns: The decorated function.
     """
-    return unittest.skipIf(_is_pyside_missing(), "PySide is missing")(func)
+
+    def _skip_if_pysideX(func):
+        found_pysideX = _has_pysideX()
+        msg = "PySideX found" if found else "PySideX missing"
+        return unittest.skipIf(found_pysideX == found, msg)(func)
+
+    return _skip_if_pysideX
 
 def _has_pyside2():
     """


### PR DESCRIPTION
Aligns the name and behaviour with `skip_if_pyside2` and `skip_if_pyside6`.