### PR TITLE
SG-42277 Fix get_currently_running_api_version() under pip install

### DIFF
--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -13,6 +13,7 @@ Encapsulates the pipeline configuration and helps navigate and resolve paths
 across storages, configurations etc.
 """
 
+import importlib.metadata
 import os
 
 from tank_vendor import yaml
@@ -440,17 +441,15 @@ def get_currently_running_api_version():
         os.path.join(os.path.dirname(__file__), "..", "..", "info.yml")
     )
     version = _get_version_from_manifest(info_yml_path)
-    if version == "unknown":
-        # In a pip install the flat site-packages layout has no info.yml.
-        # Fall back to the installed distribution metadata; PEP 440 strips the
-        # leading 'v', so re-add it to match the info.yml convention.
-        try:
-            from importlib.metadata import version as _dist_version
-
-            version = "v" + _dist_version("sgtk")
-        except Exception:
-            pass
-    return version
+    if version is not None:
+        return version
+    # In a pip install the flat site-packages layout has no info.yml.
+    # Fall back to the installed distribution metadata; PEP 440 strips the
+    # leading 'v', so re-add it to match the info.yml convention.
+    try:
+        return "v" + importlib.metadata.version("sgtk")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def get_core_api_version(core_install_root):
@@ -466,7 +465,8 @@ def get_core_api_version(core_install_root):
     """
     # now try to get to the info.yml file to get the version number
     info_yml_path = os.path.join(core_install_root, "install", "core", "info.yml")
-    return _get_version_from_manifest(info_yml_path)
+    version = _get_version_from_manifest(info_yml_path)
+    return "unknown" if version is None else version
 
 
 def _get_version_from_manifest(info_yml_path):
@@ -475,15 +475,14 @@ def _get_version_from_manifest(info_yml_path):
     Returns the version given a manifest.
 
     :param info_yml_path: path to manifest file.
