### PR TITLE
SG-39039 Add deprecation warnings for Python <3.9

### DIFF
--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -29,6 +29,7 @@ __version__ = "HEAD"
 # configuration has its python sgtk/tank module imported directly, it will associate
 # itself with the primary config rather than with the config where the code is located.
 
+import inspect
 import os
 import sys
 import uuid


### PR DESCRIPTION
This pull request introduces deprecation warnings for using Python versions older than 3.9 and for using the `Engine.log_` methods which have been marked deprecated since 2016.

### Deprecation Warnings for Python Versions:
* Added a warning in `python/tank/__init__.py` for users running Python versions older than 3.9, notifying them of the end of support after 2026-01.



Related to shotgunsoftware/python-api#417

The first deprecation notice in tk-core was added in #1042.