### PR TITLE
SG-38266 Remove useless _is_running_in_desktop

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -69,19 +69,6 @@ USER_INPUT_DELAY_BEFORE_SITE_INFO_REQUEST = 300
 # request thread.
 THREAD_WAIT_TIMEOUT_MS = 5000
 
-
-def _is_running_in_desktop():
-    """
-    Indicate if we are in the context of the PTR desktop app.
-
-    When the PTR desktop app is used, we want to disregard the value returned
-    by the call to `get_shotgun_authenticator_support_web_login()` when the
-    target site is using Autodesk Identity.
-    """
-    executable_name = os.path.splitext(os.path.basename(sys.executable))[0].lower()
-    return executable_name in ["shotgun", "shotgrid"]
-
-
 class QuerySiteAndUpdateUITask(QtCore.QThread):
     """
     This class uses a different thread to query the site's information and find
@@ -493,8 +480,7 @@ class LoginDialog(QtGui.QDialog):
             if os.environ.get("SGTK_FORCE_STANDARD_LOGIN_DIALOG"):
                 logger.info("Using the standard login dialog with the Flow Production Tracking")
             else:
-                if _is_running_in_desktop():
-                    can_use_web = can_use_web or self.site_info.autodesk_identity_enabled
+                can_use_web = can_use_web or self.site_info.autodesk_identity_enabled
 
                 # If we have full support for Web-based login, or if we enable it in our
                 # environment, use the Unified Login Flow for all authentication modes.

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -518,10 +518,6 @@ class InteractiveTests(ShotgunTestBase):
         "tank.authentication.site_info._get_site_infos",
         return_value={},
     )
-    @mock.patch(
-        "tank.authentication.login_dialog._is_running_in_desktop",
-        return_value=True,
-    )
     def test_ui_error_management(self, *unused_mocks):
         # Empty of invalid site
         with self._login_dialog() as ld:
@@ -635,10 +631,6 @@ class InteractiveTests(ShotgunTestBase):
             self.assertEqual(ld.isVisible(), False)
 
     @suppress_generated_code_qt_warnings
-    @mock.patch(
-        "tank.authentication.login_dialog._is_running_in_desktop",
-        return_value=True,
-    )
     @mock.patch(
         "tank.authentication.web_login_support.get_shotgun_authenticator_support_web_login",
         return_value=True,
@@ -779,10 +771,6 @@ class InteractiveTests(ShotgunTestBase):
 
     @suppress_generated_code_qt_warnings
     @mock.patch(
-        "tank.authentication.login_dialog._is_running_in_desktop",
-        return_value=True,
-    )
-    @mock.patch(
         "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
         return_value=True,
     )
@@ -835,9 +823,6 @@ class InteractiveTests(ShotgunTestBase):
         with mock.patch(
             "tank.authentication.login_dialog.ASL_AuthTask.start"
         ), mock.patch(
-            "tank.authentication.login_dialog._is_running_in_desktop",
-            return_value=True,
-        ), mock.patch(
             "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
             return_value=False,
         ), mock.patch(
@@ -858,9 +843,6 @@ class InteractiveTests(ShotgunTestBase):
     def test_login_dialog_method_selected_default(self):
         with mock.patch(
             "tank.authentication.login_dialog.ASL_AuthTask.start"
-        ), mock.patch(
-            "tank.authentication.login_dialog._is_running_in_desktop",
-            return_value=True,
         ), mock.patch(
             "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
             return_value=True,
@@ -933,9 +915,6 @@ class InteractiveTests(ShotgunTestBase):
                     "SGTK_DEFAULT_AUTH_METHOD": "qt_web_login",
                 },
             ), mock.patch(
-                "tank.authentication.login_dialog._is_running_in_desktop",
-                return_value=False,
-            ), mock.patch(
                 "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
                 return_value=False,
             ), self._login_dialog(
@@ -966,9 +945,6 @@ class InteractiveTests(ShotgunTestBase):
         with mock.patch(
             "tank.authentication.login_dialog.ASL_AuthTask.start"
         ), mock.patch(
-            "tank.authentication.login_dialog._is_running_in_desktop",
-            return_value=True,
-        ), mock.patch(
             "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
             return_value=True,
         ), mock.patch(
@@ -995,9 +971,6 @@ class InteractiveTests(ShotgunTestBase):
 
             # qt_web_login but method is not available
             with mock.patch(
-                "tank.authentication.login_dialog._is_running_in_desktop",
-                return_value=False,
-            ), mock.patch(
                 "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
                 return_value=False,
             ), mock.patch(
@@ -1015,10 +988,6 @@ class InteractiveTests(ShotgunTestBase):
 
     @suppress_generated_code_qt_warnings
     @mock.patch("tank.authentication.login_dialog.ASL_AuthTask.start")
-    @mock.patch(
-        "tank.authentication.login_dialog._is_running_in_desktop",
-        return_value=True,
-    )
     @mock.patch(
         "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
         return_value=True,


### PR DESCRIPTION
This was introiduced by #811 and tweaked in
shotgunsoftware/tk-framework-desktopstartup#71 but I believe this is no longer useful since we now have an authentication UI selector