-    :returns: Always a string, 'unknown' if data cannot be found
+    :returns: Version string, or None if data cannot be found.
     """
     try:
         data = yaml_cache.g_yaml_cache.get(info_yml_path, deepcopy_data=False) or {}
-        data = str(data.get("version", "unknown"))
+        version = data.get("version")
+        return str(version) if version is not None else None
     except Exception:
-        data = "unknown"
-
-    return data
+        return None
 
 
 def _get_core_descriptor_file(pipeline_config_path):

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -466,7 +466,18 @@ def get_core_api_version(core_install_root):
     # now try to get to the info.yml file to get the version number
     info_yml_path = os.path.join(core_install_root, "install", "core", "info.yml")
     version = _get_version_from_manifest(info_yml_path)
-    return "unknown" if version is None else version
+    if version is not None:
+        return version
+    # In a pip install the flat site-packages layout has no install/core/info.yml.
+    # If the requested core is the currently-running one, defer to
+    # get_currently_running_api_version which falls back to distribution metadata.
+    try:
+        current_core_root = get_path_to_current_core()
+    except TankError:
+        return "unknown"
+    if os.path.realpath(core_install_root) == os.path.realpath(current_core_root):
+        return get_currently_running_api_version()
+    return "unknown"
 
 
 def _get_version_from_manifest(info_yml_path):

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -446,6 +446,7 @@ def get_currently_running_api_version():
         # leading 'v', so re-add it to match the info.yml convention.
         try:
             from importlib.metadata import version as _dist_version
+
             version = "v" + _dist_version("sgtk")
         except Exception:
             pass

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -439,7 +439,17 @@ def get_currently_running_api_version():
     info_yml_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "..", "info.yml")
     )
-    return _get_version_from_manifest(info_yml_path)
+    version = _get_version_from_manifest(info_yml_path)
+    if version == "unknown":
+        # In a pip install the flat site-packages layout has no info.yml.
+        # Fall back to the installed distribution metadata; PEP 440 strips the
+        # leading 'v', so re-add it to match the info.yml convention.
+        try:
+            from importlib.metadata import version as _dist_version
+            version = "v" + _dist_version("sgtk")
+        except Exception:
+            pass
+    return version
 
 
 def get_core_api_version(core_install_root):

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -416,3 +416,85 @@ class TestGetCurrentlyRunningApiVersion(ShotgunTestBase):
                 pipelineconfig_utils.get_currently_running_api_version(),
                 "unknown",
             )
+
+
+class TestGetCoreApiVersion(ShotgunTestBase):
+    """
+    Tests get_core_api_version, including the distribution-metadata fallback
+    used when the requested core is the currently-running one and info.yml is
+    absent (e.g. flat pip install layout).
+    """
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_returns_manifest_version_when_present(self, manifest_mock):
+        """
+        When info.yml is present, its version is returned and no fallback runs.
+        """
+        manifest_mock.return_value = "v1.2.3"
+        with mock.patch(
+            "tank.pipelineconfig_utils.get_path_to_current_core"
+        ) as path_mock:
+            self.assertEqual(
+                pipelineconfig_utils.get_core_api_version("/some/core/root"),
+                "v1.2.3",
+            )
+            path_mock.assert_not_called()
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_returns_unknown_for_other_core_when_manifest_missing(
+        self, manifest_mock
+    ):
+        """
+        When info.yml is absent and the requested core is not the currently-running
+        one, distribution metadata must not leak in as the answer.
+        """
+        manifest_mock.return_value = None
+        with mock.patch(
+            "tank.pipelineconfig_utils.get_path_to_current_core",
+            return_value="/different/core",
+        ):
+            with mock.patch("importlib.metadata.version") as dist_mock:
+                self.assertEqual(
+                    pipelineconfig_utils.get_core_api_version("/some/core/root"),
+                    "unknown",
+                )
+                dist_mock.assert_not_called()
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_falls_back_to_dist_metadata_for_current_core(self, manifest_mock):
+        """
+        Pip install layout: info.yml is absent and the requested core matches the
+        currently-running one, so the function defers to dist-metadata via
+        get_currently_running_api_version.
+        """
+        manifest_mock.return_value = None
+        with mock.patch(
+            "tank.pipelineconfig_utils.get_path_to_current_core",
+            return_value="/some/core/root",
+        ):
+            with mock.patch(
+                "importlib.metadata.version", return_value="0.23.8"
+            ) as dist_mock:
+                self.assertEqual(
+                    pipelineconfig_utils.get_core_api_version("/some/core/root"),
+                    "v0.23.8",
+                )
+                dist_mock.assert_called_once_with("sgtk")
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_returns_unknown_when_current_core_resolution_fails(
+        self, manifest_mock
+    ):
+        """
+        If get_path_to_current_core raises (e.g. moved/symlinked install), the
+        function preserves the "unknown" contract rather than propagating.
+        """
+        manifest_mock.return_value = None
+        with mock.patch(
+            "tank.pipelineconfig_utils.get_path_to_current_core",
+            side_effect=tank.TankError("unresolvable"),
+        ):
+            self.assertEqual(
+                pipelineconfig_utils.get_core_api_version("/some/core/root"),
+                "unknown",
+            )

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import importlib.metadata
 import os
 import inspect
 import sys
@@ -384,11 +385,11 @@ class TestGetCurrentlyRunningApiVersion(ShotgunTestBase):
     @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
     def test_falls_back_to_dist_metadata_when_manifest_missing(self, manifest_mock):
         """
-        Pip install layout: info.yml is absent so the manifest yields "unknown",
+        Pip install layout: info.yml is absent so the manifest yields None,
         and the function falls back to the installed sgtk distribution version,
         re-adding the 'v' prefix that PEP 440 normalization strips.
         """
-        manifest_mock.return_value = "unknown"
+        manifest_mock.return_value = None
         with mock.patch(
             "importlib.metadata.version", return_value="0.23.8"
         ) as dist_mock:
@@ -406,10 +407,10 @@ class TestGetCurrentlyRunningApiVersion(ShotgunTestBase):
         Neither info.yml nor an installed sgtk distribution available: preserve
         the original "unknown" contract instead of raising.
         """
