### PR TITLE
SG-36372 Remove `distutls` when possible

### DIFF
--- a/_core_upgrader.py
+++ b/_core_upgrader.py
@@ -25,7 +25,8 @@ import sys
 import stat
 import datetime
 import shutil
-from distutils.version import LooseVersion
+
+from packaging import version
 
 SG_LOCAL_STORAGE_OS_MAP = {
     "linux2": "linux_path",
@@ -105,7 +106,7 @@ def __current_version_less_than(log, sgtk_install_root, ver):
     if ver.startswith("v"):
         ver = ver[1:]
 
-    return LooseVersion(current_api_version) < LooseVersion(ver)
+    return version.parse(current_api_version) < version.parse(ver)
 
 
 ###################################################################################################

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -219,7 +219,7 @@ Http protocol syntax:
 
 .. note:: The latest version for a descriptor is determined by retrieving the list of tags for
     the repository and comparing the version numbers in order to determine the highest one.
-    For this comparison, :py:class:`~distutils.version.LooseVersion` is used and we recommend
+    For this comparison, :py:class:`~packaging.version.parse` is used and we recommend
     that version numbers follow the semantic versioning standard that can be found at http://semver.org.
 
 

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -219,7 +219,7 @@ Http protocol syntax:
 
 .. note:: The latest version for a descriptor is determined by retrieving the list of tags for
     the repository and comparing the version numbers in order to determine the highest one.
-    For this comparison, :py:class:`~packaging.version.parse` is used and we recommend
+    For this comparison, :py:class:`~distutils.version.LooseVersion` is used and we recommend
     that version numbers follow the semantic versioning standard that can be found at http://semver.org.
 
 

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -9,7 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from distutils.version import StrictVersion
+
+from packaging import version
 
 from .action_base import Action
 from . import core_localize
@@ -715,7 +716,7 @@ class SetupProjectWizard(object):
         sg_minor_ver = connection.server_info["version"][1]
         sg_patch_ver = connection.server_info["version"][2]
 
-        return StrictVersion("%d.%d.%d" % (sg_major_ver, sg_minor_ver, sg_patch_ver))
+        return version.parse(f"{sg_major_ver}.{sg_minor_ver}.{sg_patch_ver}")
 
     def _is_session_based_authentication_supported(self):
         """
@@ -727,7 +728,7 @@ class SetupProjectWizard(object):
         """
         # First version to support human based authentication for all operations was
         # 6.0.2.
-        if self._get_server_version(self._sg) >= StrictVersion("6.0.2"):
+        if self._get_server_version(self._sg) >= version.parse("6.0.2"):
             return True
         else:
             return False

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -18,6 +18,7 @@ else:
         from setuptools._distutils.version import LooseVersion
     except ModuleNotFoundError:
         # Known issue with VRED 16. Unable to load the setuptools module
+        # TODO: when DCCs bumps to Python 3.12, distutils will be removed. What to do then?
         from distutils.version import LooseVersion
 
 from . import sgre as re

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -30,7 +30,6 @@ from sgtk.descriptor import create_descriptor
 
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
-from distutils.version import LooseVersion
 
 
 class TestAppStoreLabels(ShotgunTestBase):

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -23,12 +23,8 @@ from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.util import sgre as re
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
-from tank.util import suppress_known_deprecation
 
-if sys.version_info[0:2] >= (3, 10):
-    from setuptools._distutils.version import LooseVersion
-else:
-    from distutils.version import LooseVersion
+from packaging import version
 
 
 class MockStore(object):
@@ -286,11 +282,9 @@ class TankMockStoreDescriptor(IODescriptorBase):
             self._type, self.get_system_name()
         )
         latest = "v0.0.0"
-        with suppress_known_deprecation():
-            # Supress `distutils Version classes are deprecated.` for Python 3.10
-            for version in versions:
-                if LooseVersion(version) > LooseVersion(latest):
-                    latest = version
+        for v in versions:
+            if version.parse(v) > version.parse(latest):
+                latest = v
 
         return self.create(latest)
 


### PR DESCRIPTION
- [x] Switch `distutils.version` to `packaging.version` on the code that depends on FPTR python binary
- [x] Switch `distutils.version` to `packaging.version` on the code that depends on unit tests.
- [ ] Update `sgtk.util.version` code that is executed by DCCs
- [ ] Update documentation `descriptor.rst` accordingly