### PR TITLE
SG-38307 Re-add `from . import json` in util/__init__.py to fix browser integration errors

### DIFF
--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -42,6 +42,7 @@ from .shotgun_path import ShotgunPath
 
 from . import filesystem
 from . import pickle
+from . import json
 
 from .local_file_storage import LocalFileStorageManager
 

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -29,9 +29,11 @@ import hashlib
 import json
 import os
 
-from . import metrics
-
 from .. import LogManager
+# TODO: legacy json import, to be removed at a later date, it is necessary for
+# integration with the web side of shotgun.
+from . import json as json_legacy
+from . import metrics
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -30,6 +30,7 @@ import json
 import os
 
 from .. import LogManager
+
 # TODO: legacy json import, to be removed at a later date, it is necessary for
 # integration with the web side of shotgun.
 from . import json as json_legacy

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -30,10 +30,6 @@ import json
 import os
 
 from .. import LogManager
-
-# TODO: legacy json import, to be removed at a later date, it is necessary for
-# integration with the web side of shotgun.
-from . import json as json_legacy
 from . import metrics
 
 logger = LogManager.get_logger(__name__)

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -29,8 +29,9 @@ import hashlib
 import json
 import os
 
-from .. import LogManager
 from . import metrics
+
+from .. import LogManager
 
 logger = LogManager.get_logger(__name__)
 


### PR DESCRIPTION
### **Description**

This PR restores the `from . import json` statement in `python/tank/util/__init__.py`.

Although the import does not seem to be used directly, its removal caused issues with the browser integration layer. Adding it back resolves the problem.

This regression was introduced by #1030


### **Test**
<img width="1056" height="829" alt="image" src="https://github.com/user-attachments/assets/08eeb3b8-3dad-4e1a-91a2-e535ceacd68f" />

