### PR TITLE
SG-40015 Restore SsoSaml2Core import to fix FPTR integration launch failure in Nuke

### DIFF
--- a/python/tank/authentication/sso_saml2/core/__init__.py
+++ b/python/tank/authentication/sso_saml2/core/__init__.py
@@ -10,3 +10,5 @@
 """
 This module contains files which are shared between RV and Toolkit.
 """
+
+from .sso_saml2_core import SsoSaml2Core # noqa

--- a/python/tank/authentication/sso_saml2/core/__init__.py
+++ b/python/tank/authentication/sso_saml2/core/__init__.py
@@ -11,4 +11,4 @@
 This module contains files which are shared between RV and Toolkit.
 """
 
-# from .sso_saml2_core import SsoSaml2Core # noqa
+from .sso_saml2_core import SsoSaml2Core # noqa

--- a/python/tank/authentication/sso_saml2/core/__init__.py
+++ b/python/tank/authentication/sso_saml2/core/__init__.py
@@ -11,4 +11,4 @@
 This module contains files which are shared between RV and Toolkit.
 """
 
-from .sso_saml2_core import SsoSaml2Core # noqa
+# from .sso_saml2_core import SsoSaml2Core # noqa

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -34,7 +34,8 @@ class SsoSaml2(object):
 
         :param window_title: Title to use for the window.
         :param qt_modules:   a dictionnary of required Qt modules.
-                             For Qt4/PySide, we require modules QtCore, QtGui, QtNetwork and QtWebKit
+                             For Qt5/PySide2, we require modules QtCore, QtGui,
+                             QtNetwork and QtWebEngineWidgets
 
         :returns: The SsoSaml2 oject.
         """

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -16,7 +16,7 @@ Integration with Shotgun API.
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-import
 
-from .core.sso_saml2_core import SsoSaml2Core  # noqa
+from .core import SsoSaml2Core  # noqa
 
 from .core.utils import (  # noqa
     set_logger_parent,
@@ -34,8 +34,7 @@ class SsoSaml2(object):
 
         :param window_title: Title to use for the window.
         :param qt_modules:   a dictionnary of required Qt modules.
-                             For Qt5/PySide2, we require modules QtCore, QtGui,
-                             QtNetwork and QtWebEngineWidgets
+                             For Qt4/PySide, we require modules QtCore, QtGui, QtNetwork and QtWebKit
 
         :returns: The SsoSaml2 oject.
         """

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -16,8 +16,7 @@ Integration with Shotgun API.
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-import
 
-# from .core import SsoSaml2Core  # noqa
-from .core.sso_saml2_core import SsoSaml2Core
+from .core import SsoSaml2Core  # noqa
 
 from .core.utils import (  # noqa
     set_logger_parent,

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -16,7 +16,8 @@ Integration with Shotgun API.
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-import
 
-from .core import SsoSaml2Core  # noqa
+# from .core import SsoSaml2Core  # noqa
+from .core.sso_saml2_core import SsoSaml2Core
 
 from .core.utils import (  # noqa
     set_logger_parent,


### PR DESCRIPTION
### **Description**

Launching Nuke was failing to start the FPTR integration because tk-nuke relies on [sgtk.authentication.sso_saml2.core.sso_saml2_core.SsoSaml2Core](https://github.com/shotgunsoftware/tk-nuke/blob/68b5152e8e08705a6d2cfa734634621c45b9bc2c/engine.py#L396) being available without an explicit import.

A recent [change ](https://github.com/shotgunsoftware/tk-core/pull/1022/commits/adff10f88c0e5b47fbabb32d97eaa92a6e720a34)in tk-core removed the from .sso_saml2_core import SsoSaml2Core line from authentication/sso_saml2/core/__init__.py, which broke this implicit access.

This PR restores the import in core/__init__.py to maintain backward compatibility and allow the FPTR integration to launch successfully in Nuke.

### **Test**
<img width="1889" height="1042" alt="image" src="https://github.com/user-attachments/assets/a5fc3afd-5b32-4c69-adaa-d7ffebec2330" />
