### PR TITLE
feat: [SG-43645] Migrate schema_builder module to tk-core

### DIFF
--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -1145,7 +1145,8 @@ class ToolkitManager(object):
                     ],
                 )
                 if sg_project and sg_project.get(flow_auth.AM_READY_PROJECT_FIELD):
-                    # Retrieve and cache the flow am project id on the context object
+                    # Store flow fields temporarily to avoid re-querying.
+                    # They will be cached on the context object after the context object has been rebuilt.
                     self._flow_project_id = sg_project.get(
                         flow_auth.AM_READY_PROJECT_FIELD
                     )
@@ -1153,7 +1154,7 @@ class ToolkitManager(object):
                         flow_const.FLOW_SCHEMA_VERSION_FIELD
                     )
                     log.info(
-                        f"Current SG project is associated with a Flow project: {self._flow_project_id}"
+                        f"Current SG project is associated with a Flow project: {self._flow_project_id} with schema version {self._flow_schema_version}."
                     )
 
                     tk, _ = config.get_tk_instance(self._sg_user)

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -1217,6 +1217,18 @@ class ToolkitManager(object):
             ctx = tk.context_empty()
         else:
             ctx = tk.context_from_entity_dictionary(entity)
+            
+            # Inject the flow fields to context
+            if ctx.project is not None:
+                sg_project = self._sg_connection.find_one(
+                    "Project",
+                    [["id", "is", ctx.project["id"]]],
+                    [flow_const.FLOW_SCHEMA_VERSION_FIELD],
+                )
+                if sg_project:
+                    ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = (
+                        sg_project.get(flow_const.FLOW_SCHEMA_VERSION_FIELD)
+                    )
 
         self._report_progress(
             progress_callback, self._LAUNCHING_ENGINE_RATE, "Launching Engine..."

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -86,6 +86,10 @@ class ToolkitManager(object):
         self._plugin_id = None
         self._allow_config_overrides = True
 
+        # flow fields
+        self._flow_project_id = None
+        self._flow_schema_version = None
+
         # look for the standard env var SHOTGUN_PIPELINE_CONFIGURATION_ID
         # and in case this is set, use it as a default
         if constants.PIPELINE_CONFIG_ID_ENV_VAR in os.environ:
@@ -1129,17 +1133,19 @@ class ToolkitManager(object):
                 sg_project = self._sg_connection.find_one(
                     "Project",
                     [["id", "is", project_id]],
-                    [flow_auth.AM_READY_PROJECT_FIELD],
+                    [flow_auth.AM_READY_PROJECT_FIELD, flow_const.FLOW_SCHEMA_VERSION_FIELD],
                 )
                 if sg_project and sg_project.get(flow_auth.AM_READY_PROJECT_FIELD):
                     # Retrieve and cache the flow am project id on the context object
-                    flow_project_id = sg_project.get(flow_auth.AM_READY_PROJECT_FIELD)
-                    log.info(f"Current SG project is associated with a Flow project: {flow_project_id}")
+                    self._flow_project_id = sg_project.get(flow_auth.AM_READY_PROJECT_FIELD)
+                    self._flow_schema_version = sg_project.get(flow_const.FLOW_SCHEMA_VERSION_FIELD)
+                    log.info(f"Current SG project is associated with a Flow project: {self._flow_project_id}")
+                    
                     tk, _ = config.get_tk_instance(self._sg_user)
-                    ctx = tk.context_from_entity_dictionary(entity)
-                    ctx.project[flow_auth.AM_READY_PROJECT_FIELD] = flow_project_id
                     # Authenticate into Flow AM
-                    self._trigger_am_auth(tk.pipeline_configuration, entity, progress_callback)
+                    self._trigger_am_auth(
+                        tk.pipeline_configuration, entity, progress_callback
+                    )
 
         return config
 
@@ -1218,17 +1224,10 @@ class ToolkitManager(object):
         else:
             ctx = tk.context_from_entity_dictionary(entity)
             
-            # Inject the flow fields to context
-            if ctx.project is not None:
-                sg_project = self._sg_connection.find_one(
-                    "Project",
-                    [["id", "is", ctx.project["id"]]],
-                    [flow_const.FLOW_SCHEMA_VERSION_FIELD],
-                )
-                if sg_project:
-                    ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = (
-                        sg_project.get(flow_const.FLOW_SCHEMA_VERSION_FIELD)
-                    )
+            # Inject flow fields to context if current project is related to a Flow project.
+            if ctx.project and self._flow_project_id is not None:
+                ctx.project[flow_auth.AM_READY_PROJECT_FIELD] = self._flow_project_id
+                ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = self._flow_schema_version
 
         self._report_progress(
             progress_callback, self._LAUNCHING_ENGINE_RATE, "Launching Engine..."

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -975,11 +975,17 @@ class ToolkitManager(object):
             # Set authentication overrides in reserved env vars so they will persist
             # across toolkit engine sessions
             if flow_const.FLOW_AUTH_APP_ID in overrides:
-                os.environ["TK_FLOW_AUTH_APPLICATION_ID"] = overrides[flow_const.FLOW_AUTH_APP_ID]
+                os.environ["TK_FLOW_AUTH_APPLICATION_ID"] = overrides[
+                    flow_const.FLOW_AUTH_APP_ID
+                ]
             if flow_const.FLOW_AUTH_BASE_URL in overrides:
-                os.environ["TK_FLOW_AUTH_BASE_URL"] = overrides[flow_const.FLOW_AUTH_BASE_URL]
+                os.environ["TK_FLOW_AUTH_BASE_URL"] = overrides[
+                    flow_const.FLOW_AUTH_BASE_URL
+                ]
             if flow_const.FLOW_AUTH_CALLBACK_URL in overrides:
-                os.environ["TK_FLOW_AUTH_CALLBACK_URL"] = overrides[flow_const.FLOW_AUTH_CALLBACK_URL]
+                os.environ["TK_FLOW_AUTH_CALLBACK_URL"] = overrides[
+                    flow_const.FLOW_AUTH_CALLBACK_URL
+                ]
             settings = flow_auth.resolve_flow_auth_settings()
             flow_auth.init_authentication(settings)
             # Token is intentionally discarded here; it now sits in the file
@@ -1133,14 +1139,23 @@ class ToolkitManager(object):
                 sg_project = self._sg_connection.find_one(
                     "Project",
                     [["id", "is", project_id]],
-                    [flow_auth.AM_READY_PROJECT_FIELD, flow_const.FLOW_SCHEMA_VERSION_FIELD],
+                    [
+                        flow_auth.AM_READY_PROJECT_FIELD,
+                        flow_const.FLOW_SCHEMA_VERSION_FIELD,
+                    ],
                 )
                 if sg_project and sg_project.get(flow_auth.AM_READY_PROJECT_FIELD):
                     # Retrieve and cache the flow am project id on the context object
-                    self._flow_project_id = sg_project.get(flow_auth.AM_READY_PROJECT_FIELD)
-                    self._flow_schema_version = sg_project.get(flow_const.FLOW_SCHEMA_VERSION_FIELD)
-                    log.info(f"Current SG project is associated with a Flow project: {self._flow_project_id}")
-                    
+                    self._flow_project_id = sg_project.get(
+                        flow_auth.AM_READY_PROJECT_FIELD
+                    )
+                    self._flow_schema_version = sg_project.get(
+                        flow_const.FLOW_SCHEMA_VERSION_FIELD
+                    )
+                    log.info(
+                        f"Current SG project is associated with a Flow project: {self._flow_project_id}"
+                    )
+
                     tk, _ = config.get_tk_instance(self._sg_user)
                     # Authenticate into Flow AM
                     self._trigger_am_auth(
@@ -1198,6 +1213,11 @@ class ToolkitManager(object):
 
         If entity is None, the method will bootstrap into the site config.
 
+        For Flow-enabled projects, the Flow project id and schema version
+        cached during ``_get_updated_configuration()`` are injected onto
+        ``ctx.project`` so the engine can read them via
+        ``context.flow_project_id`` and ``context.flow_schema_version``.
+
         Please note that the API version of the tk instance that hosts
         the engine may not be the same as the API version that was
         executed during the bootstrap.
@@ -1223,11 +1243,13 @@ class ToolkitManager(object):
             ctx = tk.context_empty()
         else:
             ctx = tk.context_from_entity_dictionary(entity)
-            
+
             # Inject flow fields to context if current project is related to a Flow project.
             if ctx.project and self._flow_project_id is not None:
                 ctx.project[flow_auth.AM_READY_PROJECT_FIELD] = self._flow_project_id
-                ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = self._flow_schema_version
+                ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = (
+                    self._flow_schema_version
+                )
 
         self._report_progress(
             progress_callback, self._LAUNCHING_ENGINE_RATE, "Launching Engine..."

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -436,7 +436,7 @@ class Context(object):
     @property
     def flow_schema_version(self) -> str | None:
         """
-        The FlowAM schema version the project in context, or ``None`` if the project is
+        The FlowAM schema version of the project in context, or ``None`` if the project is
         not FlowAM-enabled or there is no schema created.
 
         The value is read from the ``sg_flow_schema_config_version`` field on the project dict.

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -22,6 +22,7 @@ from tank_vendor import yaml
 from tank_vendor.flow_integration_sdk import sandbox
 from . import authentication
 from .authentication import flow_auth
+from .flowam import constants as flow_const
 
 from .util import login
 from .util import shotgun_entity
@@ -431,6 +432,22 @@ class Context(object):
         If not None, this designates the current draft being worked on within the DCC session.
         """
         return self.__flow_draft_id
+
+    @property
+    def flow_schema_version(self) -> str | None:
+        """
+        The FlowAM schema version the project in context, or ``None`` if the project is
+        not FlowAM-enabled or there is no schema created.
+
+        The value is read from the ``sg_flow_schema_config_version`` field on the project dict.
+        It is populated by the bootstrap manager after it queries ShotGrid.
+
+        :returns: A string containing the FlowAM schema version, or ``None``.
+        :rtype: str or None
+        """
+        if self.project:
+            return self.project.get(flow_const.FLOW_SCHEMA_VERSION_FIELD)
+        return None
 
     @property
     def entity_locations(self):
@@ -858,7 +875,7 @@ class Context(object):
         """
         Converts the context into a dictionary with keys ``project``,
         ``entity``, ``user``, ``step``, ``task``, ``additional_entities``,
-        ``source_entity``, ``flow_project_id`` and ``flow_draft_id``.
+        ``source_entity``, ``flow_project_id``, ``flow_draft_id`` and ``flow_schema_version``.
 
         .. note ::
             Contrary to :meth:`Context.serialize`, this method discards information
@@ -879,6 +896,7 @@ class Context(object):
             "source_entity": self._cleanup_entity(self.source_entity),
             "flow_project_id": self.flow_project_id,
             "flow_draft_id": self.flow_draft_id,
+            "flow_schema_version": self.flow_schema_version,
         }
 
     def _cleanup_entity(self, entity):
@@ -955,6 +973,14 @@ class Context(object):
             and flow_auth.AM_READY_PROJECT_FIELD not in ctx.project
         ):
             ctx.project[flow_auth.AM_READY_PROJECT_FIELD] = data["flow_project_id"]
+        if (
+            ctx.project is not None
+            and "flow_schema_version" in data
+            and flow_const.FLOW_SCHEMA_VERSION_FIELD not in ctx.project
+        ):
+            ctx.project[flow_const.FLOW_SCHEMA_VERSION_FIELD] = data[
+                "flow_schema_version"
+            ]
         return ctx
 
     ################################################################################################

--- a/python/tank/flowam/constants.py
+++ b/python/tank/flowam/constants.py
@@ -29,3 +29,7 @@ FLOW_STORAGE_ROOT = "storage_root"
 # Location of config for specifying custom schemas used
 # in the toolkit Flow integration
 FLOW_SCHEMA_CONFIG_PATH = str(pathlib.Path(__file__).resolve().parent) + "/config.json"
+
+# SG Project field that stores the current schema config version,
+# used to skip schema provisioning when the version already matches.
+FLOW_SCHEMA_VERSION_FIELD = "sg_flow_schema_config_version"

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass, asdict
 
 from tank import LogManager
 from tank.authentication import flow_auth
-from tank.context import Context
 from tank.pipelineconfig import PipelineConfiguration
 from tank.util import yaml_cache
 from tank_vendor.flow_integration_sdk import globals, schema, storage
@@ -121,7 +120,7 @@ def get_config_flow_settings(pipeline_config: PipelineConfiguration) -> dict:
 def init_flow(
     pipeline_config : PipelineConfiguration,
     sg_connection,
-    context: Context,
+    context,
 ):
     """Do session set up + schema provisioning for the Flow Integration SDK.
 

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -18,11 +18,15 @@ import os
 import re
 import webbrowser
 from dataclasses import dataclass, asdict
+from typing import TYPE_CHECKING
 
 from tank import LogManager
 from tank.authentication import flow_auth
 from tank.pipelineconfig import PipelineConfiguration
 from tank.util import yaml_cache
+
+if TYPE_CHECKING:
+    from tank.context import Context
 from tank_vendor.flow_integration_sdk import globals, schema, storage
 from tank_vendor.flow_integration_sdk.exceptions import FlowError
 from tank_vendor.flow_integration_sdk.publish import (
@@ -118,9 +122,9 @@ def get_config_flow_settings(pipeline_config: PipelineConfiguration) -> dict:
 
 
 def init_flow(
-    pipeline_config : PipelineConfiguration,
+    pipeline_config: PipelineConfiguration,
     sg_connection,
-    context,
+    context: Context,
 ):
     """Do session set up + schema provisioning for the Flow Integration SDK.
 
@@ -136,7 +140,9 @@ def init_flow(
         RuntimeError
     """
     logger.info("Doing Flow Integration SDK initialization...")
-    logger.info(f"Flow AM Project ID: {context.flow_project_id}")
+    flow_project_id = context.flow_project_id
+    sg_project_id = context.project["id"]
+    logger.info(f"Flow AM Project ID: {flow_project_id}")
 
     # Read flow settings from config
     settings = get_config_flow_settings(pipeline_config)
@@ -153,7 +159,7 @@ def init_flow(
     globals.set_webapp_url(flow_web_url)
     # Set session collection
     try:
-        project = FlowProject(context.flow_project_id)
+        project = FlowProject(flow_project_id)
     except FlowError as exc:
         msg = f"Could not complete Flow initialization: {exc}"
         raise RuntimeError(msg) from exc
@@ -184,12 +190,12 @@ def init_flow(
         else:
             try:
                 create_pipeline_schemas(
-                    project_id=context.flow_project_id,
+                    project_id=flow_project_id,
                     config_path=FLOW_SCHEMA_CONFIG_PATH,
                 )
                 sg_connection.update(
                     "Project",
-                    context.project["id"],
+                    sg_project_id,
                     {FLOW_SCHEMA_VERSION_FIELD: current_version},
                 )
             except (

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -182,9 +182,7 @@ def init_flow(
     # Provision pipeline schemas for CPA collections only
     session_collection = globals.get_session_collection()
     if not session_collection.is_cpa_collection():
-        logger.info(
-            "Skipping pipeline schema provisioning - not a CPA collection."
-        )
+        logger.info("Skipping pipeline schema provisioning - not a CPA collection.")
     else:
         current_version = get_schema_config_version()
         if sg_schema_version == current_version:

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -34,9 +34,13 @@ from tank_vendor.flow_integration_sdk.publish import (
     FileSeqComponentSpec,
 )
 from tank_vendor.flow_integration_sdk.objects import FlowProject
+from tank_vendor.flow_integration_sdk.schema_builder import (
+    create_pipeline_schemas,
+    get_schema_config_version,
+)
 from tank_vendor.flow_integration_sdk.utils import trace
 
-from .constants import FLOW_SCHEMA_CONFIG_PATH
+from .constants import FLOW_SCHEMA_CONFIG_PATH, FLOW_SCHEMA_VERSION_FIELD
 
 
 logger = LogManager.get_logger(__name__)
@@ -116,12 +120,26 @@ def get_config_flow_settings(pipeline_config: PipelineConfiguration) -> dict:
     return {}
 
 
-def init_flow(pipeline_config: PipelineConfiguration, flow_project_id: str):
-    """Do some session set up in order to use the Flow Integration SDK.
+def init_flow(
+    pipeline_config,
+    sg_connection,
+    flow_project_id: str,
+    sg_schema_version: str | None,
+    sg_project_id: int,
+):
+    """Do session set up + schema provisioning for the Flow Integration SDK.
 
     Args:
-        pipeline_config: PipelineConfiguration object.
-        flow_project_id: The flow project associated with current sg project context.
+        pipeline_config: PipelineConfiguration object, used to read flow
+            settings from config.
+        sg_connection: Shotgun connection, used to write the schema config
+            version back to SG.
+        flow_project_id: The flow project associated with current sg project
+            context.
+        sg_schema_version: The schema config version stored on the SG Project,
+            used to skip provisioning when it already matches.
+        sg_project_id: The ShotGrid project entity id, used to write back
+            the schema config version after a successful build.
 
     Raises:
         RuntimeError
@@ -160,6 +178,40 @@ def init_flow(pipeline_config: PipelineConfiguration, flow_project_id: str):
     # Configure storage roots
     storage.set_sandbox_root(flow_sandbox_root, create_dir=True)
     storage.set_storage_root(flow_storage_root, create_dir=True)
+
+    # Provision pipeline schemas for CPA collections only
+    session_collection = globals.get_session_collection()
+    if not session_collection.is_cpa_collection():
+        logger.info(
+            "Skipping pipeline schema provisioning - not a CPA collection."
+        )
+    else:
+        current_version = get_schema_config_version()
+        if sg_schema_version == current_version:
+            logger.info(
+                f"Schema config version {current_version} matches. "
+                "Skipping schema provisioning."
+            )
+        else:
+            try:
+                create_pipeline_schemas(
+                    collection_id=session_collection.id,
+                    project_id=flow_project_id,
+                )
+                sg_connection.update(
+                    "Project",
+                    sg_project_id,
+                    {FLOW_SCHEMA_VERSION_FIELD: current_version},
+                )
+            except (
+                FlowError,
+                RuntimeError,
+                ValueError,
+                KeyError,
+                FileNotFoundError,
+            ) as exc:
+                msg = f"Could not complete Flow schema provisioning: {exc}"
+                raise RuntimeError(msg) from exc
 
     logger.info("Initialization complete!")
 

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, asdict
 
 from tank import LogManager
 from tank.authentication import flow_auth
+from tank.context import Context
 from tank.pipelineconfig import PipelineConfiguration
 from tank.util import yaml_cache
 from tank_vendor.flow_integration_sdk import globals, schema, storage
@@ -34,10 +35,7 @@ from tank_vendor.flow_integration_sdk.publish import (
     FileSeqComponentSpec,
 )
 from tank_vendor.flow_integration_sdk.objects import FlowProject
-from tank_vendor.flow_integration_sdk.schema_builder import (
-    create_pipeline_schemas,
-    get_schema_config_version,
-)
+from tank_vendor.flow_integration_sdk.schema_builder import create_pipeline_schemas
 from tank_vendor.flow_integration_sdk.utils import trace
 
 from .constants import FLOW_SCHEMA_CONFIG_PATH, FLOW_SCHEMA_VERSION_FIELD
@@ -121,11 +119,9 @@ def get_config_flow_settings(pipeline_config: PipelineConfiguration) -> dict:
 
 
 def init_flow(
-    pipeline_config,
+    pipeline_config : PipelineConfiguration,
     sg_connection,
-    flow_project_id: str,
-    sg_schema_version: str | None,
-    sg_project_id: int,
+    context: Context,
 ):
     """Do session set up + schema provisioning for the Flow Integration SDK.
 
@@ -134,18 +130,14 @@ def init_flow(
             settings from config.
         sg_connection: Shotgun connection, used to write the schema config
             version back to SG.
-        flow_project_id: The flow project associated with current sg project
-            context.
-        sg_schema_version: The schema config version stored on the SG Project,
-            used to skip provisioning when it already matches.
-        sg_project_id: The ShotGrid project entity id, used to write back
-            the schema config version after a successful build.
+        context: The current Toolkit context, used to read the flow project id,
+            schema version, and SG project id.
 
     Raises:
         RuntimeError
     """
     logger.info("Doing Flow Integration SDK initialization...")
-    logger.info(f"Flow AM Project ID: {flow_project_id}")
+    logger.info(f"Flow AM Project ID: {context.flow_project_id}")
 
     # Read flow settings from config
     settings = get_config_flow_settings(pipeline_config)
@@ -162,7 +154,7 @@ def init_flow(
     globals.set_webapp_url(flow_web_url)
     # Set session collection
     try:
-        project = FlowProject(flow_project_id)
+        project = FlowProject(context.flow_project_id)
     except FlowError as exc:
         msg = f"Could not complete Flow initialization: {exc}"
         raise RuntimeError(msg) from exc
@@ -184,8 +176,8 @@ def init_flow(
     if not session_collection.is_cpa_collection():
         logger.info("Skipping pipeline schema provisioning - not a CPA collection.")
     else:
-        current_version = get_schema_config_version()
-        if sg_schema_version == current_version:
+        current_version = schema.get_schema_config_version(FLOW_SCHEMA_CONFIG_PATH)
+        if context.flow_schema_version == current_version:
             logger.info(
                 f"Schema config version {current_version} matches. "
                 "Skipping schema provisioning."
@@ -193,12 +185,12 @@ def init_flow(
         else:
             try:
                 create_pipeline_schemas(
-                    collection_id=session_collection.id,
-                    project_id=flow_project_id,
+                    project_id=context.flow_project_id,
+                    config_path=FLOW_SCHEMA_CONFIG_PATH,
                 )
                 sg_connection.update(
                     "Project",
-                    sg_project_id,
+                    context.project["id"],
                     {FLOW_SCHEMA_VERSION_FIELD: current_version},
                 )
             except (

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -182,9 +182,7 @@ class Engine(TankBundle):
                 flow_utils.init_flow(
                     tk.pipeline_configuration,
                     tk.shotgun,
-                    context.flow_project_id,
-                    context.flow_schema_version,
-                    context.project["id"],
+                    context,
                 )
             except RuntimeError as exc:
                 self.log_error("Error occurred during Flow initialization!")

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -73,6 +73,11 @@ class Engine(TankBundle):
         Engine instances are constructed by the toolkit launch process
         and various factory methods such as :meth:`start_engine`.
 
+        For Flow-enabled contexts (``context.flow_project_id`` set), this
+        also runs ``flow_utils.init_flow()`` to set up the Flow Integration
+        SDK session and provision pipeline schemas when the SG schema
+        config version does not match the bundled config.
+
         :param tk: :class:`~sgtk.Sgtk` instance
         :param context: A context object to define the context on disk where the engine is operating
         :type context: :class:`~sgtk.Context`

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -174,7 +174,13 @@ class Engine(TankBundle):
         # Do Flow sdk initialization if context is configured with Flow
         if context.flow_project_id:
             try:
-                flow_utils.init_flow(tk.pipeline_configuration, context.flow_project_id)
+                flow_utils.init_flow(
+                    tk.pipeline_configuration,
+                    tk.shotgun,
+                    context.flow_project_id,
+                    context.flow_schema_version,
+                    context.project["id"],
+                )
             except RuntimeError as exc:
                 self.log_error("Error occurred during Flow initialization!")
                 self.log_exception(exc)

--- a/python/tank_vendor/flow_integration_sdk/exceptions.py
+++ b/python/tank_vendor/flow_integration_sdk/exceptions.py
@@ -104,27 +104,27 @@ class InvalidDraftError(FlowError):
         self.draft_id = draft_id
 
 
-class SchemaBuilderError(FlowError):
+class FlowSchemaBuilderError(FlowError):
     """General exception for errors related to SchemaBuilder operations."""
-    
+
     def __init__(self, *args, **kwargs):
         message = "SchemaBuilder operation failed."
         super().__init__(message, *args, **kwargs)
 
 
-class SchemaDisplayDataError(FlowError):
+class FlowSchemaDisplayDataError(FlowError):
     def __init__(self, *args, **kwargs):
         message = "Schema display data operation failed."
         super().__init__(message, *args, **kwargs)
 
 
-class SchemaError(FlowError):
+class FlowSchemaError(FlowError):
     def __init__(self, *args, **kwargs):
         message = "Schema operation failed."
         super().__init__(message, *args, **kwargs)
 
 
-class SchemaLibraryError(FlowError):
+class FlowSchemaLibraryError(FlowError):
     def __init__(self, *args, **kwargs):
         message = "Schema library operation failed."
         super().__init__(message, *args, **kwargs)

--- a/python/tank_vendor/flow_integration_sdk/exceptions.py
+++ b/python/tank_vendor/flow_integration_sdk/exceptions.py
@@ -104,6 +104,32 @@ class InvalidDraftError(FlowError):
         self.draft_id = draft_id
 
 
+class SchemaBuilderError(FlowError):
+    """General exception for errors related to SchemaBuilder operations."""
+    
+    def __init__(self, *args, **kwargs):
+        message = "SchemaBuilder operation failed."
+        super().__init__(message, *args, **kwargs)
+
+
+class SchemaDisplayDataError(FlowError):
+    def __init__(self, *args, **kwargs):
+        message = "Schema display data operation failed."
+        super().__init__(message, *args, **kwargs)
+
+
+class SchemaError(FlowError):
+    def __init__(self, *args, **kwargs):
+        message = "Schema operation failed."
+        super().__init__(message, *args, **kwargs)
+
+
+class SchemaLibraryError(FlowError):
+    def __init__(self, *args, **kwargs):
+        message = "Schema library operation failed."
+        super().__init__(message, *args, **kwargs)
+
+
 class PublishAssetError(FlowError):
     def __init__(self, *args, **kwargs):
         message = "Could not publish asset."

--- a/python/tank_vendor/flow_integration_sdk/schema.py
+++ b/python/tank_vendor/flow_integration_sdk/schema.py
@@ -239,3 +239,20 @@ def is_sub_type(base_id: str, type_id: str) -> bool:
         except GQLAPIError as exc:
             msg = f'Error querying subtypes of base type "{base_id}": {exc}'
             raise FlowError(msg) from exc
+
+
+def get_schema_config_version(config_path: str) -> str:
+    """Retrieve the schema config version from a config.json file.
+
+    Args:
+        config_path: Path to the schema config json file.
+
+    Returns:
+        The schema config version, or 'unknown' if the key is not present.
+
+    Raises:
+        RuntimeError: If the config file is not found.
+        ValueError: If the config file contains invalid JSON.
+    """
+    config = _read_schema_config(config_path)
+    return config.get("version", "unknown")

--- a/python/tank_vendor/flow_integration_sdk/schema_builder.py
+++ b/python/tank_vendor/flow_integration_sdk/schema_builder.py
@@ -1,0 +1,670 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""Schema builder utilities for creating and managing Flow pipeline schemas."""
+
+from __future__ import annotations  # needed for python 3.9 support
+
+import json
+import os
+from typing import Any
+
+from tank_vendor.flow_data_sdk.base import model as flow_model
+from tank_vendor.flow_data_sdk.base.exceptions import (
+    FlowConnectionError,
+    GQLAPIError,
+    ValidationError,
+)
+
+from .exceptions import (
+    SchemaBuilderError,
+    SchemaDisplayDataError,
+    SchemaError,
+    SchemaLibraryError,
+)
+from .globals import BASE_TYPE_ID, get_client
+from .schema import get_schema_id
+from .utils import cleanpath, get_logger
+
+
+# Constant for Flow Toolkit Library schema library ID
+FLOW_TOOLKIT_LIBRARY_ID = "FlowToolkitLibrary"
+
+
+class SchemaBuilder:
+    """Utility class to build and validate schemas from a dictionary.
+
+    This class provides methods to validate schema definitions, build new schemas,
+    update schema display names, and retrieve existing schemas from a schema library.
+    """
+
+    def __init__(
+        self,
+        schema_dict: dict,
+        schema_kind: flow_model.SchemaKind,
+        project_id: str,
+        schema_library_id: str,
+    ):
+        """Initialize the SchemaBuilder.
+
+        Args:
+            schema_dict: The dictionary containing the schema definition.
+            schema_kind: The kind of Schema to create (type, component, or property).
+            project_id: The Flow AM project ID.
+            schema_library_id: The ID of the schema library where the schema
+                will be created.
+        """
+        self.schema_dict = schema_dict
+        self.schema_kind = schema_kind
+        self.project_id = project_id
+        self.schema_library_id = schema_library_id
+        self.schema: flow_model.Schema | None = None
+
+        # Validate schema dictionary on initialization
+        self.__validate_schema_dict()
+
+    def __validate_schema_dict(self) -> None:
+        """Validate the incoming schema dictionary.
+
+        Raises:
+            KeyError: If required keys are missing or invalid.
+            ValueError: If key types or values are invalid.
+        """
+
+        # Define a dictionary mapping keys to their expected types
+        key_type_dict = {
+            "name": str,
+            "version": str,
+            "display_name": str,
+            "kind": str,
+            "description": str,
+            "inherits": list,
+            "properties": list,
+        }
+
+        # Check for mandatory keys
+        for key in ["name", "version"]:
+            if key not in self.schema_dict:
+                raise KeyError(
+                    f"The custom type schema must contain a '{key}' key of type string."
+                )
+
+        # Validate keys and types
+        for key, value in self.schema_dict.items():
+            if key not in key_type_dict:
+                raise KeyError(f"Invalid key '{key}' in custom type schema.")
+            if not isinstance(value, key_type_dict[key]):
+                raise ValueError(
+                    f"The '{key}' key must be of type {key_type_dict[key].__name__}."
+                )
+            if key == "kind":
+                # Validate against flow_model.SchemaKind enum
+                valid_kinds = [kind.value for kind in flow_model.SchemaKind]
+                if value not in valid_kinds:
+                    raise ValueError(
+                        f"Invalid kind '{value}' in custom type schema. "
+                        f"Must be one of {', '.join(valid_kinds)}"
+                    )
+            if key == "properties":
+                for property_dict in value:
+                    self.__validate_property_dict(property_dict)
+
+    def __validate_property_dict(self, property_dict: dict) -> None:
+        """Validate a schema 'property' dictionary.
+
+        Args:
+            property_dict (dict): The property dictionary to validate.
+
+        Raises:
+            KeyError: If required keys are missing or invalid.
+            ValueError: If key types or values are invalid.
+        """
+
+        # Define a dictionary mapping keys to their expected types
+        key_type_dict = {
+            "name": str,
+            "data_type": str,
+            "properties": list,
+            "default_value": Any,
+            "context": str,
+            "length": int,
+        }
+
+        # Check for mandatory keys
+        for key in ["name", "data_type"]:
+            if key not in property_dict:
+                raise KeyError(f"The property schema must contain a '{key}' key.")
+
+        # Validate keys and types
+        for key, value in property_dict.items():
+            if key not in key_type_dict:
+                raise KeyError(f"Invalid key '{key}' in property schema.")
+
+            if key_type_dict[key] is not Any:
+                if not isinstance(value, key_type_dict[key]):  # type: ignore
+                    raise ValueError(
+                        f"The '{key}' key must be of type "
+                        f"{key_type_dict[key].__name__}."  # type: ignore
+                    )
+
+            if key == "data_type":
+                # Validate that referenced schema exists in config
+                if "$ref:" in value:
+                    referenced_schema = value.split(":")[1]
+                    referenced_schema_id = get_schema_id(referenced_schema)
+                    if not referenced_schema_id:
+                        raise ValueError(
+                            f"Referenced schema '{referenced_schema}' not found "
+                            "in config.json."
+                        )
+
+            if key == "properties":
+                for sub_property_dict in value:
+                    self.__validate_property_dict(sub_property_dict)
+
+    def _create_property_type_input(
+        self, data_type: str
+    ) -> flow_model.PropertyTypeInput:
+        """Create a PropertyTypeInput from a data type string.
+
+        Args:
+            data_type: Either a primitive type name (e.g., "String") or a
+                custom schema type ID
+
+        Returns:
+            PropertyTypeInput with either primitive_type or custom_type set
+        """
+        primitive_types = [member.value for member in flow_model.PrimitiveType]
+
+        if data_type in primitive_types:
+            primitive_enum = flow_model.PrimitiveType(data_type)
+            return flow_model.PropertyTypeInput(primitive_type=primitive_enum.value)
+
+        return flow_model.PropertyTypeInput(custom_type=data_type)
+
+    def _create_properties_definition_input(
+        self, property_dict: dict
+    ) -> flow_model.PropertiesDefinitionInput:
+        """Recursively create a PropertiesDefinitionInput from a property dictionary."""
+        # Resolve references in data type
+        data_type = property_dict["data_type"]
+
+        if "$ref:" in data_type:
+            # Resolve referenced schema id
+            referenced_schema_name = property_dict["data_type"].split(":")[1]
+            referenced_schema_id = get_schema_id(referenced_schema_name)
+            if not referenced_schema_id:
+                raise ValueError(
+                    f"Referenced schema '{referenced_schema_name}' not found "
+                    "in config.json."
+                )
+            data_type = referenced_schema_id
+
+        if "$id:" in data_type:
+            data_type = ":".join(data_type.split(":")[1:])
+
+        # Create PropertyTypeInput
+        property_type_input = self._create_property_type_input(data_type)
+
+        # Recursively handle nested properties
+        nested_properties = []
+        if property_dict.get("properties"):
+            for nested_property in property_dict["properties"]:
+                nested_properties.append(
+                    self._create_properties_definition_input(nested_property)
+                )
+
+        # Create PropertiesDefinitionInput
+        properties_definition_input = flow_model.PropertiesDefinitionInput(
+            name=property_dict["name"],
+            type=property_type_input,
+            properties=nested_properties if nested_properties else None,
+        )
+
+        # Add optional fields if present
+        if property_dict.get("default_value"):
+            properties_definition_input.value = property_dict["default_value"]
+        if property_dict.get("context"):
+            properties_definition_input.context = property_dict["context"]
+        if property_dict.get("length"):
+            properties_definition_input.length = property_dict["length"]
+
+        return properties_definition_input
+
+    def build(self) -> flow_model.Schema:
+        """Build and commit the custom private Schema.
+
+        Returns:
+            Schema: The created or existing Schema instance.
+
+        Raises:
+            SchemaError: If schema creation or commit fails due to a client error.
+            ValueError: If referenced schemas in 'inherits' or 'properties' are
+                not found.
+        """
+
+        logger = get_logger(__name__)
+        client = get_client()
+
+        # Build inherits list for CreateSchemaInput
+        inherits = []
+        if self.schema_dict.get("inherits"):
+            for inherited_schema in self.schema_dict["inherits"]:
+                # If current schema inherits from another schema
+                if "$ref:" in inherited_schema:
+                    # Resolve referenced schema id
+                    inherited_schema_name = inherited_schema.split(":")[1]
+                    inherited_schema_id = get_schema_id(inherited_schema_name)
+                    if not inherited_schema_id:
+                        raise ValueError(
+                            f"Inherited schema '{inherited_schema_name}' not found "
+                            "in config.json."
+                        )
+                    inherits.append(inherited_schema_id)
+                else:
+                    inherits.append(inherited_schema)
+
+        # Build property list for CreateSchemaInput
+        properties = []
+        for property_dict in self.schema_dict.get("properties", []):
+            properties.append(
+                self._create_properties_definition_input(property_dict)
+            )
+
+        try:
+            # Create CreateSchemaInput for the mutation
+            create_schema_input = flow_model.CreateSchemaInput(
+                kind=self.schema_kind.value,
+                name=self.schema_dict["name"],
+                project_id=self.project_id,
+                schema_library_id=self.schema_library_id,
+                version=self.schema_dict["version"],
+                description=self.schema_dict.get("description", ""),
+                inherits=inherits if inherits else None,
+                properties=properties if properties else None,
+            )
+            # Create and call the schema mutation
+            create_schema_query = client.service_schema.create_schema(
+                variables=create_schema_input
+            )
+            query_response = create_schema_query.call()
+            self.schema = query_response.schema
+            logger.info("Created new schema: %s", self.schema.name)
+        except (GQLAPIError, FlowConnectionError, ValidationError) as e:
+            raise SchemaError(
+                details=(
+                    f"Failed to create schema '{self.schema_dict['name']}' "
+                    f"version '{self.schema_dict['version']}': {e}"
+                )
+            ) from e
+
+        return self.schema
+
+    def get_display_data(self) -> flow_model.SchemaDisplayData | None:
+        """Retrieve the display data object for the current schema.
+
+        This method attempts to fetch the SchemaDisplayData associated with the
+        schema instance. If the schema has not been built, a SchemaBuilderError
+        is raised. If no display data exists for the schema, None is returned.
+
+        Returns:
+            SchemaDisplayData | None: The display data instance if found,
+                otherwise None.
+
+        Raises:
+            SchemaBuilderError: If the schema instance has not been built.
+        """
+
+        if not self.schema:
+            raise SchemaBuilderError(details="Schema instance has not been built yet.")
+
+        client = get_client()
+        schema_display_data = None
+        try:
+            # Create GetSchemaDisplayDataInput for the query
+            input_data = flow_model.GetSchemaDisplayDataInput(
+                schema_type_id=self.schema.type_id
+            )
+            # Create and call the schema query
+            schema_query = client.service_schema.schema_display_data(
+                variables=input_data
+            )
+            query_response = schema_query.call()
+            schema_display_data = query_response.schema_display_data
+        except (GQLAPIError, FlowConnectionError, ValidationError):
+            # TODO: Verify get display data for new created schema's behavior
+            # Two possible scenarios:
+            # 1. Schema type doesn't exist (shouldn't happen if schema was just created)
+            # 2. No display data exists yet (expected for newly created schemas)
+            pass
+
+        return schema_display_data
+
+    def update_display_name(self) -> str | None:
+        """Update the display name of the schema to match the value in the schema
+        definition.
+
+        This method retrieves the current schema's display data and updates its
+        display name if it differs from the desired value. If the display name is
+        successfully updated, the new value is returned. If the display name
+        already matches, it is returned.
+
+        Returns:
+            str | None: The updated display name if successful, or the current
+                display name if it already matches the desired value.
+
+        Raises:
+            SchemaBuilderError: If the schema instance has not been built or the
+                schema definition does not specify a display name.
+            SchemaDisplayDataError: If updating the display name fails due to an
+                error (such as an API failure).
+        """
+
+        logger = get_logger(__name__)
+        client = get_client()
+        display_name = self.schema_dict.get("display_name")
+
+        if not self.schema:
+            raise SchemaBuilderError(details="Schema instance has not been built yet.")
+
+        if not display_name:
+            raise SchemaBuilderError(
+                details="No display name specified in schema definition."
+            )
+
+        if (
+            self.schema.display_data
+            and self.schema.display_data.display_name == display_name
+        ):
+            return display_name
+
+        schema_display_data = self.get_display_data()
+
+        try:
+            if schema_display_data:
+                # Display data exists
+                # Create UpdateSchemaDisplayDataInput for update display name
+                # mutation and call it
+                input_data = flow_model.UpdateSchemaDisplayDataInput(
+                    schema_type_id=self.schema.type_id, display_name=display_name
+                )
+                client.service_schema.update_schema_display_data(
+                    variables=input_data,
+                ).call()
+            else:
+                # Display data doesn't exist
+                # Create CreateSchemaDisplayDataInput for create display name
+                # mutation and call it
+                input_data = flow_model.CreateSchemaDisplayDataInput(
+                    schema_type_id=self.schema.type_id, display_name=display_name
+                )
+                client.service_schema.create_schema_display_data(
+                    variables=input_data,
+                ).call()
+
+            logger.debug(
+                "updated display name of schema %s to '%s'",
+                self.schema.name,
+                display_name,
+            )
+            return display_name
+        except (GQLAPIError, FlowConnectionError, ValidationError) as e:
+            raise SchemaDisplayDataError(
+                details=(
+                    f"Could not update display data for schema "
+                    f"'{self.schema.name}': {e}."
+                )
+            ) from e
+
+
+def _get_schema_library(
+    library_id: str, collection_id: str
+) -> flow_model.SchemaLibrary | None:
+    """Retrieve a schema library by its unique name (ID) if it exists, or None
+    if not found.
+
+    Raises:
+        SchemaLibraryError: If retrieving schema libraries fails due to a client
+            error.
+    """
+
+    logger = get_logger(__name__)
+    client = get_client()
+
+    try:
+        # Create SchemaLibrariesByCollectionIdInput for the query
+        input_data = flow_model.SchemaLibrariesByCollectionIdInput(
+            collection_id=collection_id
+        )
+        # Create and call the schema query
+        schema_query = client.service_schema.schema_libraries_by_collection_id(
+            variables=input_data
+        )
+        schema_libraries = list(schema_query.libraries_iterator or [])
+    except (GQLAPIError, FlowConnectionError, ValidationError) as e:
+        raise SchemaLibraryError(
+            details=f"Failed to retrieve all schema libraries: {e}"
+        ) from e
+
+    for schema_library in schema_libraries:
+        if schema_library.name == library_id:
+            logger.info("Found existing schema library %s", library_id)
+            return schema_library
+
+    logger.info("Schema Library %s not found.", library_id)
+    return None
+
+
+def _create_schema_library(
+    library_id: str,
+    title: str,
+    description: str,
+    project_id: str,
+    collection_id: str,
+) -> flow_model.SchemaLibrary:
+    """Create a schema library if it does not exist, or return the existing one.
+
+    Raises:
+        SchemaLibraryError: If retrieving or creating the schema library fails
+            due to a client error.
+    """
+
+    logger = get_logger(__name__)
+    schema_library = _get_schema_library(library_id, collection_id)
+
+    if schema_library is not None:
+        logger.info("Schema Library %s found. Skipping creation.", library_id)
+        return schema_library
+
+    client = get_client()
+
+    try:
+        # Create CreateSchemaLibraryInput for the mutation
+        input_data = flow_model.CreateSchemaLibraryInput(
+            name=library_id,
+            title=title,
+            description=description,
+            project_id=project_id,
+        )
+        # Create and call the schema mutation
+        schema_query = client.service_schema.create_schema_library(
+            variables=input_data
+        )
+        query_response = schema_query.call()
+        # Extract the created schema library from the response
+        schema_library = query_response.schema_library
+        logger.info("Successfully created a new Schema Library %s", library_id)
+        return schema_library
+
+    except (GQLAPIError, FlowConnectionError, ValidationError) as e:
+        raise SchemaLibraryError(
+            details=f"Failed to create SchemaLibrary '{library_id}': {e}"
+        ) from e
+
+
+def _load_config_file() -> dict:
+    """Load and validate the config.json file.
+
+    This function loads the config.json file from the Flow AM constants path,
+    validates that it contains valid JSON and has the required 'schemas' key.
+
+    Returns:
+        dict: The parsed config dictionary.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist or cannot be opened.
+        json.JSONDecodeError: If the config file contains invalid JSON.
+        KeyError: If the config file does not contain a 'schemas' key.
+    """
+    from tank.flowam.constants import FLOW_SCHEMA_CONFIG_PATH
+
+    config_path = FLOW_SCHEMA_CONFIG_PATH
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Could not open the config file {config_path}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise json.JSONDecodeError(
+            f"File {config_path} does not contain valid JSON.", doc="", pos=0
+        ) from exc
+
+    if "schemas" not in config:
+        raise KeyError("The config file must contain a 'schemas' key.")
+
+    return config
+
+
+def get_schema_config_version() -> str:
+    """Retrieve the schema config version from the config.json file.
+
+    This function reads the config.json file located at FLOW_SCHEMA_CONFIG_PATH
+    and extracts the 'version' key. If the file does not exist or contains
+    invalid JSON, appropriate exceptions are raised. If the 'version' key is
+    missing, a default value of 'unknown' is returned.
+
+    Returns:
+        str: The schema config version from the config.json file, or 'unknown'
+            if not specified.
+    """
+
+    config = _load_config_file()
+    return config.get("version", "unknown")
+
+
+def create_pipeline_schemas(collection_id: str, project_id: str):
+    """Create pipeline schemas under the schema library 'Flow Toolkit Library'
+    for a CPA collection.
+
+    This utility is only applicable to CPA (provisioned) collections. It is
+    designed to create or use the 'Flow Toolkit Library' and its associated
+    schemas.
+
+    The function performs the following steps:
+        1. Loads and validates the config.json file from the pipeline scripts
+           directory.
+        2. Creates or retrieves the schema library 'Flow Toolkit Library' for
+           the collection.
+        3. Iterates through the schemas defined in the config file, creating any
+           that do not exist, and updating their display names as needed.
+        4. Skips creation of schemas that already exist.
+        5. Forces schema cache refresh to include newly created schemas.
+
+    Args:
+        collection_id: The collection_id to create pipeline schemas.
+        project_id: The Flow AM project ID.
+    Raises:
+        RuntimeError: If schema library creation fails.
+        FileNotFoundError: If the config file does not exist.
+        json.JSONDecodeError: If the config file contains invalid JSON.
+        KeyError: If the config file does not contain a 'schemas' key,
+            or if required keys are missing in the schema definition.
+        ValueError: If schema definition or property values are invalid.
+        SchemaError: If schema creation or retrieval fails.
+        SchemaBuilderError: If schema building fails.
+        SchemaDisplayDataError: If updating display data fails.
+        SchemaLibraryError: If schema library operations fail.
+    """
+    logger = get_logger(__name__)
+    config = _load_config_file()
+    client = get_client()
+
+    # Retrieve all existing published schema type ids for the collection
+    try:
+        # Create SchemasBySuperTypeInput for the query
+        schemas_by_supertype_input = flow_model.SchemasBySuperTypeInput(
+            collection_id=collection_id,
+            type_id=BASE_TYPE_ID,
+            include_sub_sub_classes=True,
+        )
+        # Create and call the schema query
+        schema_query = client.service_schema.schemas_by_super_type(
+            variables=schemas_by_supertype_input
+        )
+        existing_schema_types = set(schema_query.schema_types_iterator)
+        logger.info(
+            f"Retrieved {len(existing_schema_types)} existing schemas for "
+            f"collection {collection_id}."
+        )
+    except (GQLAPIError, FlowConnectionError, ValidationError) as e:
+        raise RuntimeError(f"Failed to retrieve existing schemas: {e}") from e
+
+    # Check if schema listed in config.json already exists
+    # If not, add it to need_to_create list
+    need_to_create = []
+    for schema_dict in config.get("schemas", []):
+        # Get the schema type id for the schema and check if it already exists
+        schema_type_id = get_schema_id(schema_dict["name"])
+        if schema_type_id not in existing_schema_types:
+            logger.info(
+                "Schema '%s' not found. Adding to list to be created.",
+                schema_type_id,
+            )
+            need_to_create.append(schema_dict)
+
+    # Check if need_to_create is not empty
+    # and proceed to create schema library and schemas
+    if len(need_to_create) > 0:
+        logger.info("Attempting to create missing schemas...")
+        library_id = FLOW_TOOLKIT_LIBRARY_ID
+        _create_schema_library(
+            library_id=library_id,
+            title="Flow Toolkit Library",
+            description="Schemas for Flow Toolkit pipelines.",
+            project_id=project_id,
+            collection_id=collection_id,
+        )
+
+        schemas = []
+        # Create schemas if not exist
+        for schema_dict in need_to_create:
+            schema_builder = SchemaBuilder(
+                schema_dict=schema_dict,
+                schema_kind=flow_model.SchemaKind(schema_dict["kind"]),
+                project_id=project_id,
+                schema_library_id=library_id,
+            )
+            schema_builder.build()
+
+            if schema_builder.schema:
+                # NOTE: We need to explicitly pass the display name back because
+                # in newly created schemas, the 'display_name' property is not
+                # updated, therefore can not be reliably used to determine
+                # display name of the schema.
+                display_name = schema_builder.update_display_name()
+                schemas.append((schema_builder.schema, display_name))
+    else:
+        logger.info("All required schemas already exist.")

--- a/python/tank_vendor/flow_integration_sdk/schema_builder.py
+++ b/python/tank_vendor/flow_integration_sdk/schema_builder.py
@@ -24,10 +24,10 @@ from tank_vendor.flow_data_sdk.base.exceptions import (
 )
 
 from .exceptions import (
-    SchemaBuilderError,
-    SchemaDisplayDataError,
-    SchemaError,
-    SchemaLibraryError,
+    FlowSchemaBuilderError,
+    FlowSchemaDisplayDataError,
+    FlowSchemaError,
+    FlowSchemaLibraryError,
 )
 from .globals import BASE_TYPE_ID, get_client
 from .schema import get_schema_id
@@ -229,11 +229,11 @@ class SchemaBuilder:
         )
 
         # Add optional fields if present
-        if property_dict.get("default_value"):
+        if "default_value" in property_dict:
             properties_definition_input.value = property_dict["default_value"]
-        if property_dict.get("context"):
+        if "context" in property_dict:
             properties_definition_input.context = property_dict["context"]
-        if property_dict.get("length"):
+        if "length" in property_dict:
             properties_definition_input.length = property_dict["length"]
 
         return properties_definition_input
@@ -245,7 +245,7 @@ class SchemaBuilder:
             Schema: The created or existing Schema instance.
 
         Raises:
-            SchemaError: If schema creation or commit fails due to a client error.
+            FlowSchemaError: If schema creation or commit fails due to a client error.
             ValueError: If referenced schemas in 'inherits' or 'properties' are
                 not found.
         """
@@ -298,7 +298,7 @@ class SchemaBuilder:
             self.schema = query_response.schema
             logger.info("Created new schema: %s", self.schema.name)
         except (GQLAPIError, FlowConnectionError, ValidationError) as e:
-            raise SchemaError(
+            raise FlowSchemaError(
                 details=(
                     f"Failed to create schema '{self.schema_dict['name']}' "
                     f"version '{self.schema_dict['version']}': {e}"
@@ -311,7 +311,7 @@ class SchemaBuilder:
         """Retrieve the display data object for the current schema.
 
         This method attempts to fetch the SchemaDisplayData associated with the
-        schema instance. If the schema has not been built, a SchemaBuilderError
+        schema instance. If the schema has not been built, a FlowSchemaBuilderError
         is raised. If no display data exists for the schema, None is returned.
 
         Returns:
@@ -319,11 +319,11 @@ class SchemaBuilder:
                 otherwise None.
 
         Raises:
-            SchemaBuilderError: If the schema instance has not been built.
+            FlowSchemaBuilderError: If the schema instance has not been built.
         """
 
         if not self.schema:
-            raise SchemaBuilderError(details="Schema instance has not been built yet.")
+            raise FlowSchemaBuilderError(details="Schema instance has not been built yet.")
 
         client = get_client()
         schema_display_data = None
@@ -361,9 +361,9 @@ class SchemaBuilder:
                 display name if it already matches the desired value.
 
         Raises:
-            SchemaBuilderError: If the schema instance has not been built or the
+            FlowSchemaBuilderError: If the schema instance has not been built or the
                 schema definition does not specify a display name.
-            SchemaDisplayDataError: If updating the display name fails due to an
+            FlowSchemaDisplayDataError: If updating the display name fails due to an
                 error (such as an API failure).
         """
 
@@ -372,10 +372,10 @@ class SchemaBuilder:
         display_name = self.schema_dict.get("display_name")
 
         if not self.schema:
-            raise SchemaBuilderError(details="Schema instance has not been built yet.")
+            raise FlowSchemaBuilderError(details="Schema instance has not been built yet.")
 
         if not display_name:
-            raise SchemaBuilderError(
+            raise FlowSchemaBuilderError(
                 details="No display name specified in schema definition."
             )
 
@@ -416,7 +416,7 @@ class SchemaBuilder:
             )
             return display_name
         except (GQLAPIError, FlowConnectionError, ValidationError) as e:
-            raise SchemaDisplayDataError(
+            raise FlowSchemaDisplayDataError(
                 details=(
                     f"Could not update display data for schema "
                     f"'{self.schema.name}': {e}."
@@ -431,7 +431,7 @@ def _get_schema_library(
     if not found.
 
     Raises:
-        SchemaLibraryError: If retrieving schema libraries fails due to a client
+        FlowSchemaLibraryError: If retrieving schema libraries fails due to a client
             error.
     """
 
@@ -449,7 +449,7 @@ def _get_schema_library(
         )
         schema_libraries = list(schema_query.libraries_iterator or [])
     except (GQLAPIError, FlowConnectionError, ValidationError) as e:
-        raise SchemaLibraryError(
+        raise FlowSchemaLibraryError(
             details=f"Failed to retrieve all schema libraries: {e}"
         ) from e
 
@@ -472,7 +472,7 @@ def _create_schema_library(
     """Create a schema library if it does not exist, or return the existing one.
 
     Raises:
-        SchemaLibraryError: If retrieving or creating the schema library fails
+        FlowSchemaLibraryError: If retrieving or creating the schema library fails
             due to a client error.
     """
 
@@ -504,7 +504,7 @@ def _create_schema_library(
         return schema_library
 
     except (GQLAPIError, FlowConnectionError, ValidationError) as e:
-        raise SchemaLibraryError(
+        raise FlowSchemaLibraryError(
             details=f"Failed to create SchemaLibrary '{library_id}': {e}"
         ) from e
 
@@ -574,14 +574,10 @@ def create_pipeline_schemas(collection_id: str, project_id: str):
     schemas.
 
     The function performs the following steps:
-        1. Loads and validates the config.json file from the pipeline scripts
-           directory.
-        2. Creates or retrieves the schema library 'Flow Toolkit Library' for
-           the collection.
-        3. Iterates through the schemas defined in the config file, creating any
-           that do not exist, and updating their display names as needed.
-        4. Skips creation of schemas that already exist.
-        5. Forces schema cache refresh to include newly created schemas.
+        1. Loads and validates the config.json file.
+        2. Queries existing schema type ids for the target collection.
+        3. Creates the schema library if any configured schemas are missing.
+        4. Creates any missing schemas and sets their display names.
 
     Args:
         collection_id: The collection_id to create pipeline schemas.
@@ -593,10 +589,10 @@ def create_pipeline_schemas(collection_id: str, project_id: str):
         KeyError: If the config file does not contain a 'schemas' key,
             or if required keys are missing in the schema definition.
         ValueError: If schema definition or property values are invalid.
-        SchemaError: If schema creation or retrieval fails.
-        SchemaBuilderError: If schema building fails.
-        SchemaDisplayDataError: If updating display data fails.
-        SchemaLibraryError: If schema library operations fail.
+        FlowSchemaError: If schema creation or retrieval fails.
+        FlowSchemaBuilderError: If schema building fails.
+        FlowSchemaDisplayDataError: If updating display data fails.
+        FlowSchemaLibraryError: If schema library operations fail.
     """
     logger = get_logger(__name__)
     config = _load_config_file()

--- a/python/tank_vendor/flow_integration_sdk/schema_builder.py
+++ b/python/tank_vendor/flow_integration_sdk/schema_builder.py
@@ -12,8 +12,6 @@
 
 from __future__ import annotations  # needed for python 3.9 support
 
-import json
-import os
 from typing import Any
 
 from tank_vendor.flow_data_sdk.base import model as flow_model
@@ -30,6 +28,8 @@ from .exceptions import (
     FlowSchemaLibraryError,
 )
 from .globals import BASE_TYPE_ID, get_client
+from .objects import FlowProject
+from . import schema
 from .schema import get_schema_id
 from .utils import cleanpath, get_logger
 
@@ -509,63 +509,7 @@ def _create_schema_library(
         ) from e
 
 
-def _load_config_file() -> dict:
-    """Load and validate the config.json file.
-
-    This function loads the config.json file from the Flow AM constants path,
-    validates that it contains valid JSON and has the required 'schemas' key.
-
-    Returns:
-        dict: The parsed config dictionary.
-
-    Raises:
-        FileNotFoundError: If the config file does not exist or cannot be opened.
-        json.JSONDecodeError: If the config file contains invalid JSON.
-        KeyError: If the config file does not contain a 'schemas' key.
-    """
-    from tank.flowam.constants import FLOW_SCHEMA_CONFIG_PATH
-
-    config_path = FLOW_SCHEMA_CONFIG_PATH
-
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Config file not found: {config_path}")
-
-    try:
-        with open(config_path, encoding="utf-8") as f:
-            config = json.load(f)
-    except FileNotFoundError as exc:
-        raise FileNotFoundError(
-            f"Could not open the config file {config_path}"
-        ) from exc
-    except json.JSONDecodeError as exc:
-        raise json.JSONDecodeError(
-            f"File {config_path} does not contain valid JSON.", doc="", pos=0
-        ) from exc
-
-    if "schemas" not in config:
-        raise KeyError("The config file must contain a 'schemas' key.")
-
-    return config
-
-
-def get_schema_config_version() -> str:
-    """Retrieve the schema config version from the config.json file.
-
-    This function reads the config.json file located at FLOW_SCHEMA_CONFIG_PATH
-    and extracts the 'version' key. If the file does not exist or contains
-    invalid JSON, appropriate exceptions are raised. If the 'version' key is
-    missing, a default value of 'unknown' is returned.
-
-    Returns:
-        str: The schema config version from the config.json file, or 'unknown'
-            if not specified.
-    """
-
-    config = _load_config_file()
-    return config.get("version", "unknown")
-
-
-def create_pipeline_schemas(collection_id: str, project_id: str):
+def create_pipeline_schemas(project_id: str, config_path: str):
     """Create pipeline schemas under the schema library 'Flow Toolkit Library'
     for a CPA collection.
 
@@ -580,8 +524,8 @@ def create_pipeline_schemas(collection_id: str, project_id: str):
         4. Creates any missing schemas and sets their display names.
 
     Args:
-        collection_id: The collection_id to create pipeline schemas.
         project_id: The Flow AM project ID.
+        config_path: Path to the schema config json file.
     Raises:
         RuntimeError: If schema library creation fails.
         FileNotFoundError: If the config file does not exist.
@@ -595,8 +539,12 @@ def create_pipeline_schemas(collection_id: str, project_id: str):
         FlowSchemaLibraryError: If schema library operations fail.
     """
     logger = get_logger(__name__)
-    config = _load_config_file()
+
+    config = schema._read_schema_config(config_path)
+    if "schemas" not in config:
+        raise KeyError("The schema config file must contain a 'schemas' key with a list of schemas to create.")
     client = get_client()
+    collection_id = FlowProject.get_collection_id(project_id)
 
     # Retrieve all existing published schema type ids for the collection
     try:

--- a/tests/bootstrap_tests/test_manager.py
+++ b/tests/bootstrap_tests/test_manager.py
@@ -148,7 +148,14 @@ class TestFunctionality(ShotgunTestBase):
         class_attrs = set(dir(ToolkitManager))
         instance_attrs = set(dir(ToolkitManager()))
         unserializable_attrs = set(
-            ["_sg_connection", "_sg_user", "_pre_engine_start_callback", "_progress_cb"]
+            [
+                "_flow_project_id",
+                "_flow_schema_version",
+                "_pre_engine_start_callback",
+                "_progress_cb",
+                "_sg_connection",
+                "_sg_user",
+            ]
         )
         # Through this operation, we're taking all the symbols that are defined from an instance,
         # we then remove everything that is defined also in the class, which means we're left

--- a/tests/bootstrap_tests/test_manager.py
+++ b/tests/bootstrap_tests/test_manager.py
@@ -149,19 +149,27 @@ class TestFunctionality(ShotgunTestBase):
         instance_attrs = set(dir(ToolkitManager()))
         unserializable_attrs = set(
             [
-                "_flow_project_id",
-                "_flow_schema_version",
                 "_pre_engine_start_callback",
                 "_progress_cb",
                 "_sg_connection",
                 "_sg_user",
             ]
         )
+        # Transient runtime state: queried during bootstrap and cached onto the
+        # context object afterwards. Not user-configured, so not serialized.
+        transient_attrs = set(
+            [
+                "_flow_project_id",
+                "_flow_schema_version",
+            ]
+        )
         # Through this operation, we're taking all the symbols that are defined from an instance,
         # we then remove everything that is defined also in the class, which means we're left
         # with what was added during __init__, and then we remove the parameters we know can't
         # be serialized. We're left with a small list of values that can be serialized.
-        instance_data_members = instance_attrs - class_attrs - unserializable_attrs
+        instance_data_members = (
+            instance_attrs - class_attrs - unserializable_attrs - transient_attrs
+        )
         self.assertEqual(len(instance_data_members), 7)
 
         # Create a manager that hasn't been updated yet.

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -1263,6 +1263,7 @@ class TestSerialize(TestContext):
             "user": {"type": "HumanUser", "id": self.user["id"], "name": USER_NAME},
             "flow_project_id": None,
             "flow_draft_id": None,
+            "flow_schema_version": None,
         }
 
         ctx = context.Context(**self.kws)


### PR DESCRIPTION
## Summary

Port SchemaBuilder and create_pipeline_schemas() from tk-framework-flowam into python/tank_vendor/flow_integration_sdk/schema_builder.py, and wire schema provisioning into the Flow initialization sequence.

## Changes Made:
- Add schema_builder.py to flow_integration_sdk vendor package, ported from tk-framework-flowam with updated imports and config path handling
- Add SchemaBuilderError, SchemaDisplayDataError, SchemaError, SchemaLibraryError exception classes to exceptions.py
- Add FLOW_SCHEMA_VERSION_FIELD constant to tank/flowam/constants.py
- Fetch sg_flow_schema_config_version in manager._get_updated_configuration() alongside AM_READY_PROJECT_FIELD in the same find_one call
- Wire flow_schema_version into context.py to_dict/from_dict round-trip
- Extend flow_utils.init_flow() with pipeline_config, sg_connection, sg_schema_version, sg_project_id params; append schema provisioning block with version gating and CPA collection check
- Update engine.py (Engine.__init__()) call site to pass new init_flow() arguments                 
                                                                      
  ## Testing                                                        
                                                                    
  Tested manually in Maya against a Flow AM-enabled staging project:
                                                                      
  1. Added a `type.test` schema to `config.json` and bumped the config version. On next engine startup, `create_pipeline_schemas()` ran and created the new schema in the collection. The `sg_flow_schema_config_version` field on the SG Project was updated to the new version.        
2. Restarted the engine without changing `config.json`. The version on the SG Project matched the config version - schema provisioning was correctly skipped with the log message "Schema config version X matches. Skipping schema provisioning."