### PR TITLE
SG-43838 Make Codecov checks advisory with 80% threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,21 @@
 
+coverage:
+  status:
+    project:
+      default:
+        # Coverage checks are advisory only - never block CI
+        informational: true
+        # Only flag if overall project coverage drops below 80%
+        target: 80%
+        # Ignore drops of 1% or less (noise from small changes)
+        threshold: 1%
+    patch:
+      default:
+        # Coverage checks are advisory only - never block CI
+        informational: true
+        # Only flag if less than 80% of new/changed lines are covered
+        target: 80%
+
 ignore:
   # ignore generated QT files
   - "**tank/authentication/ui/login_dialog.py"


### PR DESCRIPTION
## Summary

- Sets `informational: true` on both project and patch Codecov checks so CI is never blocked by coverage warnings
- Sets `target: 80%` on both checks — Codecov only annotates when coverage genuinely drops below 80%
- Adds a `threshold: 1%` on the project check to suppress noise from small changes

## Context

The previous configuration had no `coverage.status` section, so Codecov was using its defaults: patch check requires 100% of new lines covered, and failures block CI. This meant a PR adding 3 lines of code with 1 uncovered line would fail CI with a 66% coverage warning — despite the uncovered line being untestable or trivial.

With these changes:
- Coverage is visible and reported in PR comments as before
- CI is never red due to coverage alone
- Codecov will still flag (advisorily) if coverage drops meaningfully below 80%

## Test plan

- [ ] Verify Codecov status checks show as informational (green) on this PR regardless of patch coverage
- [ ] Confirm Codecov PR comment still reports coverage data

Jira: [SG-43838](https://autodesk.atlassian.net/browse/SG-43838)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SG-43838]: https://autodesk.atlassian.net/browse/SG-43838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