### PR TITLE
SG-36372 Remove `distutils`

### DIFF
--- a/_core_upgrader.py
+++ b/_core_upgrader.py
@@ -25,7 +25,8 @@ import sys
 import stat
 import datetime
 import shutil
-from distutils.version import LooseVersion
+
+from packaging import version
 
 SG_LOCAL_STORAGE_OS_MAP = {
     "linux2": "linux_path",
@@ -105,7 +106,7 @@ def __current_version_less_than(log, sgtk_install_root, ver):
     if ver.startswith("v"):
         ver = ver[1:]
 
-    return LooseVersion(current_api_version) < LooseVersion(ver)
+    return version.parse(current_api_version) < version.parse(ver)
 
 
 ###################################################################################################

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -219,7 +219,8 @@ Http protocol syntax:
 
 .. note:: The latest version for a descriptor is determined by retrieving the list of tags for
     the repository and comparing the version numbers in order to determine the highest one.
-    For this comparison, :py:class:`~distutils.version.LooseVersion` is used and we recommend
+    For this comparison, :py:class:`~distutils.version.LooseVersion` or
+    :py:class:`~packaging.version` are used and we recommend
     that version numbers follow the semantic versioning standard that can be found at http://semver.org.
 
 

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -219,7 +219,7 @@ Http protocol syntax:
 
 .. note:: The latest version for a descriptor is determined by retrieving the list of tags for
     the repository and comparing the version numbers in order to determine the highest one.
-    For this comparison, :py:class:`~distutils.version.LooseVersion` is used and we recommend
+    For this comparison, :py:class:`~packaging.version.parse` is used and we recommend
     that version numbers follow the semantic versioning standard that can be found at http://semver.org.
 
 

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -219,7 +219,7 @@ Http protocol syntax:
 
 .. note:: The latest version for a descriptor is determined by retrieving the list of tags for
     the repository and comparing the version numbers in order to determine the highest one.
-    For this comparison, :py:class:`~packaging.version.parse` is used and we recommend
+    For this comparison, :py:class:`~distutils.version.LooseVersion` is used and we recommend
     that version numbers follow the semantic versioning standard that can be found at http://semver.org.
 
 

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -9,7 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from distutils.version import StrictVersion
+
+from packaging import version
 
 from .action_base import Action
 from . import core_localize
@@ -715,7 +716,7 @@ class SetupProjectWizard(object):
         sg_minor_ver = connection.server_info["version"][1]
         sg_patch_ver = connection.server_info["version"][2]
 
-        return StrictVersion("%d.%d.%d" % (sg_major_ver, sg_minor_ver, sg_patch_ver))
+        return version.parse(f"{sg_major_ver}.{sg_minor_ver}.{sg_patch_ver}")
 
     def _is_session_based_authentication_supported(self):
         """
@@ -727,7 +728,7 @@ class SetupProjectWizard(object):
         """
         # First version to support human based authentication for all operations was
         # 6.0.2.
-        if self._get_server_version(self._sg) >= StrictVersion("6.0.2"):
+        if self._get_server_version(self._sg) >= version.parse("6.0.2"):
             return True
         else:
             return False

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -18,6 +18,7 @@ else:
         from setuptools._distutils.version import LooseVersion
     except ModuleNotFoundError:
         # Known issue with VRED 16. Unable to load the setuptools module
+        # TODO: when DCCs bumps to Python 3.12, distutils will be removed. What to do then?
         from distutils.version import LooseVersion
 
 from . import sgre as re

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -11,15 +11,20 @@ import warnings
 import contextlib
 import sys
 
-if sys.version_info[0:2] < (3, 10):
+if sys.version_info[0:2] < (3, 12):
+    # DCCs with older versions of Python 3.12
     from distutils.version import LooseVersion
 else:
     try:
-        from setuptools._distutils.version import LooseVersion
+        # Try importing packaging.
+        LooseVersion = None
+        from packaging import version
     except ModuleNotFoundError:
-        # Known issue with VRED 16. Unable to load the setuptools module
-        # TODO: when DCCs bumps to Python 3.12, distutils will be removed. What to do then?
-        from distutils.version import LooseVersion
+        # Try importing from setuptools.
+        # If it fails, then we can't do much at the moment
+        # The DCC should have either setuptools or packaging installed.
+        from setuptools._distutils.version import LooseVersion
+
 
 from . import sgre as re
 from ..errors import TankError
@@ -178,68 +183,69 @@ def _compare_versions(a, b):
     if b.startswith("v"):
         b = b[1:]
 
-    # In Python 3, LooseVersion comparisons between versions where a non-numeric
-    # version component is compared to a numeric one fail.  We'll work around this
-    # as follows:
-    # First, try to use LooseVersion for comparison.  This should work in
-    # most cases.
-    try:
-        with suppress_known_deprecation():
-            # Supress `distutils Version classes are deprecated.` for Python 3.10
-            version_a = LooseVersion(a).version
-            version_b = LooseVersion(b).version
+    if LooseVersion:
+        # In Python 3, LooseVersion comparisons between versions where a non-numeric
+        # version component is compared to a numeric one fail.  We'll work around this
+        # as follows:
+        # First, try to use LooseVersion for comparison.  This should work in
+        # most cases.
+        try:
+            with suppress_known_deprecation():
+                # Supress `distutils Version classes are deprecated.` for Python 3.10
+                version_a = LooseVersion(a).version
+                version_b = LooseVersion(b).version
 
-            version_num_a = []
-            version_num_b = []
-            # taking only the integers of the version to make comparison
-            for version in version_a:
-                if isinstance(version, (int)):
-                    version_num_a.append(version)
-                elif version == "-":
-                    break
-            for version in version_b:
-                if isinstance(version, (int)):
-                    version_num_b.append(version)
-                elif version == "-":
-                    break
+                version_num_a = []
+                version_num_b = []
+                # taking only the integers of the version to make comparison
+                for version in version_a:
+                    if isinstance(version, (int)):
+                        version_num_a.append(version)
+                    elif version == "-":
+                        break
+                for version in version_b:
+                    if isinstance(version, (int)):
+                        version_num_b.append(version)
+                    elif version == "-":
+                        break
 
-            # Comparing equal number versions with with one of them with '-' appended, if a version
-            # has '-' appended it's older than the same version with '-' at the end
-            if version_num_a == version_num_b:
-                if "-" in a and "-" not in b:
-                    return False  # False, version a is older than b
-                elif "-" in b and "-" not in a:
-                    return True  # True, version a is older than b
+                # Comparing equal number versions with with one of them with '-' appended, if a version
+                # has '-' appended it's older than the same version with '-' at the end
+                if version_num_a == version_num_b:
+                    if "-" in a and "-" not in b:
+                        return False  # False, version a is older than b
+                    elif "-" in b and "-" not in a:
+                        return True  # True, version a is older than b
+                    else:
+                        return LooseVersion(a) > LooseVersion(
+                            b
+                        )  # If both has '-' compare '-rcx' versions
                 else:
                     return LooseVersion(a) > LooseVersion(
                         b
-                    )  # If both has '-' compare '-rcx' versions
-            else:
-                return LooseVersion(a) > LooseVersion(
-                    b
-                )  # If they are different numeric versions
-    except TypeError:
-        # To mimick the behavior in Python 2.7 as closely as possible, we will
-        # If LooseVersion comparison didn't work, try to extract a numeric
-        # version from both versions for comparison
-        version_expr = re.compile(r"^((?:\d+)(?:\.\d+)*)(.+)$")
-        match_a = version_expr.match(a)
-        match_b = version_expr.match(b)
-        if match_a and match_b:
-            # If we could get two numeric versions, generate LooseVersions for
-            # them.
-            ver_a = LooseVersion(match_a.group(1))
-            ver_b = LooseVersion(match_b.group(1))
-            if ver_a != ver_b:
-                # If they're not identical, return based on this comparison
-                return ver_a > ver_b
-            else:
-                # If the numeric versions do match, do a string comparsion for
-                # the rest.
-                return match_a.group(2) > match_b.group(2)
-        elif match_a or match_b:
-            # If only one had a numeric version, treat that as the newer version.
-            return bool(match_a)
+                    )  # If they are different numeric versions
+        except TypeError:
+            # To mimick the behavior in Python 2.7 as closely as possible, we will
+            # If LooseVersion comparison didn't work, try to extract a numeric
+            # version from both versions for comparison
+            version_expr = re.compile(r"^((?:\d+)(?:\.\d+)*)(.+)$")
+            match_a = version_expr.match(a)
+            match_b = version_expr.match(b)
+            if match_a and match_b:
+                # If we could get two numeric versions, generate LooseVersions for
+                # them.
+                ver_a = LooseVersion(match_a.group(1))
+                ver_b = LooseVersion(match_b.group(1))
+                if ver_a != ver_b:
+                    # If they're not identical, return based on this comparison
+                    return ver_a > ver_b
+                else:
+                    # If the numeric versions do match, do a string comparsion for
+                    # the rest.
+                    return match_a.group(2) > match_b.group(2)
+            elif match_a or match_b:
+                # If only one had a numeric version, treat that as the newer version.
+                return bool(match_a)
 
     # In the case that both versions are non-numeric, do a string comparison.
     return a > b

