### PR TITLE
Fix `test_default_configuration_location_without_suggestions`

### DIFF
--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -123,7 +123,9 @@ class TestSetupProjectWizard(TankTestBase):
         """
         self._wizard.set_project_disk_name(self.short_test_name)
         locations = self._wizard.get_default_configuration_location()
-        self.assertEqual(locations, {"win32": None, "darwin": None, "linux2": None})
+        self.assertTrue(self.short_test_name in locations["win32"])
+        self.assertTrue(self.short_test_name in locations["darwin"])
+        self.assertTrue(self.short_test_name in locations["linux2"])
 
     def test_default_configuration_location_with_existing_pipeline_configuration(self):
         """


### PR DESCRIPTION
This pull request modifies a test in `tests/commands_tests/test_project_wizard.py` to improve the validation of default configuration locations. Instead of asserting equality with static values, the test now dynamically checks that the `short_test_name` is included in the configuration locations.

This is now caused because https://github.com/shotgunsoftware/python-api/pull/217 was merged ([here](https://github.com/shotgunsoftware/python-api/pull/376)). The case-insensitive lookup was preventing loading a pipeline configuration on CI. Now it's loaded and the unit test is updated.