### PR TITLE
SG-40476 Restore linux2 for Advanced Project Setup wizard

### DIFF
--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -347,6 +347,8 @@ class SetupProjectWizard(object):
             return_data[s]["linux"] = self._params.preview_project_path(
                 s, project_disk_name, "linux"
             )
+            # Compat with tk-framework-adminui prior to TODO
+            return_data[s]["linux2"] = return_data[s]["linux"]
 
         return return_data
 
@@ -501,6 +503,9 @@ class SetupProjectWizard(object):
                 suggested_defaults["win32"] = data["windows_path"].replace(
                     old_project_disk_name_win, new_proj_disk_name_win
                 )
+
+        # Compat with tk-framework-adminui prior to TODO
+        suggested_defaults["linux2"] = suggested_defaults["linux"]
 
         return suggested_defaults
 

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -624,7 +624,7 @@ class TemplatePath(Template):
 
             platform_root_path = self._per_platform_roots.get(platform)
 
-            if platform == "linux2" and not platform in self._per_platform_roots:
+            if platform == "linux2" and platform not in self._per_platform_roots:
                 # Compat with tk-nuke prior to TODO
                 platform = "linux"
 

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -624,6 +624,10 @@ class TemplatePath(Template):
 
             platform_root_path = self._per_platform_roots.get(platform)
 
+            if platform == "linux2" and not platform in self._per_platform_roots:
+                # Compat with tk-nuke prior to TODO
+                platform = "linux"
+
             if platform_root_path is None:
                 # either the platform is undefined or unknown
                 raise TankError(

--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -103,12 +103,18 @@ class TestSetupProjectWizard(TankTestBase):
         """
         Ensure all project paths get returned properly.
         """
+
+        expected_paths = self._storage_locations.join(
+            self.short_test_name
+        ).as_system_dict()
+
+        # TODO remove ....
+        expected_paths["linux2"] = expected_paths["linux"]
+
         self.assertEqual(
             self._wizard.preview_project_paths(self.short_test_name),
             {
-                "primary": self._storage_locations.join(
-                    self.short_test_name
-                ).as_system_dict()
+                "primary": expected_paths,
             },
         )
 

--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -157,6 +157,7 @@ class TestSetupProjectWizard(TankTestBase):
             {
                 "darwin": "/Volumes/configs/{0}".format(self.short_test_name),
                 "linux": "/mnt/configs/{0}".format(self.short_test_name),
+                "linux2": "/mnt/configs/{0}".format(self.short_test_name), # TODO remove that when drop retro-compat with TODO
                 "win32": "Z:\\configs\\{0}".format(self.short_test_name),
             },
         )


### PR DESCRIPTION
This PR fixes a regression introduced by #1037 where _Advanced Project Setup Wizard_ (fw-adminui) does not show the Linux path anymore.

In parallel, shotgunsoftware/tk-framework-adminui#53 fixes the other side of the retro-compatibility issue: New adminui with current core version.




