### PR TITLE
SG-43269 Improve core swap diagnostics with version mismatch detection

### DIFF
--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -107,12 +107,13 @@ class CoreImportHandler(object):
             if pipelineconfig_utils.is_version_older(
                 target_core_version, handler_core_version
             ):
-                log.exception(
+                error_message = (
                     f"Core version mismatch: {target_core_version} might be older than"
                     f" {handler_core_version}. Please check the release notes for breaking"
                     f" changes: https://github.com/shotgunsoftware/tk-core/releases"
                 )
-            raise
+                log.error(error_message)
+                raise ImportError(error_message)
 
         finally:
             # Restore the list of warning filters.

--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -100,7 +100,7 @@ class CoreImportHandler(object):
             # Kick toolkit to re-import
             import tank
 
-        except:
+        except Exception:
             # If anything happens here, log an error and continue.
             # Check the core versions handler_core_version and target_core_version,
             # There might be a breaking change between the two versions.

--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -16,6 +16,7 @@ import uuid
 import warnings
 
 from .. import LogManager
+from .. import pipelineconfig_utils
 
 log = LogManager.get_logger(__name__)
 
@@ -49,8 +50,16 @@ class CoreImportHandler(object):
         """
         # make sure handler is up
         handler = cls._initialize()
+        handler_core_version = pipelineconfig_utils.get_currently_running_api_version()
 
-        log.debug("%s: Begin swapping core to %s" % (handler, core_path))
+        target_core_version = pipelineconfig_utils.get_core_api_version(
+            os.path.dirname(os.path.dirname(os.path.dirname(core_path)))
+        )
+
+        log.debug(
+            "%s (version %s): Begin swapping core to %s (version %s)"
+            % (handler, handler_core_version, core_path, target_core_version)
+        )
 
         # swapping core means our logging singleton will be reset.
         # make sure that there are no log handlers registered
@@ -90,6 +99,20 @@ class CoreImportHandler(object):
         try:
             # Kick toolkit to re-import
             import tank
+
+        except:
+            # If anything happens here, log an error and continue.
+            # Check the core versions handler_core_version and target_core_version,
+            # There might be a breaking change between the two versions.
+            if pipelineconfig_utils.is_version_older(
+                target_core_version, handler_core_version
+            ):
+                log.exception(
+                    f"Core version mismatch: {target_core_version} might be older than"
+                    f" {handler_core_version}. Please check the release notes for breaking"
+                    f" changes: https://github.com/shotgunsoftware/tk-core/releases"
+                )
+            raise
 
         finally:
             # Restore the list of warning filters.
@@ -289,20 +312,14 @@ class CoreImportHandler(object):
             # later raise FileNotFoundError instead of the expected ImportError
             # when the module doesn't exist on disk.
             if os.path.isdir(os.path.join(package_path[0], module_name)):
-                module_file = os.path.join(
-                    package_path[0], module_name, "__init__.py"
-                )
+                module_file = os.path.join(package_path[0], module_name, "__init__.py")
             else:
-                module_file = os.path.join(
-                    package_path[0], module_name + ".py"
-                )
+                module_file = os.path.join(package_path[0], module_name + ".py")
 
             if not os.path.isfile(module_file):
                 return None
 
-            loader = importlib.machinery.SourceFileLoader(
-                module_fullname, module_file
-            )
+            loader = importlib.machinery.SourceFileLoader(module_fullname, module_file)
             spec = importlib.util.spec_from_loader(loader.name, loader)
             self._module_info[module_fullname] = spec
         except ImportError:
@@ -328,9 +345,7 @@ class CoreImportHandler(object):
         try:
             spec.loader.exec_module(module)
         except FileNotFoundError as e:
-            raise ImportError(
-                f"No module named '{module_fullname}'"
-            ) from e
+            raise ImportError(f"No module named '{module_fullname}'") from e
 
         # the module needs to know the loader so that reload() works
         module.__loader__ = self

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -24,6 +24,7 @@ from .util import yaml_cache
 from .util import StorageRoots
 from .util import ShotgunPath
 from .util.shotgun import get_deferred_sg_connection
+from .util.version import is_version_older  # noqa: F401
 
 from .errors import TankError
 

--- a/tests/bootstrap_tests/test_import_handler.py
+++ b/tests/bootstrap_tests/test_import_handler.py
@@ -13,6 +13,7 @@ import sys
 import types
 import tempfile
 import shutil
+from unittest.mock import patch
 
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
@@ -238,4 +239,181 @@ class TestImportErrorNotFileNotFoundError(ShotgunTestBase):
             spec,
             "find_spec should return None for non-existent module QtPrintSupport, "
             "not a spec pointing to a missing file",
+        )
+
+
+class TestSwapCoreVersionMismatch(ShotgunTestBase):
+    """Tests that swap_core emits a version-mismatch diagnostic on import failure.
+
+    These tests do not perform a real core swap. Instead they patch the internal
+    helpers and inject a meta-path blocker so that the post-swap ``import tank``
+    statement always raises ImportError, letting us assert the diagnostic path in
+    isolation.
+    """
+
+    # ------------------------------------------------------------------
+    # A meta-path finder that unconditionally raises ImportError for
+    # 'tank'.  Inserting this at the front of sys.meta_path simulates a
+    # broken target core without touching the filesystem.
+    # ------------------------------------------------------------------
+    class _TankImportBlocker:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "tank":
+                raise ImportError("Simulated broken target core (test blocker)")
+            return None
+
+    def setUp(self):
+        super().setUp()
+
+        # Build a minimal fake target core layout:
+        #
+        #   <tmp_root>/
+        #     install/
+        #       core/
+        #         info.yml   <- declares version v0.22.4
+        #         python/    <- empty; no real tank modules
+        self._target_root = tempfile.mkdtemp(prefix="tk_swap_mismatch_test_")
+        core_dir = os.path.join(self._target_root, "install", "core")
+        os.makedirs(core_dir)
+        with open(os.path.join(core_dir, "info.yml"), "w") as fh:
+            fh.write('version: "v0.22.4"\n')
+        self._target_python = os.path.join(core_dir, "python")
+        os.makedirs(self._target_python)
+
+        # Snapshot sys.meta_path and the tank-related sys.modules entries so
+        # tearDown can restore them regardless of what the test does.
+        self._original_meta_path = sys.meta_path[:]
+        self._stashed_tank_modules = {
+            k: v
+            for k, v in sys.modules.items()
+            if k in ("tank", "sgtk", "tank_vendor")
+            or k.startswith(("tank.", "sgtk.", "tank_vendor."))
+        }
+
+    def tearDown(self):
+        sys.meta_path[:] = self._original_meta_path
+        sys.modules.update(self._stashed_tank_modules)
+        shutil.rmtree(self._target_root, ignore_errors=True)
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_fake_swap_core(self, handler):
+        """Return a drop-in for ``_swap_core`` that simulates the two side effects
+        that matter for these tests:
+
+        1. Redirects the handler's ``_core_path`` to the new (empty) target.
+        2. Clears all tank-namespaced modules from ``sys.modules`` so that
+           the subsequent ``import tank`` actually goes through the import
+           machinery (and hits our blocker).
+        3. Inserts the blocker at the front of ``sys.meta_path``.
+        """
+
+        def _fake(core_path):
+            handler._core_path = core_path
+            for key in list(sys.modules):
+                if key in ("tank", "sgtk", "tank_vendor") or key.startswith(
+                    ("tank.", "sgtk.", "tank_vendor.")
+                ):
+                    del sys.modules[key]
+            sys.meta_path.insert(0, TestSwapCoreVersionMismatch._TankImportBlocker())
+
+        return _fake
+
+    def _run_swap(self, handler_version, target_version_on_disk=None):
+        """Run ``CoreImportHandler.swap_core`` with controlled versions.
+
+        :param handler_version: The version reported by
+            ``get_currently_running_api_version`` (the active/site core).
+        :param target_version_on_disk: If given, overwrite the ``info.yml`` in
+            the fake target root so ``get_core_api_version`` returns this value.
+        :returns: The mock logger captured during the call.
+        :raises ImportError: The patched import always raises; the caller
+            decides whether to catch it.
+        """
+        if target_version_on_disk is not None:
+            info_path = os.path.join(
+                self._target_root, "install", "core", "info.yml"
+            )
+            with open(info_path, "w") as fh:
+                fh.write('version: "%s"\n' % target_version_on_disk)
+
+        handler = CoreImportHandler(self._target_python)
+
+        with patch(
+            "tank.pipelineconfig_utils.get_currently_running_api_version",
+            return_value=handler_version,
+        ), patch.object(
+            CoreImportHandler, "_initialize", return_value=handler
+        ), patch.object(
+            handler,
+            "_swap_core",
+            side_effect=self._make_fake_swap_core(handler),
+        ), patch(
+            "tank.bootstrap.import_handler.log"
+        ) as mock_log:
+            with self.assertRaises(ImportError):
+                CoreImportHandler.swap_core(self._target_python)
+            return mock_log
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_mismatch_message_logged_when_target_is_older(self):
+        """log.exception is called with version details when target < running core.
+
+        Scenario: Desktop ships v0.23.8 (handler_version) but the project config
+        still pins v0.22.4 (target_version). The post-swap ``import tank`` fails
+        and the diagnostic must surface both version numbers and a link to the
+        release notes.
+        """
+        mock_log = self._run_swap(handler_version="v0.23.8")
+
+        logged = " ".join(str(c) for c in mock_log.exception.call_args_list)
+        self.assertTrue(
+            mock_log.exception.called,
+            "Expected log.exception to be called for a version-mismatch but it "
+            "was not. All log calls: %s" % mock_log.mock_calls,
+        )
+        self.assertIn(
+            "v0.22.4",
+            logged,
+            "Target version v0.22.4 should appear in the mismatch message.",
+        )
+        self.assertIn(
+            "v0.23.8",
+            logged,
+            "Running version v0.23.8 should appear in the mismatch message.",
+        )
+        self.assertIn(
+            "tk-core/releases",
+            logged,
+            "Release notes URL should appear in the mismatch message.",
+        )
+
+    def test_no_mismatch_message_when_target_is_not_older(self):
+        """log.exception is NOT called when the target core is the same version or newer.
+
+        Scenario: The project config has already been updated to v0.23.8 while the
+        running core is v0.22.4. Even though the import still fails (the fake
+        blocker is always active), the version-mismatch branch must NOT fire
+        because the target is not older than the handler.
+        """
+        mock_log = self._run_swap(
+            handler_version="v0.22.4",
+            target_version_on_disk="v0.23.8",
+        )
+
+        mismatch_calls = [
+            c
+            for c in mock_log.exception.call_args_list
+            if "mismatch" in str(c).lower()
+        ]
+        self.assertFalse(
+            mismatch_calls,
+            "log.exception should NOT be called with a mismatch message when "
+            "the target core is not older. Unexpected calls: %s" % mismatch_calls,
         )

--- a/tests/bootstrap_tests/test_import_handler.py
+++ b/tests/bootstrap_tests/test_import_handler.py
@@ -329,9 +329,9 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
             ``get_currently_running_api_version`` (the active/site core).
         :param target_version_on_disk: If given, overwrite the ``info.yml`` in
             the fake target root so ``get_core_api_version`` returns this value.
-        :returns: The mock logger captured during the call.
-        :raises ImportError: The patched import always raises; the caller
-            decides whether to catch it.
+        :returns: ``(mock_log, raised_exception)`` - the mock logger captured
+            during the call and the exception raised by ``swap_core``, or
+            ``None`` if it returned normally.
         """
         if target_version_on_disk is not None:
             info_path = os.path.join(self._target_root, "install", "core", "info.yml")
@@ -359,29 +359,44 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
             # restored, which leaks state into subsequent test classes.  Mock
             # the local import so the singleton is never touched.
             "tank.log.LogManager"
-        ):
-            with self.assertRaises(ImportError):
+        ) as mock_lm:
+            # uninitialize_base_file_handler must return None (no active log
+            # file in tests) so that the `if prev_log_file:` guard in
+            # swap_core is False.  Without this, swap_core tries to call
+            # tank.LogManager() after the import failed, hitting an
+            # UnboundLocalError because the `tank` assignment never completed.
+            mock_lm.return_value.uninitialize_base_file_handler.return_value = None
+            raised = None
+            try:
                 CoreImportHandler.swap_core(self._target_python)
