### PR TITLE
SG-33297 Fix race condition on the login UX

### DIFF
--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -315,6 +315,16 @@ class LoginDialog(QtGui.QDialog):
                 % self._get_current_site()
             )
 
+        # QThread.finished is delivered through the Qt event queue and requires
+        # the event loop to be running. Since we are still in the constructor,
+        # the _toggle_web slot has not been called yet even though wait()
+        # returned and the thread is done. Call it directly here so the dialog
+        # opens with the correct UI (e.g. Identity/SSO sites must not flash the
+        # 3-fields credentials form before switching to the web-login view).
+        # The guard inside _toggle_web makes the subsequent signal delivery a
+        # no-op, so this is safe.
+        self._toggle_web()
+
         # Initialize exit confirm message box
         self.confirm_box = QtGui.QMessageBox(
             QtGui.QMessageBox.Question,

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -692,8 +692,8 @@ class InteractiveTests(ShotgunTestBase):
                 self.assertEqual(ld.method_selected, auth_constants.METHOD_WEB_LOGIN)
 
                 # login/password fields must be hidden
-                self.assertFalse(ld.ui.login.isVisible())
-                self.assertFalse(ld.ui.password.isVisible())
+                self.assertTrue(ld.ui.login.isHidden())
+                self.assertTrue(ld.ui.password.isHidden())
             finally:
                 ld._confirm_exit = lambda: True
                 ld.close()

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -638,6 +638,72 @@ class InteractiveTests(ShotgunTestBase):
         return_value=True,
     )
     @mock.patch(
+        "tank.authentication.login_dialog.get_shotgun_authenticator_support_web_login",
+        return_value=True,
+    )
+    @mock.patch(
+        "tank.authentication.session_cache.get_preferred_method",
+        return_value=None,
+    )
+    def test_initial_ui_not_basic_for_identity_site(self, *unused_mocks):
+        """
+        Regression test for the race condition where the dialog opened showing
+        the 3-fields (credentials) UI even for Identity/SSO-enabled sites.
+
+        The root cause was that _toggle_web() was only connected to the
+        QThread.finished signal, which is delivered through the Qt event queue.
+        Before the event loop ran (i.e. before show()/exec_()), the signal was
+        never dispatched, so the dialog opened with the default METHOD_BASIC.
+
+        The fix is to call _toggle_web() directly after wait() in __init__,
+        ensuring the correct UI is set synchronously before the dialog appears.
+
+        This test verifies method_selected *before* processEvents() is called
+        (simulating the window not yet having been shown) to prove the fix
+        works without relying on event-loop delivery.
+        """
+        from tank.authentication import login_dialog
+
+        identity_site_infos = {
+            "user_authentication_method": "oxygen",
+            "unified_login_flow_enabled": True,
+        }
+
+        with mock.patch(
+            "tank.authentication.site_info._get_site_infos",
+            return_value=identity_site_infos,
+        ), mock.patch("tank.authentication.login_dialog.SsoSaml2Toolkit"):
+            ld = login_dialog.LoginDialog(
+                is_session_renewal=True,
+                hostname="https://identity.shotgunstudio.com",
+            )
+            try:
+                # Check method_selected *before* any processEvents() call.
+                # Without the fix, this would be METHOD_BASIC because the
+                # QThread.finished signal had not yet been dispatched.
+                self.assertNotEqual(
+                    ld.method_selected,
+                    auth_constants.METHOD_BASIC,
+                    "Dialog opened with credentials (3-fields) UI for an Identity-"
+                    "enabled site before the event loop ran. This is the race "
+                    "condition that was fixed by calling _toggle_web() synchronously "
+                    "after wait() in the constructor.",
+                )
+                self.assertEqual(ld.method_selected, auth_constants.METHOD_WEB_LOGIN)
+
+                # login/password fields must be hidden
+                self.assertFalse(ld.ui.login.isVisible())
+                self.assertFalse(ld.ui.password.isVisible())
+            finally:
+                ld._confirm_exit = lambda: True
+                ld.close()
+
+    @suppress_generated_code_qt_warnings
+    @mock.patch(
+        "tank.authentication.login_dialog._is_running_in_desktop",
+        return_value=True,
+    )
+    @mock.patch(
         "tank.authentication.web_login_support.get_shotgun_authenticator_support_web_login",
         return_value=True,
     )


### PR DESCRIPTION
## Summary

Fix a race condition in `LoginDialog` that caused the 3-fields credentials UI (host / login / password) to appear briefly — or permanently on slow / Windows systems — even when the target site uses Autodesk Identity or SSO.

## Root Cause

`_toggle_web()` was wired exclusively to the `QThread.finished` signal of the background site-info query task. Qt cross-thread signals are delivered through the **event queue**: the slot only runs once the event loop is spinning.

Because the constructor calls `wait()` to block until the thread finishes, then returns before the event loop has started, the `finished` signal sits undelivered in the queue. The dialog opens with the hard-coded default `METHOD_BASIC` (3-fields form). Only after `exec_()` / `show()` kick the event loop does `_toggle_web` fire and correct the UI — far too late, and unreliable under timing pressure (Windows scheduler, cold cache, slow network).


## Fix

`python/tank/authentication/login_dialog.py`

Call `_toggle_web()` **synchronously** immediately after `wait()` returns, while still in the constructor. The site-info data is already populated at that point, so the dialog opens with the right UI state (web-login / ASL) before any pixels are painted.

## Test

The test constructs a LoginDialog for an oxygen (Autodesk Identity) site and asserts method_selected != METHOD_BASIC before any processEvents() call, directly reproducing the pre-fix failure window:

```python
ld = login_dialog.LoginDialog(
    is_session_renewal=True,
    hostname="https://identity.shotgunstudio.com",
)
# No processEvents() — simulates the dialog not yet having been shown.
self.assertNotEqual(ld.method_selected, auth_constants.METHOD_BASIC)
self.assertEqual(ld.method_selected, auth_constants.METHOD_WEB_LOGIN)
self.assertFalse(ld.ui.login.isVisible())
self.assertFalse(ld.ui.password.isVisible())
```

Without the fix this test fails (value is `METHOD_BASIC`); with the fix it passes deterministically regardless of Qt event-loop timing.

## Notes
- The `QThread.finished → _toggle_web` signal connection is preserved for subsequent URL changes typed into the site field during an active session; only the initial synchronous call is new.
- `SGTK_FORCE_STANDARD_LOGIN_DIALOG` and all other existing overrides continue to work unchanged — the guard in _toggle_web handles them.
- This bug was more visible on Windows and after cache purges because both increase the gap between `wait()` returning and the first event-loop tick.