### PR TITLE
SG-39184: Add RV Video Output Device metrics

### DIFF
--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -657,6 +657,7 @@ class EventMetric(object):
         EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session Created"),
         EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session ID Copied from menu"),
         EVENT_NAME_FORMAT % (GROUP_RV, "Live Review - Session Joined"),
+        EVENT_NAME_FORMAT % (GROUP_RV, "Output Video Device Changed"),
         EVENT_NAME_FORMAT % (GROUP_TASKS, "Created Task"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Logged In"),
         EVENT_NAME_FORMAT % (GROUP_TOOLKIT, "Launched Action"),


### PR DESCRIPTION
SG-39184: Add RV Video Output Device metrics
JIRA: SG-39184

This commit adds the 'Output Video Device Changed' metrics event to the allow list so that we can get some statistics of video output devices used with RV such as Blackmagic, AJA, NDI, Desktop, etc.