-            return mock_log
+            except Exception as exc:
+                raised = exc
+            return mock_log, raised
 
     # ------------------------------------------------------------------
     # Tests
     # ------------------------------------------------------------------
 
     def test_mismatch_message_logged_when_target_is_older(self):
-        """log.exception is called with version details when target < running core.
+        """log.error is called with version details when target < running core.
 
         Scenario: Desktop ships v0.23.8 (handler_version) but the project config
         still pins v0.22.4 (target_version). The post-swap ``import tank`` fails
         and the diagnostic must surface both version numbers and a link to the
-        release notes.
+        release notes. swap_core re-raises as ImportError.
         """
-        mock_log = self._run_swap(handler_version="v0.23.8")
+        mock_log, raised = self._run_swap(handler_version="v0.23.8")
 
-        logged = " ".join(str(c) for c in mock_log.exception.call_args_list)
+        self.assertIsInstance(
+            raised,
+            ImportError,
+            "swap_core should re-raise as ImportError on a version mismatch. "
+            "Got: %s" % raised,
+        )
+        logged = " ".join(str(c) for c in mock_log.error.call_args_list)
         self.assertTrue(
-            mock_log.exception.called,
-            "Expected log.exception to be called for a version-mismatch but it "
+            mock_log.error.called,
+            "Expected log.error to be called for a version-mismatch but it "
             "was not. All log calls: %s" % mock_log.mock_calls,
         )
         self.assertIn(
@@ -401,23 +416,29 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
         )
 
     def test_no_mismatch_message_when_target_is_not_older(self):
-        """log.exception is NOT called when the target core is the same version or newer.
+        """log.error is NOT called when the target core is the same version or newer.
 
         Scenario: The project config has already been updated to v0.23.8 while the
         running core is v0.22.4. Even though the import still fails (the fake
         blocker is always active), the version-mismatch branch must NOT fire
-        because the target is not older than the handler.
+        because the target is not older than the handler.  swap_core swallows
+        the exception in this case (treated as a non-fatal import warning).
         """
