### PR TITLE
SG-43592 Fix sys.path and sys.meta_path isolation during core swap

### DIFF
--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -209,6 +209,38 @@ class CoreImportHandler(object):
                     # log.debug("Removing sys.modules[%s]" % module_name)
                     del sys.modules[module_name]
 
+        # Remove the outgoing core's pkgs.zip from sys.path so the incoming
+        # core's tank_vendor/__init__.py can insert the correct one on load.
+        # Without this, a newer site core's pkgs.zip (which may lack packages
+        # like `six`) stays at sys.path[0] and is resolved by direct imports
+        # (e.g. `import shotgun_api3`) in older project core code.
+        current_core_root = os.path.normpath(os.path.dirname(self._core_path))
+        new_sys_path = []
+        for p in sys.path:
+            norm_p = os.path.normpath(p)
+            try:
+                if os.path.commonpath([norm_p, current_core_root]) == current_core_root:
+                    log.debug("Removing sys.path entry belonging to outgoing core: %s" % p)
+                    continue
+            except ValueError:
+                pass  # commonpath raises ValueError on mixed-drive paths on Windows
+            new_sys_path.append(p)
+        sys.path[:] = new_sys_path
+
+        # Remove the outgoing core's _TankVendorMetaFinder from sys.meta_path.
+        # This finder is installed by tank_vendor/__init__.py and redirects
+        # `tank_vendor.*` submodule lookups. After a swap it would intercept
+        # imports like `tank_vendor.six.moves` and fail to resolve them against
+        # the incoming core's environment. The incoming tank_vendor/__init__.py
+        # will install a fresh finder when it loads.
+        sys.meta_path[:] = [
+            h for h in sys.meta_path
+            if type(h).__name__ != "_TankVendorMetaFinder"
+        ]
+        if hasattr(sys, "_tank_vendor_meta_finder"):
+            del sys._tank_vendor_meta_finder
+        log.debug("Removed stale _TankVendorMetaFinder from sys.meta_path.")
+
         # reset importer to point at new core for future imports
         self._module_info = {}
         self._core_path = core_path


### PR DESCRIPTION
## What

Fixes a `sys.path` and `sys.meta_path` isolation bug in `_swap_core()` that caused project bootstrapping to fail when the site core is newer (pkgs.zip-style, e.g. v0.23.8) and the project core is older (vendored-style, e.g. v0.22.4).

Two things are now cleaned up in `_swap_core()` before handing off to the incoming core:

1. **`sys.path` cleanup** — removes all entries that live under the outgoing core's root directory. This ensures the site core's `pkgs.zip` is no longer on `sys.path` when the project core loads, so direct imports like `import shotgun_api3` resolve to the project core's vendored copy rather than the site's.

2. **`sys.meta_path` cleanup** — removes the stale `_TankVendorMetaFinder` instance registered by the outgoing core's `tank_vendor/__init__.py`. The incoming core's `tank_vendor/__init__.py` installs a fresh one when `import tank` loads it.

## Why

Two distinct customer-facing failures traced to the same root cause:

**SGD 3.0 + project config ≤ v1.7.5 → `ModuleNotFoundError: No module named 'tank_vendor.six.moves'`**

- Site core (v0.23.8) boots → `tank_vendor/__init__.py` inserts its `pkgs.zip` at `sys.path[0]` and registers `_TankVendorMetaFinder` in `sys.meta_path`.
- `_swap_core()` runs → stashes `sys.modules` entries but leaves `sys.path` and `sys.meta_path` untouched.
- Project core (v0.22.4) has `six.py` as a plain file; `six.__path__ == []`. When `tank_vendor.six.moves` is requested, `CoreImportHandler.find_spec` returns `None` (empty `package_path`), and the stale `_TankVendorMetaFinder` intercepts the import — but the site `pkgs.zip` has no `six`, so it fails.

**Flame 2025.1 + project config ≤ v1.10.20 → `ImportError: cannot import name 'sgsix' from 'shotgun_api3.lib'`**

- Same root cause: after the swap, the site `pkgs.zip` is still at `sys.path[0]`.
- `shotgun_api3` is not in `NAMESPACES_TO_TRACK`, so `CoreImportHandler` ignores it.
- Python's default `PathFinder` resolves `shotgun_api3` from the site `pkgs.zip`, which has a newer version without `sgsix`. Project code that expects `sgsix` fails.

## Changes

- `python/tank/bootstrap/import_handler.py` — `_swap_core()`: strip outgoing-core `sys.path` entries and remove stale `_TankVendorMetaFinder` before resetting `self._core_path`.

## Related

Closes / supersedes the diagnostic-only approach in #1099.