### PR TITLE
[SG-40146] FIx an issue where the package version was wrong when installing using a package manager

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,11 @@ def get_version():
     # (e.g. pip install ./tk-core), the version number
     # will be picked up from the most recently added tag.
     try:
+        # need to use the command line as a string and not a list, as the quotes/double quotes use in the match pattern
+        # is raising an error otherwise
+        cmd = ["git", "describe", "--tags", '--match="v[0-9]*.[0-9]*.[0-9]*"']
         version_git = subprocess.check_output(
-            ["git", "describe", "--abbrev=0"], universal_newlines=True
+            " ".join(cmd), universal_newlines=True, shell=True
         ).rstrip()
         return version_git
     except:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@
 
 # Basic setup.py so tk-core could be installed as
 # a standard Python package
+import re
 from setuptools import setup, find_packages
 import subprocess
 
@@ -30,13 +31,12 @@ def get_version():
     # (e.g. pip install ./tk-core), the version number
     # will be picked up from the most recently added tag.
     try:
-        # need to use the command line as a string and not a list, as the quotes/double quotes use in the match pattern
-        # is raising an error otherwise
-        cmd = ["git", "describe", "--tags", '--match="v[0-9]*.[0-9]*.[0-9]*"']
         version_git = subprocess.check_output(
-            " ".join(cmd), universal_newlines=True, shell=True
+            ["git", "describe", "--tags", "--abbrev=0"], universal_newlines=True
         ).rstrip()
-        return version_git
+        if re.match(r"v[0-9]*.[0-9]*.[0-9]*", version_git):
+            return version_git
+        return "dev"
     except:
         # Blindly ignore problems, git might be not available, or the user could
         # be installing from zip archive, etc...


### PR DESCRIPTION
Because of the change in the release process, the code used to fetch the version from Github was not working anymore.
With the code change, we're looking at all the git tags and not only the annotated tags to get the latest tag and get the version from it. 
Adding a glob match pattern as well to make sure we're not going to fetch the "non-released" tags