-        mock_log = self._run_swap(
+        mock_log, raised = self._run_swap(
             handler_version="v0.22.4",
             target_version_on_disk="v0.23.8",
         )
 
+        self.assertIsNone(
+            raised,
+            "swap_core should NOT raise when the target core is not older. "
+            "Got: %s" % raised,
+        )
         mismatch_calls = [
-            c for c in mock_log.exception.call_args_list if "mismatch" in str(c).lower()
+            c for c in mock_log.error.call_args_list if "mismatch" in str(c).lower()
         ]
         self.assertFalse(
             mismatch_calls,
-            "log.exception should NOT be called with a mismatch message when "
+            "log.error should NOT be called with a mismatch message when "
             "the target core is not older. Unexpected calls: %s" % mismatch_calls,
         )

--- a/tests/bootstrap_tests/test_import_handler.py
+++ b/tests/bootstrap_tests/test_import_handler.py
@@ -334,9 +334,7 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
             decides whether to catch it.
         """
         if target_version_on_disk is not None:
-            info_path = os.path.join(
-                self._target_root, "install", "core", "info.yml"
-            )
+            info_path = os.path.join(self._target_root, "install", "core", "info.yml")
             with open(info_path, "w") as fh:
                 fh.write('version: "%s"\n' % target_version_on_disk)
 
@@ -353,7 +351,15 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
             side_effect=self._make_fake_swap_core(handler),
         ), patch(
             "tank.bootstrap.import_handler.log"
-        ) as mock_log:
+        ) as mock_log, patch(
+            # swap_core calls LogManager().uninitialize_base_file_handler() on
+            # the process-wide singleton before the swap, and relies on the
+            # post-swap `import tank` to re-initialize it.  Because our test
+            # intentionally makes that import fail, the handler is never
+            # restored, which leaks state into subsequent test classes.  Mock
+            # the local import so the singleton is never touched.
+            "tank.log.LogManager"
+        ):
             with self.assertRaises(ImportError):
                 CoreImportHandler.swap_core(self._target_python)
             return mock_log
@@ -408,9 +414,7 @@ class TestSwapCoreVersionMismatch(ShotgunTestBase):
         )
 
         mismatch_calls = [
-            c
-            for c in mock_log.exception.call_args_list
-            if "mismatch" in str(c).lower()
+            c for c in mock_log.exception.call_args_list if "mismatch" in str(c).lower()
         ]
         self.assertFalse(
             mismatch_calls,


### PR DESCRIPTION
## What
When Toolkit performs a core swap (e.g. from the bundled Desktop core to a site or project config core), it now:

- Logs both the current core version and the target core version at swap time, making it immediately clear which two versions are involved.
- On any import failure during the swap, detects whether the target core is older than the currently running core and, if so, logs an actionable error message pointing to the tk-core release notes.


## Why
Core swap failures are notoriously hard to diagnose because the previous log line only printed the target path, with no version context. When a customer upgrades FPT Desktop (which ships a newer bundled tk-core) while their site or project config still pins an older core, the swap can fail with cryptic ModuleNotFoundError or ImportError tracebacks that give no hint about the root cause.

With this change, support and engineers can immediately see entries like:

```
CoreImportHandler (version v0.23.8): Begin swapping core to .../install/core/python (version v0.22.4)
...
Core version mismatch: v0.22.4 might be older than v0.23.8. Please check the release notes for breaking changes: 
https://github.com/shotgunsoftware/tk-core/releases
```

This cuts down diagnostic time significantly for the class of issues where a project or site config is pinned to an outdated core that is incompatible with the currently running version.

##  Changes
- bootstrap/import_handler.py - reads site and target core versions before the swap and includes them in the existing debug log; adds a bare except after the import tank block that checks for a version downgrade and logs an exception-level message with a link to the release notes before re-raising.
- pipelineconfig_utils.py - re-exports is_version_older via # noqa: F401 so callers can import it from the public pipelineconfig_utils surface rather than the internal util.version module.


## Testing
Reproduced locally with FPT Desktop v3.0.0 (bundled tk-core v0.23.8) and a project pipeline config pinned to tk-core v0.22.4. The new log lines appear correctly before the failure, and the version mismatch message is emitted with a stack trace attached.