-        manifest_mock.return_value = "unknown"
+        manifest_mock.return_value = None
         with mock.patch(
             "importlib.metadata.version",
-            side_effect=Exception("PackageNotFoundError"),
+            side_effect=importlib.metadata.PackageNotFoundError("sgtk"),
         ):
             self.assertEqual(
                 pipelineconfig_utils.get_currently_running_api_version(),

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -359,3 +359,59 @@ class TestPipelineConfigUtils(ShotgunTestBase):
 
         self.assertEqual(sgtk.get_sgtk_module_path(), python_path)
         self.assertEqual(sgtk.get_sgtk_module_path(), tank.get_sgtk_module_path())
+
+
+class TestGetCurrentlyRunningApiVersion(ShotgunTestBase):
+    """
+    Tests get_currently_running_api_version, including the importlib.metadata
+    fallback used when info.yml is absent (e.g. flat pip install layout).
+    """
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_returns_manifest_version_when_present(self, manifest_mock):
+        """
+        When info.yml is present, its version is returned and the dist-metadata
+        fallback is not consulted.
+        """
+        manifest_mock.return_value = "v1.2.3"
+        with mock.patch("importlib.metadata.version") as dist_mock:
+            self.assertEqual(
+                pipelineconfig_utils.get_currently_running_api_version(),
+                "v1.2.3",
+            )
+            dist_mock.assert_not_called()
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_falls_back_to_dist_metadata_when_manifest_missing(self, manifest_mock):
+        """
+        Pip install layout: info.yml is absent so the manifest yields "unknown",
+        and the function falls back to the installed sgtk distribution version,
+        re-adding the 'v' prefix that PEP 440 normalization strips.
+        """
+        manifest_mock.return_value = "unknown"
+        with mock.patch(
+            "importlib.metadata.version", return_value="0.23.8"
+        ) as dist_mock:
+            self.assertEqual(
+                pipelineconfig_utils.get_currently_running_api_version(),
+                "v0.23.8",
+            )
+            dist_mock.assert_called_once_with("sgtk")
+
+    @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
+    def test_returns_unknown_when_manifest_and_dist_metadata_missing(
+        self, manifest_mock
+    ):
+        """
+        Neither info.yml nor an installed sgtk distribution available: preserve
+        the original "unknown" contract instead of raising.
+        """
+        manifest_mock.return_value = "unknown"
+        with mock.patch(
+            "importlib.metadata.version",
+            side_effect=Exception("PackageNotFoundError"),
+        ):
+            self.assertEqual(
+                pipelineconfig_utils.get_currently_running_api_version(),
+                "unknown",
+            )

--- a/tests/integration_tests/pip_install.py
+++ b/tests/integration_tests/pip_install.py
@@ -62,7 +62,13 @@ class PipInstallTests(SgtkIntegrationTest):
 
             # Under the flat pip layout info.yml is absent; the version must
             # come from the installed sgtk distribution metadata instead of
-            # falling through to "unknown".
+            # falling through to "unknown". Strip PYTHONPATH from the
+            # subprocess env — the integration runner sets it to the source
+            # tree, which would otherwise shadow the venv's pip-installed
+            # sgtk and let _get_version_from_manifest pick up the source
+            # repo's info.yml.
+            subprocess_env = dict(os.environ)
+            subprocess_env.pop("PYTHONPATH", None)
             version = subprocess.check_output(  # nosec B603
                 [
                     python,
@@ -70,6 +76,7 @@ class PipInstallTests(SgtkIntegrationTest):
                     "import sgtk; print(sgtk.pipelineconfig_utils.get_currently_running_api_version())",
                 ],
                 text=True,
+                env=subprocess_env,
             ).strip()
             self.assertNotEqual(version, "unknown")
             self.assertTrue(

--- a/tests/integration_tests/pip_install.py
+++ b/tests/integration_tests/pip_install.py
@@ -60,6 +60,23 @@ class PipInstallTests(SgtkIntegrationTest):
                 ]
             )
 
+            # Under the flat pip layout info.yml is absent; the version must
+            # come from the installed sgtk distribution metadata instead of
+            # falling through to "unknown".
+            version = subprocess.check_output(  # nosec B603
+                [
+                    python,
+                    "-c",
+                    "import sgtk; print(sgtk.get_currently_running_api_version())",
+                ],
+                text=True,
+            ).strip()
+            self.assertNotEqual(version, "unknown")
+            self.assertTrue(
+                version.startswith("v"),
+                "expected vX.Y.Z, got %r" % version,
+            )
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True, verbosity=2)

--- a/tests/integration_tests/pip_install.py
+++ b/tests/integration_tests/pip_install.py
@@ -67,7 +67,7 @@ class PipInstallTests(SgtkIntegrationTest):
                 [
                     python,
                     "-c",
-                    "import sgtk; print(sgtk.get_currently_running_api_version())",
+                    "import sgtk; print(sgtk.pipelineconfig_utils.get_currently_running_api_version())",
                 ],
                 text=True,
             ).strip()

--- a/tests/integration_tests/pip_install_bootstrap.py
+++ b/tests/integration_tests/pip_install_bootstrap.py
@@ -100,6 +100,21 @@ class BootstrapPipTests(SgtkIntegrationTest):
         engine = manager.bootstrap_engine("tk-shell", self.asset)
         self.assertEqual(engine.name, "tk-shell")
 
