### PR TITLE
SG-36372 Remove excessive logging

### DIFF
--- a/python/tank/util/version.py
+++ b/python/tank/util/version.py
@@ -163,15 +163,14 @@ def version_parse(version_string):
         try:
             return packaging.version.parse(version_string)
         except packaging.version.InvalidVersion:
-            logger.warning(
-                f"Cannot parse version '{version_string}' using packaging.version."
-            )
+            # Version cannot be parsed with packaging.version (SG-40480)
+            pass
 
     if LooseVersion:
         with suppress_known_deprecation():
             return LooseVersion(version_string)
 
-    logger.warning("Either packaging or distutils module is not available.")
+    # Fallback to string comparison
     return version_string
 
 


### PR DESCRIPTION
We're logging an excessive amount of cases when the launchapp component starts to register the scanned software.

We need to plan some work in the future to fix this at the engine level on SG-40480.

Introduced by #1045