### PR TITLE
SG-43835 Fix black pre-commit/CI discrepancy by removing exclude

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -14,5 +14,8 @@ python:
   enabled: true
   config_file: .flake8
 
+black:
+  enabled: false
+
 rubocop:
   enabled: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,4 +57,3 @@ repos:
     rev: 26.5.1
     hooks:
     - id: black
-      exclude: "tests|python\/tank"

--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -171,6 +171,6 @@ from .templatekey import TemplateKey, SequenceKey, IntegerKey, StringKey, Timest
 
 # expose the support url
 from .constants import (
-  DEFAULT_STORAGE_ROOT_HOOK_NAME,
-  SUPPORT_URL as support_url,
+    DEFAULT_STORAGE_ROOT_HOOK_NAME,
+    SUPPORT_URL as support_url,
 )

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -38,7 +38,7 @@ class Sgtk(object):
     manipulation and the Toolkit template system.
     """
 
-    (DEFAULT, CENTRALIZED, DISTRIBUTED) = range(3)
+    DEFAULT, CENTRALIZED, DISTRIBUTED = range(3)
 
     def __init__(self, project_path):
         """

--- a/python/tank/authentication/app_session_launcher.py
+++ b/python/tank/authentication/app_session_launcher.py
@@ -89,7 +89,7 @@ def process(
 
         url_handlers.append(
             urllib.request.HTTPSHandler(
-                context = ssl.create_default_context(
+                context=ssl.create_default_context(
                     cafile=ca_certs,
                 ),
             ),
@@ -255,10 +255,12 @@ def process(
         elif response_code_major == 3:
             location = response.headers.get("location", None)
 
-            logger.debug("Request redirected: http code: {code}; redirect to: {location}".format(
-                code=response.code,
-                location=location,
-            ))
+            logger.debug(
+                "Request redirected: http code: {code}; redirect to: {location}".format(
+                    code=response.code,
+                    location=location,
+                )
+            )
 
             raise AuthenticationError(
                 "Request redirected",
@@ -286,9 +288,11 @@ def process(
             )
 
         elif response.code != http.client.OK:
-            logger.debug("Request denied: http code is: {code}".format(
-                code=response.code,
-            ))
+            logger.debug(
+                "Request denied: http code is: {code}".format(
+                    code=response.code,
+                )
+            )
             raise AuthenticationError(
                 "Request denied",
                 payload=getattr(response, "json", response),
@@ -503,9 +507,11 @@ if __name__ == "__main__":
 
     lh = logging.StreamHandler()
     lh.setLevel(logging.DEBUG)
-    lh.setFormatter(logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(message)s",
-    ))
+    lh.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(message)s",
+        )
+    )
 
     logger.addHandler(lh)
     print()

--- a/python/tank/authentication/constants.py
+++ b/python/tank/authentication/constants.py
@@ -22,6 +22,6 @@ method_resolve = {
 def method_resolve_reverse(m):
     global method_resolve
 
-    for (k, v) in method_resolve.items():
+    for k, v in method_resolve.items():
         if v == m:
             return k

--- a/python/tank/authentication/errors.py
+++ b/python/tank/authentication/errors.py
@@ -73,9 +73,7 @@ class UnresolvableHumanUser(UnresolvableUser):
         """
         :param str login: ``login`` field value of the ``HumanUser`` that could not be resolved.
         """
-        super().__init__(
-            "person", "HumanUser", "login", login
-        )
+        super().__init__("person", "HumanUser", "login", login)
 
 
 class UnresolvableScriptUser(UnresolvableUser):
@@ -87,9 +85,7 @@ class UnresolvableScriptUser(UnresolvableUser):
         """
         :param str script_name: ``firstname`` field value of the ``ApiUser`` that could not be resolved.
         """
-        super().__init__(
-            "script", "ApiUser", "firstname", script_name
-        )
+        super().__init__("script", "ApiUser", "firstname", script_name)
 
 
 class ConsoleLoginNotSupportedError(ShotgunAuthenticationError):

--- a/python/tank/authentication/interactive_authentication.py
+++ b/python/tank/authentication/interactive_authentication.py
@@ -33,7 +33,6 @@ import threading
 import os
 from tank.util import is_windows
 
-
 logger = LogManager.get_logger(__name__)
 
 

--- a/python/tank/authentication/interactive_authentication.py
+++ b/python/tank/authentication/interactive_authentication.py
@@ -78,6 +78,7 @@ def _get_ui_state() -> bool:
 
     return bool(QtGui and QtGui.QApplication.instance())
 
+
 class SessionRenewal(object):
     """
     Handles multi-threaded session renewal. This class handles the use case when
@@ -220,6 +221,7 @@ def renew_session(user):
     # If we have a gui, we need gui based authentication
     if has_ui:
         from .ui_authentication import UiAuthenticationHandler
+
         authenticator = UiAuthenticationHandler(
             is_session_renewal=True, session_metadata=user.get_session_metadata()
         )

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -17,6 +17,7 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
+
 import os
 import sys
 from tank_vendor import shotgun_api3

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -109,6 +109,7 @@ class QuerySiteAndUpdateUITask(QtCore.QThread):
         """
         self._site_info.reload(self._url_to_test, self._http_proxy)
 
+
 class LoginDialog(QtGui.QDialog):
     """
     Dialog for getting user credentials.
@@ -494,15 +495,21 @@ class LoginDialog(QtGui.QDialog):
             # - they need to use the legacy login / passphrase to use a PAT with
             #   Autodesk Identity authentication
             if os.environ.get("SGTK_FORCE_STANDARD_LOGIN_DIALOG"):
-                logger.info("Using the standard login dialog with the Flow Production Tracking")
+                logger.info(
+                    "Using the standard login dialog with the Flow Production Tracking"
+                )
             else:
                 if _is_running_in_desktop():
-                    can_use_web = can_use_web or self.site_info.autodesk_identity_enabled
+                    can_use_web = (
+                        can_use_web or self.site_info.autodesk_identity_enabled
+                    )
 
                 # If we have full support for Web-based login, or if we enable it in our
                 # environment, use the Unified Login Flow for all authentication modes.
                 if get_shotgun_authenticator_support_web_login():
-                    can_use_web = can_use_web or self.site_info.unified_login_flow_enabled
+                    can_use_web = (
+                        can_use_web or self.site_info.unified_login_flow_enabled
+                    )
 
         if method_selected:
             # Selecting requested mode (credentials, qt_web_login or app_session_launcher)
@@ -514,9 +521,7 @@ class LoginDialog(QtGui.QDialog):
             method_selected = session_cache.get_preferred_method(site)
 
         # Make sure that the method_selected is currently supported
-        if (
-            method_selected == auth_constants.METHOD_WEB_LOGIN and not can_use_web
-        ) or (
+        if (method_selected == auth_constants.METHOD_WEB_LOGIN and not can_use_web) or (
             method_selected == auth_constants.METHOD_ASL and not can_use_asl
         ):
             method_selected = None
@@ -528,9 +533,7 @@ class LoginDialog(QtGui.QDialog):
             )
 
         # Make sure that the method_selected is currently supported
-        if (
-            method_selected == auth_constants.METHOD_WEB_LOGIN and not can_use_web
-        ) or (
+        if (method_selected == auth_constants.METHOD_WEB_LOGIN and not can_use_web) or (
             method_selected == auth_constants.METHOD_ASL and not can_use_asl
         ):
             method_selected = None
@@ -701,7 +704,9 @@ class LoginDialog(QtGui.QDialog):
             "Logged In",
             properties={
                 "authentication_method": self.site_info.user_authentication_method,
-                "authentication_experience": auth_constants.method_resolve.get(self.method_selected),
+                "authentication_experience": auth_constants.method_resolve.get(
+                    self.method_selected
+                ),
                 "authentication_interface": "qt_dialog",
                 "authentication_renewal": self._is_session_renewal,
             },
@@ -770,7 +775,10 @@ class LoginDialog(QtGui.QDialog):
 
         # Cleanup the URL and update the GUI.
         if self.method_selected != auth_constants.METHOD_BASIC:
-            if site.startswith("http://") and "SGTK_AUTH_ALLOW_NO_HTTPS" not in os.environ:
+            if (
+                site.startswith("http://")
+                and "SGTK_AUTH_ALLOW_NO_HTTPS" not in os.environ
+            ):
                 site = "https" + site[4:]
             self.ui.site.setEditText(site)
 

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -222,7 +222,7 @@ def _try_load_site_authentication_file(file_path):
     content.setdefault(_RECENT_USERS, [])
 
     if content.get(_PREFERRED_METHOD, "not null") is None:
-        del(content[_PREFERRED_METHOD])
+        del content[_PREFERRED_METHOD]
 
     for user in content[_USERS]:
         user[_LOGIN] = user[_LOGIN].strip()

--- a/python/tank/authentication/shotgun_wrapper.py
+++ b/python/tank/authentication/shotgun_wrapper.py
@@ -15,6 +15,7 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
+
 import http.client
 
 from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault

--- a/python/tank/authentication/site_info.py
+++ b/python/tank/authentication/site_info.py
@@ -53,7 +53,9 @@ def _get_site_infos(url, http_proxy=None):
         # require authentication.
         http_proxy = utils.sanitize_http_proxy(http_proxy).netloc
         if http_proxy:
-            logger.debug("Using HTTP proxy to connect to the PTR server: %s", http_proxy)
+            logger.debug(
+                "Using HTTP proxy to connect to the PTR server: %s", http_proxy
+            )
 
         logger.info("Infos for site '%s' not in cache or expired", url)
         sg = shotgun_api3.Shotgun(

--- a/python/tank/authentication/sso_saml2/core/__init__.py
+++ b/python/tank/authentication/sso_saml2/core/__init__.py
@@ -11,6 +11,7 @@
 This module contains files which are shared between RV and Toolkit.
 """
 
+
 def __getattr__(name):
     """
     Retro compatibility - SG-40049 - Temporary workaround for compatibility for
@@ -22,7 +23,7 @@ def __getattr__(name):
     https://github.com/shotgunsoftware/tk-nuke/blob/v0.16.0/engine.py#L396
     This was removed in https://github.com/shotgunsoftware/tk-nuke/pull/125.
 
-	TODO: Remove this after 2026-07.
+        TODO: Remove this after 2026-07.
     """
 
     try:
@@ -33,6 +34,7 @@ def __getattr__(name):
 
         try:
             import inspect
+
             frame = inspect.currentframe().f_back
             caller_mod = frame.f_globals.get("__name__", "")
             is_import = caller_mod.startswith("importlib.") or caller_mod == "builtins"
@@ -50,6 +52,7 @@ def __getattr__(name):
         )
 
         import warnings
+
         warnings.warn(
             deprecation_message,
             DeprecationWarning,
@@ -58,10 +61,12 @@ def __getattr__(name):
 
         try:
             import tank
+
             logger = tank.LogManager.get_logger(__name__)
             logger.warning(deprecation_message)
         except:
-            pass # nosec
+            pass  # nosec
 
         import importlib
+
         return importlib.import_module(f"{__name__}.{name}")

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -129,7 +129,9 @@ def get_renew_path(session, logger):
     # When this variable is set, it is passed to Autodesk Identity's login.
     tk_shotgun_default_login = os.getenv("TK_SHOTGRID_DEFAULT_LOGIN")
     # When this variable is set for a SSO domain, skip the initial login page.
-    tk_shotgun_sso_domain = sanitize_http_proxy(os.getenv("TK_SHOTGRID_SSO_DOMAIN")).netloc
+    tk_shotgun_sso_domain = sanitize_http_proxy(
+        os.getenv("TK_SHOTGRID_SSO_DOMAIN")
+    ).netloc
 
     # Flow Production Tracking's renew endpoint supports some useful
     # Autodesk Identity params.
@@ -210,6 +212,7 @@ class SsoSaml2Core(object):
             )
         if QtNetwork and not hasattr(QtNetwork, "QSslConfiguration"):
             raise SsoSaml2IncompletePySide2("Missing class QtNetwork.QSslConfiguration")
+
         class TKWebPageQtWebEngine(QtWebEngineWidgets.QWebEnginePage):
             """
             Wrapper class to better control the behaviour when clicking on links

--- a/python/tank/authentication/sso_saml2/core/username_password_dialog.py
+++ b/python/tank/authentication/sso_saml2/core/username_password_dialog.py
@@ -75,8 +75,7 @@ class UsernamePasswordDialog(QtGui.QDialog):
         buttons.button(QtGui.QDialogButtonBox.Cancel).clicked.connect(self.close)
 
         # On Qt4, this sets the look-and-feel to that of the toolkit.
-        self.setStyleSheet(
-            """QWidget
+        self.setStyleSheet("""QWidget
             {
                 background-color:  rgb(36, 39, 42);
                 color: rgb(192, 193, 195);
@@ -98,8 +97,7 @@ class UsernamePasswordDialog(QtGui.QDialog):
                 color: rgb(248, 248, 248);
                 background-color: rgb(35, 165, 225);
             }
-            """
-        )
+            """)
 
     @property
     def username(self):

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -17,7 +17,7 @@ from .core.utils import (  # noqa
     get_saml_claims_expiration,
     get_session_expiration,
     _decode_cookies,
-    _get_shotgun_user_id
+    _get_shotgun_user_id,
 )
 
 

--- a/python/tank/authentication/ui/aspect_preserving_label.py
+++ b/python/tank/authentication/ui/aspect_preserving_label.py
@@ -17,6 +17,7 @@ class AspectPreservingLabel(QtGui.QLabel):
     Label that displays a scaled down version of an image if it is bigger
     than the label.
     """
+
     def __init__(self, parent=None):
         """
         Constructor
@@ -35,7 +36,8 @@ class AspectPreservingLabel(QtGui.QLabel):
         """
         self._pix = pixmap
         scaled_pixmap = self._pix.scaled(
-            self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+            self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
+        )
         QtGui.QLabel.setPixmap(self, scaled_pixmap)
 
     def heightForWidth(self, width):
@@ -67,6 +69,7 @@ class AspectPreservingLabel(QtGui.QLabel):
             return
 
         scaled_pixmap = self._pix.scaled(
-            self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+            self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
+        )
         QtGui.QLabel.setPixmap(self, scaled_pixmap)
         QtGui.QApplication.instance().processEvents()

--- a/python/tank/authentication/ui/completion_filter_proxy.py
+++ b/python/tank/authentication/ui/completion_filter_proxy.py
@@ -23,13 +23,14 @@ from tank.util import sgre as re
 from .qt_abstraction import QtGui
 
 
-class FuzzyMatcher():
+class FuzzyMatcher:
     """
     Implement an algorithm to rank strings via fuzzy matching.
 
     Based on the analysis at
     http://crossplatform.net/sublime-text-ctrl-p-fuzzy-matching-in-python
     """
+
     def __init__(self, pattern):
         # construct a pattern that matches the letters in order
         # for example "aad" turns into "(a).*?(a).*?(d)".
@@ -51,6 +52,7 @@ class CompletionFilterProxy(QtGui.QSortFilterProxyModel):
     """
     Filters rows based on fuzzy matching and sorts them based on their score.
     """
+
     def __init__(self, parent):
         super().__init__(parent)
         self.set_filter("")

--- a/python/tank/authentication/ui/login_dialog.py
+++ b/python/tank/authentication/ui/login_dialog.py
@@ -9,166 +9,175 @@
 ################################################################################
 
 from .qt_abstraction import QtCore
+
 for name, cls in QtCore.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 from .qt_abstraction import QtGui
+
 for name, cls in QtGui.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 
 from .recent_box import RecentBox
 from .aspect_preserving_label import AspectPreservingLabel
 
-from  . import resources_rc
+from . import resources_rc
+
 
 class Ui_LoginDialog(object):
     def setupUi(self, LoginDialog):
         if not LoginDialog.objectName():
-            LoginDialog.setObjectName(u"LoginDialog")
+            LoginDialog.setObjectName("LoginDialog")
         LoginDialog.setWindowModality(Qt.NonModal)
         LoginDialog.resize(424, 304)
         LoginDialog.setMinimumSize(QSize(424, 304))
-        LoginDialog.setStyleSheet(u"\n"
-"QWidget\n"
-"{\n"
-"    background-color: rgb(36, 39, 42);\n"
-"    color: rgb(192, 192, 192);\n"
-"    selection-background-color: rgb(168, 123, 43);\n"
-"    selection-color: rgb(230, 230, 230);\n"
-"    font-size: 11px;\n"
-"}\n"
-"\n"
-"QPushButton\n"
-"{\n"
-"    background-color: transparent;\n"
-"    border: 1px solid transparent;\n"
-"    border-radius: 2px;\n"
-"    padding: 8px;\n"
-"    padding-left: 15px;\n"
-"    padding-right: 15px;\n"
-"}\n"
-"\n"
-"QPushButton::menu-indicator {\n"
-"    subcontrol-position: right center;\n"
-"}\n"
-"\n"
-"QPushButton QMenu::item {\n"
-"    padding: 15px;\n"
-"    border: 1px solid transparent;\n"
-"}\n"
-"\n"
-"QPushButton QMenu::item:disabled {\n"
-"    color: rgb(160, 160, 160);\n"
-"    font-style: italic;\n"
-"}\n"
-"\n"
-"QPushButton QMenu::item:selected {\n"
-"    border-color: rgb(54, 60, 66);\n"
-"}\n"
-"\n"
-"QPushButton QMenu::item:pressed\n"
-"{\n"
-"    border-color: rgb(192, 192, 192);\n"
-"}\n"
-"\n"
-"QLineEdit, QComboBox\n"
-"{\n"
-"    background-color: rgb(29, 31, 34);\n"
-"    bord"
-                        "er: 1px solid rgb(54, 60, 66);\n"
-"    border-radius: 2px;\n"
-"    padding: 5px;\n"
-"    font-size: 12px;\n"
-"}\n"
-"\n"
-"QComboBox\n"
-"{\n"
-"    margin-left: 3px;\n"
-"    margin-right: 3px;\n"
-"}\n"
-"\n"
-"QPushButton:focus\n"
-"{\n"
-"    border-color: rgb(48, 167, 227);\n"
-"    outline: none;\n"
-"}\n"
-"\n"
-"QPushButton:hover {\n"
-"    border-color: rgb(54, 60, 66);\n"
-"}\n"
-"\n"
-"QPushButton:pressed\n"
-"{\n"
-"    border-color: rgb(192, 192, 192);\n"
-"}\n"
-"\n"
-"QComboBox:focus, QLineEdit:focus\n"
-"{\n"
-"    border: 1px solid rgb(48, 167, 227);\n"
-"}\n"
-"\n"
-"QComboBox:drop-down:button {\n"
-"    border: 1px solid rgb(54, 60, 66);\n"
-"}\n"
-"\n"
-"QComboBox:down-arrow {\n"
-"    image: url(:/shotgun_authentication/down-arrow.png);\n"
-"}\n"
-"\n"
-"QLineEdit:disabled {\n"
-"    background-color: rgb(60, 60, 60);\n"
-"    color: rgb(160, 160, 160);\n"
-"}\n"
-"\n"
-"QComboBox::drop-down:disabled {\n"
-"    border-width: 0px;\n"
-"}\n"
-"\n"
-"QComboBox::down-arrow:disabled {\n"
-"    image: url(noimg); border-width: 0px;\n"
-"}\n"
-""
-                        "\n"
-"QComboBox::disabled {\n"
-"    background-color: rgb(60, 60, 60);\n"
-"    color: rgb(160, 160, 160);\n"
-"}\n"
-"\n"
-"QPushButton.main\n"
-"{\n"
-"    background-color: rgb(35, 165, 225);\n"
-"    border-color: rgb(36, 39, 42);\n"
-"    color: rgb(248, 248, 248);\n"
-"}\n"
-"\n"
-"QPushButton.main:focus, QPushButton.main:hover\n"
-"{\n"
-"    border-color: rgb(54, 60, 66);\n"
-"}\n"
-"\n"
-"QPushButton.main:pressed\n"
-"{\n"
-"    border-color: rgb(248, 248, 248);\n"
-"}\n"
-"")
+        LoginDialog.setStyleSheet(
+            "\n"
+            "QWidget\n"
+            "{\n"
+            "    background-color: rgb(36, 39, 42);\n"
+            "    color: rgb(192, 192, 192);\n"
+            "    selection-background-color: rgb(168, 123, 43);\n"
+            "    selection-color: rgb(230, 230, 230);\n"
+            "    font-size: 11px;\n"
+            "}\n"
+            "\n"
+            "QPushButton\n"
+            "{\n"
+            "    background-color: transparent;\n"
+            "    border: 1px solid transparent;\n"
+            "    border-radius: 2px;\n"
+            "    padding: 8px;\n"
+            "    padding-left: 15px;\n"
+            "    padding-right: 15px;\n"
+            "}\n"
+            "\n"
+            "QPushButton::menu-indicator {\n"
+            "    subcontrol-position: right center;\n"
+            "}\n"
+            "\n"
+            "QPushButton QMenu::item {\n"
+            "    padding: 15px;\n"
+            "    border: 1px solid transparent;\n"
+            "}\n"
+            "\n"
+            "QPushButton QMenu::item:disabled {\n"
+            "    color: rgb(160, 160, 160);\n"
+            "    font-style: italic;\n"
+            "}\n"
+            "\n"
+            "QPushButton QMenu::item:selected {\n"
+            "    border-color: rgb(54, 60, 66);\n"
+            "}\n"
+            "\n"
+            "QPushButton QMenu::item:pressed\n"
+            "{\n"
+            "    border-color: rgb(192, 192, 192);\n"
+            "}\n"
+            "\n"
+            "QLineEdit, QComboBox\n"
+            "{\n"
+            "    background-color: rgb(29, 31, 34);\n"
+            "    bord"
+            "er: 1px solid rgb(54, 60, 66);\n"
+            "    border-radius: 2px;\n"
+            "    padding: 5px;\n"
+            "    font-size: 12px;\n"
+            "}\n"
+            "\n"
+            "QComboBox\n"
+            "{\n"
+            "    margin-left: 3px;\n"
+            "    margin-right: 3px;\n"
+            "}\n"
+            "\n"
+            "QPushButton:focus\n"
+            "{\n"
+            "    border-color: rgb(48, 167, 227);\n"
+            "    outline: none;\n"
+            "}\n"
+            "\n"
+            "QPushButton:hover {\n"
+            "    border-color: rgb(54, 60, 66);\n"
+            "}\n"
+            "\n"
+            "QPushButton:pressed\n"
+            "{\n"
+            "    border-color: rgb(192, 192, 192);\n"
+            "}\n"
+            "\n"
+            "QComboBox:focus, QLineEdit:focus\n"
+            "{\n"
+            "    border: 1px solid rgb(48, 167, 227);\n"
+            "}\n"
+            "\n"
+            "QComboBox:drop-down:button {\n"
+            "    border: 1px solid rgb(54, 60, 66);\n"
+            "}\n"
+            "\n"
+            "QComboBox:down-arrow {\n"
+            "    image: url(:/shotgun_authentication/down-arrow.png);\n"
+            "}\n"
+            "\n"
+            "QLineEdit:disabled {\n"
+            "    background-color: rgb(60, 60, 60);\n"
+            "    color: rgb(160, 160, 160);\n"
+            "}\n"
+            "\n"
+            "QComboBox::drop-down:disabled {\n"
+            "    border-width: 0px;\n"
+            "}\n"
+            "\n"
+            "QComboBox::down-arrow:disabled {\n"
+            "    image: url(noimg); border-width: 0px;\n"
+            "}\n"
+            ""
+            "\n"
+            "QComboBox::disabled {\n"
+            "    background-color: rgb(60, 60, 60);\n"
+            "    color: rgb(160, 160, 160);\n"
+            "}\n"
+            "\n"
+            "QPushButton.main\n"
+            "{\n"
+            "    background-color: rgb(35, 165, 225);\n"
+            "    border-color: rgb(36, 39, 42);\n"
+            "    color: rgb(248, 248, 248);\n"
+            "}\n"
+            "\n"
+            "QPushButton.main:focus, QPushButton.main:hover\n"
+            "{\n"
+            "    border-color: rgb(54, 60, 66);\n"
+            "}\n"
+            "\n"
+            "QPushButton.main:pressed\n"
+            "{\n"
+            "    border-color: rgb(248, 248, 248);\n"
+            "}\n"
+            ""
+        )
         LoginDialog.setModal(True)
         self.verticalLayout_2 = QVBoxLayout(LoginDialog)
         self.verticalLayout_2.setContentsMargins(20, 20, 20, 20)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setSpacing(0)
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setObjectName("horizontalLayout")
         self.horizontalLayout.setSizeConstraint(QLayout.SetMinAndMaxSize)
         self.logo = AspectPreservingLabel(LoginDialog)
-        self.logo.setObjectName(u"logo")
+        self.logo.setObjectName("logo")
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.logo.sizePolicy().hasHeightForWidth())
         self.logo.setSizePolicy(sizePolicy)
         self.logo.setMaximumSize(QSize(320, 72))
-        self.logo.setPixmap(QPixmap(u":/shotgun_authentication/shotgun_logo_light_medium.png"))
+        self.logo.setPixmap(
+            QPixmap(":/shotgun_authentication/shotgun_logo_light_medium.png")
+        )
         self.logo.setAlignment(Qt.AlignCenter)
         self.logo.setTextInteractionFlags(Qt.NoTextInteraction)
 
@@ -177,52 +186,54 @@ class Ui_LoginDialog(object):
         self.verticalLayout_2.addLayout(self.horizontalLayout)
 
         self.stackedWidget = QStackedWidget(LoginDialog)
-        self.stackedWidget.setObjectName(u"stackedWidget")
+        self.stackedWidget.setObjectName("stackedWidget")
         self.stackedWidget.setMinimumSize(QSize(324, 172))
         self.login_page = QWidget()
-        self.login_page.setObjectName(u"login_page")
+        self.login_page.setObjectName("login_page")
         self.verticalLayout_3 = QVBoxLayout(self.login_page)
         self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setObjectName("verticalLayout_3")
         self.credentials = QWidget(self.login_page)
-        self.credentials.setObjectName(u"credentials")
+        self.credentials.setObjectName("credentials")
         self.credentials.setMinimumSize(QSize(0, 126))
         self.verticalLayout_7 = QVBoxLayout(self.credentials)
         self.verticalLayout_7.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_7.setObjectName(u"verticalLayout_7")
+        self.verticalLayout_7.setObjectName("verticalLayout_7")
         self.site = RecentBox(self.credentials)
-        self.site.setObjectName(u"site")
+        self.site.setObjectName("site")
 
         self.verticalLayout_7.addWidget(self.site)
 
         self.login = RecentBox(self.credentials)
-        self.login.setObjectName(u"login")
+        self.login.setObjectName("login")
 
         self.verticalLayout_7.addWidget(self.login)
 
         self.password = QLineEdit(self.credentials)
-        self.password.setObjectName(u"password")
+        self.password.setObjectName("password")
         self.password.setMinimumSize(QSize(308, 0))
         self.password.setEchoMode(QLineEdit.Password)
 
         self.verticalLayout_7.addWidget(self.password)
 
         self.message = QLabel(self.credentials)
-        self.message.setObjectName(u"message")
+        self.message.setObjectName("message")
         sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.message.sizePolicy().hasHeightForWidth())
         self.message.setSizePolicy(sizePolicy1)
         self.message.setTextFormat(Qt.RichText)
-        self.message.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.message.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.message.setWordWrap(True)
         self.message.setMargin(4)
         self.message.setOpenExternalLinks(True)
 
         self.verticalLayout_7.addWidget(self.message)
 
-        self.verticalSpacer_3 = QSpacerItem(20, 0, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer_3 = QSpacerItem(
+            20, 0, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout_7.addItem(self.verticalSpacer_3)
 
@@ -230,19 +241,19 @@ class Ui_LoginDialog(object):
 
         self.button_layout = QHBoxLayout()
         self.button_layout.setSpacing(10)
-        self.button_layout.setObjectName(u"button_layout")
+        self.button_layout.setObjectName("button_layout")
         self.button_layout.setContentsMargins(0, -1, -1, -1)
         self.button_options = QPushButton(self.login_page)
-        self.button_options.setObjectName(u"button_options")
+        self.button_options.setObjectName("button_options")
         self.button_options.setAutoDefault(False)
         self.button_options.setFlat(True)
 
         self.button_layout.addWidget(self.button_options)
 
         self.links = QVBoxLayout()
-        self.links.setObjectName(u"links")
+        self.links.setObjectName("links")
         self.forgot_password_link = QLabel(self.login_page)
-        self.forgot_password_link.setObjectName(u"forgot_password_link")
+        self.forgot_password_link.setObjectName("forgot_password_link")
         self.forgot_password_link.setCursor(QCursor(Qt.PointingHandCursor))
         self.forgot_password_link.setTextFormat(Qt.RichText)
         self.forgot_password_link.setMargin(4)
@@ -252,12 +263,14 @@ class Ui_LoginDialog(object):
 
         self.button_layout.addLayout(self.links)
 
-        self.sign_in_hspacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.sign_in_hspacer = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.button_layout.addItem(self.sign_in_hspacer)
 
         self.sign_in = QPushButton(self.login_page)
-        self.sign_in.setObjectName(u"sign_in")
+        self.sign_in.setObjectName("sign_in")
         self.sign_in.setAutoDefault(True)
         self.sign_in.setFlat(True)
 
@@ -269,54 +282,60 @@ class Ui_LoginDialog(object):
 
         self.stackedWidget.addWidget(self.login_page)
         self._2fa_page = QWidget()
-        self._2fa_page.setObjectName(u"_2fa_page")
+        self._2fa_page.setObjectName("_2fa_page")
         self.verticalLayout_4 = QVBoxLayout(self._2fa_page)
         self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.verticalLayout_4.setObjectName("verticalLayout_4")
         self.credentials_2 = QWidget(self._2fa_page)
-        self.credentials_2.setObjectName(u"credentials_2")
+        self.credentials_2.setObjectName("credentials_2")
         self.credentials_2.setMinimumSize(QSize(0, 133))
         self.horizontalLayout_2 = QHBoxLayout(self.credentials_2)
         self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.label = QLabel(self.credentials_2)
-        self.label.setObjectName(u"label")
+        self.label.setObjectName("label")
         self.label.setMinimumSize(QSize(86, 0))
-        self.label.setPixmap(QPixmap(u":/google_authenticator/google_authenticator.png"))
-        self.label.setAlignment(Qt.AlignHCenter|Qt.AlignTop)
+        self.label.setPixmap(QPixmap(":/google_authenticator/google_authenticator.png"))
+        self.label.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
 
         self.horizontalLayout_2.addWidget(self.label)
 
         self.widget_2 = QWidget(self.credentials_2)
-        self.widget_2.setObjectName(u"widget_2")
+        self.widget_2.setObjectName("widget_2")
         self.verticalLayout = QVBoxLayout(self.widget_2)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setObjectName("verticalLayout")
         self._2fa_message = QLabel(self.widget_2)
-        self._2fa_message.setObjectName(u"_2fa_message")
+        self._2fa_message.setObjectName("_2fa_message")
         sizePolicy2 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
-        sizePolicy2.setHeightForWidth(self._2fa_message.sizePolicy().hasHeightForWidth())
+        sizePolicy2.setHeightForWidth(
+            self._2fa_message.sizePolicy().hasHeightForWidth()
+        )
         self._2fa_message.setSizePolicy(sizePolicy2)
-        self._2fa_message.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self._2fa_message.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self._2fa_message.setWordWrap(True)
         self._2fa_message.setMargin(0)
 
         self.verticalLayout.addWidget(self._2fa_message)
 
         self._2fa_code = QLineEdit(self.widget_2)
-        self._2fa_code.setObjectName(u"_2fa_code")
+        self._2fa_code.setObjectName("_2fa_code")
 
         self.verticalLayout.addWidget(self._2fa_code)
 
         self.invalid_code = QLabel(self.widget_2)
-        self.invalid_code.setObjectName(u"invalid_code")
-        sizePolicy2.setHeightForWidth(self.invalid_code.sizePolicy().hasHeightForWidth())
+        self.invalid_code.setObjectName("invalid_code")
+        sizePolicy2.setHeightForWidth(
+            self.invalid_code.sizePolicy().hasHeightForWidth()
+        )
         self.invalid_code.setSizePolicy(sizePolicy2)
 
         self.verticalLayout.addWidget(self.invalid_code)
 
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer_2 = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout.addItem(self.verticalSpacer_2)
 
@@ -326,20 +345,22 @@ class Ui_LoginDialog(object):
 
         self.button_layout_2 = QHBoxLayout()
         self.button_layout_2.setSpacing(10)
-        self.button_layout_2.setObjectName(u"button_layout_2")
+        self.button_layout_2.setObjectName("button_layout_2")
         self.button_layout_2.setContentsMargins(0, -1, -1, -1)
         self.use_backup = QPushButton(self._2fa_page)
-        self.use_backup.setObjectName(u"use_backup")
+        self.use_backup.setObjectName("use_backup")
         self.use_backup.setFlat(True)
 
         self.button_layout_2.addWidget(self.use_backup)
 
-        self._2fa_hspacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self._2fa_hspacer = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.button_layout_2.addItem(self._2fa_hspacer)
 
         self.verify_2fa = QPushButton(self._2fa_page)
-        self.verify_2fa.setObjectName(u"verify_2fa")
+        self.verify_2fa.setObjectName("verify_2fa")
         self.verify_2fa.setMinimumSize(QSize(65, 0))
         self.verify_2fa.setAutoDefault(False)
         self.verify_2fa.setFlat(True)
@@ -350,50 +371,58 @@ class Ui_LoginDialog(object):
 
         self.stackedWidget.addWidget(self._2fa_page)
         self.backup_page = QWidget()
-        self.backup_page.setObjectName(u"backup_page")
+        self.backup_page.setObjectName("backup_page")
         self.verticalLayout_6 = QVBoxLayout(self.backup_page)
         self.verticalLayout_6.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
+        self.verticalLayout_6.setObjectName("verticalLayout_6")
         self.credentials_3 = QWidget(self.backup_page)
-        self.credentials_3.setObjectName(u"credentials_3")
+        self.credentials_3.setObjectName("credentials_3")
         self.credentials_3.setMinimumSize(QSize(0, 133))
         self.horizontalLayout_3 = QHBoxLayout(self.credentials_3)
         self.horizontalLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
+        self.horizontalLayout_3.setObjectName("horizontalLayout_3")
         self.label_2 = QLabel(self.credentials_3)
-        self.label_2.setObjectName(u"label_2")
-        self.label_2.setPixmap(QPixmap(u":/backup_codes/backup_codes_light_bg.png"))
-        self.label_2.setAlignment(Qt.AlignHCenter|Qt.AlignTop)
+        self.label_2.setObjectName("label_2")
+        self.label_2.setPixmap(QPixmap(":/backup_codes/backup_codes_light_bg.png"))
+        self.label_2.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
 
         self.horizontalLayout_3.addWidget(self.label_2)
 
         self.widget_4 = QWidget(self.credentials_3)
-        self.widget_4.setObjectName(u"widget_4")
+        self.widget_4.setObjectName("widget_4")
         self.verticalLayout_5 = QVBoxLayout(self.widget_4)
-        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.verticalLayout_5.setObjectName("verticalLayout_5")
         self._2fa_message_2 = QLabel(self.widget_4)
-        self._2fa_message_2.setObjectName(u"_2fa_message_2")
-        sizePolicy2.setHeightForWidth(self._2fa_message_2.sizePolicy().hasHeightForWidth())
+        self._2fa_message_2.setObjectName("_2fa_message_2")
+        sizePolicy2.setHeightForWidth(
+            self._2fa_message_2.sizePolicy().hasHeightForWidth()
+        )
         self._2fa_message_2.setSizePolicy(sizePolicy2)
-        self._2fa_message_2.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self._2fa_message_2.setAlignment(
+            Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
+        )
         self._2fa_message_2.setWordWrap(True)
         self._2fa_message_2.setMargin(0)
 
         self.verticalLayout_5.addWidget(self._2fa_message_2)
 
         self.backup_code = QLineEdit(self.widget_4)
-        self.backup_code.setObjectName(u"backup_code")
+        self.backup_code.setObjectName("backup_code")
 
         self.verticalLayout_5.addWidget(self.backup_code)
 
         self.invalid_backup_code = QLabel(self.widget_4)
-        self.invalid_backup_code.setObjectName(u"invalid_backup_code")
-        sizePolicy2.setHeightForWidth(self.invalid_backup_code.sizePolicy().hasHeightForWidth())
+        self.invalid_backup_code.setObjectName("invalid_backup_code")
+        sizePolicy2.setHeightForWidth(
+            self.invalid_backup_code.sizePolicy().hasHeightForWidth()
+        )
         self.invalid_backup_code.setSizePolicy(sizePolicy2)
 
         self.verticalLayout_5.addWidget(self.invalid_backup_code)
 
-        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout_5.addItem(self.verticalSpacer)
 
@@ -403,21 +432,23 @@ class Ui_LoginDialog(object):
 
         self.button_layout_3 = QHBoxLayout()
         self.button_layout_3.setSpacing(10)
-        self.button_layout_3.setObjectName(u"button_layout_3")
+        self.button_layout_3.setObjectName("button_layout_3")
         self.button_layout_3.setContentsMargins(0, -1, -1, -1)
         self.use_app = QPushButton(self.backup_page)
-        self.use_app.setObjectName(u"use_app")
+        self.use_app.setObjectName("use_app")
         self.use_app.setAutoDefault(False)
         self.use_app.setFlat(True)
 
         self.button_layout_3.addWidget(self.use_app)
 
-        self.backup_hspacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.backup_hspacer = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.button_layout_3.addItem(self.backup_hspacer)
 
         self.verify_backup = QPushButton(self.backup_page)
-        self.verify_backup.setObjectName(u"verify_backup")
+        self.verify_backup.setObjectName("verify_backup")
         self.verify_backup.setMinimumSize(QSize(65, 0))
         self.verify_backup.setAutoDefault(True)
         self.verify_backup.setFlat(True)
@@ -428,33 +459,37 @@ class Ui_LoginDialog(object):
 
         self.stackedWidget.addWidget(self.backup_page)
         self.asl_page = QWidget()
-        self.asl_page.setObjectName(u"asl_page")
+        self.asl_page.setObjectName("asl_page")
         self.verticalLayout_21 = QVBoxLayout(self.asl_page)
         self.verticalLayout_21.setContentsMargins(20, 20, 20, 20)
-        self.verticalLayout_21.setObjectName(u"verticalLayout_21")
+        self.verticalLayout_21.setObjectName("verticalLayout_21")
         self.asl_msg = QLabel(self.asl_page)
-        self.asl_msg.setObjectName(u"asl_msg")
+        self.asl_msg.setObjectName("asl_msg")
         sizePolicy1.setHeightForWidth(self.asl_msg.sizePolicy().hasHeightForWidth())
         self.asl_msg.setSizePolicy(sizePolicy1)
-        self.asl_msg.setStyleSheet(u"padding-left: 40px; padding-left: 40px;padding-right: 40px;")
+        self.asl_msg.setStyleSheet(
+            "padding-left: 40px; padding-left: 40px;padding-right: 40px;"
+        )
         self.asl_msg.setAlignment(Qt.AlignCenter)
         self.asl_msg.setWordWrap(True)
 
         self.verticalLayout_21.addWidget(self.asl_msg)
 
         self.asl_msg_back = QLabel(self.asl_page)
-        self.asl_msg_back.setObjectName(u"asl_msg_back")
+        self.asl_msg_back.setObjectName("asl_msg_back")
         self.asl_msg_back.setAlignment(Qt.AlignCenter)
         self.asl_msg_back.setWordWrap(True)
 
         self.verticalLayout_21.addWidget(self.asl_msg_back)
 
-        self.asl_spacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.asl_spacer = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout_21.addItem(self.asl_spacer)
 
         self.asl_msg_help = QLabel(self.asl_page)
-        self.asl_msg_help.setObjectName(u"asl_msg_help")
+        self.asl_msg_help.setObjectName("asl_msg_help")
         self.asl_msg_help.setAlignment(Qt.AlignCenter)
         self.asl_msg_help.setWordWrap(True)
 
@@ -474,48 +509,124 @@ class Ui_LoginDialog(object):
         self.verify_backup.setDefault(True)
 
         QMetaObject.connectSlotsByName(LoginDialog)
+
     # setupUi
 
     def retranslateUi(self, LoginDialog):
-        LoginDialog.setWindowTitle(QCoreApplication.translate("LoginDialog", u"Flow Production Tracking Login", None))
+        LoginDialog.setWindowTitle(
+            QCoreApplication.translate(
+                "LoginDialog", "Flow Production Tracking Login", None
+            )
+        )
         self.logo.setText("")
-#if QT_CONFIG(accessibility)
-        self.site.setAccessibleName(QCoreApplication.translate("LoginDialog", u"site", None))
-#endif // QT_CONFIG(accessibility)
-#if QT_CONFIG(accessibility)
-        self.login.setAccessibleName(QCoreApplication.translate("LoginDialog", u"login", None))
-#endif // QT_CONFIG(accessibility)
-#if QT_CONFIG(accessibility)
-        self.password.setAccessibleName(QCoreApplication.translate("LoginDialog", u"password", None))
-#endif // QT_CONFIG(accessibility)
-        self.password.setPlaceholderText(QCoreApplication.translate("LoginDialog", u"password", None))
-        self.message.setText(QCoreApplication.translate("LoginDialog", u"Please enter your credentials.", None))
-        self.button_options.setText(QCoreApplication.translate("LoginDialog", u"See other options", None))
-        self.forgot_password_link.setText(QCoreApplication.translate("LoginDialog", u"<html><head/><body><p><a href=\"#\" style=\"color:#c0c1c3;\">Forgot your password?</a></p></body></html>", None))
-        self.sign_in.setText(QCoreApplication.translate("LoginDialog", u"Sign In", None))
-        self.sign_in.setProperty("class", QCoreApplication.translate("LoginDialog", u"main", None))
+        # if QT_CONFIG(accessibility)
+        self.site.setAccessibleName(
+            QCoreApplication.translate("LoginDialog", "site", None)
+        )
+        # endif // QT_CONFIG(accessibility)
+        # if QT_CONFIG(accessibility)
+        self.login.setAccessibleName(
+            QCoreApplication.translate("LoginDialog", "login", None)
+        )
+        # endif // QT_CONFIG(accessibility)
+        # if QT_CONFIG(accessibility)
+        self.password.setAccessibleName(
+            QCoreApplication.translate("LoginDialog", "password", None)
+        )
+        # endif // QT_CONFIG(accessibility)
+        self.password.setPlaceholderText(
+            QCoreApplication.translate("LoginDialog", "password", None)
+        )
+        self.message.setText(
+            QCoreApplication.translate(
+                "LoginDialog", "Please enter your credentials.", None
+            )
+        )
+        self.button_options.setText(
+            QCoreApplication.translate("LoginDialog", "See other options", None)
+        )
+        self.forgot_password_link.setText(
+            QCoreApplication.translate(
+                "LoginDialog",
+                '<html><head/><body><p><a href="#" style="color:#c0c1c3;">Forgot your password?</a></p></body></html>',
+                None,
+            )
+        )
+        self.sign_in.setText(QCoreApplication.translate("LoginDialog", "Sign In", None))
+        self.sign_in.setProperty(
+            "class", QCoreApplication.translate("LoginDialog", "main", None)
+        )
         self.label.setText("")
-        self._2fa_message.setText(QCoreApplication.translate("LoginDialog", u"Enter the code generated by the Google Authenticator or Duo Mobile app.", None))
-#if QT_CONFIG(accessibility)
-        self._2fa_code.setAccessibleName(QCoreApplication.translate("LoginDialog", u"2fa code", None))
-#endif // QT_CONFIG(accessibility)
-        self._2fa_code.setPlaceholderText(QCoreApplication.translate("LoginDialog", u"Enter code", None))
+        self._2fa_message.setText(
+            QCoreApplication.translate(
+                "LoginDialog",
+                "Enter the code generated by the Google Authenticator or Duo Mobile app.",
+                None,
+            )
+        )
+        # if QT_CONFIG(accessibility)
+        self._2fa_code.setAccessibleName(
+            QCoreApplication.translate("LoginDialog", "2fa code", None)
+        )
+        # endif // QT_CONFIG(accessibility)
+        self._2fa_code.setPlaceholderText(
+            QCoreApplication.translate("LoginDialog", "Enter code", None)
+        )
         self.invalid_code.setText("")
-        self.use_backup.setText(QCoreApplication.translate("LoginDialog", u"Use backup code", None))
-        self.verify_2fa.setText(QCoreApplication.translate("LoginDialog", u"Verify", None))
-        self.verify_2fa.setProperty("class", QCoreApplication.translate("LoginDialog", u"main", None))
+        self.use_backup.setText(
+            QCoreApplication.translate("LoginDialog", "Use backup code", None)
+        )
+        self.verify_2fa.setText(
+            QCoreApplication.translate("LoginDialog", "Verify", None)
+        )
+        self.verify_2fa.setProperty(
+            "class", QCoreApplication.translate("LoginDialog", "main", None)
+        )
         self.label_2.setText("")
-        self._2fa_message_2.setText(QCoreApplication.translate("LoginDialog", u"Please enter one of your backup codes.", None))
-#if QT_CONFIG(accessibility)
-        self.backup_code.setAccessibleName(QCoreApplication.translate("LoginDialog", u"backup code", None))
-#endif // QT_CONFIG(accessibility)
+        self._2fa_message_2.setText(
+            QCoreApplication.translate(
+                "LoginDialog", "Please enter one of your backup codes.", None
+            )
+        )
+        # if QT_CONFIG(accessibility)
+        self.backup_code.setAccessibleName(
+            QCoreApplication.translate("LoginDialog", "backup code", None)
+        )
+        # endif // QT_CONFIG(accessibility)
         self.backup_code.setText("")
-        self.backup_code.setPlaceholderText(QCoreApplication.translate("LoginDialog", u"Enter backup code", None))
+        self.backup_code.setPlaceholderText(
+            QCoreApplication.translate("LoginDialog", "Enter backup code", None)
+        )
         self.invalid_backup_code.setText("")
-        self.use_app.setText(QCoreApplication.translate("LoginDialog", u"Use Google App", None))
-        self.verify_backup.setText(QCoreApplication.translate("LoginDialog", u"Verify", None))
-        self.verify_backup.setProperty("class", QCoreApplication.translate("LoginDialog", u"main", None))
-        self.asl_msg.setText(QCoreApplication.translate("LoginDialog", u"Check your default web browser to continue logging in.", None))
-        self.asl_msg_back.setText(QCoreApplication.translate("LoginDialog", u"<html><head/><body><p><a href=\"#\"><span style=\" text-decoration: underline; color:#c0c1c3;\">Cancel & return to the login page</span></a></p></body></html>", None))
-        self.asl_msg_help.setText(QCoreApplication.translate("LoginDialog", u"<html><head/><body><p>If you are having trouble logging in with the browser, <a href=\"{url}\"><span style=\" text-decoration: underline; color:#c0c1c3;\">select this support link</span></a></p></body></html>", None))
+        self.use_app.setText(
+            QCoreApplication.translate("LoginDialog", "Use Google App", None)
+        )
+        self.verify_backup.setText(
+            QCoreApplication.translate("LoginDialog", "Verify", None)
+        )
+        self.verify_backup.setProperty(
+            "class", QCoreApplication.translate("LoginDialog", "main", None)
+        )
+        self.asl_msg.setText(
+            QCoreApplication.translate(
+                "LoginDialog",
+                "Check your default web browser to continue logging in.",
+                None,
+            )
+        )
+        self.asl_msg_back.setText(
+            QCoreApplication.translate(
+                "LoginDialog",
+                '<html><head/><body><p><a href="#"><span style=" text-decoration: underline; color:#c0c1c3;">Cancel & return to the login page</span></a></p></body></html>',
+                None,
+            )
+        )
+        self.asl_msg_help.setText(
+            QCoreApplication.translate(
+                "LoginDialog",
+                '<html><head/><body><p>If you are having trouble logging in with the browser, <a href="{url}"><span style=" text-decoration: underline; color:#c0c1c3;">select this support link</span></a></p></body></html>',
+                None,
+            )
+        )
+
     # retranslateUi

--- a/python/tank/authentication/ui/resources_rc.py
+++ b/python/tank/authentication/ui/resources_rc.py
@@ -3715,10 +3715,17 @@ qt_resource_struct = b"\
 \x00\x00\x01\x8f05\xd1\xf5\
 "
 
+
 def qInitResources():
-    QtCore.qRegisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qRegisterResourceData(
+        0x03, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 def qCleanupResources():
-    QtCore.qUnregisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qUnregisterResourceData(
+        0x03, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 qInitResources()

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -18,7 +18,6 @@ from . import user_impl
 from .. import LogManager
 from .errors import AuthenticationCancelled
 
-
 logger = LogManager.get_logger(__name__)
 
 # Ensure that the SSO-related logging will be merged in our loggin.

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -18,6 +18,7 @@ not be called directly. Interfaces and implementation of this module may change
 at any point.
 --------------------------------------------------------------------------------
 """
+
 import json
 import http.client
 

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -140,7 +140,7 @@ class CachedConfiguration(Configuration):
             % (storage_roots.roots_file, storage_roots.required_roots)
         )
 
-        (_, unmapped_roots) = storage_roots.get_local_storages(self._sg_connection)
+        _, unmapped_roots = storage_roots.get_local_storages(self._sg_connection)
 
         # get a list of all defined storage roots without a corresponding PTR
         # local storage defined
@@ -258,7 +258,7 @@ class CachedConfiguration(Configuration):
         try:
             # Move to backup needs to undo changes when failing because we need to put the configuration
             # in a usable state.
-            (config_backup_path, core_backup_path) = self._config_writer.move_to_backup(
+            config_backup_path, core_backup_path = self._config_writer.move_to_backup(
                 undo_on_error=True
             )
         except Exception as e:

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -265,7 +265,9 @@ class ConfigurationWriter(object):
         if current_interpreter:
             log.debug("Current OS interpreter will be %s.", current_interpreter)
         else:
-            log.debug("Current OS interpreter will be the default PTR desktop app location.")
+            log.debug(
+                "Current OS interpreter will be the default PTR desktop app location."
+            )
 
         config_root_path = self._path.current_os
 
@@ -339,7 +341,9 @@ class ConfigurationWriter(object):
 
         with filesystem.auto_created_yml(config_info_file) as fh:
             fh.write("# This file contains metadata describing what exact version\n")
-            fh.write("# Of the config that was downloaded from Flow Production Tracking\n")
+            fh.write(
+                "# Of the config that was downloaded from Flow Production Tracking\n"
+            )
             fh.write("\n")
             fh.write("# Below follows details for the sg attachment that is\n")
             fh.write("# reflected within this local configuration.\n")

--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -289,20 +289,14 @@ class CoreImportHandler(object):
             # later raise FileNotFoundError instead of the expected ImportError
             # when the module doesn't exist on disk.
             if os.path.isdir(os.path.join(package_path[0], module_name)):
-                module_file = os.path.join(
-                    package_path[0], module_name, "__init__.py"
-                )
+                module_file = os.path.join(package_path[0], module_name, "__init__.py")
             else:
-                module_file = os.path.join(
-                    package_path[0], module_name + ".py"
-                )
+                module_file = os.path.join(package_path[0], module_name + ".py")
 
             if not os.path.isfile(module_file):
                 return None
 
-            loader = importlib.machinery.SourceFileLoader(
-                module_fullname, module_file
-            )
+            loader = importlib.machinery.SourceFileLoader(module_fullname, module_file)
             spec = importlib.util.spec_from_loader(loader.name, loader)
             self._module_info[module_fullname] = spec
         except ImportError:
@@ -328,9 +322,7 @@ class CoreImportHandler(object):
         try:
             spec.loader.exec_module(module)
         except FileNotFoundError as e:
-            raise ImportError(
-                f"No module named '{module_fullname}'"
-            ) from e
+            raise ImportError(f"No module named '{module_fullname}'") from e
 
         # the module needs to know the loader so that reload() works
         module.__loader__ = self

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -971,11 +971,17 @@ class ToolkitManager(object):
             # Set authentication overrides in reserved env vars so they will persist
             # across toolkit engine sessions
             if flow_const.FLOW_AUTH_APP_ID in overrides:
-                os.environ["TK_FLOW_AUTH_APPLICATION_ID"] = overrides[flow_const.FLOW_AUTH_APP_ID]
+                os.environ["TK_FLOW_AUTH_APPLICATION_ID"] = overrides[
+                    flow_const.FLOW_AUTH_APP_ID
+                ]
             if flow_const.FLOW_AUTH_BASE_URL in overrides:
-                os.environ["TK_FLOW_AUTH_BASE_URL"] = overrides[flow_const.FLOW_AUTH_BASE_URL]
+                os.environ["TK_FLOW_AUTH_BASE_URL"] = overrides[
+                    flow_const.FLOW_AUTH_BASE_URL
+                ]
             if flow_const.FLOW_AUTH_CALLBACK_URL in overrides:
-                os.environ["TK_FLOW_AUTH_CALLBACK_URL"] = overrides[flow_const.FLOW_AUTH_CALLBACK_URL]
+                os.environ["TK_FLOW_AUTH_CALLBACK_URL"] = overrides[
+                    flow_const.FLOW_AUTH_CALLBACK_URL
+                ]
             settings = flow_auth.resolve_flow_auth_settings()
             flow_auth.init_authentication(settings)
             # Token is intentionally discarded here; it now sits in the file
@@ -986,9 +992,7 @@ class ToolkitManager(object):
                 "MEDM auth misconfigured for AM-ready project: %s" % e
             )
         except Exception as e:
-            raise TankBootstrapError(
-                "MEDM auth failed for AM-ready project: %s" % e
-            )
+            raise TankBootstrapError("MEDM auth failed for AM-ready project: %s" % e)
 
     def _get_configuration(self, entity, progress_callback):
         """
@@ -1134,12 +1138,16 @@ class ToolkitManager(object):
                 if sg_project and sg_project.get(flow_auth.AM_READY_PROJECT_FIELD):
                     # Retrieve and cache the flow am project id on the context object
                     flow_project_id = sg_project.get(flow_auth.AM_READY_PROJECT_FIELD)
-                    log.info(f"Current SG project is associated with a Flow project: {flow_project_id}")
+                    log.info(
+                        f"Current SG project is associated with a Flow project: {flow_project_id}"
+                    )
                     tk, _ = config.get_tk_instance(self._sg_user)
                     ctx = tk.context_from_entity_dictionary(entity)
                     ctx.project[flow_auth.AM_READY_PROJECT_FIELD] = flow_project_id
                     # Authenticate into Flow AM
-                    self._trigger_am_auth(tk.pipeline_configuration, entity, progress_callback)
+                    self._trigger_am_auth(
+                        tk.pipeline_configuration, entity, progress_callback
+                    )
 
         return config
 

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -376,9 +376,9 @@ class ConfigurationResolver(object):
                 # field. Note that this may be None if for example the pipeline configuration
                 # is defined for another operating system.
                 try:
-                    pipeline_config[
-                        "config_descriptor"
-                    ] = self._create_config_descriptor(sg_connection, pipeline_config)
+                    pipeline_config["config_descriptor"] = (
+                        self._create_config_descriptor(sg_connection, pipeline_config)
+                    )
                     yield pipeline_config
 
                 except TankBootstrapInvalidPipelineConfigurationError as e:
@@ -841,7 +841,9 @@ class ConfigurationResolver(object):
                 "Will use pipeline configuration id '%s'" % pipeline_config_identifier
             )
 
-            log.debug("Requesting pipeline configuration data from Flow Production Tracking...")
+            log.debug(
+                "Requesting pipeline configuration data from Flow Production Tracking..."
+            )
 
             # Fetch the one and only config that matches this id.
             pipeline_config = sg_connection.find_one(
@@ -869,7 +871,9 @@ class ConfigurationResolver(object):
 
             # We couldn't resolve anything from Shotgun, so we'll resolve the configuration using
             # an offline resolve.
-            return self.resolve_not_found_sg_configuration(fallback_config_descriptor, sg_connection)
+            return self.resolve_not_found_sg_configuration(
+                fallback_config_descriptor, sg_connection
+            )
 
         else:
             # Something was found in Shotgun, which means we've also potentially resolved its

--- a/python/tank/commands/app_info.py
+++ b/python/tank/commands/app_info.py
@@ -108,7 +108,7 @@ class AppInfoAction(Action):
                 descriptor = env.get_app_descriptor(eng, app)
                 log.info("App %s" % app)
                 log.info("-" * (4 + len(app)))
-                for (k, v) in descriptor.get_dict().items():
+                for k, v in descriptor.get_dict().items():
                     log.info(" %s: %s" % (k.capitalize(), v))
                 log.info(" Docs: %s" % descriptor.documentation_url)
                 log.info("")

--- a/python/tank/commands/console_utils.py
+++ b/python/tank/commands/console_utils.py
@@ -20,7 +20,6 @@ from ..errors import TankError, TankNoDefaultValueError
 from ..descriptor import CheckVersionConstraintsError
 from ..platform.bundle import resolve_default_value
 
-
 ##########################################################################################
 # displaying of info in the terminal, ascii-graphcics style
 
@@ -34,7 +33,7 @@ def format_bundle_info(log, descriptor, required_updates=None):
     :param required_updates: A list of bundle names that require updating.
     """
     # yay we can install! - get release notes
-    (summary, url) = descriptor.changelog
+    summary, url = descriptor.changelog
 
     if required_updates:
         add_padding = "     "

--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -11,6 +11,7 @@
 """
 Tank command allowing to do core updates.
 """
+
 from ..errors import TankError
 from .action_base import Action
 
@@ -197,7 +198,7 @@ class CoreUpdateAction(Action):
 
         elif status == TankCoreUpdater.UPDATE_POSSIBLE:
 
-            (summary, url) = installer.get_release_notes()
+            summary, url = installer.get_release_notes()
 
             log.info("")
             log.info("Newer version %s is available." % new_version)

--- a/python/tank/commands/get_entity_commands.py
+++ b/python/tank/commands/get_entity_commands.py
@@ -150,7 +150,7 @@ class GetEntityCommandsAction(Action):
         per_entity_type = itertools.groupby(entities, operator.itemgetter(0))
 
         commands_per_entity = {}
-        for (entity_type, entities_of_type) in per_entity_type:
+        for entity_type, entities_of_type in per_entity_type:
             # make a list out of the grouped entity tuples
             entities_of_type = list(entities_of_type)
             try:

--- a/python/tank/commands/get_entity_commands.py
+++ b/python/tank/commands/get_entity_commands.py
@@ -311,7 +311,7 @@ class GetEntityCommandsAction(Action):
             tokens += [""] * (NUM_EXPECTED_TOKENS - len(tokens))
 
             # extract the information from the tokens
-            (name, title, _, _, icon, description) = tuple(tokens)
+            name, title, _, _, icon, description = tuple(tokens)
 
             commands.append(
                 {"name": name, "title": title, "icon": icon, "description": description}

--- a/python/tank/commands/install.py
+++ b/python/tank/commands/install.py
@@ -539,8 +539,8 @@ class InstallEngineAction(Action):
             # run descriptor factory method
             log.info("Connecting to git...")
             location = {"type": "git", "path": engine_name}
-            engine_descriptor = self.tk.pipeline_configuration.get_latest_engine_descriptor(
-                location
+            engine_descriptor = (
+                self.tk.pipeline_configuration.get_latest_engine_descriptor(location)
             )
             log.info(
                 "Latest tag in repository '%s' is %s."
@@ -559,8 +559,8 @@ class InstallEngineAction(Action):
             # this is an app store app!
             log.info("Connecting to the Toolkit App Store...")
             location = {"type": "app_store", "name": engine_name}
-            engine_descriptor = self.tk.pipeline_configuration.get_latest_engine_descriptor(
-                location
+            engine_descriptor = (
+                self.tk.pipeline_configuration.get_latest_engine_descriptor(location)
             )
             log.info(
                 "Latest approved App Store Version is %s." % engine_descriptor.version

--- a/python/tank/commands/install.py
+++ b/python/tank/commands/install.py
@@ -94,7 +94,7 @@ class InstallAppAction(Action):
         :param log: std python logger
         :param args: command line args
         """
-        (use_legacy_parser, args) = util.should_use_legacy_yaml_parser(args)
+        use_legacy_parser, args = util.should_use_legacy_yaml_parser(args)
         preserve_yaml = not use_legacy_parser
 
         if len(args) != 3:
@@ -411,7 +411,7 @@ class InstallEngineAction(Action):
         :param log: std python logger
         :param args: command line args
         """
-        (use_legacy_parser, args) = util.should_use_legacy_yaml_parser(args)
+        use_legacy_parser, args = util.should_use_legacy_yaml_parser(args)
         preserve_yaml = not use_legacy_parser
 
         if len(args) != 2:

--- a/python/tank/commands/interaction.py
+++ b/python/tank/commands/interaction.py
@@ -14,7 +14,6 @@ Interfaces for prompting the user for input during tank command execution.
 
 from .. import LogManager
 
-
 log = LogManager.get_logger(__name__)
 
 

--- a/python/tank/commands/path_cache.py
+++ b/python/tank/commands/path_cache.py
@@ -176,7 +176,9 @@ class PathCacheMigrationAction(Action):
         # first load up the current path cache file and make sure
         # shotgun has got all those entries present as FilesystemLocations.
         log.info("")
-        log.info("Phase 1/3: Pushing data from the current path cache to Flow Production Tracking...")
+        log.info(
+            "Phase 1/3: Pushing data from the current path cache to Flow Production Tracking..."
+        )
         curr_pc = path_cache.PathCache(self.tk)
         try:
             curr_pc.ensure_all_entries_are_in_shotgun()
@@ -191,7 +193,9 @@ class PathCacheMigrationAction(Action):
 
         # and synchronize path cache
         log.info("")
-        log.info("Phase 3/3: Synchronizing your local machine with Flow Production Tracking...")
+        log.info(
+            "Phase 3/3: Synchronizing your local machine with Flow Production Tracking..."
+        )
         pc = path_cache.PathCache(self.tk)
         try:
             pc.synchronize(full_sync=True)

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -687,9 +687,7 @@ class SetupProjectAction(Action):
 
         default_config_locations = self._get_default_configuration_location(log, params)
 
-        linux_path = self._ask_location(
-            log, default_config_locations["linux"], "Linux"
-        )
+        linux_path = self._ask_location(log, default_config_locations["linux"], "Linux")
         windows_path = self._ask_location(
             log, default_config_locations["win32"], "Windows"
         )
@@ -950,7 +948,7 @@ class SetupProjectAction(Action):
         mapped_roots = []
 
         # loop over required storage roots
-        for (root_name, root_info) in required_roots.items():
+        for root_name, root_info in required_roots.items():
 
             log.info("%s" % (root_name,))
             log.info("-" * len(root_name))
@@ -1057,7 +1055,7 @@ class SetupProjectAction(Action):
         # ---- now we've mapped the roots, and they're all valid, we need to
         #      update the root information on the core wizard
 
-        for (root_name, storage_name) in mapped_roots:
+        for root_name, storage_name in mapped_roots:
 
             root_info = required_roots[root_name]
             storage_data = storage_by_name[storage_name.lower()]

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -57,7 +57,7 @@ class ProjectSetupParameters(object):
     - run project setup!
     """
 
-    (CENTRALIZED_CONFIG, DISTRIBUTED_CONFIG) = range(2)
+    CENTRALIZED_CONFIG, DISTRIBUTED_CONFIG = range(2)
 
     def __init__(self, log, sg):
         """
@@ -1019,7 +1019,7 @@ class TemplateConfiguration(object):
         # now extract the cfg and validate
         old_umask = os.umask(0)
         try:
-            (self._cfg_folder, self._version, self._config_mode) = self._process_config(
+            self._cfg_folder, self._version, self._config_mode = self._process_config(
                 config_uri
             )
         finally:
@@ -1272,7 +1272,7 @@ class TemplateConfiguration(object):
         storage_info = {}
 
         # do the storage lookup and mapping in PTR
-        (local_storage_lookup, unmapped_roots) = self._storage_roots.get_local_storages(
+        local_storage_lookup, unmapped_roots = self._storage_roots.get_local_storages(
             self._sg
         )
 

--- a/python/tank/commands/setup_project_wizard.py
+++ b/python/tank/commands/setup_project_wizard.py
@@ -651,9 +651,9 @@ class SetupProjectWizard(object):
                     )
                     return_data["using_runtime"] = False
                     return_data["pipeline_config"] = data
-                    return_data[
-                        "core_path"
-                    ] = pipelineconfig_utils.resolve_all_os_paths_to_core(core_api_root)
+                    return_data["core_path"] = (
+                        pipelineconfig_utils.resolve_all_os_paths_to_core(core_api_root)
+                    )
 
                     # finally, check the logic for localization:
                     # if this core that we have found and resolved is localized,

--- a/python/tank/commands/switch.py
+++ b/python/tank/commands/switch.py
@@ -203,13 +203,13 @@ class SwitchAppAction(Action):
         log.info("")
         log.info("Current version")
         log.info("------------------------------------")
-        for (k, v) in descriptor.get_dict().items():
+        for k, v in descriptor.get_dict().items():
             log.info(" - %s: %s" % (k.capitalize(), v))
 
         log.info("")
         log.info("New version")
         log.info("------------------------------------")
-        for (k, v) in new_descriptor.get_dict().items():
+        for k, v in new_descriptor.get_dict().items():
             log.info(" - %s: %s" % (k.capitalize(), v))
 
         log.info("")

--- a/python/tank/commands/switch.py
+++ b/python/tank/commands/switch.py
@@ -116,7 +116,7 @@ class SwitchAppAction(Action):
             log.info("")
             return
 
-        (use_legacy_parser, args) = util.should_use_legacy_yaml_parser(args)
+        use_legacy_parser, args = util.should_use_legacy_yaml_parser(args)
         preserve_yaml = not use_legacy_parser
 
         # get parameters
@@ -229,9 +229,7 @@ class SwitchAppAction(Action):
 
         # ensure that all required frameworks have been installed
         # find the file where our item is being installed
-        (_, yml_file) = env.find_location_for_app(
-            engine_instance_name, app_instance_name
-        )
+        _, yml_file = env.find_location_for_app(engine_instance_name, app_instance_name)
 
         console_utils.ensure_frameworks_installed(
             log, self.tk, yml_file, new_descriptor, env, self._interaction_interface

--- a/python/tank/commands/update.py
+++ b/python/tank/commands/update.py
@@ -110,7 +110,7 @@ class AppUpdatesAction(Action):
         :param log: std python logger
         :param args: command line args
         """
-        (use_legacy_parser, args) = util.should_use_legacy_yaml_parser(args)
+        use_legacy_parser, args = util.should_use_legacy_yaml_parser(args)
         preserve_yaml = not use_legacy_parser
 
         if len(args) == 0:
@@ -368,7 +368,7 @@ class AppUpdatesAction(Action):
                         x["new_descriptor"].version,
                     )
                 )
-                (_, url) = x["new_descriptor"].changelog
+                _, url = x["new_descriptor"].changelog
                 if url:
                     summary.append("Change Log: %s" % url)
                 summary.append("")
@@ -512,11 +512,11 @@ class AppUpdatesAction(Action):
         # ensure that all required frameworks have been installed
         # find the file where our item is being installed
         if framework_name:
-            (_, yml_file) = env.find_location_for_framework(framework_name)
+            _, yml_file = env.find_location_for_framework(framework_name)
         elif app_name:
-            (_, yml_file) = env.find_location_for_app(engine_name, app_name)
+            _, yml_file = env.find_location_for_app(engine_name, app_name)
         else:
-            (_, yml_file) = env.find_location_for_engine(engine_name)
+            _, yml_file = env.find_location_for_engine(engine_name)
 
         console_utils.ensure_frameworks_installed(
             log, tk, yml_file, new_descriptor, env, self._interaction_interface
@@ -791,7 +791,7 @@ class AppUpdatesAction(Action):
         out_of_date = latest_desc.version != curr_desc.version
 
         # check deprecation
-        (is_dep, dep_msg) = latest_desc.deprecation_status
+        is_dep, dep_msg = latest_desc.deprecation_status
 
         if is_dep:
             # we treat deprecation as an out of date that cannot be upgraded!

--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -83,9 +83,7 @@ class ValidateConfigAction(Action):
 
         log.info("")
         log.info("")
-        log.info(
-            "Welcome to the Flow Production Tracking Configuration validator!"
-        )
+        log.info("Welcome to the Flow Production Tracking Configuration validator!")
         log.info("")
 
         log.info("Found the following environments:")

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -12,6 +12,7 @@
 Management of the current context, e.g. the current shotgun entity/step/task.
 
 """
+
 from __future__ import annotations  # needed for python 3.9 support
 
 import os

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -19,7 +19,6 @@ from ..util import LocalFileStorageManager
 from . import constants
 from .. import constants as constants2
 
-
 logger = LogManager.get_logger(__name__)
 
 

--- a/python/tank/descriptor/descriptor_cached_config.py
+++ b/python/tank/descriptor/descriptor_cached_config.py
@@ -69,7 +69,7 @@ class CachedConfigDescriptor(ConfigDescriptor):
             #
             # location:
             #    name: tk-core
-            #    type: app_store
+            # type: app_store
             #    version: v0.16.34
 
             log.debug("Detected core descriptor file '%s'" % core_descriptor_path)

--- a/python/tank/descriptor/io_descriptor/appstore.py
+++ b/python/tank/descriptor/io_descriptor/appstore.py
@@ -65,7 +65,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
     _app_store_connections = {}
 
     # internal app store mappings
-    (APP, FRAMEWORK, ENGINE, CONFIG, CORE) = range(5)
+    APP, FRAMEWORK, ENGINE, CONFIG, CORE = range(5)
 
     _APP_STORE_OBJECT = {
         constants.DESCRIPTOR_APP: constants.TANK_APP_ENTITY_TYPE,
@@ -231,7 +231,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
             link_field = self._APP_STORE_LINK[self._bundle_type]
 
             # connect to the app store
-            (sg, _) = self.__create_sg_app_store_connection()
+            sg, _ = self.__create_sg_app_store_connection()
 
             if self._bundle_type == self.CORE:
                 # special handling of core since it doesn't have a high-level 'bundle' entity
@@ -413,7 +413,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         is to be downloaded to.
         """
         # connect to the app store
-        (sg, script_user) = self.__create_sg_app_store_connection()
+        sg, script_user = self.__create_sg_app_store_connection()
 
         # fetch metadata from sg...
         metadata = self.__refresh_metadata(destination_path)
@@ -445,7 +445,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         # write a stats record to the tank app store
         try:
             # connect to the app store
-            (sg, script_user) = self.__create_sg_app_store_connection()
+            sg, script_user = self.__create_sg_app_store_connection()
 
             # fetch metadata from sg...
             metadata = self.__refresh_metadata(download_path)
@@ -745,7 +745,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
         )
 
         # connect to the app store
-        (sg, _) = self.__create_sg_app_store_connection()
+        sg, _ = self.__create_sg_app_store_connection()
 
         # get latest get the filter logic for what to exclude
         if constants.APP_STORE_QA_MODE_ENV_VAR in os.environ:
@@ -981,7 +981,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
             # Connect to associated Shotgun site and retrieve the credentials to use to
             # connect to the app store site
             try:
-                (script_name, script_key) = self.__get_app_store_key_from_shotgun()
+                script_name, script_key = self.__get_app_store_key_from_shotgun()
             except urllib.error.HTTPError as e:
                 if e.code == 403:
                     # edge case alert!
@@ -994,7 +994,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
                     # trigger a refresh of our session token by issuing a shotgun API call
                     self._sg_connection.find_one("HumanUser", [])
                     # and retry
-                    (script_name, script_key) = self.__get_app_store_key_from_shotgun()
+                    script_name, script_key = self.__get_app_store_key_from_shotgun()
                 else:
                     raise
 
@@ -1146,7 +1146,7 @@ class IODescriptorAppStore(IODescriptorDownloadable):
                 % self
             )
             # connect to the app store
-            (sg, _) = self.__create_sg_app_store_connection()
+            sg, _ = self.__create_sg_app_store_connection()
             log.debug("...connection established: %s" % sg)
         except Exception as e:
             log.debug("...could not establish connection: %s" % e)

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -236,7 +236,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         and for folders on disk, e.g. 'tk-maya'
         """
         bn = os.path.basename(self._path)
-        (name, ext) = os.path.splitext(bn)
+        name, ext = os.path.splitext(bn)
         return name
 
     def has_remote_access(self):

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -51,9 +51,7 @@ class IODescriptorGitTag(IODescriptorGit):
         )
 
         # call base class
-        super().__init__(
-            descriptor_dict, sg_connection, bundle_type
-        )
+        super().__init__(descriptor_dict, sg_connection, bundle_type)
 
         # path is handled by base class - all git descriptors
         # have a path to a repo

--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -64,7 +64,7 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
     The latest version is defined as the current record available in Shotgun.
     """
 
-    (_MODE_ID_BASED, _MODE_NAME_BASED) = range(2)
+    _MODE_ID_BASED, _MODE_NAME_BASED = range(2)
 
     def __init__(self, descriptor_dict, sg_connection, bundle_type):
         """

--- a/python/tank/flowam/constants.py
+++ b/python/tank/flowam/constants.py
@@ -12,7 +12,6 @@
 
 import pathlib
 
-
 # Flow Settings
 # -------------
 # These are settings names that can be configured within a flow.yml file.

--- a/python/tank/flowam/open.py
+++ b/python/tank/flowam/open.py
@@ -31,7 +31,6 @@ from tank_vendor.flow_integration_sdk.sandbox import (
 )
 from tank_vendor.flow_integration_sdk.utils import trace
 
-
 logger = LogManager.get_logger(__name__)
 
 

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -24,7 +24,6 @@ from tank_vendor.flow_integration_sdk.objects import FlowProject
 
 from .constants import FLOW_SCHEMA_CONFIG_PATH
 
-
 logger = LogManager.get_logger(__name__)
 
 

--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -336,7 +336,7 @@ class FolderConfiguration(object):
             self._process_config_r(cur_node, full_path)
 
         # process symlinks
-        for (path, target, metadata) in self._get_symlinks_in_folder(parent_path):
+        for path, target, metadata in self._get_symlinks_in_folder(parent_path):
             parent_node.add_symlink(path, target, metadata)
 
         # now process all files and add them to the parent_node token

--- a/python/tank/folder/folder_types/base.py
+++ b/python/tank/folder/folder_types/base.py
@@ -176,7 +176,7 @@ class Folder(object):
             # has been created at this level in the folder structure
             static_children = [ch for ch in self._children if ch.is_dynamic() == False]
 
-            for (created_folder, sg_data_dict) in created_data:
+            for created_folder, sg_data_dict in created_data:
 
                 # first process the static folders
                 for cp in static_children:
@@ -208,7 +208,7 @@ class Folder(object):
             # no explicit list! instead process all children.
             # run the folder creation for all new folders created and for all
             # configuration children
-            for (created_folder, sg_data_dict) in created_data:
+            for created_folder, sg_data_dict in created_data:
                 for cp in self._children:
                     cp.create_folders(
                         io_receiver,

--- a/python/tank/folder/folder_types/expression_tokens.py
+++ b/python/tank/folder/folder_types/expression_tokens.py
@@ -59,7 +59,7 @@ class SymlinkToken(object):
             # - listfield tokens contain the value
             # - sg entity values contain the value in a compute_name key
             name_value = None
-            for (field_name, field_value) in sg_data.items():
+            for field_name, field_value in sg_data.items():
 
                 if token == field_name:
                     if isinstance(field_value, dict):

--- a/python/tank/folder/folder_types/listfield.py
+++ b/python/tank/folder/folder_types/listfield.py
@@ -190,7 +190,9 @@ class ListField(Folder):
                 # validate that the data type is of type list
                 field_type = resp[field_name]["data_type"]["value"]
             except Exception as e:
-                msg = "Folder creation error: Cannot retrieve values for PTR list field "
+                msg = (
+                    "Folder creation error: Cannot retrieve values for PTR list field "
+                )
                 msg += "%s.%s. Error reported: %s" % (entity_type, field_name, e)
                 raise TankError(msg)
 

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -11,6 +11,7 @@
 """
 Defines the base class for all Tank Hooks.
 """
+
 import os
 import sys
 import logging

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -220,7 +220,6 @@ Python provides a large number of log handlers as part of its standard library.
 For more information, see https://docs.python.org/2/library/logging.handlers.html#module-logging.handlers
 """
 
-
 import logging
 from logging.handlers import RotatingFileHandler
 import os

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -595,7 +595,7 @@ class LogManager(object):
 
     @property
     def log_file(self):
-        """ Full path to the current log file or None if logging is not active. """
+        """Full path to the current log file or None if logging is not active."""
         return self._std_file_handler_log_file
 
     @property
@@ -832,6 +832,8 @@ sgtk_root_logger.propagate = False
 # this should not be changed, but any filtering
 # should happen via log handlers
 sgtk_root_logger.setLevel(logging.DEBUG)
+
+
 #
 # create a 'nop' log handler to be attached.
 # this is to avoid warnings being reported that

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -501,7 +501,10 @@ class PathCache(object):
             sg_batch_data.append(req)
 
         # push to shotgun in a single xact
-        log.debug("Uploading %s path entries to Flow Production Tracking..." % len(sg_batch_data))
+        log.debug(
+            "Uploading %s path entries to Flow Production Tracking..."
+            % len(sg_batch_data)
+        )
 
         try:
             response = self._tk.shotgun.batch(sg_batch_data)
@@ -905,7 +908,9 @@ class PathCache(object):
                     - path
 
         """
-        log.debug("Fetching already registered folders from Flow Production Tracking...")
+        log.debug(
+            "Fetching already registered folders from Flow Production Tracking..."
+        )
 
         sg_data = self._get_filesystem_location_entities(folder_ids=None)
 
@@ -1334,7 +1339,7 @@ class PathCache(object):
                 )
                 self._update_last_event_log_synced(c, event_log_id)
                 # and indicate in the path cache that all these records have been pushed
-                for (pc_row_id, sg_id) in sg_id_lookup.items():
+                for pc_row_id, sg_id in sg_id_lookup.items():
                     c.execute(
                         "INSERT INTO shotgun_status(path_cache_id, shotgun_id) "
                         "VALUES(?, ?)",
@@ -1745,7 +1750,9 @@ class PathCache(object):
         SG_BATCH_SIZE = 50
 
         log.info("")
-        log.info("Step 1 - Downloading current path data from Flow Production Tracking...")
+        log.info(
+            "Step 1 - Downloading current path data from Flow Production Tracking..."
+        )
 
         sg_data = self._tk.shotgun.find(
             SHOTGUN_ENTITY,
@@ -1860,9 +1867,12 @@ class PathCache(object):
         # now query shotgun for each of the types
         ids_in_shotgun = {}
         sg_valid_records = []
-        for (et, sg_records_for_et) in ids_to_look_for.items():
+        for et, sg_records_for_et in ids_to_look_for.items():
 
-            log.info(" - Checking %s %ss in Flow Production Tracking..." % (len(sg_records_for_et), et))
+            log.info(
+                " - Checking %s %ss in Flow Production Tracking..."
+                % (len(sg_records_for_et), et)
+            )
 
             # get the ids from shotgun for the current et.
             sg_ids = [x["entity"]["id"] for x in sg_records_for_et]
@@ -1898,5 +1908,6 @@ class PathCache(object):
 
         log.info("")
         log.info(
-            "Migration complete. %s records created in Flow Production Tracking" % len(sg_valid_records)
+            "Migration complete. %s records created in Flow Production Tracking"
+            % len(sg_valid_records)
         )

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -115,8 +115,7 @@ class PathCache(object):
                 # up the default page size somewhat (from 4k -> 8k) to improve
                 # performance. See https://sqlite.org/pragma.html#pragma_page_size
 
-                c.executescript(
-                    """
+                c.executescript("""
                     PRAGMA page_size=8192;
 
                     CREATE TABLE path_cache (entity_type text, entity_id integer, entity_name text, root text, path text, primary_entity integer);
@@ -134,8 +133,7 @@ class PathCache(object):
                     CREATE UNIQUE INDEX shotgun_status_id ON shotgun_status(path_cache_id);
 
                     CREATE INDEX shotgun_status_shotgun_id ON shotgun_status(shotgun_id);
-                    """
-                )
+                    """)
                 self._connection.commit()
 
             else:
@@ -160,8 +158,7 @@ class PathCache(object):
 
                 # check for primary entity field - this was added back in 0.12.x
                 if "primary_entity" not in field_names:
-                    c.executescript(
-                        """
+                    c.executescript("""
                         ALTER TABLE path_cache ADD COLUMN primary_entity integer;
                         UPDATE path_cache SET primary_entity=1;
 
@@ -170,8 +167,7 @@ class PathCache(object):
 
                         DROP INDEX IF EXISTS path_cache_all;
                         CREATE UNIQUE INDEX IF NOT EXISTS path_cache_all ON path_cache(entity_type, entity_id, root, path, primary_entity);
-                        """
-                    )
+                        """)
 
                     self._connection.commit()
 
@@ -1334,7 +1330,7 @@ class PathCache(object):
                 )
 
                 # now push to shotgun
-                (event_log_id, sg_id_lookup) = self._upload_cache_data_to_shotgun(
+                event_log_id, sg_id_lookup = self._upload_cache_data_to_shotgun(
                     data_for_sg, desc
                 )
                 self._update_last_event_log_synced(c, event_log_id)
@@ -1780,18 +1776,14 @@ class PathCache(object):
 
         try:
             # get all records and check each one against shotgun.
-            pc_data = list(
-                cursor.execute(
-                    """select pc.rowid,
+            pc_data = list(cursor.execute("""select pc.rowid,
                                                     pc.entity_type,
                                                     pc.entity_id,
                                                     pc.entity_name,
                                                     pc.root,
                                                     pc.path,
                                                     pc.primary_entity
-                                             from path_cache pc"""
-                )
-            )
+                                             from path_cache pc"""))
         finally:
             cursor.close()
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -12,6 +12,7 @@
 Encapsulates the pipeline configuration and helps navigate and resolve paths
 across storages, configurations etc.
 """
+
 import os
 import glob
 import pickle
@@ -664,7 +665,7 @@ class PipelineConfiguration(object):
             return None
 
         # get the storage data for required roots
-        (mapped_roots, unmapped_roots) = self.get_local_storage_mapping()
+        mapped_roots, unmapped_roots = self.get_local_storage_mapping()
 
         if root_name in mapped_roots:
             return mapped_roots[root_name]
@@ -1127,7 +1128,7 @@ class PipelineConfiguration(object):
         env_names = []
         for f in glob.glob(self.get_environment_path("*")):
             file_name = os.path.basename(f)
-            (name, _) = os.path.splitext(file_name)
+            name, _ = os.path.splitext(file_name)
             env_names.append(name)
         return env_names
 

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -260,7 +260,7 @@ def _validate_and_create_pipeline_configuration(associated_pipeline_configs, sou
     """
     # extract path data from the pipeline configuration shotgun data
     # this will return lists of dicts with keys ``id``, (local os) ``path`` and ``project_id``
-    (all_pc_data, primary_pc_data) = _get_pipeline_configuration_data(
+    all_pc_data, primary_pc_data = _get_pipeline_configuration_data(
         associated_pipeline_configs
     )
 

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -184,7 +184,8 @@ def _from_path(path, force_reread_shotgun_cache):
         pc_registered_path = pipelineconfig_utils.get_config_install_location(path)
 
         log.debug(
-            "Resolved the official path registered in PTR to be %s." % pc_registered_path
+            "Resolved the official path registered in PTR to be %s."
+            % pc_registered_path
         )
 
         if pc_registered_path is None:

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -1133,7 +1133,7 @@ def _post_process_settings_r(tk, key, value, schema, bundle=None):
         items = schema.get("items", {})
         # note - we assign the original values here because we
         processed_val = value
-        for (key, value_schema) in items.items():
+        for key, value_schema in items.items():
             processed_val[key] = _post_process_settings_r(
                 tk=tk, key=key, value=value[key], schema=value_schema, bundle=bundle
             )

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -827,7 +827,7 @@ class TankBundle(object):
             # Entries are on the following form
             #
             # hook_publish_file:
-            #    type: hook
+            # type: hook
             #    description: Called when a file is published, e.g. copied from a work area to a publish area.
             #    default_value: maya_publish_file
             #

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -279,7 +279,7 @@ class Environment(object):
         without its extension
         """
         file_name_with_ext = os.path.basename(self._env_path)
-        (file_name, ext) = os.path.splitext(file_name_with_ext)
+        file_name, ext = os.path.splitext(file_name_with_ext)
         return file_name
 
     @property
@@ -596,7 +596,7 @@ class Environment(object):
             absolute_location,
         )
         # first, find the location of the engine:
-        (engine_tokens, engine_yml_file) = self.find_location_for_engine(engine_name)
+        engine_tokens, engine_yml_file = self.find_location_for_engine(engine_name)
 
         # load the engine data:
         engine_yml_data = self.__load_data(engine_yml_file)
@@ -813,7 +813,7 @@ class WritableEnvironment(InstalledEnvironment):
     content back to disk.
     """
 
-    (NONE, INCLUDE_DEFAULTS, STRIP_DEFAULTS) = range(3)
+    NONE, INCLUDE_DEFAULTS, STRIP_DEFAULTS = range(3)
     """Format enumeration to use when dumping an environment.
 
     NONE: Don't modify the settings.
@@ -1013,7 +1013,7 @@ class WritableEnvironment(InstalledEnvironment):
         # It is the difference between the following:
         #
         # common.engines.tk-maya.location:
-        #   type: app_store
+        # type: app_store
         #   name: tk-maya
         #   version: v0.8.1
         #
@@ -1021,7 +1021,7 @@ class WritableEnvironment(InstalledEnvironment):
         #
         # common.apps.tk-multi-shotgunpanel:
         #   location:
-        #     type: app_store
+        # type: app_store
         #     name: tk-multi-shotgunpanel
         #     version: v1.4.3
         #
@@ -1051,7 +1051,7 @@ class WritableEnvironment(InstalledEnvironment):
         # in a concrete manner (ie: the actual dict and not an include
         # to another yml file). The absolute_location argument will allow
         # us to do that.
-        (tokens, yml_file) = self._find_location_for_engine(
+        tokens, yml_file = self._find_location_for_engine(
             engine_name, absolute_location=True
         )
 
@@ -1094,7 +1094,7 @@ class WritableEnvironment(InstalledEnvironment):
         # in a concrete manner (ie: the actual dict and not an include
         # to another yml file). The absolute_location argument will allow
         # us to do that.
-        (tokens, yml_file) = self._find_location_for_app(
+        tokens, yml_file = self._find_location_for_app(
             engine_name, app_name, absolute_location=True
         )
 
@@ -1132,7 +1132,7 @@ class WritableEnvironment(InstalledEnvironment):
         # in a concrete manner (ie: the actual dict and not an include
         # to another yml file). The absolute_location argument will allow
         # us to do that.
-        (tokens, yml_file) = self._find_location_for_framework(
+        tokens, yml_file = self._find_location_for_framework(
             framework_name, absolute_location=True
         )
 
@@ -1404,7 +1404,7 @@ class WritableEnvironment(InstalledEnvironment):
         for engine_name in self.get_engines():
 
             # only process settings in this file
-            (tokens, engine_file) = self.find_location_for_engine(engine_name)
+            tokens, engine_file = self.find_location_for_engine(engine_name)
             if not engine_file == self._env_path:
                 continue
 
@@ -1437,7 +1437,7 @@ class WritableEnvironment(InstalledEnvironment):
             for app_name in self.get_apps(engine_name):
 
                 # only process settings in this file
-                (tokens, app_file) = self.find_location_for_app(engine_name, app_name)
+                tokens, app_file = self.find_location_for_app(engine_name, app_name)
                 if not app_file == self._env_path:
                     continue
 
@@ -1470,7 +1470,7 @@ class WritableEnvironment(InstalledEnvironment):
         for fw_name in self.get_frameworks():
 
             # only process settings in this file
-            (tokens, fw_file) = self.find_location_for_framework(fw_name)
+            tokens, fw_file = self.find_location_for_framework(fw_name)
             if not fw_file == self._env_path:
                 continue
 

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -67,8 +67,7 @@ class Environment(object):
         return "Environment %s" % os.path.basename(self._env_path)
 
     def _refresh(self):
-        """Refreshes the environment data from disk
-        """
+        """Refreshes the environment data from disk"""
         data = self.__load_environment_data()
 
         self._env_data = environment_includes.process_includes(
@@ -233,7 +232,7 @@ class Environment(object):
                 constants.ENVIRONMENT_LOCATION_KEY
             )
 
-        for (eng, app) in self.__app_settings:
+        for eng, app in self.__app_settings:
             descriptor_dict = self.__app_settings[(eng, app)].get(
                 constants.ENVIRONMENT_LOCATION_KEY
             )
@@ -323,7 +322,7 @@ class Environment(object):
 
         apps = []
         engine_app_tuples = list(self.__app_settings.keys())
-        for (engine_name, app_name) in engine_app_tuples:
+        for engine_name, app_name in engine_app_tuples:
             if engine_name == engine:
                 apps.append(app_name)
         return apps
@@ -834,7 +833,7 @@ class WritableEnvironment(InstalledEnvironment):
         super().__init__(env_path, pipeline_config, context)
 
     def _get_ruamel_yaml(self):
-        vendor_path  = os.path.join(os.path.dirname(__file__), "../..", "tank_vendor")
+        vendor_path = os.path.join(os.path.dirname(__file__), "../..", "tank_vendor")
 
         if vendor_path not in sys.path:
             sys.path.append(vendor_path)

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -27,7 +27,6 @@ relative paths are always required and context based paths are always optional.
 
 """
 
-
 import os
 import sys
 import copy

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -136,7 +136,7 @@ def _resolve_refs_r(lookup_dict, data):
 
     elif isinstance(data, dict):
         processed_val = {}
-        for (k, v) in data.items():
+        for k, v in data.items():
             processed_val[k] = _resolve_refs_r(lookup_dict, v)
 
     elif isinstance(data, str) and data.startswith("@"):
@@ -350,9 +350,7 @@ def find_reference(file_name, context, token, absolute_location=False):
                 # If the value of the token is an include, then we can
                 # recurse up, directly referencing the include name as
                 # the new token.
-                if isinstance(token_data, str) and token_data.startswith(
-                    "@"
-                ):
+                if isinstance(token_data, str) and token_data.startswith("@"):
                     include_token = token_data
                 else:
                     # In the case where the data isn't itself an include,

--- a/python/tank/platform/qt/resources_rc.py
+++ b/python/tank/platform/qt/resources_rc.py
@@ -1959,10 +1959,17 @@ qt_resource_struct = b"\
 \x00\x00\x01\x8f05\xd2\x9e\
 "
 
+
 def qInitResources():
-    QtCore.qRegisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qRegisterResourceData(
+        0x03, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 def qCleanupResources():
-    QtCore.qUnregisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qUnregisterResourceData(
+        0x03, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 qInitResources()

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -331,7 +331,8 @@ class TankQDialog(TankDialogBase):
             tooltip += "<b>System Information</b>"
             tooltip += "<hr>"
             tooltip += (
-                "<b>Flow Production Tracking Toolkit Version: </b>%s<br>" % self._bundle.tank.version
+                "<b>Flow Production Tracking Toolkit Version: </b>%s<br>"
+                % self._bundle.tank.version
             )
             tooltip += "<b>Pipeline Config: </b>%s<br>" % pc.get_name()
             tooltip += "<b>Config Path: </b>%s<br>" % pc.get_path()

--- a/python/tank/platform/qt/ui_busy_dialog.py
+++ b/python/tank/platform/qt/ui_busy_dialog.py
@@ -9,69 +9,76 @@
 ################################################################################
 
 from . import QtCore
+
 for name, cls in QtCore.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 from . import QtGui
+
 for name, cls in QtGui.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 
-from  . import resources_rc
+from . import resources_rc
+
 
 class Ui_BusyDialog(object):
     def setupUi(self, BusyDialog):
         if not BusyDialog.objectName():
-            BusyDialog.setObjectName(u"BusyDialog")
+            BusyDialog.setObjectName("BusyDialog")
         BusyDialog.resize(500, 110)
-        BusyDialog.setStyleSheet(u"/* Style for the window itself */\n"
-"#frame {\n"
-"border-color: #30A7E3;\n"
-"border-style: solid;\n"
-"border-width: 2px;\n"
-"}\n"
-"\n"
-"/* Style for the header text */\n"
-"#title {\n"
-"color: #30A7E3;\n"
-"margin-top: 15px;\n"
-"margin-bottom: 0px;\n"
-"margin-left: 1px;\n"
-"font-size: 16px;\n"
-"font-weight: bold;\n"
-"}\n"
-"\n"
-"/* Style for the details text */\n"
-"#details {\n"
-"margin-top: 1px;\n"
-"margin-left: 3px;\n"
-"margin-bottom: 0px;\n"
-"font-size: 11px;\n"
-"}\n"
-"")
+        BusyDialog.setStyleSheet(
+            "/* Style for the window itself */\n"
+            "#frame {\n"
+            "border-color: #30A7E3;\n"
+            "border-style: solid;\n"
+            "border-width: 2px;\n"
+            "}\n"
+            "\n"
+            "/* Style for the header text */\n"
+            "#title {\n"
+            "color: #30A7E3;\n"
+            "margin-top: 15px;\n"
+            "margin-bottom: 0px;\n"
+            "margin-left: 1px;\n"
+            "font-size: 16px;\n"
+            "font-weight: bold;\n"
+            "}\n"
+            "\n"
+            "/* Style for the details text */\n"
+            "#details {\n"
+            "margin-top: 1px;\n"
+            "margin-left: 3px;\n"
+            "margin-bottom: 0px;\n"
+            "font-size: 11px;\n"
+            "}\n"
+            ""
+        )
         self.horizontalLayout_2 = QHBoxLayout(BusyDialog)
         self.horizontalLayout_2.setSpacing(2)
         self.horizontalLayout_2.setContentsMargins(2, 2, 2, 2)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.frame = QFrame(BusyDialog)
-        self.frame.setObjectName(u"frame")
+        self.frame.setObjectName("frame")
         self.frame.setFrameShape(QFrame.StyledPanel)
         self.frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout = QHBoxLayout(self.frame)
         self.horizontalLayout.setSpacing(5)
         self.horizontalLayout.setContentsMargins(5, 5, 5, 5)
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setObjectName("horizontalLayout")
         self.label = QLabel(self.frame)
-        self.label.setObjectName(u"label")
-        self.label.setPixmap(QPixmap(u":/Tank.Platform.Qt/sg_logo_80px.png"))
+        self.label.setObjectName("label")
+        self.label.setPixmap(QPixmap(":/Tank.Platform.Qt/sg_logo_80px.png"))
 
         self.horizontalLayout.addWidget(self.label)
 
         self.verticalLayout = QVBoxLayout()
         self.verticalLayout.setSpacing(0)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setObjectName("verticalLayout")
         self.title = QLabel(self.frame)
-        self.title.setObjectName(u"title")
+        self.title.setObjectName("title")
         sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -81,13 +88,13 @@ class Ui_BusyDialog(object):
         self.verticalLayout.addWidget(self.title)
 
         self.details = QLabel(self.frame)
-        self.details.setObjectName(u"details")
+        self.details.setObjectName("details")
         sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.details.sizePolicy().hasHeightForWidth())
         self.details.setSizePolicy(sizePolicy1)
-        self.details.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignTop)
+        self.details.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignTop)
         self.details.setWordWrap(True)
 
         self.verticalLayout.addWidget(self.details)
@@ -99,11 +106,21 @@ class Ui_BusyDialog(object):
         self.retranslateUi(BusyDialog)
 
         QMetaObject.connectSlotsByName(BusyDialog)
+
     # setupUi
 
     def retranslateUi(self, BusyDialog):
-        BusyDialog.setWindowTitle(QCoreApplication.translate("BusyDialog", u"Dialog", None))
+        BusyDialog.setWindowTitle(
+            QCoreApplication.translate("BusyDialog", "Dialog", None)
+        )
         self.label.setText("")
-        self.title.setText(QCoreApplication.translate("BusyDialog", u"Doing something, hang on!", None))
-        self.details.setText(QCoreApplication.translate("BusyDialog", u"Lots of interesting details about what is going on", None))
+        self.title.setText(
+            QCoreApplication.translate("BusyDialog", "Doing something, hang on!", None)
+        )
+        self.details.setText(
+            QCoreApplication.translate(
+                "BusyDialog", "Lots of interesting details about what is going on", None
+            )
+        )
+
     # retranslateUi

--- a/python/tank/platform/qt/ui_item.py
+++ b/python/tank/platform/qt/ui_item.py
@@ -9,56 +9,61 @@
 ################################################################################
 
 from . import QtCore
+
 for name, cls in QtCore.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 from . import QtGui
+
 for name, cls in QtGui.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 
-from  . import resources_rc
+from . import resources_rc
+
 
 class Ui_Item(object):
     def setupUi(self, Item):
         if not Item.objectName():
-            Item.setObjectName(u"Item")
+            Item.setObjectName("Item")
         Item.resize(335, 110)
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(Item.sizePolicy().hasHeightForWidth())
         Item.setSizePolicy(sizePolicy)
-        Item.setStyleSheet(u"QLabel{\n"
-"   font-size: 11px;\n"
-"   margin-bottom: 3px\n"
-"}\n"
-"")
+        Item.setStyleSheet(
+            "QLabel{\n" "   font-size: 11px;\n" "   margin-bottom: 3px\n" "}\n" ""
+        )
         self.verticalLayout = QVBoxLayout(Item)
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setObjectName("verticalLayout")
         self.verticalLayout_2 = QVBoxLayout()
         self.verticalLayout_2.setSpacing(0)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.name = QLabel(Item)
-        self.name.setObjectName(u"name")
+        self.name.setObjectName("name")
         sizePolicy1 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.name.sizePolicy().hasHeightForWidth())
         self.name.setSizePolicy(sizePolicy1)
-        self.name.setStyleSheet(u"font-size: 13px;")
-        self.name.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.name.setStyleSheet("font-size: 13px;")
+        self.name.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.name.setWordWrap(True)
 
         self.verticalLayout_2.addWidget(self.name)
 
         self.line = QFrame(Item)
-        self.line.setObjectName(u"line")
-        self.line.setStyleSheet(u"border: none;\n"
-"border-bottom-color: rgba(150,150,150,100);\n"
-"border-bottom-width: 1px;\n"
-"border-bottom-style: solid;")
+        self.line.setObjectName("line")
+        self.line.setStyleSheet(
+            "border: none;\n"
+            "border-bottom-color: rgba(150,150,150,100);\n"
+            "border-bottom-width: 1px;\n"
+            "border-bottom-style: solid;"
+        )
         self.line.setFrameShape(QFrame.HLine)
         self.line.setFrameShadow(QFrame.Sunken)
 
@@ -67,36 +72,44 @@ class Ui_Item(object):
         self.verticalLayout.addLayout(self.verticalLayout_2)
 
         self.value = QLabel(Item)
-        self.value.setObjectName(u"value")
+        self.value.setObjectName("value")
         sizePolicy1.setHeightForWidth(self.value.sizePolicy().hasHeightForWidth())
         self.value.setSizePolicy(sizePolicy1)
-        self.value.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.value.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.value.setWordWrap(True)
-        self.value.setTextInteractionFlags(Qt.LinksAccessibleByMouse|Qt.TextSelectableByMouse)
+        self.value.setTextInteractionFlags(
+            Qt.LinksAccessibleByMouse | Qt.TextSelectableByMouse
+        )
 
         self.verticalLayout.addWidget(self.value)
 
         self.type = QLabel(Item)
-        self.type.setObjectName(u"type")
+        self.type.setObjectName("type")
         sizePolicy1.setHeightForWidth(self.type.sizePolicy().hasHeightForWidth())
         self.type.setSizePolicy(sizePolicy1)
-        self.type.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.type.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.type.setWordWrap(True)
-        self.type.setTextInteractionFlags(Qt.LinksAccessibleByMouse|Qt.TextSelectableByMouse)
+        self.type.setTextInteractionFlags(
+            Qt.LinksAccessibleByMouse | Qt.TextSelectableByMouse
+        )
 
         self.verticalLayout.addWidget(self.type)
 
         self.description = QLabel(Item)
-        self.description.setObjectName(u"description")
+        self.description.setObjectName("description")
         self.description.setMaximumSize(QSize(350, 16777215))
         self.description.setTextFormat(Qt.RichText)
-        self.description.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.description.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.description.setWordWrap(True)
-        self.description.setTextInteractionFlags(Qt.LinksAccessibleByMouse|Qt.TextSelectableByMouse)
+        self.description.setTextInteractionFlags(
+            Qt.LinksAccessibleByMouse | Qt.TextSelectableByMouse
+        )
 
         self.verticalLayout.addWidget(self.description)
 
-        self.verticalSpacer = QSpacerItem(20, 0, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer = QSpacerItem(
+            20, 0, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
@@ -105,16 +118,24 @@ class Ui_Item(object):
         self.retranslateUi(Item)
 
         QMetaObject.connectSlotsByName(Item)
+
     # setupUi
 
     def retranslateUi(self, Item):
-        Item.setWindowTitle(QCoreApplication.translate("Item", u"Form", None))
-        self.name.setText(QCoreApplication.translate("Item", u"Settings Name", None))
-        self.value.setText(QCoreApplication.translate("Item", u"Value: foo bar", None))
-        self.type.setText(QCoreApplication.translate("Item", u"Type: bool", None))
-        self.description.setText(QCoreApplication.translate("Item", u"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-weight:400; font-style:normal;\">\n"
-"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">description</p></body></html>", None))
+        Item.setWindowTitle(QCoreApplication.translate("Item", "Form", None))
+        self.name.setText(QCoreApplication.translate("Item", "Settings Name", None))
+        self.value.setText(QCoreApplication.translate("Item", "Value: foo bar", None))
+        self.type.setText(QCoreApplication.translate("Item", "Type: bool", None))
+        self.description.setText(
+            QCoreApplication.translate(
+                "Item",
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
+                '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
+                "p, li { white-space: pre-wrap; }\n"
+                "</style></head><body style=\" font-family:'Lucida Grande'; font-weight:400; font-style:normal;\">\n"
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">description</p></body></html>',
+                None,
+            )
+        )
+
     # retranslateUi

--- a/python/tank/platform/qt/ui_tank_dialog.py
+++ b/python/tank/platform/qt/ui_tank_dialog.py
@@ -9,138 +9,153 @@
 ################################################################################
 
 from . import QtCore
+
 for name, cls in QtCore.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 from . import QtGui
+
 for name, cls in QtGui.__dict__.items():
-    if isinstance(cls, type): globals()[name] = cls
+    if isinstance(cls, type):
+        globals()[name] = cls
 
 
-from  . import resources_rc
+from . import resources_rc
+
 
 class Ui_TankDialog(object):
     def setupUi(self, TankDialog):
         if not TankDialog.objectName():
-            TankDialog.setObjectName(u"TankDialog")
+            TankDialog.setObjectName("TankDialog")
         TankDialog.resize(879, 551)
-        TankDialog.setStyleSheet(u"")
+        TankDialog.setStyleSheet("")
         self.verticalLayout_3 = QVBoxLayout(TankDialog)
         self.verticalLayout_3.setSpacing(0)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setObjectName("verticalLayout_3")
         self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.stackedWidget = QStackedWidget(TankDialog)
-        self.stackedWidget.setObjectName(u"stackedWidget")
+        self.stackedWidget.setObjectName("stackedWidget")
         self.page_1 = QWidget()
-        self.page_1.setObjectName(u"page_1")
-        self.page_1.setStyleSheet(u"QWidget#page_1 {\n"
-"margin: 0px;\n"
-"}")
+        self.page_1.setObjectName("page_1")
+        self.page_1.setStyleSheet("QWidget#page_1 {\n" "margin: 0px;\n" "}")
         self.verticalLayout = QVBoxLayout(self.page_1)
         self.verticalLayout.setSpacing(0)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setObjectName("verticalLayout")
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.top_group = QGroupBox(self.page_1)
-        self.top_group.setObjectName(u"top_group")
+        self.top_group.setObjectName("top_group")
         self.top_group.setMinimumSize(QSize(0, 45))
         self.top_group.setMaximumSize(QSize(16777215, 45))
-        self.top_group.setStyleSheet(u"#top_group {\n"
-"background-color:  #2D2D2D;\n"
-"border: none;\n"
-"border-bottom:1px solid #202020;\n"
-"}\n"
-"")
+        self.top_group.setStyleSheet(
+            "#top_group {\n"
+            "background-color:  #2D2D2D;\n"
+            "border: none;\n"
+            "border-bottom:1px solid #202020;\n"
+            "}\n"
+            ""
+        )
         self.top_group.setFlat(False)
         self.horizontalLayout = QHBoxLayout(self.top_group)
         self.horizontalLayout.setSpacing(0)
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setObjectName("horizontalLayout")
         self.horizontalLayout.setContentsMargins(4, 0, 1, 1)
         self.tank_logo = QLabel(self.top_group)
-        self.tank_logo.setObjectName(u"tank_logo")
+        self.tank_logo.setObjectName("tank_logo")
         sizePolicy = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.tank_logo.sizePolicy().hasHeightForWidth())
         self.tank_logo.setSizePolicy(sizePolicy)
-        self.tank_logo.setPixmap(QPixmap(u":/Tank.Platform.Qt/tank_logo.png"))
+        self.tank_logo.setPixmap(QPixmap(":/Tank.Platform.Qt/tank_logo.png"))
 
         self.horizontalLayout.addWidget(self.tank_logo)
 
         self.label = QLabel(self.top_group)
-        self.label.setObjectName(u"label")
-        self.label.setStyleSheet(u"/* want this stylesheet to apply to the label but not the tooltip */\n"
-"QLabel{\n"
-"    color: white;\n"
-"    font-size: 20px;\n"
-"    margin-left: 5px;\n"
-"    font-family: \"Open Sans\";\n"
-"    font-style: \"Regular\";\n"
-"}")
+        self.label.setObjectName("label")
+        self.label.setStyleSheet(
+            "/* want this stylesheet to apply to the label but not the tooltip */\n"
+            "QLabel{\n"
+            "    color: white;\n"
+            "    font-size: 20px;\n"
+            "    margin-left: 5px;\n"
+            '    font-family: "Open Sans";\n'
+            '    font-style: "Regular";\n'
+            "}"
+        )
 
         self.horizontalLayout.addWidget(self.label)
 
         self.lbl_context = QLabel(self.top_group)
-        self.lbl_context.setObjectName(u"lbl_context")
-        self.lbl_context.setStyleSheet(u"/* want this stylesheet to apply to the label but not the tooltip */\n"
-"QLabel {\n"
-"    color: rgba(250,250,250,180);\n"
-"    font-size: 11px;\n"
-"    margin-right: 8px;\n"
-"    font-family: \"Open Sans\";\n"
-"    font-style: \"Regular\";\n"
-"}\n"
-"\n"
-"\n"
-"")
-        self.lbl_context.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
+        self.lbl_context.setObjectName("lbl_context")
+        self.lbl_context.setStyleSheet(
+            "/* want this stylesheet to apply to the label but not the tooltip */\n"
+            "QLabel {\n"
+            "    color: rgba(250,250,250,180);\n"
+            "    font-size: 11px;\n"
+            "    margin-right: 8px;\n"
+            '    font-family: "Open Sans";\n'
+            '    font-style: "Regular";\n'
+            "}\n"
+            "\n"
+            "\n"
+            ""
+        )
+        self.lbl_context.setAlignment(
+            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
+        )
 
         self.horizontalLayout.addWidget(self.lbl_context)
 
         self.details_show = QToolButton(self.top_group)
-        self.details_show.setObjectName(u"details_show")
+        self.details_show.setObjectName("details_show")
         self.details_show.setMinimumSize(QSize(34, 34))
         self.details_show.setFocusPolicy(Qt.ClickFocus)
-        self.details_show.setStyleSheet(u"QToolButton{\n"
-"width: 12px;\n"
-"height: 20px;\n"
-"background-image: url(:/Tank.Platform.Qt/arrow.png);\n"
-"border: none;\n"
-"background-color: none;\n"
-"}\n"
-"\n"
-"QToolButton:hover{\n"
-"background-image: url(:/Tank.Platform.Qt/arrow_hover.png);\n"
-"}\n"
-"\n"
-"QToolButton:pressed{\n"
-"background-image: url(:/Tank.Platform.Qt/arrow_pressed.png);\n"
-"}\n"
-"")
+        self.details_show.setStyleSheet(
+            "QToolButton{\n"
+            "width: 12px;\n"
+            "height: 20px;\n"
+            "background-image: url(:/Tank.Platform.Qt/arrow.png);\n"
+            "border: none;\n"
+            "background-color: none;\n"
+            "}\n"
+            "\n"
+            "QToolButton:hover{\n"
+            "background-image: url(:/Tank.Platform.Qt/arrow_hover.png);\n"
+            "}\n"
+            "\n"
+            "QToolButton:pressed{\n"
+            "background-image: url(:/Tank.Platform.Qt/arrow_pressed.png);\n"
+            "}\n"
+            ""
+        )
         self.details_show.setAutoRaise(True)
 
         self.horizontalLayout.addWidget(self.details_show)
 
         self.details_hide = QToolButton(self.top_group)
-        self.details_hide.setObjectName(u"details_hide")
+        self.details_hide.setObjectName("details_hide")
         self.details_hide.setMinimumSize(QSize(34, 34))
         self.details_hide.setFocusPolicy(Qt.ClickFocus)
         self.details_hide.setVisible(False)
-        self.details_hide.setStyleSheet(u"QToolButton{\n"
-" width: 12px;\n"
-" height: 20px;\n"
-" background-image: url(:/Tank.Platform.Qt/arrow_flipped.png);\n"
-" border: none;\n"
-" background-color: none;\n"
-" }\n"
-"\n"
-" QToolButton:hover{\n"
-" background-image: url(:/Tank.Platform.Qt/arrow_flipped_hover.png);\n"
-" }\n"
-"\n"
-" QToolButton:pressed{\n"
-" background-image: url(:/Tank.Platform.Qt/arrow_flipped_pressed.png);\n"
-" }\n"
-" ")
+        self.details_hide.setStyleSheet(
+            "QToolButton{\n"
+            " width: 12px;\n"
+            " height: 20px;\n"
+            " background-image: url(:/Tank.Platform.Qt/arrow_flipped.png);\n"
+            " border: none;\n"
+            " background-color: none;\n"
+            " }\n"
+            "\n"
+            " QToolButton:hover{\n"
+            " background-image: url(:/Tank.Platform.Qt/arrow_flipped_hover.png);\n"
+            " }\n"
+            "\n"
+            " QToolButton:pressed{\n"
+            " background-image: url(:/Tank.Platform.Qt/arrow_flipped_pressed.png);\n"
+            " }\n"
+            " "
+        )
         self.details_hide.setAutoRaise(True)
 
         self.horizontalLayout.addWidget(self.details_hide)
@@ -149,79 +164,85 @@ class Ui_TankDialog(object):
 
         self.target = QVBoxLayout()
         self.target.setSpacing(4)
-        self.target.setObjectName(u"target")
+        self.target.setObjectName("target")
 
         self.verticalLayout.addLayout(self.target)
 
         self.stackedWidget.addWidget(self.page_1)
         self.page_2 = QWidget()
-        self.page_2.setObjectName(u"page_2")
-        self.page_2.setStyleSheet(u"QWidget {\n"
-"    font-family: \"Open Sans\";\n"
-"    font-style: \"Regular\";\n"
-"}")
+        self.page_2.setObjectName("page_2")
+        self.page_2.setStyleSheet(
+            "QWidget {\n"
+            '    font-family: "Open Sans";\n'
+            '    font-style: "Regular";\n'
+            "}"
+        )
         self.verticalLayout_2 = QVBoxLayout(self.page_2)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.verticalLayout_2.setContentsMargins(1, 1, 1, 1)
         self.page_2_group = QGroupBox(self.page_2)
-        self.page_2_group.setObjectName(u"page_2_group")
+        self.page_2_group.setObjectName("page_2_group")
         self.page_2_group.setMinimumSize(QSize(0, 100))
-        self.page_2_group.setStyleSheet(u"QGroupBox {\n"
-"margin: 0px;\n"
-"}")
+        self.page_2_group.setStyleSheet("QGroupBox {\n" "margin: 0px;\n" "}")
         self.horizontalLayout_2 = QHBoxLayout(self.page_2_group)
         self.horizontalLayout_2.setSpacing(0)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.horizontalSpacer = QSpacerItem(145, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer = QSpacerItem(
+            145, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.horizontalLayout_2.addItem(self.horizontalSpacer)
 
         self.label_3 = QLabel(self.page_2_group)
-        self.label_3.setObjectName(u"label_3")
+        self.label_3.setObjectName("label_3")
         self.label_3.setMinimumSize(QSize(40, 0))
         self.label_3.setMaximumSize(QSize(40, 16777215))
 
         self.horizontalLayout_2.addWidget(self.label_3)
 
         self.gradient = QGroupBox(self.page_2_group)
-        self.gradient.setObjectName(u"gradient")
+        self.gradient.setObjectName("gradient")
         self.gradient.setMinimumSize(QSize(11, 0))
         self.gradient.setMaximumSize(QSize(11, 16777215))
-        self.gradient.setStyleSheet(u"#gradient {\n"
-"background-image: url(:/Tank.Platform.Qt/gradient.png);\n"
-"border: none;\n"
-"}")
+        self.gradient.setStyleSheet(
+            "#gradient {\n"
+            "background-image: url(:/Tank.Platform.Qt/gradient.png);\n"
+            "border: none;\n"
+            "}"
+        )
 
         self.horizontalLayout_2.addWidget(self.gradient)
 
         self.scrollArea = QScrollArea(self.page_2_group)
-        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setObjectName("scrollArea")
         self.scrollArea.setMinimumSize(QSize(400, 0))
         self.scrollArea.setMaximumSize(QSize(400, 16777215))
-        self.scrollArea.setStyleSheet(u"/*\n"
-"All labels inside this scroll area should be 12px font.\n"
-"This is to avoid the UI looking different in different app like\n"
-"maya and nuke which all use slightly different style sheets.\n"
-" */\n"
-"QLabel{\n"
-"   font-size: 11px;\n"
-"   margin-bottom: 8px\n"
-"}\n"
-"")
+        self.scrollArea.setStyleSheet(
+            "/*\n"
+            "All labels inside this scroll area should be 12px font.\n"
+            "This is to avoid the UI looking different in different app like\n"
+            "maya and nuke which all use slightly different style sheets.\n"
+            " */\n"
+            "QLabel{\n"
+            "   font-size: 11px;\n"
+            "   margin-bottom: 8px\n"
+            "}\n"
+            ""
+        )
         self.scrollArea.setWidgetResizable(True)
         self.scrollAreaWidgetContents = QWidget()
-        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
         self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 398, 550))
         self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.verticalLayout_4.setObjectName("verticalLayout_4")
         self.horizontalLayout_4 = QHBoxLayout()
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.horizontalLayout_4.setObjectName("horizontalLayout_4")
         self.app_icon = QLabel(self.scrollAreaWidgetContents)
-        self.app_icon.setObjectName(u"app_icon")
+        self.app_icon.setObjectName("app_icon")
         self.app_icon.setMinimumSize(QSize(64, 64))
         self.app_icon.setMaximumSize(QSize(64, 64))
-        self.app_icon.setPixmap(QPixmap(u":/Tank.Platform.Qt/default_app_icon_256.png"))
+        self.app_icon.setPixmap(QPixmap(":/Tank.Platform.Qt/default_app_icon_256.png"))
         self.app_icon.setScaledContents(True)
         self.app_icon.setAlignment(Qt.AlignCenter)
 
@@ -229,12 +250,11 @@ class Ui_TankDialog(object):
 
         self.verticalLayout_8 = QVBoxLayout()
         self.verticalLayout_8.setSpacing(1)
-        self.verticalLayout_8.setObjectName(u"verticalLayout_8")
+        self.verticalLayout_8.setObjectName("verticalLayout_8")
         self.app_name = QLabel(self.scrollAreaWidgetContents)
-        self.app_name.setObjectName(u"app_name")
-        self.app_name.setStyleSheet(u"font-size: 16px;\n"
-"")
-        self.app_name.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.app_name.setObjectName("app_name")
+        self.app_name.setStyleSheet("font-size: 16px;\n" "")
+        self.app_name.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
 
         self.verticalLayout_8.addWidget(self.app_name)
 
@@ -243,61 +263,66 @@ class Ui_TankDialog(object):
         self.verticalLayout_4.addLayout(self.horizontalLayout_4)
 
         self.app_description = QLabel(self.scrollAreaWidgetContents)
-        self.app_description.setObjectName(u"app_description")
+        self.app_description.setObjectName("app_description")
         self.app_description.setMaximumSize(QSize(350, 16777215))
         self.app_description.setWordWrap(True)
 
         self.verticalLayout_4.addWidget(self.app_description)
 
         self.app_tech_details = QLabel(self.scrollAreaWidgetContents)
-        self.app_tech_details.setObjectName(u"app_tech_details")
+        self.app_tech_details.setObjectName("app_tech_details")
         sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
-        sizePolicy1.setHeightForWidth(self.app_tech_details.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.app_tech_details.sizePolicy().hasHeightForWidth()
+        )
         self.app_tech_details.setSizePolicy(sizePolicy1)
         self.app_tech_details.setMinimumSize(QSize(0, 22))
         self.app_tech_details.setMaximumSize(QSize(16777215, 22))
-        self.app_tech_details.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.app_tech_details.setAlignment(
+            Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
+        )
         self.app_tech_details.setWordWrap(True)
 
         self.verticalLayout_4.addWidget(self.app_tech_details)
 
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setSpacing(2)
-        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
+        self.horizontalLayout_9.setObjectName("horizontalLayout_9")
         self.btn_documentation = QToolButton(self.scrollAreaWidgetContents)
-        self.btn_documentation.setObjectName(u"btn_documentation")
+        self.btn_documentation.setObjectName("btn_documentation")
 
         self.horizontalLayout_9.addWidget(self.btn_documentation)
 
         self.btn_support = QToolButton(self.scrollAreaWidgetContents)
-        self.btn_support.setObjectName(u"btn_support")
+        self.btn_support.setObjectName("btn_support")
 
         self.horizontalLayout_9.addWidget(self.btn_support)
 
-        self.horizontalSpacer_5 = QSpacerItem(0, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_5 = QSpacerItem(
+            0, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.horizontalLayout_9.addItem(self.horizontalSpacer_5)
 
         self.verticalLayout_4.addLayout(self.horizontalLayout_9)
 
         self.label_5 = QLabel(self.scrollAreaWidgetContents)
-        self.label_5.setObjectName(u"label_5")
-        self.label_5.setStyleSheet(u"font-size: 16px;\n"
-"margin-top: 30px;")
+        self.label_5.setObjectName("label_5")
+        self.label_5.setStyleSheet("font-size: 16px;\n" "margin-top: 30px;")
 
         self.verticalLayout_4.addWidget(self.label_5)
 
         self.line = QFrame(self.scrollAreaWidgetContents)
-        self.line.setObjectName(u"line")
+        self.line.setObjectName("line")
         self.line.setFrameShape(QFrame.HLine)
         self.line.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_4.addWidget(self.line)
 
         self.app_work_area_info = QLabel(self.scrollAreaWidgetContents)
-        self.app_work_area_info.setObjectName(u"app_work_area_info")
+        self.app_work_area_info.setObjectName("app_work_area_info")
         self.app_work_area_info.setMaximumSize(QSize(350, 16777215))
         self.app_work_area_info.setWordWrap(True)
 
@@ -305,51 +330,52 @@ class Ui_TankDialog(object):
 
         self.horizontalLayout_10 = QHBoxLayout()
         self.horizontalLayout_10.setSpacing(2)
-        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
+        self.horizontalLayout_10.setObjectName("horizontalLayout_10")
         self.btn_file_system = QToolButton(self.scrollAreaWidgetContents)
-        self.btn_file_system.setObjectName(u"btn_file_system")
+        self.btn_file_system.setObjectName("btn_file_system")
 
         self.horizontalLayout_10.addWidget(self.btn_file_system)
 
         self.btn_shotgun = QToolButton(self.scrollAreaWidgetContents)
-        self.btn_shotgun.setObjectName(u"btn_shotgun")
+        self.btn_shotgun.setObjectName("btn_shotgun")
 
         self.horizontalLayout_10.addWidget(self.btn_shotgun)
 
-        self.horizontalSpacer_6 = QSpacerItem(0, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_6 = QSpacerItem(
+            0, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.horizontalLayout_10.addItem(self.horizontalSpacer_6)
 
         self.verticalLayout_4.addLayout(self.horizontalLayout_10)
 
         self.app_work_area_info_2 = QLabel(self.scrollAreaWidgetContents)
-        self.app_work_area_info_2.setObjectName(u"app_work_area_info_2")
+        self.app_work_area_info_2.setObjectName("app_work_area_info_2")
         self.app_work_area_info_2.setMaximumSize(QSize(350, 16777215))
         self.app_work_area_info_2.setWordWrap(True)
 
         self.verticalLayout_4.addWidget(self.app_work_area_info_2)
 
         self.btn_reload = QToolButton(self.scrollAreaWidgetContents)
-        self.btn_reload.setObjectName(u"btn_reload")
+        self.btn_reload.setObjectName("btn_reload")
 
         self.verticalLayout_4.addWidget(self.btn_reload)
 
         self.config_header = QLabel(self.scrollAreaWidgetContents)
-        self.config_header.setObjectName(u"config_header")
-        self.config_header.setStyleSheet(u"font-size: 16px;\n"
-"margin-top: 30px;")
+        self.config_header.setObjectName("config_header")
+        self.config_header.setStyleSheet("font-size: 16px;\n" "margin-top: 30px;")
 
         self.verticalLayout_4.addWidget(self.config_header)
 
         self.config_line = QFrame(self.scrollAreaWidgetContents)
-        self.config_line.setObjectName(u"config_line")
+        self.config_line.setObjectName("config_line")
         self.config_line.setFrameShape(QFrame.HLine)
         self.config_line.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_4.addWidget(self.config_line)
 
         self.config_label = QLabel(self.scrollAreaWidgetContents)
-        self.config_label.setObjectName(u"config_label")
+        self.config_label.setObjectName("config_label")
         self.config_label.setMaximumSize(QSize(350, 16777215))
         self.config_label.setWordWrap(True)
 
@@ -357,11 +383,13 @@ class Ui_TankDialog(object):
 
         self.config_layout = QVBoxLayout()
         self.config_layout.setSpacing(20)
-        self.config_layout.setObjectName(u"config_layout")
+        self.config_layout.setObjectName("config_layout")
 
         self.verticalLayout_4.addLayout(self.config_layout)
 
-        self.verticalSpacer_2 = QSpacerItem(328, 0, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer_2 = QSpacerItem(
+            328, 0, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
 
         self.verticalLayout_4.addItem(self.verticalSpacer_2)
 
@@ -380,41 +408,94 @@ class Ui_TankDialog(object):
         self.stackedWidget.setCurrentIndex(0)
 
         QMetaObject.connectSlotsByName(TankDialog)
+
     # setupUi
 
     def retranslateUi(self, TankDialog):
-        TankDialog.setWindowTitle(QCoreApplication.translate("TankDialog", u"Dialog", None))
+        TankDialog.setWindowTitle(
+            QCoreApplication.translate("TankDialog", "Dialog", None)
+        )
         self.top_group.setTitle("")
         self.tank_logo.setText("")
-        self.label.setText(QCoreApplication.translate("TankDialog", u"TextLabel", None))
-#if QT_CONFIG(tooltip)
-        self.lbl_context.setToolTip(QCoreApplication.translate("TankDialog", u"foo bar", None))
-#endif // QT_CONFIG(tooltip)
-        self.lbl_context.setText(QCoreApplication.translate("TankDialog", u"Current Work Area:\n"
-"TextLabel", None))
-#if QT_CONFIG(tooltip)
-        self.details_show.setToolTip(QCoreApplication.translate("TankDialog", u"Click for App Details", None))
-#endif // QT_CONFIG(tooltip)
+        self.label.setText(QCoreApplication.translate("TankDialog", "TextLabel", None))
+        # if QT_CONFIG(tooltip)
+        self.lbl_context.setToolTip(
+            QCoreApplication.translate("TankDialog", "foo bar", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.lbl_context.setText(
+            QCoreApplication.translate(
+                "TankDialog", "Current Work Area:\n" "TextLabel", None
+            )
+        )
+        # if QT_CONFIG(tooltip)
+        self.details_show.setToolTip(
+            QCoreApplication.translate("TankDialog", "Click for App Details", None)
+        )
+        # endif // QT_CONFIG(tooltip)
         self.details_show.setText("")
-#if QT_CONFIG(tooltip)
-        self.details_hide.setToolTip(QCoreApplication.translate("TankDialog", u"Hide App Details", None))
-#endif // QT_CONFIG(tooltip)
+        # if QT_CONFIG(tooltip)
+        self.details_hide.setToolTip(
+            QCoreApplication.translate("TankDialog", "Hide App Details", None)
+        )
+        # endif // QT_CONFIG(tooltip)
         self.details_hide.setText("")
         self.page_2_group.setTitle("")
         self.label_3.setText("")
         self.gradient.setTitle("")
         self.app_icon.setText("")
-        self.app_name.setText(QCoreApplication.translate("TankDialog", u"Publish And Snapshot", None))
-        self.app_description.setText(QCoreApplication.translate("TankDialog", u"Tools to see what is out of date in your scene etc etc.", None))
-        self.app_tech_details.setText(QCoreApplication.translate("TankDialog", u"tk-multi-snapshot, v1.2.3", None))
-        self.btn_documentation.setText(QCoreApplication.translate("TankDialog", u"Documentation", None))
-        self.btn_support.setText(QCoreApplication.translate("TankDialog", u"Help && Support", None))
-        self.label_5.setText(QCoreApplication.translate("TankDialog", u"Your Current Work Area", None))
-        self.app_work_area_info.setText(QCoreApplication.translate("TankDialog", u"TextLabel", None))
-        self.btn_file_system.setText(QCoreApplication.translate("TankDialog", u"Jump to File System", None))
-        self.btn_shotgun.setText(QCoreApplication.translate("TankDialog", u"Jump to Flow Production Tracking", None))
-        self.app_work_area_info_2.setText(QCoreApplication.translate("TankDialog", u"If you are making changes to configuration or code, use the reload button to quickly load your changes in without having to restart:", None))
-        self.btn_reload.setText(QCoreApplication.translate("TankDialog", u"Reload Engine and Apps", None))
-        self.config_header.setText(QCoreApplication.translate("TankDialog", u"Configuration", None))
-        self.config_label.setText(QCoreApplication.translate("TankDialog", u"Below is a list of all the configuration settings for this app, as defined in your environment file:", None))
+        self.app_name.setText(
+            QCoreApplication.translate("TankDialog", "Publish And Snapshot", None)
+        )
+        self.app_description.setText(
+            QCoreApplication.translate(
+                "TankDialog",
+                "Tools to see what is out of date in your scene etc etc.",
+                None,
+            )
+        )
+        self.app_tech_details.setText(
+            QCoreApplication.translate("TankDialog", "tk-multi-snapshot, v1.2.3", None)
+        )
+        self.btn_documentation.setText(
+            QCoreApplication.translate("TankDialog", "Documentation", None)
+        )
+        self.btn_support.setText(
+            QCoreApplication.translate("TankDialog", "Help && Support", None)
+        )
+        self.label_5.setText(
+            QCoreApplication.translate("TankDialog", "Your Current Work Area", None)
+        )
+        self.app_work_area_info.setText(
+            QCoreApplication.translate("TankDialog", "TextLabel", None)
+        )
+        self.btn_file_system.setText(
+            QCoreApplication.translate("TankDialog", "Jump to File System", None)
+        )
+        self.btn_shotgun.setText(
+            QCoreApplication.translate(
+                "TankDialog", "Jump to Flow Production Tracking", None
+            )
+        )
+        self.app_work_area_info_2.setText(
+            QCoreApplication.translate(
+                "TankDialog",
+                "If you are making changes to configuration or code, use the reload button to quickly load your changes in without having to restart:",
+                None,
+            )
+        )
+        self.btn_reload.setText(
+            QCoreApplication.translate("TankDialog", "Reload Engine and Apps", None)
+        )
+        self.config_header.setText(
+            QCoreApplication.translate("TankDialog", "Configuration", None)
+        )
+        self.config_label.setText(
+            QCoreApplication.translate(
+                "TankDialog",
+                "Below is a list of all the configuration settings for this app, as defined in your environment file:",
+                None,
+            )
+        )
+
     # retranslateUi

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -79,9 +79,7 @@ def create_engine_launcher(tk, context, engine_name, versions=None, products=Non
              on disk.
     """
     # Get the engine environment and descriptor using engine.py code
-    (env, engine_descriptor) = get_env_and_descriptor_for_engine(
-        engine_name, tk, context
-    )
+    env, engine_descriptor = get_env_and_descriptor_for_engine(engine_name, tk, context)
 
     # Make sure it exists locally
     if not engine_descriptor.exists_local():

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -12,6 +12,7 @@
 App configuration and schema validation.
 
 """
+
 import os
 import sys
 

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -514,7 +514,7 @@ class StringKey(TemplateKey):
             if match is None:
                 # no match. return empty string
                 # validate should prevent this from happening
-                resolved_value = u""
+                resolved_value = ""
 
             elif self._subset_format:
                 # we have an explicit format string we want to apply to the match.
@@ -1099,9 +1099,7 @@ class SequenceKey(IntegerKey):
         error_msg += "Valid frame specs: %s\n" % str(self._frame_specs)
         error_msg += "Valid format strings: %s\n" % full_format_strings
 
-        if isinstance(value, str) and value.startswith(
-            self.FRAMESPEC_FORMAT_INDICATOR
-        ):
+        if isinstance(value, str) and value.startswith(self.FRAMESPEC_FORMAT_INDICATOR):
             # FORMAT: YXZ string - check that XYZ is in VALID_FORMAT_STRINGS
             pattern = self._extract_format_string(value)
             if pattern in self.VALID_FORMAT_STRINGS:
@@ -1110,9 +1108,7 @@ class SequenceKey(IntegerKey):
                 self._last_error = error_msg
                 return False
 
-        elif isinstance(value, str) and re.match(
-            self.FLAME_PATTERN_REGEX, value
-        ):
+        elif isinstance(value, str) and re.match(self.FLAME_PATTERN_REGEX, value):
             # value is matching the flame-style sequence pattern
             # [1234-5678]
             return True
@@ -1131,16 +1127,12 @@ class SequenceKey(IntegerKey):
 
     def _as_string(self, value):
 
-        if isinstance(value, str) and value.startswith(
-            self.FRAMESPEC_FORMAT_INDICATOR
-        ):
+        if isinstance(value, str) and value.startswith(self.FRAMESPEC_FORMAT_INDICATOR):
             # this is a FORMAT: XYZ - convert it to the proper resolved frame spec
             pattern = self._extract_format_string(value)
             return self._resolve_frame_spec(pattern, self.format_spec)
 
-        if isinstance(value, str) and re.match(
-            self.FLAME_PATTERN_REGEX, value
-        ):
+        if isinstance(value, str) and re.match(self.FLAME_PATTERN_REGEX, value):
             # this is a flame style sequence token [1234-56773]
             return value
 
@@ -1167,9 +1159,7 @@ class SequenceKey(IntegerKey):
         """
         Returns XYZ given the string "FORMAT:    XYZ"
         """
-        if isinstance(value, str) and value.startswith(
-            self.FRAMESPEC_FORMAT_INDICATOR
-        ):
+        if isinstance(value, str) and value.startswith(self.FRAMESPEC_FORMAT_INDICATOR):
             pattern = value.replace(self.FRAMESPEC_FORMAT_INDICATOR, "").strip()
         else:
             # passthrough

--- a/python/tank/util/loader.py
+++ b/python/tank/util/loader.py
@@ -66,7 +66,7 @@ def load_plugin(plugin_file, valid_base_class, alternate_base_classes=None):
         log.exception("Cannot load plugin file '%s'" % plugin_file)
 
         # dump out the callstack for this one -- to help people get good messages when there is a plugin error
-        (exc_type, exc_value, exc_traceback) = sys.exc_info()
+        exc_type, exc_value, exc_traceback = sys.exc_info()
         message = ""
         message += (
             "Failed to load plugin %s. The following error was reported:\n"

--- a/python/tank/util/local_file_storage.py
+++ b/python/tank/util/local_file_storage.py
@@ -57,10 +57,10 @@ class LocalFileStorageManager(object):
     """
 
     # generation of path structures
-    (CORE_V17, CORE_V18) = range(2)
+    CORE_V17, CORE_V18 = range(2)
 
     # supported types of paths
-    (LOGGING, CACHE, PERSISTENT, PREFERENCES) = range(4)
+    LOGGING, CACHE, PERSISTENT, PREFERENCES = range(4)
 
     @classmethod
     def get_global_root(cls, path_type, generation=CORE_V18):

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -97,7 +97,7 @@ def consume():
             logger.debug("Invalid cached metric format")
             continue
 
-        (args, kwargs) = data
+        args, kwargs = data
         if not isinstance(args, list) or not isinstance(kwargs, dict):
             logger.debug("Invalid cached metric format")
             continue

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -91,7 +91,7 @@ class PySide6Patcher(PySide2Patcher):
         QTextCodec has been removed in Qt6. Using this class will do nothing.
         """
 
-        class QTextCodec():
+        class QTextCodec:
             @staticmethod
             def codecForName(name):
                 return None
@@ -135,7 +135,6 @@ class PySide6Patcher(PySide2Patcher):
                 screen = QtGui.QApplication.primaryScreen()
                 return screen.grabWindow(window, x, y, width, height)
 
-
         QtGui.QPixmap = QPixmap
 
     @classmethod
@@ -152,7 +151,6 @@ class PySide6Patcher(PySide2Patcher):
             return QtGui.QPixmap(original_QIcon_pixmap(self, *args, **kwargs))
 
         QtGui.QIcon.pixmap = pixmap
-
 
     @classmethod
     def _patch_QLabel(cls, QtGui):
@@ -232,8 +230,8 @@ class PySide6Patcher(PySide2Patcher):
                 except:
                     pass
 
-
         original_QScreen_availableGeometry = QtGui.QScreen.availableGeometry
+
         def availableGeometry(self, arg__1=None):
             """
             Patch QScreen to also act as QDesktopWidget.
@@ -298,7 +296,9 @@ class PySide6Patcher(PySide2Patcher):
 
         def versionFunctions(self, version_profile=None):
             if version_profile:
-                return QtGui.QOpenGLVersionFunctionsFactory.get(versionProfile=version_profile, context=self)
+                return QtGui.QOpenGLVersionFunctionsFactory.get(
+                    versionProfile=version_profile, context=self
+                )
             return QtGui.QOpenGLVersionFunctionsFactory.get(context=self)
 
         QtGui.QOpenGLContext.versionFunctions = versionFunctions
@@ -352,18 +352,39 @@ class PySide6Patcher(PySide2Patcher):
                     if case_sensitivity is None:
                         original_QRegularExpression.__init__(self, args[0])
                     else:
-                        if case_sensitivity == original_QRegularExpression.CaseInsensitiveOption:
+                        if (
+                            case_sensitivity
+                            == original_QRegularExpression.CaseInsensitiveOption
+                        ):
                             opts = original_QRegularExpression.CaseInsensitiveOption
                         else:
                             opts = original_QRegularExpression.NoPatternOption
-                        original_QRegularExpression.__init__(self, args[0], options=opts)
+                        original_QRegularExpression.__init__(
+                            self, args[0], options=opts
+                        )
 
-                self.isEmpty = lambda *args, **kwargs: QRegularExpression.isEmpty(self, *args, **kwargs)
-                self.indexIn = lambda *args, **kwargs: QRegularExpression.indexIn(self, *args, **kwargs)
-                self.matchedLength = lambda *args, **kwargs: QRegularExpression.matchedLength(self, *args, **kwargs)
-                self.setCaseSensitivity = lambda *args, **kwargs: QRegularExpression.setCaseSensitivity(self, *args, **kwargs)
-                self.pos = lambda *args, **kwargs: QRegularExpression.pos(self, *args, **kwargs)
-                self.cap = lambda *args, **kwargs: QRegularExpression.cap(self, *args, **kwargs)
+                self.isEmpty = lambda *args, **kwargs: QRegularExpression.isEmpty(
+                    self, *args, **kwargs
+                )
+                self.indexIn = lambda *args, **kwargs: QRegularExpression.indexIn(
+                    self, *args, **kwargs
+                )
+                self.matchedLength = (
+                    lambda *args, **kwargs: QRegularExpression.matchedLength(
+                        self, *args, **kwargs
+                    )
+                )
+                self.setCaseSensitivity = (
+                    lambda *args, **kwargs: QRegularExpression.setCaseSensitivity(
+                        self, *args, **kwargs
+                    )
+                )
+                self.pos = lambda *args, **kwargs: QRegularExpression.pos(
+                    self, *args, **kwargs
+                )
+                self.cap = lambda *args, **kwargs: QRegularExpression.cap(
+                    self, *args, **kwargs
+                )
 
             @staticmethod
             def isEmpty(re):
@@ -426,7 +447,9 @@ class PySide6Patcher(PySide2Patcher):
         QtCore.QRegularExpression.isEmpty = QRegularExpression.isEmpty
         QtCore.QRegularExpression.indexIn = QRegularExpression.indexIn
         QtCore.QRegularExpression.matchedLength = QRegularExpression.matchedLength
-        QtCore.QRegularExpression.setCaseSensitivity = QRegularExpression.setCaseSensitivity
+        QtCore.QRegularExpression.setCaseSensitivity = (
+            QRegularExpression.setCaseSensitivity
+        )
         QtCore.QRegularExpression.pos = QRegularExpression.pos
 
         # This pattern matching flag is obsolete now.
@@ -452,9 +475,9 @@ class PySide6Patcher(PySide2Patcher):
 
     @classmethod
     def patch(
-            cls,
-            QtWebEngineWidgets,
-            QtWebEngineCore,
+        cls,
+        QtWebEngineWidgets,
+        QtWebEngineCore,
     ):
         """
         Patch the PySide6 modules, classes and function to conform to the PySide interface.
@@ -546,8 +569,12 @@ class PySide6Patcher(PySide2Patcher):
         cls._patch_QRegularExpression(qt_core_shim)
         qt_core_shim.QRegExp = qt_core_shim.QRegularExpression
         # Rename RegExp functions to RegularExpression
-        qt_gui_shim.QSortFilterProxyModel.filterRegExp = qt_gui_shim.QSortFilterProxyModel.filterRegularExpression
-        qt_gui_shim.QSortFilterProxyModel.setFilterRegExp = qt_gui_shim.QSortFilterProxyModel.setFilterRegularExpression
+        qt_gui_shim.QSortFilterProxyModel.filterRegExp = (
+            qt_gui_shim.QSortFilterProxyModel.filterRegularExpression
+        )
+        qt_gui_shim.QSortFilterProxyModel.setFilterRegExp = (
+            qt_gui_shim.QSortFilterProxyModel.setFilterRegularExpression
+        )
 
         # Patch the QCoreApplication.flush() method to ensure compatibility with code
         # that expects this method, which is marked as obsolete.
@@ -588,7 +615,9 @@ class PySide6Patcher(PySide2Patcher):
         # The default timeout parameter removed. This param, if given, will be ignored. It will
         # always timeout after 100 ms
         # https://doc.qt.io/qt-6/widgets-changes-qt6.html#the-qabstractbutton-class
-        qt_gui_shim.QAbstractButton.animateClick = lambda self, msec=0: self.animateClick()
+        qt_gui_shim.QAbstractButton.animateClick = (
+            lambda self, msec=0: self.animateClick()
+        )
 
         # Changes to QFont
         # https://doc.qt.io/qt-6/gui-changes-qt6.html#the-qfont-class
@@ -596,7 +625,9 @@ class PySide6Patcher(PySide2Patcher):
         qt_gui_shim.QFont.setWeight = qt_gui_shim.QFont.setLegacyWeight
 
         # QHeaderView method rename
-        qt_gui_shim.QHeaderView.setResizeMode = qt_gui_shim.QHeaderView.setSectionResizeMode
+        qt_gui_shim.QHeaderView.setResizeMode = (
+            qt_gui_shim.QHeaderView.setSectionResizeMode
+        )
 
         # QPainter HighQualityAntialiasing is obsolete. Use Antiasliasing instead.
         # https://doc.qt.io/qt-5/qpainter.html#RenderHint-enum
@@ -609,6 +640,8 @@ class PySide6Patcher(PySide2Patcher):
         if qt_web_engine_widgets_shim:
             # QtWwebEngineWidgets
             qt_web_engine_widgets_shim.QWebEnginePage = QtWebEngineCore.QWebEnginePage
-            qt_web_engine_widgets_shim.QWebEngineProfile = QtWebEngineCore.QWebEngineProfile
+            qt_web_engine_widgets_shim.QWebEngineProfile = (
+                QtWebEngineCore.QWebEngineProfile
+            )
 
         return qt_core_shim, qt_gui_shim, qt_web_engine_widgets_shim

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -148,7 +148,6 @@ class QtImporter(object):
         except Exception as e:
             logger.debug("Unable to import module '%s': %s", module_name, e)
 
-
     def _import_pyside2(self):
         """
         This will be called at initialization to discover every PySide 2 modules.

--- a/python/tank/util/shotgun/download.py
+++ b/python/tank/util/shotgun/download.py
@@ -181,7 +181,9 @@ def download_and_unpack_attachment(
     )
 
 
-def download_and_unpack_url(sg, url, target, retries=5, auto_detect_bundle=False, headers=None):
+def download_and_unpack_url(
+    sg, url, target, retries=5, auto_detect_bundle=False, headers=None
+):
     """
     Downloads the content from the provided url, assumes it is a zip file
     and attempts to unpack it into the given location.
@@ -197,7 +199,9 @@ def download_and_unpack_url(sg, url, target, retries=5, auto_detect_bundle=False
         the bundle in a subfolder, this should be correctly unfolded.
     :raises: ShotgunAttachmentDownloadError on failure
     """
-    return _download_and_unpack(sg, target, retries, auto_detect_bundle, url=url, headers=headers or {})
+    return _download_and_unpack(
+        sg, target, retries, auto_detect_bundle, url=url, headers=headers or {}
+    )
 
 
 @LogManager.log_timing

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -428,7 +428,7 @@ class EntityExpression(object):
         match = regex_obj.match(value_to_convert)
         if match is None:
             # no match. return empty string
-            resolved_value = u""
+            resolved_value = ""
         else:
             # we have a match object. concatenate the groups
             resolved_value = "".join(match.groups())

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -165,7 +165,7 @@ class EntityExpression(object):
                 regex_obj = None
 
                 if ":" in field_token_expression:
-                    (full_field_name, regex) = field_token_expression.split(":", 1)
+                    full_field_name, regex = field_token_expression.split(":", 1)
 
                     try:
                         regex_obj = re.compile(regex, re.UNICODE)

--- a/python/tank/util/storage_roots.py
+++ b/python/tank/util/storage_roots.py
@@ -144,7 +144,7 @@ class StorageRoots(object):
             the required roots.
         """
 
-        (local_storage_lookup, unmapped_roots) = storage_roots.get_local_storages(
+        local_storage_lookup, unmapped_roots = storage_roots.get_local_storages(
             sg_connection
         )
 

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -21,7 +21,6 @@ from .. import LogManager
 from .singleton import Singleton
 from .system_settings import SystemSettings
 
-
 logger = LogManager.get_logger(__name__)
 
 

--- a/tests/authentication_tests/test_app_session_launcher.py
+++ b/tests/authentication_tests/test_app_session_launcher.py
@@ -108,7 +108,8 @@ class AppSessionLauncherTests(ShotgunTestBase):
             }
 
         with mock.patch(
-            "tank.platform.current_engine", MyEngine,
+            "tank.platform.current_engine",
+            MyEngine,
         ):
             self.assertEqual(
                 app_session_launcher.get_product_name(),
@@ -146,15 +147,15 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
                 "url": "https://1.2.3.4/click_me/a1b2c3",
             }
         }
-        self.httpd.router[
-            "[PUT]/internal_api/app_session_request/a1b2c3"
-        ] = lambda request: {
-            "json": {
-                "approved": True,
-                "sessionToken": "to123",
-                "userLogin": "john",
-            },
-        }
+        self.httpd.router["[PUT]/internal_api/app_session_request/a1b2c3"] = (
+            lambda request: {
+                "json": {
+                    "approved": True,
+                    "sessionToken": "to123",
+                    "userLogin": "john",
+                },
+            }
+        )
 
         def url_opener(url):
             os.environ["test_f444c4820c16e8"] = url
@@ -242,9 +243,9 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
             }
 
         self.httpd.router["[POST]/internal_api/app_session_request"] = api_post_handler
-        self.httpd.router[
-            "[PUT]/internal_api/app_session_request/a1b2c3"
-        ] = api_put_handler
+        self.httpd.router["[PUT]/internal_api/app_session_request/a1b2c3"] = (
+            api_put_handler
+        )
 
         self.assertEqual(
             app_session_launcher.process(
@@ -317,9 +318,9 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
         )
 
         # 200 but no json
-        self.httpd.router[
-            "[POST]/internal_api/app_session_request"
-        ] = lambda request: {}
+        self.httpd.router["[POST]/internal_api/app_session_request"] = (
+            lambda request: {}
+        )
         with self.assertRaises(app_session_launcher.AuthenticationError) as cm:
             app_session_launcher.process(
                 self.api_url,
@@ -498,9 +499,9 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
         def api_handler1(request):
             raise AttributeError("test")
 
-        self.httpd.router[
-            "[PUT]/internal_api/app_session_request/a1b2c3"
-        ] = api_handler1
+        self.httpd.router["[PUT]/internal_api/app_session_request/a1b2c3"] = (
+            api_handler1
+        )
         with self.assertRaises(app_session_launcher.AuthenticationError) as cm:
             app_session_launcher.process(
                 self.api_url,
@@ -523,9 +524,9 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
         )
 
         # Unsupported method
-        self.httpd.router[
-            "[PUT]/internal_api/app_session_request/a1b2c3"
-        ] = lambda request: {"json": {"approved": False}}
+        self.httpd.router["[PUT]/internal_api/app_session_request/a1b2c3"] = (
+            lambda request: {"json": {"approved": False}}
+        )
         with self.assertRaises(app_session_launcher.AuthenticationError) as cm:
             app_session_launcher.process(
                 self.api_url,
@@ -535,9 +536,9 @@ class AppSessionLauncherAPITests(ShotgunTestBase):
 
         self.assertEqual(cm.exception.args[0], "The request has never been approved")
 
-        self.httpd.router[
-            "[PUT]/internal_api/app_session_request/a1b2c3"
-        ] = lambda request: {"json": {}}
+        self.httpd.router["[PUT]/internal_api/app_session_request/a1b2c3"] = (
+            lambda request: {"json": {}}
+        )
 
         with self.assertRaises(app_session_launcher.AuthenticationError) as cm:
             app_session_launcher.process(

--- a/tests/authentication_tests/test_saml_sso_core_utils.py
+++ b/tests/authentication_tests/test_saml_sso_core_utils.py
@@ -20,8 +20,10 @@ class SamlSsoCoreUtilsTests(ShotgunTestBase):
 
     def test_username_valid(self):
         login_cookies = {
-            'user+name': 'shotgun_current_user_login=user%2Bname; domain=shotgrid.autodesk.com; path=/',
-            'user name': 'shotgun_current_user_login=user+name; domain=shotgrid.autodesk.com; path=/'
+            "user+name": "shotgun_current_user_login=user%2Bname; domain=shotgrid.autodesk.com; path=/",
+            "user name": "shotgun_current_user_login=user+name; domain=shotgrid.autodesk.com; path=/",
         }
         for login in login_cookies:
-            self.assertEqual(login, get_user_name(_encode_cookies(login_cookies[login])))
+            self.assertEqual(
+                login, get_user_name(_encode_cookies(login_cookies[login]))
+            )

--- a/tests/bootstrap_tests/test_manager_flow_auth.py
+++ b/tests/bootstrap_tests/test_manager_flow_auth.py
@@ -161,6 +161,7 @@ class TriggerAmAuthTests(ShotgunTestBase):
         mock_init.assert_called_once_with(mock_resolve.return_value)
         mock_get.assert_called_once()
 
+
 @mock.patch(
     "tank.authentication.ShotgunAuthenticator.get_user",
     return_value=mock.Mock(),

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -340,15 +340,18 @@ class TestFallbackHandling(TestResolverBase):
         # make sure we didn't talk to shotgun
         self.assertEqual(find_mock.called, False)
 
+
 class TestAutoUpdate(TestResolverBase):
     """
     A test class for the config resolved when
     the PTR desktop app is launched to startup the tk-desktop
     engine on a site or Project context.
     """
+
     def setUp(self):
         super().setUp()
-        self.resolver._plugin_id = 'basic.desktop'
+        self.resolver._plugin_id = "basic.desktop"
+
 
 class TestResolverPriority(TestResolverBase):
     """
@@ -765,9 +768,7 @@ class TestPipelineLocationFieldPriority(TestResolverBase):
         self.assertEqual(pcs[0]["id"], pc_id)
         self.assertIsNotNone(pcs[0]["config_descriptor"])
 
-        field_lookup = dict(
-            linux="linux_path", darwin="mac_path", win32="windows_path"
-        )
+        field_lookup = dict(linux="linux_path", darwin="mac_path", win32="windows_path")
 
         base_path = "sg_path"
         base_paths = dict(

--- a/tests/commands_tests/test_core_update.py
+++ b/tests/commands_tests/test_core_update.py
@@ -88,7 +88,8 @@ class TestCoreUpdate(TankTestBase):
         self.assertEqual(descriptor.version, "v0.19.5")
 
     @mock.patch(
-        "tank.descriptor.descriptor.Descriptor.is_immutable", return_value=True,
+        "tank.descriptor.descriptor.Descriptor.is_immutable",
+        return_value=True,
     )
     def test_immutable_config_core_update_core_api_yaml(
         self, _mock_is_immutable, mock_config_path, *_
@@ -110,7 +111,8 @@ class TestCoreUpdate(TankTestBase):
         self.assertEqual(descriptor.version, "v0.18.91")
 
     @mock.patch(
-        "tank.descriptor.descriptor.Descriptor.is_dev", return_value=True,
+        "tank.descriptor.descriptor.Descriptor.is_dev",
+        return_value=True,
     )
     @mock.patch("tank.descriptor.descriptor.Descriptor.get_path")
     def test_dev_config_core_update_core_api_yaml(

--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -163,10 +163,8 @@ class TestSetupProjectWizard(TankTestBase):
             {
                 "darwin": "/Volumes/configs/{0}".format(self.short_test_name),
                 "linux": "/mnt/configs/{0}".format(self.short_test_name),
-
                 # Compat with tk-framework-adminui prior to v0.8.1
                 "linux2": "/mnt/configs/{0}".format(self.short_test_name),
-
                 "win32": "Z:\\configs\\{0}".format(self.short_test_name),
             },
         )

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -702,7 +702,8 @@ class TestFromEntity(TestContext):
             context.from_entity(self.tk, "Task", -1)
         # PublishedFiles go through some dedicated code.
         with self.assertRaisesRegex(
-            TankError, "Entity PublishedFile with id -1 not found in Flow Production Tracking!"
+            TankError,
+            "Entity PublishedFile with id -1 not found in Flow Production Tracking!",
         ):
             context.from_entity(self.tk, "PublishedFile", -1)
 

--- a/tests/core_tests/test_default_storage_root_hook.py
+++ b/tests/core_tests/test_default_storage_root_hook.py
@@ -39,13 +39,13 @@ class TestDefaultStorageRootHook(TankTestBase):
         """
         self.tk.shotgun.create("LocalStorage", {"code": "project_specific_root"})
         with mock.patch.object(
-                self.tk.shotgun,
-                "find_one",
-                return_value={
-                    "type": "Project",
-                    "id": 1,
-                    "sg_storage_root_name": "project_specific_root",
-                },
+            self.tk.shotgun,
+            "find_one",
+            return_value={
+                "type": "Project",
+                "id": 1,
+                "sg_storage_root_name": "project_specific_root",
+            },
         ):
             tk2 = tank.sgtk_from_path(self.project_root)
             self.assertEqual(
@@ -66,13 +66,13 @@ class TestDefaultStorageRootHook(TankTestBase):
         Fall back to global root.
         """
         with mock.patch.object(
-                self.tk.shotgun,
-                "find_one",
-                return_value={
-                    "type": "Project",
-                    "id": 1,
-                    "sg_storage_root_name": "project_specific_root",
-                },
+            self.tk.shotgun,
+            "find_one",
+            return_value={
+                "type": "Project",
+                "id": 1,
+                "sg_storage_root_name": "project_specific_root",
+            },
         ):
             tk2 = tank.sgtk_from_path(self.project_root)
             self.assertEqual(
@@ -109,13 +109,13 @@ class TestDefaultStorageRootHook(TankTestBase):
         Project-specific root is retrieved from environment variables.
         """
         with mock.patch.dict(
-                os.environ,
-                {
-                    "STORAGE_ROOT_"
-                    + str(
-                        self.pipeline_configuration.get_project_id()
-                    ): "project_specific_root"
-                },
+            os.environ,
+            {
+                "STORAGE_ROOT_"
+                + str(
+                    self.pipeline_configuration.get_project_id()
+                ): "project_specific_root"
+            },
         ):
             tk2 = tank.sgtk_from_path(self.project_root)
             self.assertEqual(
@@ -158,17 +158,22 @@ class TestDefaultStorageRootHook(TankTestBase):
         """
         Project-specific windows root is retrieved from custom Flow Production Tracking project field.
         """
-        self.tk.shotgun.create("LocalStorage", {"code": "primary_mapped",
-                                                "windows_path": "P:\\Foo\\test_root", })
+        self.tk.shotgun.create(
+            "LocalStorage",
+            {
+                "code": "primary_mapped",
+                "windows_path": "P:\\Foo\\test_root",
+            },
+        )
 
         with mock.patch.object(
-                self.tk.shotgun,
-                "find_one",
-                return_value={
-                    "type": "Project",
-                    "id": 1,
-                    "sg_projects_root": "P:\\Foo\\test_root",
-                },
+            self.tk.shotgun,
+            "find_one",
+            return_value={
+                "type": "Project",
+                "id": 1,
+                "sg_projects_root": "P:\\Foo\\test_root",
+            },
         ):
             tk2 = tank.sgtk_from_path(self.project_root)
             self.assertEqual(
@@ -189,13 +194,13 @@ class TestDefaultStorageRootHook(TankTestBase):
         Fall back to global root.
         """
         with mock.patch.object(
-                self.tk.shotgun,
-                "find_one",
-                return_value={
-                    "type": "Project",
-                    "id": 1,
-                    "sg_projects_root": "P:\\Foo\\test_root",
-                },
+            self.tk.shotgun,
+            "find_one",
+            return_value={
+                "type": "Project",
+                "id": 1,
+                "sg_projects_root": "P:\\Foo\\test_root",
+            },
         ):
             tk2 = tank.sgtk_from_path(self.project_root)
             self.assertEqual(
@@ -215,7 +220,10 @@ class TestDefaultStorageRootHook(TankTestBase):
         Test fallback behaviour if no custom project field set.
         """
         #
-        self.tk.shotgun.create("LocalStorage", {"code": "primary_mapped", "windows_path": "P:\\Foo\\test_root"})
+        self.tk.shotgun.create(
+            "LocalStorage",
+            {"code": "primary_mapped", "windows_path": "P:\\Foo\\test_root"},
+        )
         tk2 = tank.sgtk_from_path(self.project_root)
         self.assertEqual(
             tk2.pipeline_configuration.get_primary_data_root_name(),

--- a/tests/core_tests/test_default_storage_root_hook/example1/default_storage_root.py
+++ b/tests/core_tests/test_default_storage_root_hook/example1/default_storage_root.py
@@ -12,6 +12,7 @@
 Hook that gets executed during Toolkit initialization.
 This hook makes it possible to modify the default storage root.
 """
+
 import sgtk
 from tank import Hook
 

--- a/tests/core_tests/test_default_storage_root_hook/example2/default_storage_root.py
+++ b/tests/core_tests/test_default_storage_root_hook/example2/default_storage_root.py
@@ -12,6 +12,7 @@
 Hook that gets executed during Toolkit initialization.
 This hook makes it possible to modify the default storage root.
 """
+
 import os
 
 import sgtk

--- a/tests/core_tests/test_default_storage_root_hook/example3/default_storage_root.py
+++ b/tests/core_tests/test_default_storage_root_hook/example3/default_storage_root.py
@@ -25,14 +25,16 @@ class DefaultStorageRoot(Hook):
 
         # check if custom field was set and filled
         if not sg_data or not sg_data.get("sg_projects_root"):
-            log.info("No project root for project configured, using global storage root.")
+            log.info(
+                "No project root for project configured, using global storage root."
+            )
             return
 
         # Stores the Windows drive for the project, e.g "P:"
         drive_root = sg_data["sg_projects_root"]
         # check if local storage exists on PTR site
         local_storage = self.parent.shotgun.find(
-            "LocalStorage", [['windows_path', 'is', drive_root]], ['code']
+            "LocalStorage", [["windows_path", "is", drive_root]], ["code"]
         )
 
         if not local_storage:
@@ -44,22 +46,24 @@ class DefaultStorageRoot(Hook):
         # Check if we have folder creation metadata
         if metadata:
             # Override data associated with the directory to use the new storage root.
-            metadata.update({"root_name": local_storage[0]['code']})
+            metadata.update({"root_name": local_storage[0]["code"]})
 
         # Update the default configuration root to map to the correct PTR LocalStorage in the
         # StorageRoots object.
-        log.info('Overriding project root to LocalStorage %s' % local_storage)
+        log.info("Overriding project root to LocalStorage %s" % local_storage)
         storage_roots.update_root(
-            'primary_mapped',
+            "primary_mapped",
             {
                 "default": True,
-                "shotgun_storage_id": local_storage[0]['id'],
+                "shotgun_storage_id": local_storage[0]["id"],
                 "windows_path": drive_root,
-            }
+            },
         )
 
         # Write the updated metadata into the '.../config/core/roots.yml' file in the localised
         # configuration. This should ensure that any StorageRoots.from_config(...) calls return
         # correctly.
-        config_folder = os.path.join(self.parent.pipeline_configuration.get_path(), 'config')
+        config_folder = os.path.join(
+            self.parent.pipeline_configuration.get_path(), "config"
+        )
         StorageRoots.write(self.parent.shotgun, config_folder, storage_roots)

--- a/tests/core_tests/test_path_cache.py
+++ b/tests/core_tests/test_path_cache.py
@@ -410,8 +410,8 @@ class TestAddMapping(TestPathCache):
             response = original_batch(batch_data)
             for entity in response:
                 if entity.get("path") and entity["path"].get("local_path"):
-                    entity["path"]["local_path"] = (
-                        entity["path"]["local_path"].replace("\\", "/")
+                    entity["path"]["local_path"] = entity["path"]["local_path"].replace(
+                        "\\", "/"
                     )
             return response
 
@@ -427,8 +427,7 @@ class TestAddMapping(TestPathCache):
 
         # Verify the path-cache row was committed.
         res = self.db_cursor.execute(
-            "SELECT path FROM path_cache "
-            "WHERE entity_type = ? AND entity_id = ?",
+            "SELECT path FROM path_cache " "WHERE entity_type = ? AND entity_id = ?",
             (self.entity["type"], self.entity["id"]),
         )
         self.assertEqual(len(res.fetchall()), 1)
@@ -575,9 +574,7 @@ class TestShotgunSync(TankTestBase):
         to pass in as callbacks to Schema.create_folders. The mock objects are
         then queried to see what paths the code attempted to create.
         """
-        super().setUp(
-            parameters={"project_tank_name": project_tank_name}
-        )
+        super().setUp(parameters={"project_tank_name": project_tank_name})
         self.setup_fixtures()
 
         self.seq = {

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -671,9 +671,7 @@ class TestTankFromPathWindowsNoSlash(TankTestBase):
     def setUp(self):
 
         # set up a project named temp, so that it will end up in c:\temp
-        super().setUp(
-            parameters={"project_tank_name": self.PROJECT_NAME}
-        )
+        super().setUp(parameters={"project_tank_name": self.PROJECT_NAME})
 
         # set up std fixtures
         self.setup_fixtures()
@@ -746,9 +744,7 @@ class TestTankFromPathOverlapStorage(TankTestBase):
     def setUp(self):
 
         # set up two storages and two projects
-        super().setUp(
-            parameters={"project_tank_name": "foo"}
-        )
+        super().setUp(parameters={"project_tank_name": "foo"})
 
         # add second project
         self.project_2 = {

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -32,6 +32,7 @@ from tank_test.tank_test_base import (
     temp_env_var,
 )
 
+
 class TestGetConfigInstallLocationPathSlashes(ShotgunTestBase):
     """
     Tests the case where a Windows config location uses double slashes.
@@ -303,8 +304,8 @@ class TestPipelineConfigUtils(ShotgunTestBase):
             )
 
         # Test with a core location that is invalid.
-        config_with_invalid_core_location = self._create_unlocalized_pipeline_configuration(
-            "config_with_invalid_core"
+        config_with_invalid_core_location = (
+            self._create_unlocalized_pipeline_configuration("config_with_invalid_core")
         )
 
         self._create_core_file(
@@ -317,8 +318,8 @@ class TestPipelineConfigUtils(ShotgunTestBase):
             )
 
         # Test when the core file is missing.
-        config_with_no_core_file_location = self._create_unlocalized_pipeline_configuration(
-            "config_with_no_core_file"
+        config_with_no_core_file_location = (
+            self._create_unlocalized_pipeline_configuration("config_with_no_core_file")
         )
 
         with self.assertRaisesRegex(
@@ -441,9 +442,7 @@ class TestGetCoreApiVersion(ShotgunTestBase):
             path_mock.assert_not_called()
 
     @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
-    def test_returns_unknown_for_other_core_when_manifest_missing(
-        self, manifest_mock
-    ):
+    def test_returns_unknown_for_other_core_when_manifest_missing(self, manifest_mock):
         """
         When info.yml is absent and the requested core is not the currently-running
         one, distribution metadata must not leak in as the answer.
@@ -482,9 +481,7 @@ class TestGetCoreApiVersion(ShotgunTestBase):
                 dist_mock.assert_called_once_with("sgtk")
 
     @mock.patch("tank.pipelineconfig_utils._get_version_from_manifest")
-    def test_returns_unknown_when_current_core_resolution_fails(
-        self, manifest_mock
-    ):
+    def test_returns_unknown_when_current_core_resolution_fails(self, manifest_mock):
         """
         If get_path_to_current_core raises (e.g. moved/symlinked install), the
         function preserves the "unknown" contract rather than propagating.

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -320,8 +320,8 @@ class TestStringKey(ShotgunTestBase):
         )
         tests.append(
             {
-                "short": u"foo",
-                "full": u"foobar",
+                "short": "foo",
+                "full": "foobar",
                 "template": StringKey("field_name", subset="(.{3}).*"),
             }
         )
@@ -329,8 +329,8 @@ class TestStringKey(ShotgunTestBase):
         # unicode
         tests.append(
             {
-                "short": u"\u3042\u308a\u304c",
-                "full": u"\u3042\u308a\u304c\u3068",
+                "short": "\u3042\u308a\u304c",
+                "full": "\u3042\u308a\u304c\u3068",
                 "template": StringKey("field_name", subset="(.{3}).*"),
             }
         )
@@ -392,8 +392,8 @@ class TestStringKey(ShotgunTestBase):
         # unicode
         tests.append(
             {
-                "short": u"\u3042\u308a\u304c ",
-                "full": u"\u3042\u308a\u304c\u3068",
+                "short": "\u3042\u308a\u304c ",
+                "full": "\u3042\u308a\u304c\u3068",
                 "template": StringKey(
                     "field_name", subset="(.{3}).*", subset_format="{0} "
                 ),
@@ -1208,9 +1208,7 @@ class TestTimestampKey(ShotgunTestBase):
         """
         key = TimestampKey("test")
         self.assertEqual(key.value_from_str(self._datetime_string), self._datetime)
-        self.assertEqual(
-            key.value_from_str(str(self._datetime_string)), self._datetime
-        )
+        self.assertEqual(key.value_from_str(str(self._datetime_string)), self._datetime)
 
     def test_bad_str(self):
         """

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -489,14 +489,16 @@ class TestDescriptorSupport(TankTestBase):
             with mock.patch(
                 "tank.descriptor.io_descriptor.appstore.log.debug"
             ) as log_debug_mock:
-                descriptor = sgtk.descriptor.io_descriptor.appstore.IODescriptorAppStore(
-                    {
-                        "name": "tk-config-basic",
-                        "version": "v1.0.0",
-                        "type": "app_store",
-                    },
-                    self.mockgun,
-                    sgtk.descriptor.Descriptor.CONFIG,
+                descriptor = (
+                    sgtk.descriptor.io_descriptor.appstore.IODescriptorAppStore(
+                        {
+                            "name": "tk-config-basic",
+                            "version": "v1.0.0",
+                            "type": "app_store",
+                        },
+                        self.mockgun,
+                        sgtk.descriptor.Descriptor.CONFIG,
+                    )
                 )
                 self.assertEqual(descriptor.has_remote_access(), False)
 
@@ -688,12 +690,20 @@ class TestDescriptorSupport(TankTestBase):
                 target_path, depth=1, ref="master"
             ),
             'git clone --no-hardlinks -q "%s" %s "%s" '
-            % (self.git_repo_uri, "-b master", target_path,),
+            % (
+                self.git_repo_uri,
+                "-b master",
+                target_path,
+            ),
         )
         self.assertEqual(
             desc._io_descriptor._validate_git_commands(target_path, ref="master"),
             'git clone --no-hardlinks -q "%s" %s "%s" '
-            % (self.git_repo_uri, "-b master", target_path,),
+            % (
+                self.git_repo_uri,
+                "-b master",
+                target_path,
+            ),
         )
 
 

--- a/tests/descriptor_tests/test_io_descriptors.py
+++ b/tests/descriptor_tests/test_io_descriptors.py
@@ -231,7 +231,9 @@ class TestIODescriptors(ShotgunTestBase):
             "path": self.git_repo_uri,
         }
         d = sgtk.descriptor.create_descriptor(
-            sg, sgtk.descriptor.Descriptor.APP, location,
+            sg,
+            sgtk.descriptor.Descriptor.APP,
+            location,
         )
 
         self.assertEqual(

--- a/tests/folder_tests/test_configuration.py
+++ b/tests/folder_tests/test_configuration.py
@@ -16,7 +16,7 @@ from tank_vendor import yaml
 from tank import TankError
 from tank import hook
 from tank import folder
-from tank_test.tank_test_base import setUpModule # noqa
+from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 
 

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -21,15 +21,14 @@ from tank_test.tank_test_base import *
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
+
 class TestSchemaCreateFolders(TankTestBase):
     def setUp(self, project_tank_name="project_code"):
         """Sets up entities in mocked shotgun database and creates Mock objects
         to pass in as callbacks to Schema.create_folders. The mock objects are
         then queried to see what paths the code attempted to create.
         """
-        super().setUp(
-            parameters={"project_tank_name": project_tank_name}
-        )
+        super().setUp(parameters={"project_tank_name": project_tank_name})
         self.setup_fixtures()
 
         self.seq = {
@@ -120,8 +119,9 @@ class TestSchemaCreateFolders(TankTestBase):
         # some japanese characters, UTF-8 encoded, just like we would get the from
         # the shotgun API.
 
-        self.shot["code"] = b"\xe3\x81\xbe\xe3\x82\x93\xe3\x81\x88 foo bar".decode("utf-8")
-
+        self.shot["code"] = b"\xe3\x81\xbe\xe3\x82\x93\xe3\x81\x88 foo bar".decode(
+            "utf-8"
+        )
 
         expected_paths = self._construct_shot_paths(
             shot_name=b"\xe3\x81\xbe\xe3\x82\x93\xe3\x81\x88-foo-bar".decode("utf-8")
@@ -324,7 +324,6 @@ class TestSchemaCreateFolders(TankTestBase):
 
 
 class TestSchemaCreateFoldersMultiLevelProjectRoot(TestSchemaCreateFolders):
-
     """
     Test a setup where there are more than a single folder in the Project.tank_name.
 
@@ -332,9 +331,7 @@ class TestSchemaCreateFoldersMultiLevelProjectRoot(TestSchemaCreateFolders):
     """
 
     def setUp(self):
-        super().setUp(
-            project_tank_name="multi/root/project/name"
-        )
+        super().setUp(project_tank_name="multi/root/project/name")
 
 
 class TestSchemaCreateFoldersMultiRoot(TankTestBase):
@@ -606,8 +603,7 @@ class TestCreateFilesystemStructure(TankTestBase):
         self.assertTrue(os.path.exists(expected))
 
     def test_wrong_type_entity_ids(self):
-        """Test passing in type other than list, int or tuple as value for entity_ids parameter.
-        """
+        """Test passing in type other than list, int or tuple as value for entity_ids parameter."""
         for bad_entity_ids in ["abab", self.shot, object()]:
             self.assertRaises(
                 ValueError,

--- a/tests/folder_tests/test_optional_fields.py
+++ b/tests/folder_tests/test_optional_fields.py
@@ -20,7 +20,6 @@ from tank_test.tank_test_base import *
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
-
 # test secondary entities.
 
 

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -466,7 +466,7 @@ class TestExecuteHook(TestApplication):
             "{config}/config_test_hook.py:{config}/more_hooks/config_test_hook.py"
         )
 
-        (disk_location_1, disk_location_2) = hook.test_inheritance_disk_location()
+        disk_location_1, disk_location_2 = hook.test_inheritance_disk_location()
 
         self.assertEqual(
             disk_location_1, os.path.join(self.project_config, "hooks", "toolkitty.png")

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -384,7 +384,7 @@ class TestUpdateEnvironment(TankTestBase):
         prev_settings = self.env.get_engine_settings("test_engine")
 
         self.env.update_engine_settings(
-            "test_engine", {"foo": u"bar"}, {"type": "dev", "path": "foo"}
+            "test_engine", {"foo": "bar"}, {"type": "dev", "path": "foo"}
         )
 
         # get raw environment after

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -296,7 +296,7 @@ class TestEngineLauncher(TankTestBase):
         )
         sw_versions = launcher.scan_software()
         for sw_version in sw_versions:
-            (supported, reason) = launcher._is_supported(sw_version)
+            supported, reason = launcher._is_supported(sw_version)
             if sw_version.version in [2, 3, 4]:
                 self.assertEqual(supported, True)
                 self.assertEqual(reason, "")

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -397,6 +397,7 @@ class _Patcher(object):
         :returns: A decorated function with an extra
             positional argument referencing the mock store singleton.
         """
+
         # Need to reapply doc and name to the method or we won't be able
         # to invoke the test individually.
         @functools.wraps(func)

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -763,16 +763,16 @@ class TankTestBase(unittest.TestCase):
 
         # Add multiple project roots. Do not update the roots file on creating each storage, wait until all are
         # created and write them all at once (also, we need to swap storage 3 and 4)
-        (self.alt_root_1, self.alt_storage_1) = self.create_storage_root(
+        self.alt_root_1, self.alt_storage_1 = self.create_storage_root(
             project_name, "alternate_1", False
         )
-        (self.alt_root_2, self.alt_storage_2) = self.create_storage_root(
+        self.alt_root_2, self.alt_storage_2 = self.create_storage_root(
             project_name, "alternate_2", False
         )
-        (self.alt_root_3, self.alt_storage_3) = self.create_storage_root(
+        self.alt_root_3, self.alt_storage_3 = self.create_storage_root(
             project_name, "alternate_3", False
         )
-        (self.alt_root_4, self.alt_storage_4) = self.create_storage_root(
+        self.alt_root_4, self.alt_storage_4 = self.create_storage_root(
             project_name, "alternate_4", False
         )
 

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -153,6 +153,7 @@ def skip_if_pyside_missing(func):
     """
     return unittest.skipIf(_is_pyside_missing(), "PySide is missing")(func)
 
+
 def _has_pyside2():
     """
     Tests if PySide2 is avalable.
@@ -161,6 +162,7 @@ def _has_pyside2():
     pyside2_spec = importlib.util.find_spec("PySide2")
     found = pyside2_spec is not None
     return found
+
 
 def skip_if_pyside2(found=True):
     """
@@ -188,6 +190,7 @@ def _has_pyside6():
     found = pyside6_spec is not None
     return found
 
+
 def skip_if_pyside6(found=True):
     """
     Decorator that allows to skip tests if PySide6 is missing.
@@ -203,6 +206,7 @@ def skip_if_pyside6(found=True):
         return unittest.skipIf(found_pyside6 == found, msg)(func)
 
     return _skip_if_pyside6
+
 
 def suppress_generated_code_qt_warnings(func):
     """
@@ -798,16 +802,12 @@ class TankTestBase(unittest.TestCase):
             )
 
         # swap the mapped storage ids
-        self.roots[self.alt_storage_3["code"]][
-            "shotgun_storage_id"
-        ] = self.alt_storage_4[
-            "id"
-        ]  # local storage 4
-        self.roots[self.alt_storage_4["code"]][
-            "shotgun_storage_id"
-        ] = self.alt_storage_3[
-            "id"
-        ]  # local storage 3
+        self.roots[self.alt_storage_3["code"]]["shotgun_storage_id"] = (
+            self.alt_storage_4["id"]
+        )  # local storage 4
+        self.roots[self.alt_storage_4["code"]]["shotgun_storage_id"] = (
+            self.alt_storage_3["id"]
+        )  # local storage 3
 
         roots_path = os.path.join(
             self.pipeline_config_root, "config", "core", "roots.yml"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -16,7 +16,6 @@ import tempfile
 import traceback
 from optparse import OptionParser
 
-
 # Let the user know which Python is picked up to run the tests.
 print()
 print(
@@ -253,7 +252,7 @@ def _parse_command_line():
         help="Run tests and redirect logging output to the console.",
     )
 
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
 
     test_names = args or []
 

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -182,7 +182,9 @@ class TestFileSystem(TankTestBase):
         copy_test_root_folder = os.path.join(self.tank_temp, "copy_tests")
         fs.ensure_folder_exists(copy_test_root_folder, permissions=0o777)
         # Source folder
-        copy_test_src_folder = os.path.join(copy_test_root_folder, "copy_test_src_folder")
+        copy_test_src_folder = os.path.join(
+            copy_test_root_folder, "copy_test_src_folder"
+        )
         fs.ensure_folder_exists(copy_test_src_folder, permissions=0o777)
         # Copy src file
         copy_test_basename = "copy_file.txt"

--- a/tests/util_tests/test_json_and_pickle.py
+++ b/tests/util_tests/test_json_and_pickle.py
@@ -129,7 +129,7 @@ class Impl:
             assertion(None)
             # Strings
             assertion("a")
-            assertion(u"a")
+            assertion("a")
             assertion(self.kanji)
 
         def test_array_values(self):
@@ -144,9 +144,9 @@ class Impl:
                     True,
                     False,
                     None,
-                    {"a": "b", u"c": u"d"},
+                    {"a": "b", "c": "d"},
                     "e",
-                    u"f",
+                    "f",
                 ]
             )
 
@@ -155,10 +155,10 @@ class Impl:
             Ensures we can properly encode a dictionary.
             """
             self._assert_no_unicode_after_load({})
-            self._assert_no_unicode_after_load({"a": "b", u"c": u"d"})
-            self._assert_no_unicode_after_load({"e": ["f"], u"g": [u"h"]})
+            self._assert_no_unicode_after_load({"a": "b", "c": "d"})
+            self._assert_no_unicode_after_load({"e": ["f"], "g": ["h"]})
             self._assert_no_unicode_after_load(
-                {"i": [{"j": ["k"]}], u"l": [{u"m": [u"n"]}]}
+                {"i": [{"j": ["k"]}], "l": [{"m": ["n"]}]}
             )
 
         def _assert_no_unicode_after_load(self, original_value):

--- a/tests/util_tests/test_login.py
+++ b/tests/util_tests/test_login.py
@@ -33,8 +33,13 @@ class LoginTests(TankTestBase):
         session.
         """
         find_one_mock.return_value = {"login": "tk-user"}
-        get_authenticated_user_mock.return_value = ShotgunAuthenticator().create_session_user(
-            host="host", login="tk-user", session_token="session_token", http_proxy=None
+        get_authenticated_user_mock.return_value = (
+            ShotgunAuthenticator().create_session_user(
+                host="host",
+                login="tk-user",
+                session_token="session_token",
+                http_proxy=None,
+            )
         )
         try:
             # Clear the cache so that get_current_user can work. Path cache is being updated by

--- a/tests/util_tests/test_metrics.py
+++ b/tests/util_tests/test_metrics.py
@@ -21,10 +21,14 @@ import urllib.request
 import tank
 from tank.authentication import ShotgunAuthenticator
 from tank.util.constants import TANK_LOG_METRICS_HOOK_NAME
-from tank.util.metrics import (EventMetric, MetricsDispatchWorkerThread,
-                               MetricsQueueSingleton, log_metric,
-                               log_user_activity_metric,
-                               log_user_attribute_metric)
+from tank.util.metrics import (
+    EventMetric,
+    MetricsDispatchWorkerThread,
+    MetricsQueueSingleton,
+    log_metric,
+    log_user_activity_metric,
+    log_user_attribute_metric,
+)
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, mock
 
@@ -929,8 +933,7 @@ class TestMetricsDeprecatedFunctions(ShotgunTestBase):
         in util.__init__ to preserve retro compatibility and prevent
         exception in legacy engine code.
         """
-        from tank.util import (log_user_activity_metric,
-                               log_user_attribute_metric)
+        from tank.util import log_user_activity_metric, log_user_attribute_metric
 
         # Bogus test call to the two legacy metric methods
         log_user_activity_metric("Test Module", "Test Action")

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -112,6 +112,7 @@ class TestShotgunRegisterPublish(TankTestBase):
         seq_path = os.path.join(self.project_root, "folder", "name_001.ext")
 
         create_data = []
+
         # wrap create so we can keep tabs of things
         def create_mock(entity_type, data, return_fields=None):
             create_data.append(data)

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -34,8 +34,14 @@ class PySide6PatcherTests(TankTestBase):
         # Assert QtGui attributes
         assert gui.QApplication.desktop
         assert gui.QAbstractButton.animateClick
-        assert gui.QSortFilterProxyModel.filterRegExp == gui.QSortFilterProxyModel.filterRegularExpression
-        assert gui.QSortFilterProxyModel.setFilterRegExp == gui.QSortFilterProxyModel.setFilterRegularExpression
+        assert (
+            gui.QSortFilterProxyModel.filterRegExp
+            == gui.QSortFilterProxyModel.filterRegularExpression
+        )
+        assert (
+            gui.QSortFilterProxyModel.setFilterRegExp
+            == gui.QSortFilterProxyModel.setFilterRegularExpression
+        )
         assert gui.QDesktopWidget == gui.QScreen
         assert gui.QFontMetrics.width == gui.QFontMetrics.horizontalAdvance
         assert gui.QFont.setWeight == gui.QFont.setLegacyWeight

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -40,9 +40,8 @@ class QtImporterTests(TankTestBase):
         assert qt.shiboken
         assert qt.shiboken.__name__ == "shiboken2"
 
-        assert (
-            qt.QtWebEngineWidgets is None
-            or isinstance(qt.QtWebEngineWidgets, types.ModuleType)
+        assert qt.QtWebEngineWidgets is None or isinstance(
+            qt.QtWebEngineWidgets, types.ModuleType
         )
 
         # Expect PySide2 as the binding
@@ -134,7 +133,7 @@ class QtImporterTests(TankTestBase):
     @unittest.mock.patch.dict(
         # Set the SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT variable
         "os.environ",
-        {"SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT": "1"}
+        {"SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT": "1"},
     )
     def test_skip_webengine_qt5(self, *mocks):
         # Test default Qt interface (Qt4)
@@ -167,7 +166,7 @@ class QtImporterTests(TankTestBase):
     @unittest.mock.patch.dict(
         # Set the SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT variable
         "os.environ",
-        {"SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT": "1"}
+        {"SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT": "1"},
     )
     def test_skip_webengine_qt6(self, *mocks):
         # Test default Qt interface (Qt4)

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -22,7 +22,7 @@ class TestSgre(TestCase):
         Ensure that sgre injects the re.ASCII flag appropriately, and that
         unicode characters do not match.
         """
-        char = u"漢字"
+        char = "漢字"
         expr = r"\w+"
 
         # test all wrapped methods
@@ -38,7 +38,7 @@ class TestSgre(TestCase):
         Ensure that `sgre` injects the `re.ASCII` flag appropriately when flags
         are passed positionally, and that Unicode characters do not match.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods
@@ -61,7 +61,7 @@ class TestSgre(TestCase):
         also passed as keyword arguments, and that unicode characters do not
         match.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods
@@ -76,7 +76,7 @@ class TestSgre(TestCase):
         """
         Ensure that the unicode flag overrides the flag insertion behavior.
         """
-        char = u"a漢字"
+        char = "a漢字"
         expr = r"a\w+"
 
         # test all wrapped methods

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -483,7 +483,7 @@ class TestMultiRoot(TankTestBase):
 
         _, proj_2_root = self.create_project({"name": "second project"})
         proj_2_name = os.path.basename(proj_2_root)
-        (proj_2_alt_root, proj_2_alt_storage) = self.create_storage_root(
+        proj_2_alt_root, proj_2_alt_storage = self.create_storage_root(
             proj_2_name, "second_alternate_1"
         )
         proj_2_pub = {

--- a/tests/util_tests/test_shotgun.py
+++ b/tests/util_tests/test_shotgun.py
@@ -535,7 +535,7 @@ class TestShotgunDownloadUrl(ShotgunTestBase):
         # `file:///fixtures_root/config/hooks/toolkitty.png`
         if sys.platform == "win32":
             self.download_url = "file:///{p}".format(
-                p = self.download_source.replace("\\", "/")
+                p=self.download_source.replace("\\", "/")
             )
         else:
             self.download_url = urllib.parse.urlunparse(

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -13,7 +13,6 @@ import tank
 from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule  # noqa
 from tank.util.shotgun_entity import get_sg_entity_name_field, sg_entity_to_string
 
-
 KNOWN_SG_ENTITIES = [
     "ActionMenuItem",
     "ApiUser",

--- a/tests/util_tests/test_storage_roots.py
+++ b/tests/util_tests/test_storage_roots.py
@@ -339,7 +339,7 @@ class TestStorageRoots(ShotgunTestBase):
         """Test the get_local_storages method."""
 
         single_root = StorageRoots.from_metadata(self._single_root_metadata)
-        (single_root_lookup, unmapped_roots) = single_root.get_local_storages(
+        single_root_lookup, unmapped_roots = single_root.get_local_storages(
             self.mockgun
         )
 
@@ -357,7 +357,7 @@ class TestStorageRoots(ShotgunTestBase):
         self.assertEqual(unmapped_roots, [])
 
         multiple_roots = StorageRoots.from_metadata(self._multiple_roots_metadata)
-        (multiple_root_lookup, unmapped_roots) = multiple_roots.get_local_storages(
+        multiple_root_lookup, unmapped_roots = multiple_roots.get_local_storages(
             self.mockgun
         )
 

--- a/tests/util_tests/test_unicode.py
+++ b/tests/util_tests/test_unicode.py
@@ -75,25 +75,24 @@ class TestUnicode(TestCase):
         Ensure all values encoded with ISO-8859-1 are properly converted to str.
         """
         logins = [
-            'AñoVolvió',
-            'JiříVyčítal',
-            '日本のユーザー*',
-            '이사이트에서는개발자가',
-            'およびその他の教育リソース'
-            '工作流技术总监或将要设置工作流并希望开发',
-            'Martin Tlustý',
+            "AñoVolvió",
+            "JiříVyčítal",
+            "日本のユーザー*",
+            "이사이트에서는개발자가",
+            "およびその他の教育リソース" "工作流技术总监或将要设置工作流并希望开发",
+            "Martin Tlustý",
         ]
 
         for login in logins:
             expected_value = {
-                'type': 'SessionUser',
-                'data': {
-                    'http_proxy': None,
-                    'host': 'https://xyxyxyxyx.jjj',
-                    'login': login,
-                    'session_token': 'de97e6ff868b6b2ce332',
-                    'session_metadata': 'G9kZXNrLmNvbTsgcGF0aD0v'
-                }
+                "type": "SessionUser",
+                "data": {
+                    "http_proxy": None,
+                    "host": "https://xyxyxyxyx.jjj",
+                    "login": login,
+                    "session_token": "de97e6ff868b6b2ce332",
+                    "session_metadata": "G9kZXNrLmNvbTsgcGF0aD0v",
+                },
             }
 
             dumps_value = sgtk.util.pickle.dumps(expected_value)


### PR DESCRIPTION
## Summary

- Remove `exclude: "tests|python/tank"` from the black hook in `.pre-commit-config.yaml` so local pre-commit and CI run black on the same set of files
- Apply black formatting to the 78 previously-excluded files in `tests/` and `python/tank/` to bring them into compliance
- Disabled black from the Hound CI bot

## Root cause

The CI pipeline (via `tk-ci-tools`) runs black with no exclusions, while the local pre-commit config excluded `tests/` and `python/tank/`. This caused pre-commit to pass locally on unformatted files in those directories, only for CI to fail.

## Test plan

- [ ] CI code-style-validation job passes
- [ ] `pre-commit run --all` passes locally