+    def test_get_currently_running_api_version_in_simulated_pip_layout(self):
+        """
+        The simulated layout has no info.yml. The function must not raise; it
+        should return a non-empty string. The exact value depends on whether
+        sgtk is also pip-installed in the test runner's Python — importlib's
+        distribution metadata is read from the runtime Python's site-packages,
+        not from the sys.path-prepended simulated copy.
+        """
+        self.__clean_sgtk_modules()
+        import sgtk
+
+        result = sgtk.get_currently_running_api_version()
+        self.assertIsInstance(result, str)
+        self.assertTrue(result, "version must be non-empty")
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True, verbosity=2)

--- a/tests/integration_tests/pip_install_bootstrap.py
+++ b/tests/integration_tests/pip_install_bootstrap.py
@@ -111,7 +111,7 @@ class BootstrapPipTests(SgtkIntegrationTest):
         self.__clean_sgtk_modules()
         import sgtk
 
-        result = sgtk.get_currently_running_api_version()
+        result = sgtk.pipelineconfig_utils.get_currently_running_api_version()
         self.assertIsInstance(result, str)
         self.assertTrue(result, "version must be non-empty")
 


### PR DESCRIPTION
## Background

When tk-core is pip-installed into a venv, the package lands in a flat
`site-packages/tank/` layout. The native install layout assumed by the code
(`install/core/python/tank/` with `info.yml` two levels up from `tank/`) is
absent, so [`pipelineconfig_utils.get_currently_running_api_version()`](https://github.com/shotgunsoftware/tk-core/blob/master/python/tank/pipelineconfig_utils.py#L431)
resolves `info.yml` to a non-existent `<venv>/Lib/info.yml`,
`_get_version_from_manifest` swallows the error, and `"unknown"` is returned.

This silently breaks `Sgtk.version` and any code path that compares the
currently-running core version against a config's required core version
(e.g. `PipelineConfiguration.__init__` at
[`pipelineconfig.py:73`](https://github.com/shotgunsoftware/tk-core/blob/master/python/tank/pipelineconfig.py#L73)).

Related to the broader pip-install layout cleanup in #1091.

## Fix

Add an `importlib.metadata.version("sgtk")` fallback in
`get_currently_running_api_version()`. The `info.yml` read remains the
primary source — only when it returns `"unknown"` do we consult the
installed sgtk distribution metadata. PEP 440 strips the leading `v`, so
the fallback re-adds it to match the `info.yml` format and the docstring's
documented return shape (`'v1.2.3'`).

Behavior:

| Install layout | `info.yml` present? | `sgtk` dist-info present? | Returned value |
|---|---|---|---|
| Source / native | yes | n/a | manifest value (e.g. `"HEAD"`, `"v0.23.8"`) |
| Pip install | no | yes | `"v" + dist_version` (e.g. `"v0.23.8"`) |
| Bare copy / no metadata | no | no | `"unknown"` (preserves original contract) |

`_get_version_from_manifest` and `get_core_api_version(core_install_root)`
are unchanged. The latter has different semantics — "what version is at
*this* core install root?" — where `"unknown"` is the correct answer when
the manifest at that root is missing.

**Out of scope** (still broken under pip; can be addressed separately):
`Sgtk.documentation_url`, core hook resolution, the `TANK_CURRENT_PC` skip
in `tank/__init__.py`, and `setup_project_core`'s binary copying. Each of
those reads files (`hooks/`, `schema/`, `setup/`) that aren't shipped to
`site-packages/`.

## Testing

Three layers:

- **Unit tests** in `tests/core_tests/test_pipelineconfig_utils.py` —
  new `TestGetCurrentlyRunningApiVersion` class with three mocked tests:
  manifest present (fallback not consulted), manifest missing → fallback
  succeeds, both missing → `"unknown"`. Hermetic, fast.
- **`tests/integration_tests/pip_install.py`** — extended
  `test_pip_install_and_import` to assert
  `get_currently_running_api_version()` returns a non-`"unknown"` `vX.Y.Z`
  string after a real `pip install` into a fresh venv.
- **`tests/integration_tests/pip_install_bootstrap.py`** — added
  `test_get_currently_running_api_version_in_simulated_pip_layout`
  asserting the function returns a string and does not raise in the
  simulated flat layout. Assertion is intentionally permissive:
  `importlib.metadata` reads from the runtime Python's `site-packages`,
  not the `sys.path`-prepended simulated copy, so a developer who also
  has sgtk pip-installed in their dev Python will get the dist version
  rather than `"unknown"`.

> **Note:** Draft. The first commit on this branch contains the new tests
> only — the fix in `pipelineconfig_utils.py` will land in a follow-up
> commit. CI on this commit is expected to fail
> `test_falls_back_to_dist_metadata_when_manifest_missing` and the
> extended `test_pip_install_and_import`, demonstrating that the new
> tests catch the bug. CI should go green once the fix is added.
