### PR TITLE
SG-43219 Fix sys.modules order during loading 

### DIFF
--- a/python/tank/util/loader.py
+++ b/python/tank/util/loader.py
@@ -57,8 +57,8 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
     try:
         plugin_spec = importlib.util.spec_from_file_location(module_uid, plugin_file)
         module = importlib.util.module_from_spec(plugin_spec)
-        plugin_spec.loader.exec_module(module)
         sys.modules[module.__name__] = module
+        plugin_spec.loader.exec_module(module)
     except Exception:
         # log the full callstack to make sure that whatever the
         # calling code is doing, this error is logged to help

--- a/tests/fixtures/config/hooks/dataclass_hook.py
+++ b/tests/fixtures/config/hooks/dataclass_hook.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Autodesk.
 """Case where we check defining a Python dataclass won't fail during hook loading.
 
-The dataclasses module check the `.sys.modules` for the ``Data`` class's ``__module__``
+The dataclasses module checks the `.sys.modules` for the ``Data`` class's ``__module__``
 during type checking, so it should exist in there and not fatally error when loading
 this hook.
 

--- a/tests/fixtures/config/hooks/dataclass_hook.py
+++ b/tests/fixtures/config/hooks/dataclass_hook.py
@@ -38,12 +38,12 @@ class Data:
 
 
 class TestHook(sgtk.get_hook_baseclass()):
-    def execute(self, dummy_param):
+    def execute(self):
         return Data("foo", 123)
 
-    def second_method(self, another_dummy_param):
+    def second_method(self):
         return Data(
             None,
             -3.1419,
-            error=sgtk.authentication.AuthenticationCancelled("Cancelled"),
+            error=sgtk.authentication.AuthenticationCancelled(),
         )

--- a/tests/fixtures/config/hooks/dataclass_hook.py
+++ b/tests/fixtures/config/hooks/dataclass_hook.py
@@ -16,3 +16,34 @@ this hook.
 This is a regression test for https://github.com/shotgunsoftware/tk-core/pull/1047
 (https://github.com/shotgunsoftware/tk-core/commit/eaaadceafa4b449f819cf9c1b05cba229daaeeab)
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import sgtk
+
+
+@dataclass(frozen=True)
+class Data:
+    name: str | None
+    number: int | float
+    error: (
+        sgtk.authentication.AuthenticationError
+        | sgtk.authentication.IncompleteCredentials
+        | sgtk.authentication.AuthenticationCancelled
+        | sgtk.authentication.ConsoleLoginNotSupportedError
+        | None
+    ) = None
+
+
+class TestHook(sgtk.get_hook_baseclass()):
+    def execute(self, dummy_param):
+        return Data("foo", 123)
+
+    def second_method(self, another_dummy_param):
+        return Data(
+            None,
+            -3.1419,
+            error=sgtk.authentication.AuthenticationCancelled("Cancelled"),
+        )

--- a/tests/fixtures/config/hooks/dataclass_hook.py
+++ b/tests/fixtures/config/hooks/dataclass_hook.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+"""Case where we check defining a Python dataclass won't fail during hook loading.
+
+The dataclasses module check the `.sys.modules` for the ``Data`` class's ``__module__``
+during type checking, so it should exist in there and not fatally error when loading
+this hook.
+
+This is a regression test for https://github.com/shotgunsoftware/tk-core/pull/1047
+(https://github.com/shotgunsoftware/tk-core/commit/eaaadceafa4b449f819cf9c1b05cba229daaeeab)
+"""

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -280,13 +280,11 @@ class TestDataclassHook(TestApplication):
 
     def test_execute(self):
         app = self.engine.apps["test_app"]
-        app.execute_hook_by_name("dataclass_hook", dummy_param=True)
+        app.execute_hook_by_name("dataclass_hook")
 
     def test_legacy_format(self):
         app = self.engine.apps["test_app"]
-        app.execute_hook_expression(
-            "dataclass_hook", "second_method", another_dummy_param=True
-        )
+        app.execute_hook_expression("dataclass_hook", "second_method")
 
 
 class TestExecuteHookByName(TestApplication):

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -273,6 +273,22 @@ class TestGetSetting(TestApplication):
         )
 
 
+class TestDataclassHook(TestApplication):
+    """
+    Test loading, executing and calling ``dataclass_hook``.
+    """
+
+    def test_execute(self):
+        app = self.engine.apps["test_app"]
+        app.execute_hook_by_name("dataclass_hook", dummy_param=True)
+
+    def test_legacy_format(self):
+        app = self.engine.apps["test_app"]
+        app.execute_hook_expression(
+            "dataclass_hook", "second_method", another_dummy_param=True
+        )
+
+
 class TestExecuteHookByName(TestApplication):
     """
     Tests execute_hook_by_name


### PR DESCRIPTION
Found in [tk-core v0.23.8](https://github.com/shotgunsoftware/tk-core/releases/tag/v0.23.8)

When a `hook.py` defines a [dataclasses.dataclass](https://docs.python.org/3.11/library/dataclasses.html) , we run into this error:

```python
Traceback (most recent call last):
  File "/home/an_artist/.shotgun/our_org/p353c3334.basic.desktop/cfg/install/core/python/tank/util/loader.py", line 60, in load_plugin
    plugin_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/an_artist/.shotgun/bundle_cache/sg/our_org.shotgrid.autodesk.com/v366522/hooks/tk-multi-publish2/hook.py", line 142, in <module>
    class Data:
  File "/opt/Shotgun/Python3/lib/python3.10/dataclasses.py", line 1175, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
  File "/opt/Shotgun/Python3/lib/python3.10/dataclasses.py", line 944, in _process_class
    and _is_type(type, cls, dataclasses, dataclasses.KW_ONLY,
  File "/opt/Shotgun/Python3/lib/python3.10/dataclasses.py", line 711, in _is_type
    ns = sys.modules.get(cls.__module__).__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

- [x] Create test case and see if CI can replicate same error
  - Example: [Failed Linux Python 3.9](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/results?buildId=19601&view=logs&j=0a22f5d8-9f3e-5735-4672-5a55fb1a2abf&t=54eda56b-1edb-5323-7e77-015b18825273) ([raw](https://dev.azure.com/shotgun-ecosystem/1e9dee7c-030c-4741-a34e-1400feede440/_apis/build/builds/19601/logs/129))
- [x] Adjust ordering of https://github.com/shotgunsoftware/tk-core/blob/v0.23.8/python/tank/util/loader.py#L58-L61
  so it's more in-line with examples given at https://docs.python.org/3.11/library/importlib.html#examples
- [x] See if that fixes the test case