### PR TITLE
SG-38851 Skip the test_exec_in_main_thread test in Python 3.11 Linux

### DIFF
--- a/tests/platform_tests/test_engine.py
+++ b/tests/platform_tests/test_engine.py
@@ -20,6 +20,7 @@ import random
 import sys
 import threading
 import time
+import unittest
 from unittest import mock
 
 import sgtk
@@ -221,6 +222,13 @@ class TestExecuteInMainThread(TestEngineBase):
 
         tank.platform.start_engine("test_engine", self.tk, self.context)
 
+    @unittest.skipIf(
+        (
+            (sys.version_info.major, sys.version_info.minor) == (3, 11)
+            and sys.platform.startswith("linux")
+        ),
+        "Problem - SG-38851",
+    )
     def test_exec_in_main_thread(self):
         """
         Checks that execute in main thread actually executes in the main thread.


### PR DESCRIPTION
The `test_exec_in_main_thread` is very flaky. Especially on Python 3.11/Linux

```
tests/platform_tests/test_engine.py::TestExecuteInMainThread::test_exec_in_main_thread Fatal Python error: Segmentation fault
```

**Important**: this is a temporary workaround to make CI happy while we deal with this issue.