--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -18,7 +18,7 @@ else:
     try:
         # Try importing packaging.
         LooseVersion = None
-        from packaging import version
+        import packaging.version
     except ModuleNotFoundError:
         # Try importing from setuptools.
         # If it fails, then we can't do much at the moment
@@ -246,6 +246,15 @@ def _compare_versions(a, b):
             elif match_a or match_b:
                 # If only one had a numeric version, treat that as the newer version.
                 return bool(match_a)
+
+    else:
+        # We're using packaging.version
+        try:
+            version_a = packaging.version.parse(a)
+            version_b = packaging.version.parse(b)
+            return version_a > version_b
+        except version.InvalidVersion:
+            pass
 
     # In the case that both versions are non-numeric, do a string comparison.
     return a > b

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -30,7 +30,6 @@ from sgtk.descriptor import create_descriptor
 
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
-from distutils.version import LooseVersion
 
 
 class TestAppStoreLabels(ShotgunTestBase):

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -23,12 +23,8 @@ from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.util import sgre as re
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
-from tank.util import suppress_known_deprecation
 
-if sys.version_info[0:2] >= (3, 10):
-    from setuptools._distutils.version import LooseVersion
-else:
-    from distutils.version import LooseVersion
+from packaging import version
 
 
 class MockStore(object):
@@ -286,11 +282,9 @@ class TankMockStoreDescriptor(IODescriptorBase):
             self._type, self.get_system_name()
         )
         latest = "v0.0.0"
-        with suppress_known_deprecation():
-            # Supress `distutils Version classes are deprecated.` for Python 3.10
-            for version in versions:
-                if LooseVersion(version) > LooseVersion(latest):
-                    latest = version
+        for v in versions:
+            if version.parse(v) > version.parse(latest):
+                latest = v
 
         return self.create(latest)
 


### PR DESCRIPTION
- [x] Switch `distutils.version` to `packaging.version` on the code that depends on FPTR python binary
- [x] Switch `distutils.version` to `packaging.version` on the code that depends on unit tests.
- [x] Update `sgtk.util.version` code that is executed by DCCs
- [x] Update documentation `descriptor.rst` accordingly

Related to #920