### PR TITLE
SG-43836 Add isort to pre-commit for tk-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,12 @@ repos:
     - id: trailing-whitespace
       # Same comment as the end-of-file-fixer
       exclude: "scripts\/tank_cmd.bat|setup\/root_binaries\/tank.bat"
+  # Sorts imports. Must run before black so black has the final say on formatting.
+  - repo: https://github.com/PyCQA/isort
+    rev: 8.0.1
+    hooks:
+    - id: isort
+      args: ["--profile", "black", "--filter-files"]
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
     rev: 26.5.1

--- a/_core_upgrader.py
+++ b/_core_upgrader.py
@@ -19,11 +19,11 @@ next to it in the file system. This is what it will attempt to install.
 
 """
 
-import os
-import sys
-import stat
 import datetime
+import os
 import shutil
+import stat
+import sys
 
 LooseVersion = None
 try:

--- a/developer/bake_config.py
+++ b/developer/bake_config.py
@@ -15,8 +15,8 @@ a local path.
 
 # system imports
 import os
-import sys
 import shutil
+import sys
 
 # add sgtk API
 this_folder = os.path.abspath(os.path.dirname(__file__))
@@ -25,23 +25,27 @@ python_folder = os.path.abspath(os.path.join(this_folder, "..", "python"))
 # any installed version in site-packages
 sys.path.insert(0, python_folder)
 
-# sgtk imports
-from tank import LogManager
-from tank.util import filesystem
-from tank.descriptor import Descriptor, descriptor_uri_to_dict
-from tank.descriptor import create_descriptor, is_descriptor_version_missing
-from tank.descriptor.errors import TankDescriptorError
-from tank.bootstrap import constants as bootstrap_constants
 import functools
 
+# sgtk imports
+from tank import LogManager
+from tank.bootstrap import constants as bootstrap_constants
+from tank.descriptor import (
+    Descriptor,
+    create_descriptor,
+    descriptor_uri_to_dict,
+    is_descriptor_version_missing,
+)
+from tank.descriptor.errors import TankDescriptorError
+from tank.util import filesystem
 from utils import (
-    cache_apps,
-    authenticate,
-    add_authentication_options,
     OptionParserLineBreakingEpilog,
+    add_authentication_options,
+    authenticate,
+    automated_setup_documentation,
+    cache_apps,
     cleanup_bundle_cache,
     wipe_folder,
-    automated_setup_documentation,
 )
 
 # Set up logging

--- a/developer/build_plugin.py
+++ b/developer/build_plugin.py
@@ -16,11 +16,12 @@ and create a plugin scaffold, complete with standard helpers and
 a primed bundle cache.
 """
 
+import datetime
+
 # system imports
 import os
-import sys
 import shutil
-import datetime
+import sys
 
 # add sgtk API
 this_folder = os.path.abspath(os.path.dirname(__file__))
@@ -31,22 +32,27 @@ sys.path.insert(0, python_folder)
 
 # sgtk imports
 from tank import LogManager
-from tank.util import filesystem, sgre as re
-from tank.errors import TankError
-from tank.descriptor import Descriptor, descriptor_uri_to_dict, descriptor_dict_to_uri
-from tank.descriptor import create_descriptor, is_descriptor_version_missing
-from tank.bootstrap.baked_configuration import BakedConfiguration
 from tank.bootstrap import constants as bootstrap_constants
+from tank.bootstrap.baked_configuration import BakedConfiguration
+from tank.descriptor import (
+    Descriptor,
+    create_descriptor,
+    descriptor_dict_to_uri,
+    descriptor_uri_to_dict,
+    is_descriptor_version_missing,
+)
+from tank.errors import TankError
+from tank.util import filesystem
+from tank.util import sgre as re
 from tank_vendor import yaml
-
 from utils import (
-    cache_apps,
-    authenticate,
-    add_authentication_options,
     OptionParserLineBreakingEpilog,
+    add_authentication_options,
+    authenticate,
+    automated_setup_documentation,
+    cache_apps,
     cleanup_bundle_cache,
     wipe_folder,
-    automated_setup_documentation,
 )
 
 # set up logging

--- a/developer/populate_bundle_cache.py
+++ b/developer/populate_bundle_cache.py
@@ -18,7 +18,6 @@ a primed bundle cache.
 
 # system imports
 import os
-
 import sys
 
 # add sgtk API
@@ -30,16 +29,15 @@ sys.path.insert(0, python_folder)
 
 # sgtk imports
 from sgtk import LogManager
-from sgtk.util import filesystem
 from sgtk.descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
-
+from sgtk.util import filesystem
 from utils import (
-    cache_apps,
-    authenticate,
-    add_authentication_options,
     OptionParserLineBreakingEpilog,
-    cleanup_bundle_cache,
+    add_authentication_options,
+    authenticate,
     automated_setup_documentation,
+    cache_apps,
+    cleanup_bundle_cache,
 )
 
 # set up logging

--- a/developer/utils/__init__.py
+++ b/developer/utils/__init__.py
@@ -1,7 +1,7 @@
-from .caching import cache_apps, cleanup_bundle_cache, wipe_folder  # noqa
-from .option_parser import OptionParserLineBreakingEpilog  # noqa
-from .authentication import (
+from .authentication import (  # noqa
     add_authentication_options,
     authenticate,
     automated_setup_documentation,
-)  # noqa
+)
+from .caching import cache_apps, cleanup_bundle_cache, wipe_folder  # noqa
+from .option_parser import OptionParserLineBreakingEpilog  # noqa

--- a/developer/utils/caching.py
+++ b/developer/utils/caching.py
@@ -8,16 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import glob
+import os
 import shutil
 import stat
 
-from tank.util import filesystem
-from tank.platform import environment
-from tank.descriptor import Descriptor, create_descriptor
-
 from tank import LogManager
+from tank.descriptor import Descriptor, create_descriptor
+from tank.platform import environment
+from tank.util import filesystem
 
 logger = LogManager.get_logger("utils.caching")
 

--- a/hooks/cache_location.py
+++ b/hooks/cache_location.py
@@ -12,9 +12,10 @@
 Hook to control path cache and bundle cache folder creation.
 """
 
-import sgtk
 import os
-from sgtk.util import filesystem, LocalFileStorageManager
+
+import sgtk
+from sgtk.util import LocalFileStorageManager, filesystem
 
 HookBaseClass = sgtk.get_hook_baseclass()
 log = sgtk.LogManager.get_logger(__name__)

--- a/hooks/ensure_folder_exists.py
+++ b/hooks/ensure_folder_exists.py
@@ -13,8 +13,8 @@ This hook is called when an engine, app or framework's
 :class:`~sgtk.platform.Application.ensure_folder_exists` method is called.
 """
 
-from sgtk.util import filesystem
 from sgtk import Hook
+from sgtk.util import filesystem
 
 
 class EnsureFolderExists(Hook):

--- a/hooks/get_current_login.py
+++ b/hooks/get_current_login.py
@@ -27,8 +27,9 @@ for all users in Shotgun and if a match is found, this is deemed to be the
 current user.
 """
 
-from tank import Hook
 import os
+
+from tank import Hook
 from tank.util import is_windows
 
 

--- a/hooks/process_folder_creation.py
+++ b/hooks/process_folder_creation.py
@@ -13,9 +13,10 @@ This hook is invoked during folder creation when :meth:`sgtk.Sgtk.create_filesys
 called.
 """
 
-from tank import Hook
 import os
 import shutil
+
+from tank import Hook
 from tank.util import is_windows
 
 

--- a/hooks/process_folder_name.py
+++ b/hooks/process_folder_name.py
@@ -24,8 +24,9 @@ is being used, for example:
        raise TankError("Shot names cannot start with AA!")
 """
 
-from tank import Hook
 import re
+
+from tank import Hook
 
 
 class ProcessFolderName(Hook):

--- a/python/sgtk/__init__.py
+++ b/python/sgtk/__init__.py
@@ -12,11 +12,11 @@
 ALT_API_NAME = "tank"
 THIS_MODULE_NAME = "sgtk"
 
-# first import our alternative API
-import tank
-
 # now go through and duplicate all entries in sys.modules
 import sys
+
+# first import our alternative API
+import tank
 
 # Generate a list of keys to iterate over,
 # since we'll be mutating the dict as we iterate.

--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -118,59 +118,59 @@ if "TANK_CURRENT_PC" not in os.environ:
 
 ########################################################################
 
-# first import the log manager since a lot of modules require this.
-from .log import LogManager
-
 # make sure that all sub-modules are imported at the same as the main module
-from . import authentication
-from . import descriptor
-from . import bootstrap
-from . import commands
-from . import deploy
-from . import folder
-from . import platform
-from . import util
+from . import (
+    authentication,
+    bootstrap,
+    commands,
+    deploy,
+    descriptor,
+    folder,
+    platform,
+    util,
+)
 
 # core functionality
 from .api import (
+    Sgtk,
     Tank,
-    tank_from_path,
-    tank_from_entity,
-    set_authenticated_user,
     get_authenticated_user,
+    set_authenticated_user,
+    sgtk_from_entity,
+    sgtk_from_path,
+    tank_from_entity,
+    tank_from_path,
 )
-from .api import Sgtk, sgtk_from_path, sgtk_from_entity
-from .authentication.flow_auth import get_flow_client, get_flow_access_token
-from .pipelineconfig_utils import (
-    get_python_interpreter_for_config,
-    get_core_python_path_for_config,
-    get_sgtk_module_path,
-)
+from .authentication.flow_auth import get_flow_access_token, get_flow_client
+from .commands import CommandInteraction, SgtkSystemCommand, get_command, list_commands
 
+# expose the support url
+from .constants import (
+    DEFAULT_STORAGE_ROOT_HOOK_NAME,
+)
+from .constants import SUPPORT_URL as support_url
 from .context import Context
-
 from .errors import (
     TankError,
     TankErrorProjectIsSetup,
-    TankHookMethodDoesNotExistError,
     TankFileDoesNotExistError,
-    TankUnreadableFileError,
-    TankInvalidInterpreterLocationError,
+    TankHookMethodDoesNotExistError,
     TankInvalidCoreLocationError,
+    TankInvalidInterpreterLocationError,
     TankNotPipelineConfigurationError,
+    TankUnreadableFileError,
+)
+from .hook import Hook, get_hook_baseclass
+
+# first import the log manager since a lot of modules require this.
+from .log import LogManager
+from .pipelineconfig_utils import (
+    get_core_python_path_for_config,
+    get_python_interpreter_for_config,
+    get_sgtk_module_path,
 )
 
 # note: TankEngineInitError used to reside in .errors but was moved into platform.errors
 from .platform.errors import TankEngineInitError
 from .template import Template, TemplatePath, TemplateString
-from .hook import Hook, get_hook_baseclass
-
-from .commands import list_commands, get_command, SgtkSystemCommand, CommandInteraction
-
-from .templatekey import TemplateKey, SequenceKey, IntegerKey, StringKey, TimestampKey
-
-# expose the support url
-from .constants import (
-    DEFAULT_STORAGE_ROOT_HOOK_NAME,
-    SUPPORT_URL as support_url,
-)
+from .templatekey import IntegerKey, SequenceKey, StringKey, TemplateKey, TimestampKey

--- a/python/tank/__init__.py
+++ b/python/tank/__init__.py
@@ -118,6 +118,9 @@ if "TANK_CURRENT_PC" not in os.environ:
 
 ########################################################################
 
+# first import the log manager since a lot of modules require this.
+from .log import LogManager  # isort: skip
+
 # make sure that all sub-modules are imported at the same as the main module
 from . import (
     authentication,
@@ -161,9 +164,6 @@ from .errors import (
     TankUnreadableFileError,
 )
 from .hook import Hook, get_hook_baseclass
-
-# first import the log manager since a lot of modules require this.
-from .log import LogManager
 from .pipelineconfig_utils import (
     get_core_python_path_for_config,
     get_python_interpreter_for_config,

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -12,20 +12,22 @@
 Classes for the main Sgtk API.
 """
 
-import os
 import glob
+import os
 
-from . import folder
-from . import context
-from .util import shotgun, yaml_cache
+from . import (
+    LogManager,
+    constants,
+    context,
+    folder,
+    pipelineconfig,
+    pipelineconfig_factory,
+    pipelineconfig_utils,
+)
 from .errors import TankError, TankMultipleMatchingTemplatesError
 from .path_cache import PathCache
 from .template import read_templates
-from . import constants
-from . import pipelineconfig
-from . import pipelineconfig_utils
-from . import pipelineconfig_factory
-from . import LogManager
+from .util import shotgun, yaml_cache
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/__init__.py
+++ b/python/tank/authentication/__init__.py
@@ -18,28 +18,28 @@ credentials are reused. If a Toolkit-enabled process is launched a second time, 
 credentials are reused if available.
 """
 
+from .core_defaults_manager import CoreDefaultsManager
+from .defaults_manager import DefaultsManager
+from .errors import ConsoleLoginWithSSONotSupportedError  # For backward compatibility.
 from .errors import (  # noqa
     AuthenticationCancelled,
     AuthenticationError,
-    ConsoleLoginWithSSONotSupportedError,  # For backward compatibility.
     ConsoleLoginNotSupportedError,
     IncompleteCredentials,
     ShotgunAuthenticationError,
     UnresolvableHumanUser,
     UnresolvableScriptUser,
 )
-from .web_login_support import (
-    get_shotgun_authenticator_support_web_login,
-    set_shotgun_authenticator_support_web_login,
-)
+from .flow_auth import FlowAuthenticationHandler, get_flow_access_token, get_flow_client
 from .shotgun_authenticator import ShotgunAuthenticator
-from .flow_auth import get_flow_access_token, FlowAuthenticationHandler, get_flow_client
-from .defaults_manager import DefaultsManager
-from .core_defaults_manager import CoreDefaultsManager
 from .user import (  # noqa
-    deserialize_user,
-    serialize_user,
     ShotgunSamlUser,
     ShotgunUser,
     ShotgunWebUser,
+    deserialize_user,
+    serialize_user,
+)
+from .web_login_support import (
+    get_shotgun_authenticator_support_web_login,
+    set_shotgun_authenticator_support_web_login,
 )

--- a/python/tank/authentication/console_authentication.py
+++ b/python/tank/authentication/console_authentication.py
@@ -19,23 +19,21 @@ at any point.
 --------------------------------------------------------------------------------
 """
 
-from . import constants
-from . import session_cache
-from .. import LogManager
-from .errors import (
-    AuthenticationError,
-    AuthenticationCancelled,
-    ConsoleLoginNotSupportedError,
-)
+import webbrowser
+from getpass import getpass
+
 from tank_vendor.shotgun_api3 import MissingTwoFactorAuthenticationFault
-from . import site_info
-from . import app_session_launcher
+
+from .. import LogManager
 from ..util import metrics_cache
 from ..util.metrics import EventMetric
 from ..util.shotgun.connection import sanitize_url
-
-from getpass import getpass
-import webbrowser
+from . import app_session_launcher, constants, session_cache, site_info
+from .errors import (
+    AuthenticationCancelled,
+    AuthenticationError,
+    ConsoleLoginNotSupportedError,
+)
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/core_defaults_manager.py
+++ b/python/tank/authentication/core_defaults_manager.py
@@ -14,8 +14,8 @@ will provide a default host and an optional http proxy. If a script user has
 been configured with the core, its credentials will also be provided.
 """
 
-from .defaults_manager import DefaultsManager
 from ..util import shotgun
+from .defaults_manager import DefaultsManager
 
 
 class CoreDefaultsManager(DefaultsManager):

--- a/python/tank/authentication/defaults_manager.py
+++ b/python/tank/authentication/defaults_manager.py
@@ -8,9 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import session_cache
-from ..util.user_settings import UserSettings
 from ..util.system_settings import SystemSettings
+from ..util.user_settings import UserSettings
+from . import session_cache
 
 
 class DefaultsManager(object):

--- a/python/tank/authentication/flow_auth/__init__.py
+++ b/python/tank/authentication/flow_auth/__init__.py
@@ -16,15 +16,15 @@ access token via PKCE; the token is cached in a local file store for reuse.
 """
 
 from ._authentication import (
-    init_authentication,
+    check_token_expiry,
     get_access_token,
     get_flow_access_token,
-    check_token_expiry,
+    init_authentication,
 )
 from ._client import FlowAuthenticationHandler, get_flow_client
 from ._constants import AM_READY_PROJECT_FIELD
 from ._settings import FlowAuthSettings, resolve_flow_auth_settings
-from .errors import FlowAuthError, FlowAuthConfigurationError
+from .errors import FlowAuthConfigurationError, FlowAuthError
 
 __all__ = [
     "init_authentication",

--- a/python/tank/authentication/flow_auth/_authentication.py
+++ b/python/tank/authentication/flow_auth/_authentication.py
@@ -19,8 +19,8 @@ import time
 
 from tank_vendor.adsk_auth import (
     AuthConfig,
-    get_access_token as get_access_token_from_adsk_auth,
 )
+from tank_vendor.adsk_auth import get_access_token as get_access_token_from_adsk_auth
 
 from ... import LogManager
 from ...util import LocalFileStorageManager

--- a/python/tank/authentication/interactive_authentication.py
+++ b/python/tank/authentication/interactive_authentication.py
@@ -24,14 +24,14 @@ at any point.
 
 # Using "with" with the lock to make sure it is always released.
 
-from .errors import AuthenticationCancelled
-from .console_authentication import ConsoleLoginHandler, ConsoleRenewSessionHandler
+import os
+import threading
+
+from tank.util import is_windows
 
 from .. import LogManager
-
-import threading
-import os
-from tank.util import is_windows
+from .console_authentication import ConsoleLoginHandler, ConsoleRenewSessionHandler
+from .errors import AuthenticationCancelled
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -20,35 +20,32 @@ at any point.
 
 import os
 import sys
+
 from tank_vendor import shotgun_api3
-from .. import constants
-from .web_login_support import get_shotgun_authenticator_support_web_login
-from .ui import resources_rc  # noqa
-from .ui import login_dialog
-from . import constants as auth_constants
-from . import session_cache
+
+from .. import LogManager, constants
+from ..util import LocalFileStorageManager, login, metrics_cache
 from ..util.metrics import EventMetric
 from ..util.shotgun import connection
-from ..util import login
-from ..util import LocalFileStorageManager
-from ..util import metrics_cache
-from .errors import AuthenticationError
-from .ui.qt_abstraction import (
-    QtGui,
-    QtCore,
-    QtNetwork,
-    QtWebEngineWidgets,
-    qt_version_tuple,
-)
 from . import app_session_launcher
-from . import site_info
+from . import constants as auth_constants
+from . import session_cache, site_info
+from .errors import AuthenticationError
 from .sso_saml2 import (
     SsoSaml2IncompletePySide2,
     SsoSaml2MissingQtModuleError,
 )
 from .sso_saml2.sso_saml2_toolkit import SsoSaml2Toolkit
-
-from .. import LogManager
+from .ui import resources_rc  # noqa
+from .ui import login_dialog
+from .ui.qt_abstraction import (
+    QtCore,
+    QtGui,
+    QtNetwork,
+    QtWebEngineWidgets,
+    qt_version_tuple,
+)
+from .web_login_support import get_shotgun_authenticator_support_web_login
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/session_cache.py
+++ b/python/tank/authentication/session_cache.py
@@ -21,19 +21,21 @@ at any point.
 
 import os
 import socket
+
+from tank_vendor import yaml
 from tank_vendor.shotgun_api3 import (
-    Shotgun,
     AuthenticationFault,
-    ProtocolError,
     MissingTwoFactorAuthenticationFault,
+    ProtocolError,
+    Shotgun,
 )
 from tank_vendor.shotgun_api3.lib import httplib2
-from tank_vendor import yaml
+
+from .. import LogManager
+from ..util import LocalFileStorageManager
+from ..util.shotgun import connection
 from . import constants
 from .errors import AuthenticationError
-from .. import LogManager
-from ..util.shotgun import connection
-from ..util import LocalFileStorageManager
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/shotgun_authenticator.py
+++ b/python/tank/authentication/shotgun_authenticator.py
@@ -10,14 +10,11 @@
 
 """PTR Authenticator."""
 
-from .sso_saml2 import has_sso_info_in_cookies, has_unified_login_flow_info_in_cookies
-from . import interactive_authentication
-from . import user
-from . import user_impl
-from . import session_cache
-from .errors import IncompleteCredentials
-from .defaults_manager import DefaultsManager
 from .. import LogManager
+from . import interactive_authentication, session_cache, user, user_impl
+from .defaults_manager import DefaultsManager
+from .errors import IncompleteCredentials
+from .sso_saml2 import has_sso_info_in_cookies, has_unified_login_flow_info_in_cookies
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/shotgun_wrapper.py
+++ b/python/tank/authentication/shotgun_wrapper.py
@@ -17,11 +17,12 @@ at any point.
 """
 
 import http.client
-
-from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault
 from xmlrpc.client import ProtocolError
-from . import interactive_authentication, session_cache
+
+from tank_vendor.shotgun_api3 import AuthenticationFault, Shotgun
+
 from .. import LogManager
+from . import interactive_authentication, session_cache
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/site_info.py
+++ b/python/tank/authentication/site_info.py
@@ -11,11 +11,10 @@
 
 import time
 
-from . import utils
-
 from tank_vendor import shotgun_api3
 
 from .. import LogManager
+from . import utils
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/sso_saml2/__init__.py
+++ b/python/tank/authentication/sso_saml2/__init__.py
@@ -21,15 +21,14 @@ from .core.errors import (  # noqa
     SsoSaml2MissingQtNetwork,
     SsoSaml2MultiSessionNotSupportedError,
 )
+from .core.utils import (  # noqa
+    get_logger,
+    set_logger_parent,
+)
 
 # Functions
 from .utils import (  # noqa
     get_saml_claims_expiration,
     has_sso_info_in_cookies,
     has_unified_login_flow_info_in_cookies,
-)
-
-from .core.utils import (  # noqa
-    get_logger,
-    set_logger_parent,
 )

--- a/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
+++ b/python/tank/authentication/sso_saml2/core/sso_saml2_core.py
@@ -21,6 +21,7 @@ import os
 import sys
 import time
 
+from ...utils import sanitize_http_proxy
 from .authentication_session_data import AuthenticationSessionData
 from .errors import (
     SsoSaml2IncompletePySide2,
@@ -39,7 +40,6 @@ from .utils import (
     get_session_id,
     get_user_name,
 )
-from ...utils import sanitize_http_proxy
 
 try:
     from .username_password_dialog import UsernamePasswordDialog

--- a/python/tank/authentication/sso_saml2/core/utils.py
+++ b/python/tank/authentication/sso_saml2/core/utils.py
@@ -13,13 +13,12 @@ SSO/SAML2 Core utility functions.
 
 # pylint: disable=line-too-long
 
-import sys
 import base64
 import binascii
 import logging
-from urllib.parse import unquote_plus
+import sys
 from http.cookies import SimpleCookie
-
+from urllib.parse import unquote_plus
 
 from .errors import SsoSaml2MultiSessionNotSupportedError
 

--- a/python/tank/authentication/sso_saml2/sso_saml2.py
+++ b/python/tank/authentication/sso_saml2/sso_saml2.py
@@ -17,7 +17,6 @@ Integration with Shotgun API.
 # pylint: disable=unused-import
 
 from .core.sso_saml2_core import SsoSaml2Core  # noqa
-
 from .core.utils import (  # noqa
     set_logger_parent,
 )

--- a/python/tank/authentication/sso_saml2/utils.py
+++ b/python/tank/authentication/sso_saml2/utils.py
@@ -14,10 +14,10 @@ SSO/SAML2 Utility functions.
 # pylint: disable=unused-import
 
 from .core.utils import (  # noqa
-    get_saml_claims_expiration,
-    get_session_expiration,
     _decode_cookies,
     _get_shotgun_user_id,
+    get_saml_claims_expiration,
+    get_session_expiration,
 )
 
 

--- a/python/tank/authentication/ui_authentication.py
+++ b/python/tank/authentication/ui_authentication.py
@@ -18,9 +18,9 @@ at any point.
 --------------------------------------------------------------------------------
 """
 
-from .errors import AuthenticationCancelled, ShotgunAuthenticationError
-from . import invoker
 from .. import LogManager
+from . import invoker
+from .errors import AuthenticationCancelled, ShotgunAuthenticationError
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/authentication/user.py
+++ b/python/tank/authentication/user.py
@@ -12,10 +12,8 @@ import os
 import threading
 import time
 
-from . import sso_saml2
-from . import interactive_authentication
-from . import user_impl
 from .. import LogManager
+from . import interactive_authentication, sso_saml2, user_impl
 from .errors import AuthenticationCancelled
 
 logger = LogManager.get_logger(__name__)

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -19,16 +19,16 @@ at any point.
 --------------------------------------------------------------------------------
 """
 
-import json
 import http.client
+import json
 
-from .shotgun_wrapper import ShotgunWrapper
-from tank_vendor.shotgun_api3 import Shotgun, AuthenticationFault, ProtocolError
+from tank_vendor.shotgun_api3 import AuthenticationFault, ProtocolError, Shotgun
 
-from . import session_cache
-from .errors import IncompleteCredentials, UnresolvableHumanUser, UnresolvableScriptUser
 from .. import LogManager
 from ..util import pickle
+from . import session_cache
+from .errors import IncompleteCredentials, UnresolvableHumanUser, UnresolvableScriptUser
+from .shotgun_wrapper import ShotgunWrapper
 
 # Indirection to create ShotgunWrapper instances. Great for unit testing.
 _shotgun_instance_factory = ShotgunWrapper

--- a/python/tank/bootstrap/__init__.py
+++ b/python/tank/bootstrap/__init__.py
@@ -8,5 +8,5 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .manager import ToolkitManager
 from .errors import TankBootstrapError, TankMissingTankNameError
+from .manager import ToolkitManager

--- a/python/tank/bootstrap/baked_configuration.py
+++ b/python/tank/bootstrap/baked_configuration.py
@@ -10,16 +10,12 @@
 
 import os
 
-from .configuration import Configuration
-from .configuration_writer import ConfigurationWriter
-
-from .. import LogManager
-from .. import constants
-
+from .. import LogManager, constants, pipelineconfig_utils
+from ..errors import TankFileDoesNotExistError
 from ..util import ShotgunPath
 from ..util.pickle import store_env_var_pickled
-from ..errors import TankFileDoesNotExistError
-from .. import pipelineconfig_utils
+from .configuration import Configuration
+from .configuration_writer import ConfigurationWriter
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/bundle_downloader.py
+++ b/python/tank/bootstrap/bundle_downloader.py
@@ -9,8 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from sgtk import hook
-from sgtk import LogManager
+
+from sgtk import LogManager, hook
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -9,21 +9,19 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import pprint
 import sys
 import traceback
-import pprint
-
-from . import constants
-
-from ..descriptor import create_descriptor, Descriptor
-from .errors import TankBootstrapError, TankMissingTankNameError
-
-from ..util import filesystem, version
 
 from tank_vendor import yaml
+
+from .. import LogManager
+from ..descriptor import Descriptor, create_descriptor
+from ..util import filesystem, version
+from . import constants
 from .configuration import Configuration
 from .configuration_writer import ConfigurationWriter
-from .. import LogManager
+from .errors import TankBootstrapError, TankMissingTankNameError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/configuration.py
+++ b/python/tank/bootstrap/configuration.py
@@ -11,16 +11,14 @@
 import inspect
 import os
 
-from .import_handler import CoreImportHandler
-
-from ..log import LogManager
-from .. import pipelineconfig_utils
-from .. import constants
+from .. import constants, pipelineconfig_utils
 from ..authentication import (
+    ShotgunSamlUser,
     get_shotgun_authenticator_support_web_login,
     serialize_user,
-    ShotgunSamlUser,
 )
+from ..log import LogManager
+from .import_handler import CoreImportHandler
 
 log = LogManager.get_logger(__name__)
 
@@ -178,8 +176,7 @@ class Configuration(object):
         """
         # Perform a local import here to make sure we are getting
         # the newly swapped in core code, if it was swapped
-        from .. import api
-        from .. import pipelineconfig
+        from .. import api, pipelineconfig
 
         log.debug("Executing tank_from_path('%s')" % path)
 
@@ -267,6 +264,7 @@ class Configuration(object):
                 ShotgunAuthenticator,
                 deserialize_user,
             )
+
             from ..util import CoreDefaultsManager
         except ImportError:
             log.debug("Using pre-0.16 core, no authenticated user will be set.")

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -8,23 +8,18 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import datetime
 import os
 import sys
-import datetime
-
-from . import constants
-
-from ..descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
-
-from ..util import filesystem
-from ..util import StorageRoots
-from ..util.shotgun import connection
-from ..util.move_guard import MoveGuard
-from ..util import is_macos, is_windows
 
 from tank_vendor import yaml
 
 from .. import LogManager
+from ..descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
+from ..util import StorageRoots, filesystem, is_macos, is_windows
+from ..util.move_guard import MoveGuard
+from ..util.shotgun import connection
+from . import constants
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/installed_configuration.py
+++ b/python/tank/bootstrap/installed_configuration.py
@@ -10,9 +10,9 @@
 
 import os
 
-from .errors import TankBootstrapError
-from .configuration import Configuration
 from .. import LogManager
+from .configuration import Configuration
+from .errors import TankBootstrapError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/manager.py
+++ b/python/tank/bootstrap/manager.py
@@ -8,20 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import inspect
+import os
 
-from . import constants
-from .errors import TankBootstrapError
-from .configuration import Configuration
-from .resolver import ConfigurationResolver
+from .. import LogManager
 from ..authentication import ShotgunAuthenticator, flow_auth
+from ..errors import TankError
 from ..flowam import constants as flow_const
 from ..flowam import utils as flow_utils
 from ..pipelineconfig import PipelineConfiguration
-from .. import LogManager
-from ..errors import TankError
 from ..util import ShotgunPath
+from . import constants
+from .configuration import Configuration
+from .errors import TankBootstrapError
+from .resolver import ConfigurationResolver
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/bootstrap/resolver.py
+++ b/python/tank/bootstrap/resolver.py
@@ -13,27 +13,25 @@ Resolver module. This module provides a way to resolve a pipeline configuration
 on disk.
 """
 
-import sys
-import os
 import fnmatch
+import os
 import pprint
+import sys
 
+from .. import LogManager
 from ..descriptor import (
     Descriptor,
     create_descriptor,
     descriptor_uri_to_dict,
     is_descriptor_version_missing,
 )
-from .errors import TankBootstrapError, TankBootstrapInvalidPipelineConfigurationError
+from ..descriptor.descriptor_installed_config import InstalledConfigDescriptor
+from ..util import LocalFileStorageManager, ShotgunPath, filesystem
+from . import constants
 from .baked_configuration import BakedConfiguration
 from .cached_configuration import CachedConfiguration
+from .errors import TankBootstrapError, TankBootstrapInvalidPipelineConfigurationError
 from .installed_configuration import InstalledConfiguration
-from ..descriptor.descriptor_installed_config import InstalledConfigDescriptor
-from ..util import filesystem
-from ..util import ShotgunPath
-from ..util import LocalFileStorageManager
-from .. import LogManager
-from . import constants
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/commands/__init__.py
+++ b/python/tank/commands/__init__.py
@@ -8,5 +8,5 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .tank_command import list_commands, get_command, SgtkSystemCommand
 from .interaction import CommandInteraction
+from .tank_command import SgtkSystemCommand, get_command, list_commands

--- a/python/tank/commands/app_info.py
+++ b/python/tank/commands/app_info.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .action_base import Action
 from ..errors import TankError
+from .action_base import Action
 
 
 class AppInfoAction(Action):

--- a/python/tank/commands/cache_apps.py
+++ b/python/tank/commands/cache_apps.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .action_base import Action
 from ..errors import TankError
+from .action_base import Action
 
 
 class CacheAppsAction(Action):

--- a/python/tank/commands/cache_yaml.py
+++ b/python/tank/commands/cache_yaml.py
@@ -8,13 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import fnmatch
+import os
 
-
-from .action_base import Action
 from ..errors import TankError
-from ..util import yaml_cache, pickle
+from ..util import pickle, yaml_cache
+from .action_base import Action
 
 
 class CacheYamlAction(Action):

--- a/python/tank/commands/clone_configuration.py
+++ b/python/tank/commands/clone_configuration.py
@@ -8,18 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from ..util import ShotgunPath
-from ..errors import TankError
-from . import constants
-from ..util import filesystem
-from ..util import is_linux, is_macos, is_windows
+import os
+import shutil
 
 from tank_vendor import yaml
 
+from ..errors import TankError
+from ..util import ShotgunPath, filesystem, is_linux, is_macos, is_windows
+from . import constants
 from .action_base import Action
-
-import os
-import shutil
 
 
 class CloneConfigAction(Action):

--- a/python/tank/commands/console_utils.py
+++ b/python/tank/commands/console_utils.py
@@ -15,9 +15,9 @@ Various helper methods relating to user interaction via the shell.
 import textwrap
 
 from .. import pipelineconfig_utils
-from ..platform import validation
-from ..errors import TankError, TankNoDefaultValueError
 from ..descriptor import CheckVersionConstraintsError
+from ..errors import TankError, TankNoDefaultValueError
+from ..platform import validation
 from ..platform.bundle import resolve_default_value
 
 ##########################################################################################

--- a/python/tank/commands/core_localize.py
+++ b/python/tank/commands/core_localize.py
@@ -8,17 +8,16 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import sys
-import shutil
 import datetime
+import os
+import shutil
+import sys
 
+from .. import pipelineconfig_factory, pipelineconfig_utils
 from ..errors import TankError
 from ..util import filesystem
 from ..util.version import is_version_older
 from .action_base import Action
-from .. import pipelineconfig_utils
-from .. import pipelineconfig_factory
 
 # these are the items that need to be copied across
 # when a configuration is upgraded to contain a core API

--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -12,21 +12,20 @@
 Tank command allowing to do core updates.
 """
 
-from ..errors import TankError
-from .action_base import Action
-
+import copy
+import optparse
 import os
 import sys
 import textwrap
-import optparse
-import copy
-
-from ..util import shotgun
-from .. import pipelineconfig_utils
-from . import console_utils
-from ..util.version import is_version_newer, is_version_head
 
 from tank_vendor import yaml
+
+from .. import pipelineconfig_utils
+from ..errors import TankError
+from ..util import shotgun
+from ..util.version import is_version_head, is_version_newer
+from . import console_utils
+from .action_base import Action
 
 
 # FIXME: This should be refactored into something that can be used by other commands.

--- a/python/tank/commands/desktop_migration.py
+++ b/python/tank/commands/desktop_migration.py
@@ -8,9 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from . import console_utils, constants
 from .action_base import Action
-from . import console_utils
-from . import constants
 
 _MESSAGE = (
     "This command will migrate the PTR site configuration used by the Desktop app so "

--- a/python/tank/commands/dump_config.py
+++ b/python/tank/commands/dump_config.py
@@ -12,8 +12,8 @@ import os
 from io import StringIO
 
 from ..errors import TankError
-from .action_base import Action
 from ..util import filesystem
+from .action_base import Action
 
 
 class DumpConfigAction(Action):

--- a/python/tank/commands/get_entity_commands.py
+++ b/python/tank/commands/get_entity_commands.py
@@ -7,16 +7,15 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
-import sys
-
-from .action_base import Action
-from ..errors import TankError
-from ..util.process import SubprocessCalledProcessError, subprocess_check_output
-from ..util import is_linux, is_macos, is_windows
-
 import itertools
 import operator
 import os
+import sys
+
+from ..errors import TankError
+from ..util import is_linux, is_macos, is_windows
+from ..util.process import SubprocessCalledProcessError, subprocess_check_output
+from .action_base import Action
 
 
 def execute_tank_command(pipeline_config_path, args):

--- a/python/tank/commands/install.py
+++ b/python/tank/commands/install.py
@@ -9,10 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from ..errors import TankError
-from . import console_utils
+from . import console_utils, constants, util
 from .action_base import Action
-from . import util
-from . import constants
 
 
 class InstallAppAction(Action):

--- a/python/tank/commands/misc.py
+++ b/python/tank/commands/misc.py
@@ -8,12 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import code
+import os
+import sys
+
 from ..errors import TankError
 from .action_base import Action
-
-import code
-import sys
-import os
 
 
 class ClearCacheAction(Action):
@@ -128,8 +128,8 @@ class InteractiveShellAction(Action):
 
         # attempt install tab command completion
         try:
-            import rlcompleter
             import readline
+            import rlcompleter
 
             if "libedit" in readline.__doc__:
                 # macosx, some versions - see

--- a/python/tank/commands/move_pc.py
+++ b/python/tank/commands/move_pc.py
@@ -8,14 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import constants
-from ..errors import TankError
-
-from .action_base import Action
-
 import os
 import shutil
 import sys
+
+from ..errors import TankError
+from . import constants
+from .action_base import Action
 
 
 class MovePCAction(Action):

--- a/python/tank/commands/path_cache.py
+++ b/python/tank/commands/path_cache.py
@@ -12,10 +12,8 @@
 Methods relating to the path cache
 """
 
+from .. import folder, path_cache
 from ..errors import TankError
-from .. import path_cache
-from .. import folder
-
 from .action_base import Action
 
 

--- a/python/tank/commands/pc_overview.py
+++ b/python/tank/commands/pc_overview.py
@@ -9,13 +9,13 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
+import os
+
 from .. import pipelineconfig_utils
+from ..errors import TankError
 from ..util import ShotgunPath
 from . import constants
-from ..errors import TankError
 from .action_base import Action
-
-import os
 
 
 class PCBreakdownAction(Action):

--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -8,20 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from ..util import filesystem
-from . import constants
+import datetime
+import os
+import shutil
+
 from ..errors import TankError
 from ..pipelineconfig import PipelineConfiguration
-
-from . import console_utils
-
+from ..util import ShotgunPath, filesystem
+from . import console_utils, constants
 from .action_base import Action
-
-from ..util import ShotgunPath
-
-import os
-import datetime
-import shutil
 
 # Core configuration files which are associated with the core API installation and not
 # the pipeline configuration.

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -13,19 +13,15 @@ import sys
 import textwrap
 import traceback
 
-from .action_base import Action
-from . import core_localize
-from ..errors import TankError
-from ..util import shotgun
-from ..util import ShotgunPath
-from ..util import is_linux, is_macos, is_windows
-from . import constants
 from .. import pipelineconfig_utils
+from ..errors import TankError
+from ..util import ShotgunPath, is_linux, is_macos, is_windows, shotgun
 from ..util.filesystem import ensure_folder_exists
-
+from . import constants, core_localize
+from .action_base import Action
+from .interaction import YesToEverythingInteraction
 from .setup_project_core import run_project_setup
 from .setup_project_params import ProjectSetupParameters
-from .interaction import YesToEverythingInteraction
 
 
 class SetupProjectAction(Action):

--- a/python/tank/commands/setup_project_core.py
+++ b/python/tank/commands/setup_project_core.py
@@ -8,17 +8,16 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
 import os
 import shutil
-
-from . import constants
-from ..errors import TankError
-from ..util import StorageRoots
-from ..util import filesystem
-from ..api import sgtk_from_path
+import sys
 
 from tank_vendor import yaml
+
+from ..api import sgtk_from_path
+from ..errors import TankError
+from ..util import StorageRoots, filesystem
+from . import constants
 
 
 @filesystem.with_cleared_umask

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -9,29 +9,21 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import sys
 import tempfile
 import uuid
-import sys
-
-from . import constants
-from . import util
-
-from ..util import StorageRoots
-from ..util import sgre as re
-from ..util import shotgun
-from ..util import filesystem
-from ..util import is_windows
-from ..util.version import is_version_newer
-from ..util.zip import unzip_file, zip_file
-
-from .. import hook
-from ..errors import TankError, TankErrorProjectIsSetup
-from .. import pipelineconfig_utils
-from ..descriptor import create_descriptor, Descriptor
 
 from tank_vendor import yaml
 
-from ..util import ShotgunPath
+from .. import hook, pipelineconfig_utils
+from ..descriptor import Descriptor, create_descriptor
+from ..errors import TankError, TankErrorProjectIsSetup
+from ..util import ShotgunPath, StorageRoots, filesystem, is_windows
+from ..util import sgre as re
+from ..util import shotgun
+from ..util.version import is_version_newer
+from ..util.zip import unzip_file, zip_file
+from . import constants, util
 
 
 class ProjectSetupParameters(object):

--- a/python/tank/commands/switch.py
+++ b/python/tank/commands/switch.py
@@ -8,13 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from ..errors import TankError
-from . import constants
-from . import util
-from . import console_utils
-from .action_base import Action
-
 import os
+
+from ..errors import TankError
+from . import console_utils, constants, util
+from .action_base import Action
 
 
 class SwitchAppAction(Action):

--- a/python/tank/commands/tank_command.py
+++ b/python/tank/commands/tank_command.py
@@ -15,38 +15,38 @@ Methods for handling of the tank command
 
 import logging
 
+from .. import LogManager
+from .. import constants as constants_global
+from ..errors import TankError
+from ..platform.engine import get_environment_from_context, start_engine
+from . import (
+    app_info,
+    cache_apps,
+    cache_yaml,
+    clone_configuration,
+    constants,
+    copy_apps,
+    core_localize,
+    core_upgrade,
+    desktop_migration,
+    dump_config,
+    folders,
+    get_entity_commands,
+    install,
+    misc,
+    move_pc,
+    path_cache,
+    pc_overview,
+    push_pc,
+    setup_project,
+    setup_project_wizard,
+    switch,
+    unregister_folders,
+    update,
+    validate_config,
+)
 from .action_base import Action
 from .interaction import RawInputCommandInteraction, YesToEverythingInteraction
-from . import folders
-from . import misc
-from . import move_pc
-from . import pc_overview
-from . import path_cache
-from . import update
-from . import push_pc
-from . import setup_project
-from . import setup_project_wizard
-from . import dump_config
-from . import validate_config
-from . import cache_apps
-from . import switch
-from . import app_info
-from . import core_upgrade
-from . import core_localize
-from . import install
-from . import clone_configuration
-from . import copy_apps
-from . import unregister_folders
-from . import desktop_migration
-from . import cache_yaml
-from . import get_entity_commands
-from . import constants
-
-
-from .. import constants as constants_global
-from .. import LogManager
-from ..platform.engine import start_engine, get_environment_from_context
-from ..errors import TankError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/commands/unregister_folders.py
+++ b/python/tank/commands/unregister_folders.py
@@ -12,10 +12,10 @@
 Method to unregister folders from the path cache
 """
 
-from ..errors import TankError
 from .. import path_cache
-from .action_base import Action
+from ..errors import TankError
 from ..util.login import get_current_user
+from .action_base import Action
 
 
 class UnregisterFoldersAction(Action):

--- a/python/tank/commands/update.py
+++ b/python/tank/commands/update.py
@@ -10,14 +10,12 @@
 
 import os
 
-from .action_base import Action
-from . import console_utils
-from . import util
-from ..platform.environment import WritableEnvironment
-from ..descriptor import CheckVersionConstraintsError
-from . import constants
-from ..util.version import is_version_number, is_version_newer
 from .. import pipelineconfig_utils
+from ..descriptor import CheckVersionConstraintsError
+from ..platform.environment import WritableEnvironment
+from ..util.version import is_version_newer, is_version_number
+from . import console_utils, constants, util
+from .action_base import Action
 
 
 class AppUpdatesAction(Action):

--- a/python/tank/commands/validate_config.py
+++ b/python/tank/commands/validate_config.py
@@ -9,9 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from .action_base import Action
+
 from ..errors import TankError
-from ..platform import validation, bundle
+from ..platform import bundle, validation
+from .action_base import Action
 
 
 class ValidateConfigAction(Action):

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -15,25 +15,20 @@ Management of the current context, e.g. the current shotgun entity/step/task.
 
 from __future__ import annotations  # needed for python 3.9 support
 
-import os
 import copy
 import json
+import os
 
 from tank_vendor import yaml
 from tank_vendor.flow_integration_sdk import sandbox
-from . import authentication
-from .authentication import flow_auth
-from .flowam import constants as flow_const
 
-from .util import login
-from .util import shotgun_entity
-from .util import shotgun
-from .util import get_sg_entity_name_field
-from .util import pickle
-from . import constants
-from .errors import TankError, TankContextDeserializationError
+from . import authentication, constants
+from .authentication import flow_auth
+from .errors import TankContextDeserializationError, TankError
+from .flowam import constants as flow_const
 from .path_cache import PathCache
 from .template import TemplatePath
+from .util import get_sg_entity_name_field, login, pickle, shotgun, shotgun_entity
 
 
 class Context(object):

--- a/python/tank/deploy/__init__.py
+++ b/python/tank/deploy/__init__.py
@@ -8,6 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import descriptor
-from . import dev_descriptor
-from . import util
+from . import descriptor, dev_descriptor, util

--- a/python/tank/deploy/descriptor.py
+++ b/python/tank/deploy/descriptor.py
@@ -14,7 +14,7 @@ Legacy handling of descriptors for the PTR desktop app.
 This code may be removed at some point in the future.
 """
 
-from ..descriptor import create_descriptor, Descriptor
+from ..descriptor import Descriptor, create_descriptor
 from ..util import shotgun
 
 

--- a/python/tank/descriptor/__init__.py
+++ b/python/tank/descriptor/__init__.py
@@ -10,22 +10,20 @@
 
 
 from .descriptor import Descriptor, create_descriptor
-from .descriptor_core import CoreDescriptor
-from .descriptor_bundle import AppDescriptor, FrameworkDescriptor, EngineDescriptor
+from .descriptor_bundle import AppDescriptor, EngineDescriptor, FrameworkDescriptor
 from .descriptor_config import ConfigDescriptor
-
+from .descriptor_core import CoreDescriptor
 from .errors import (
+    CheckVersionConstraintsError,
+    InvalidAppStoreCredentialsError,
     TankAppStoreConnectionError,
     TankAppStoreError,
-    TankDescriptorError,
-    InvalidAppStoreCredentialsError,
-    TankInvalidAppStoreCredentialsError,
-    CheckVersionConstraintsError,
     TankCheckVersionConstraintsError,
+    TankDescriptorError,
+    TankInvalidAppStoreCredentialsError,
     TankInvalidInterpreterLocationError,
     TankMissingManifestError,
 )
-
 from .io_descriptor import (
     descriptor_dict_to_uri,
     descriptor_uri_to_dict,

--- a/python/tank/descriptor/descriptor.py
+++ b/python/tank/descriptor/descriptor.py
@@ -8,16 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
-from ..log import LogManager
-from ..util import filesystem
-from .io_descriptor import create_io_descriptor
-from .errors import TankDescriptorError
-from ..util import LocalFileStorageManager
-from . import constants
 from .. import constants as constants2
+from ..log import LogManager
+from ..util import LocalFileStorageManager, filesystem
+from . import constants
+from .errors import TankDescriptorError
+from .io_descriptor import create_io_descriptor
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/descriptor_bundle.py
+++ b/python/tank/descriptor/descriptor_bundle.py
@@ -8,13 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .descriptor import Descriptor
-from .errors import TankDescriptorError, CheckVersionConstraintsError
-from . import constants
-from .. import LogManager
-from ..util.version import is_version_older
+from .. import LogManager, pipelineconfig_utils
 from ..util import shotgun
-from .. import pipelineconfig_utils
+from ..util.version import is_version_older
+from . import constants
+from .descriptor import Descriptor
+from .errors import CheckVersionConstraintsError, TankDescriptorError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/descriptor_cached_config.py
+++ b/python/tank/descriptor/descriptor_cached_config.py
@@ -12,10 +12,10 @@ import os
 
 from tank_vendor import yaml
 
-from . import constants
-from .errors import TankDescriptorError
-from .descriptor_config import ConfigDescriptor
 from .. import LogManager
+from . import constants
+from .descriptor_config import ConfigDescriptor
+from .errors import TankDescriptorError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/descriptor_config.py
+++ b/python/tank/descriptor/descriptor_config.py
@@ -10,16 +10,14 @@
 
 import os
 
-from ..errors import TankFileDoesNotExistError
-from . import constants
-from .errors import TankInvalidInterpreterLocationError
-from .descriptor import Descriptor, create_descriptor
-from .io_descriptor import is_descriptor_version_missing
 from .. import LogManager
-from ..util import StorageRoots
-from ..util import ShotgunPath
+from ..errors import TankFileDoesNotExistError
+from ..util import ShotgunPath, StorageRoots
 from ..util.version import is_version_older
-from .io_descriptor import descriptor_uri_to_dict
+from . import constants
+from .descriptor import Descriptor, create_descriptor
+from .errors import TankInvalidInterpreterLocationError
+from .io_descriptor import descriptor_uri_to_dict, is_descriptor_version_missing
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/descriptor_core.py
+++ b/python/tank/descriptor/descriptor_core.py
@@ -8,9 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from . import constants
 from .descriptor import Descriptor
 from .errors import TankMissingManifestError
-from . import constants
 
 
 class CoreDescriptor(Descriptor):

--- a/python/tank/descriptor/descriptor_installed_config.py
+++ b/python/tank/descriptor/descriptor_installed_config.py
@@ -10,18 +10,16 @@
 
 import os
 
-from .descriptor_config import ConfigDescriptor
-from .. import pipelineconfig_utils
-from .. import LogManager
-from ..util import ShotgunPath
-from . import constants
-from .errors import TankMissingManifestError
-
+from .. import LogManager, pipelineconfig_utils
 from ..errors import (
-    TankNotPipelineConfigurationError,
     TankFileDoesNotExistError,
     TankInvalidCoreLocationError,
+    TankNotPipelineConfigurationError,
 )
+from ..util import ShotgunPath
+from . import constants
+from .descriptor_config import ConfigDescriptor
+from .errors import TankMissingManifestError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/errors.py
+++ b/python/tank/descriptor/errors.py
@@ -12,8 +12,8 @@
 All custom exceptions that this module emits are defined here.
 """
 
-from ..errors import TankError
 from .. import errors
+from ..errors import TankError
 
 
 class TankDescriptorError(TankError):

--- a/python/tank/descriptor/io_descriptor/__init__.py
+++ b/python/tank/descriptor/io_descriptor/__init__.py
@@ -10,8 +10,8 @@
 
 from .factory import (
     create_io_descriptor,
-    descriptor_uri_to_dict,
     descriptor_dict_to_uri,
+    descriptor_uri_to_dict,
     is_descriptor_version_missing,
 )
 
@@ -22,15 +22,15 @@ def _initialize_descriptor_factory():
     This complex process for handling the IODescriptor abstract factory
     management is in order to avoid local imports in classes.
     """
-    from .base import IODescriptorBase
     from .appstore import IODescriptorAppStore
+    from .base import IODescriptorBase
     from .dev import IODescriptorDev
-    from .path import IODescriptorPath
-    from .shotgun_entity import IODescriptorShotgunEntity
-    from .git_tag import IODescriptorGitTag
     from .git_branch import IODescriptorGitBranch
+    from .git_tag import IODescriptorGitTag
     from .github_release import IODescriptorGithubRelease
     from .manual import IODescriptorManual
+    from .path import IODescriptorPath
+    from .shotgun_entity import IODescriptorShotgunEntity
 
     IODescriptorBase.register_descriptor_factory("app_store", IODescriptorAppStore)
     IODescriptorBase.register_descriptor_factory("dev", IODescriptorDev)

--- a/python/tank/descriptor/io_descriptor/dev.py
+++ b/python/tank/descriptor/io_descriptor/dev.py
@@ -8,9 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .path import IODescriptorPath
-
 from ... import LogManager
+from .path import IODescriptorPath
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/downloadable.py
+++ b/python/tank/descriptor/io_descriptor/downloadable.py
@@ -12,11 +12,10 @@ import contextlib
 import os
 import uuid
 
-from .base import IODescriptorBase
-from ..errors import TankDescriptorIOError
-from ...util import filesystem
-
 from ... import LogManager
+from ...util import filesystem
+from ..errors import TankDescriptorIOError
+from .base import IODescriptorBase
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/factory.py
+++ b/python/tank/descriptor/io_descriptor/factory.py
@@ -10,10 +10,9 @@
 
 import copy
 
+from ... import LogManager
 from ..errors import TankDescriptorError
 from .base import IODescriptorBase
-
-from ... import LogManager
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -8,18 +8,16 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
-import uuid
 import shutil
-import tempfile
 import subprocess
+import tempfile
+import uuid
 
-from .downloadable import IODescriptorDownloadable
 from ... import LogManager
-from ...util.process import subprocess_check_output, SubprocessCalledProcessError
-
+from ...util import filesystem, is_windows
+from ...util.process import SubprocessCalledProcessError, subprocess_check_output
 from ..errors import TankError
-from ...util import filesystem
-from ...util import is_windows
+from .downloadable import IODescriptorDownloadable
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/git_tag.py
+++ b/python/tank/descriptor/io_descriptor/git_tag.py
@@ -7,13 +7,13 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
-import os
 import copy
+import os
 import re
 
-from .git import IODescriptorGit
-from ..errors import TankDescriptorError
 from ... import LogManager
+from ..errors import TankDescriptorError
+from .git import IODescriptorGit
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/manual.py
+++ b/python/tank/descriptor/io_descriptor/manual.py
@@ -8,9 +8,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
-from .base import IODescriptorBase
+
 from ... import LogManager
 from ..errors import TankDescriptorError
+from .base import IODescriptorBase
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/descriptor/io_descriptor/path.py
+++ b/python/tank/descriptor/io_descriptor/path.py
@@ -10,10 +10,10 @@
 
 import os
 
-from .base import IODescriptorBase
-from ..errors import TankDescriptorError
-from ...util import ShotgunPath
 from ... import LogManager
+from ...util import ShotgunPath
+from ..errors import TankDescriptorError
+from .base import IODescriptorBase
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/flowam/open.py
+++ b/python/tank/flowam/open.py
@@ -13,7 +13,6 @@ from __future__ import annotations  # needed for python 3.9 support
 import os
 
 import sgtk
-
 from tank import LogManager
 from tank_vendor.flow_integration_sdk.exceptions import (
     DraftExistsError,
@@ -21,10 +20,14 @@ from tank_vendor.flow_integration_sdk.exceptions import (
     InvalidDraftError,
 )
 from tank_vendor.flow_integration_sdk.globals import SOURCE_PURPOSE
-from tank_vendor.flow_integration_sdk.objects import FlowVersion, FlowRevision
+from tank_vendor.flow_integration_sdk.objects import FlowRevision, FlowVersion
 from tank_vendor.flow_integration_sdk.sandbox import (
     CheckoutDraftInfo,
+)
+from tank_vendor.flow_integration_sdk.sandbox import (
     checkout_revision as checkout_revision_in_sandbox,
+)
+from tank_vendor.flow_integration_sdk.sandbox import (
     get_draft_id,
     is_local_draft,
     read_draft_info,

--- a/python/tank/flowam/utils.py
+++ b/python/tank/flowam/utils.py
@@ -12,14 +12,14 @@
 
 from __future__ import annotations  # needed for python 3.9 support
 
-import fileseq
 import glob
 import os
 import re
 import webbrowser
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
+import fileseq
 from tank import LogManager
 from tank.authentication import flow_auth
 from tank.pipelineconfig import PipelineConfiguration
@@ -27,17 +27,18 @@ from tank.util import yaml_cache
 
 if TYPE_CHECKING:
     from tank.context import Context
+
 from tank_vendor.flow_integration_sdk import globals, schema, storage
 from tank_vendor.flow_integration_sdk.exceptions import FlowError
+from tank_vendor.flow_integration_sdk.objects import FlowProject
 from tank_vendor.flow_integration_sdk.publish import (
-    ComponentSpec,
     CommentComponentSpec,
+    ComponentSpec,
+    FileSeqComponentSpec,
     SourceComponentSpec,
     ThumbnailComponentSpec,
     TypeComponentSpec,
-    FileSeqComponentSpec,
 )
-from tank_vendor.flow_integration_sdk.objects import FlowProject
 from tank_vendor.flow_integration_sdk.schema_builder import create_pipeline_schemas
 from tank_vendor.flow_integration_sdk.utils import trace
 

--- a/python/tank/folder/__init__.py
+++ b/python/tank/folder/__init__.py
@@ -13,5 +13,5 @@ This module contains functionality relating to folder creation.
 
 """
 
-from .operations import process_filesystem_structure, synchronize_folders
 from .configuration import read_ignore_files
+from .operations import process_filesystem_structure, synchronize_folders

--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -13,21 +13,20 @@ Handles the creation of a configuration object structure based on the folder con
 
 """
 
-import os
 import fnmatch
-
-from .folder_types import (
-    Static,
-    ListField,
-    Entity,
-    Project,
-    UserWorkspace,
-    ShotgunStep,
-    ShotgunTask,
-)
+import os
 
 from ..errors import TankError, TankUnreadableFileError
 from ..util import yaml_cache
+from .folder_types import (
+    Entity,
+    ListField,
+    Project,
+    ShotgunStep,
+    ShotgunTask,
+    Static,
+    UserWorkspace,
+)
 
 
 def read_ignore_files(schema_config_path):

--- a/python/tank/folder/folder_io.py
+++ b/python/tank/folder/folder_io.py
@@ -16,10 +16,9 @@ Known constraints:
 
 """
 
-from . import constants
 from ..errors import TankError
-
 from ..path_cache import PathCache
+from . import constants
 
 
 class FolderIOReceiver(object):

--- a/python/tank/folder/folder_types/__init__.py
+++ b/python/tank/folder/folder_types/__init__.py
@@ -13,11 +13,11 @@ This module contains all the implementations for the different
 folder types that can be created.
 """
 
-from .errors import EntityLinkTypeMismatch
-from .static import Static
-from .listfield import ListField
 from .entity import Entity
+from .errors import EntityLinkTypeMismatch
+from .listfield import ListField
 from .project import Project
-from .user import UserWorkspace
+from .static import Static
 from .step import ShotgunStep
 from .task import ShotgunTask
+from .user import UserWorkspace

--- a/python/tank/folder/folder_types/base.py
+++ b/python/tank/folder/folder_types/base.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
 from .expression_tokens import SymlinkToken
 

--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -8,16 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
 from ...errors import TankError
 from ...util import shotgun_entity
-
-from .errors import EntityLinkTypeMismatch
 from .base import Folder
+from .errors import EntityLinkTypeMismatch
 from .expression_tokens import FilterExpressionToken
-from .util import translate_filter_tokens, resolve_shotgun_filters
+from .util import resolve_shotgun_filters, translate_filter_tokens
 
 
 class Entity(Folder):

--- a/python/tank/folder/folder_types/listfield.py
+++ b/python/tank/folder/folder_types/listfield.py
@@ -8,12 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
 from ...errors import TankError
 from ...util import shotgun_entity
-
 from .base import Folder
 from .expression_tokens import FilterExpressionToken
 

--- a/python/tank/folder/folder_types/project.py
+++ b/python/tank/folder/folder_types/project.py
@@ -8,10 +8,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from ...errors import TankError
-from .entity import Entity
 from ... import constants
+from ...errors import TankError
 from ...log import LogManager
+from .entity import Entity
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/folder/folder_types/static.py
+++ b/python/tank/folder/folder_types/static.py
@@ -11,10 +11,9 @@
 import os
 
 from ...errors import TankError
-
 from .base import Folder
 from .entity import Entity
-from .util import translate_filter_tokens, resolve_shotgun_filters
+from .util import resolve_shotgun_filters, translate_filter_tokens
 
 
 class Static(Folder):

--- a/python/tank/folder/folder_types/step.py
+++ b/python/tank/folder/folder_types/step.py
@@ -11,10 +11,9 @@
 import os
 
 from ...errors import TankError
-
 from .entity import Entity
+from .expression_tokens import CurrentStepExpressionToken, FilterExpressionToken
 from .util import translate_filter_tokens
-from .expression_tokens import FilterExpressionToken, CurrentStepExpressionToken
 
 
 class ShotgunStep(Entity):

--- a/python/tank/folder/folder_types/task.py
+++ b/python/tank/folder/folder_types/task.py
@@ -11,11 +11,10 @@
 import os
 
 from ...errors import TankError
-
 from .entity import Entity
-from .util import translate_filter_tokens
-from .expression_tokens import FilterExpressionToken, CurrentTaskExpressionToken
+from .expression_tokens import CurrentTaskExpressionToken, FilterExpressionToken
 from .step import ShotgunStep
+from .util import translate_filter_tokens
 
 
 class ShotgunTask(Entity):

--- a/python/tank/folder/folder_types/user.py
+++ b/python/tank/folder/folder_types/user.py
@@ -8,9 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from ...util import login
 from ...errors import TankError
-
+from ...util import login
 from .entity import Entity
 from .util import translate_filter_tokens
 

--- a/python/tank/folder/folder_types/util.py
+++ b/python/tank/folder/folder_types/util.py
@@ -15,11 +15,10 @@ Utility methods related to folder creation
 import copy
 
 from ...errors import TankError
-
 from .expression_tokens import (
-    FilterExpressionToken,
     CurrentStepExpressionToken,
     CurrentTaskExpressionToken,
+    FilterExpressionToken,
 )
 
 

--- a/python/tank/folder/operations.py
+++ b/python/tank/folder/operations.py
@@ -13,10 +13,10 @@ Main entry points for folder creation.
 
 """
 
+from ..errors import TankError
 from .configuration import FolderConfiguration
 from .folder_io import FolderIOReceiver
 from .folder_types import EntityLinkTypeMismatch
-from ..errors import TankError
 
 
 def create_single_folder_item(

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -12,18 +12,19 @@
 Defines the base class for all Tank Hooks.
 """
 
+import inspect
+import logging
 import os
 import sys
-import logging
-import inspect
 import threading
-from .util.loader import load_plugin
+
 from . import LogManager
 from .errors import (
     TankError,
     TankFileDoesNotExistError,
     TankHookMethodDoesNotExistError,
 )
+from .util.loader import load_plugin
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -221,13 +221,14 @@ For more information, see https://docs.python.org/2/library/logging.handlers.htm
 """
 
 import logging
-from logging.handlers import RotatingFileHandler
 import os
 import sys
 import time
-import weakref
 import uuid
+import weakref
 from functools import wraps
+from logging.handlers import RotatingFileHandler
+
 from . import constants
 
 

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -15,16 +15,15 @@ all Tank items in the file system are kept.
 """
 
 import collections
-import sqlite3
-import sys
-import os
 import itertools
 import json
+import os
+import sqlite3
+import sys
 
-from .platform.engine import show_global_busy, clear_global_busy
-from . import constants
+from . import LogManager, constants
 from .errors import TankError
-from . import LogManager
+from .platform.engine import clear_global_busy, show_global_busy
 from .util.login import get_current_user
 
 # Shotgun field definitions to store the path cache data

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -13,26 +13,19 @@ Encapsulates the pipeline configuration and helps navigate and resolve paths
 across storages, configurations etc.
 """
 
-import os
 import glob
+import os
 import pickle
 
 from tank_vendor import yaml
 
-from .errors import TankError, TankUnreadableFileError
-from .util.version import is_version_older
-from . import constants
-from .platform.environment import InstalledEnvironment, WritableEnvironment
-from .util import shotgun, yaml_cache
-from .util import ShotgunPath
-from .util import StorageRoots
-from .util.pickle import retrieve_env_var_pickled
-from . import hook
-from . import pipelineconfig_utils
-from . import template_includes
-from . import LogManager
-
+from . import LogManager, constants, hook, pipelineconfig_utils, template_includes
 from .descriptor import Descriptor, create_descriptor, descriptor_uri_to_dict
+from .errors import TankError, TankUnreadableFileError
+from .platform.environment import InstalledEnvironment, WritableEnvironment
+from .util import ShotgunPath, StorageRoots, shotgun, yaml_cache
+from .util.pickle import retrieve_env_var_pickled
+from .util.version import is_version_older
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/pipelineconfig_factory.py
+++ b/python/tank/pipelineconfig_factory.py
@@ -8,21 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import collections
+import os
 import pprint
 
-
+from . import LogManager, constants, pipelineconfig_utils
 from .errors import TankError, TankInitError
-from . import LogManager
-from .util import shotgun
-from .util import pickle
-from .util import filesystem
-from .util import ShotgunPath
-from . import constants
-from . import pipelineconfig_utils
 from .pipelineconfig import PipelineConfiguration
-from .util import LocalFileStorageManager
+from .util import LocalFileStorageManager, ShotgunPath, filesystem, pickle, shotgun
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/pipelineconfig_utils.py
+++ b/python/tank/pipelineconfig_utils.py
@@ -18,15 +18,10 @@ import os
 
 from tank_vendor import yaml
 
-from . import constants
-from . import LogManager
-
-from .util import yaml_cache
-from .util import StorageRoots
-from .util import ShotgunPath
-from .util.shotgun import get_deferred_sg_connection
-
+from . import LogManager, constants
 from .errors import TankError
+from .util import ShotgunPath, StorageRoots, yaml_cache
+from .util.shotgun import get_deferred_sg_connection
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/__init__.py
+++ b/python/tank/platform/__init__.py
@@ -9,28 +9,38 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
-# Engine management
-from .engine import start_engine, current_engine, get_engine_path, find_app_settings
-from .errors import (
-    TankEngineInitError,
-    TankUnresolvedEnvironmentError,
-    TankContextChangeNotSupportedError,
-    TankMissingEngineError,
-    TankMissingEnvironmentFile,
-)
-from .software_launcher import create_engine_launcher
+from . import events
 
 # base classes to derive from
 from .application import Application
-from .engine import Engine
-from .software_launcher import SoftwareLauncher, SoftwareVersion, LaunchInformation
+
+# Engine management
+from .engine import (
+    Engine,
+    current_engine,
+    find_app_settings,
+    get_engine_path,
+    start_engine,
+)
+from .errors import (
+    TankContextChangeNotSupportedError,
+    TankEngineInitError,
+    TankMissingEngineError,
+    TankMissingEnvironmentFile,
+    TankUnresolvedEnvironmentError,
+)
 from .framework import Framework
+from .software_launcher import (
+    LaunchInformation,
+    SoftwareLauncher,
+    SoftwareVersion,
+    create_engine_launcher,
+)
 from .util import (
     change_context,
-    get_framework,
-    import_framework,
     current_bundle,
-    restart,
+    get_framework,
     get_logger,
+    import_framework,
+    restart,
 )
-from . import events

--- a/python/tank/platform/application.py
+++ b/python/tank/platform/application.py
@@ -17,10 +17,9 @@ import os
 import sys
 
 from ..util.loader import load_plugin
-from . import constants
-
-from .bundle import TankBundle
 from ..util.metrics import EventMetric
+from . import constants
+from .bundle import TankBundle
 
 
 class Application(TankBundle):

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -14,47 +14,37 @@ Defines the base class for all Tank Engines.
 
 from __future__ import annotations  # required to support python 3.9
 
-import os
-import sys
-import logging
-import pprint
-import traceback
 import inspect
-import weakref
+import logging
+import os
+import pprint
+import sys
 import threading
+import traceback
+import weakref
 
-from tank.flowam import utils as flow_utils
 from tank.flowam import host as flow_host
+from tank.flowam import utils as flow_utils
 
-from ..util.qt_importer import QtImporter
-from ..util.loader import load_plugin
 from .. import hook
-
 from ..errors import TankError
+from ..log import LogManager
+from ..util import metrics_cache
+from ..util import sgre as re
+from ..util.loader import load_plugin
+from ..util.metrics import EventMetric, MetricsDispatcher
+from ..util.qt_importer import QtImporter
+from . import application, constants, events, qt, qt5, qt6, validation
+from .bundle import TankBundle
+from .engine_logging import ToolkitEngineHandler, ToolkitEngineLegacyHandler
 from .errors import (
-    TankEngineInitError,
-    TankUnresolvedEnvironmentError,
     TankContextChangeNotSupportedError,
     TankEngineEventError,
+    TankEngineInitError,
     TankMissingEngineError,
+    TankUnresolvedEnvironmentError,
 )
-
-from ..util import sgre as re
-from ..util.metrics import EventMetric
-from ..util.metrics import MetricsDispatcher
-from ..util import metrics_cache
-from ..log import LogManager
-
-from . import application
-from . import constants
-from . import validation
-from . import events
-from . import qt
-from . import qt5
-from . import qt6
-from .bundle import TankBundle
 from .framework import setup_frameworks
-from .engine_logging import ToolkitEngineHandler, ToolkitEngineLegacyHandler
 
 # std core level logger
 core_logger = LogManager.get_logger(__name__)
@@ -348,7 +338,7 @@ class Engine(TankBundle):
 
         if self.has_ui:
             # only import QT if we have a UI
-            from .qt import QtGui, QtCore
+            from .qt import QtCore, QtGui
 
             url = QtCore.QUrl.fromLocalFile(LogManager().log_folder)
             status = QtGui.QDesktopServices.openUrl(url)
@@ -436,8 +426,8 @@ class Engine(TankBundle):
         if self.has_ui:
             # we cannot import QT until here as non-ui engines don't have QT defined.
             try:
+                from .qt import QtCore, QtGui
                 from .qt.busy_dialog import BusyDialog
-                from .qt import QtGui, QtCore
 
             except:
                 # QT import failed. This may be because someone has upgraded the core
@@ -1236,7 +1226,7 @@ class Engine(TankBundle):
             self._invoker if invoker_id == self._SYNC_INVOKER else self._async_invoker
         )
         if invoker:
-            from .qt import QtGui, QtCore
+            from .qt import QtCore, QtGui
 
             if (
                 QtGui.QApplication.instance()
@@ -1722,7 +1712,8 @@ class Engine(TankBundle):
             self.logger.exception(exc)
 
             import traceback
-            from sgtk.platform.qt import QtGui, QtCore
+
+            from sgtk.platform.qt import QtCore, QtGui
 
             # A very simple widget that ensures that the exception is visible and
             # selectable should the user need to copy/paste it into a support
@@ -2484,7 +2475,7 @@ class Engine(TankBundle):
         invoker = None
         async_invoker = None
         if self.has_ui:
-            from .qt import QtGui, QtCore
+            from .qt import QtCore, QtGui
 
             # Classes are defined locally since Qt might not be available.
             if QtGui and QtCore:

--- a/python/tank/platform/environment.py
+++ b/python/tank/platform/environment.py
@@ -13,19 +13,18 @@ Environment Settings Object and access.
 
 """
 
+import copy
 import os
 import sys
-import copy
 
 from tank_vendor import yaml
-from .bundle import resolve_default_value
-from . import constants
-from . import environment_includes
-from ..errors import TankError, TankUnreadableFileError
-from .errors import TankMissingEnvironmentFile
 
-from ..util.yaml_cache import g_yaml_cache
 from .. import LogManager
+from ..errors import TankError, TankUnreadableFileError
+from ..util.yaml_cache import g_yaml_cache
+from . import constants, environment_includes
+from .bundle import resolve_default_value
+from .errors import TankMissingEnvironmentFile
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -27,20 +27,18 @@ relative paths are always required and context based paths are always optional.
 
 """
 
+import copy
 import os
 import sys
-import copy
 
 from ..errors import TankError
+from ..log import LogManager
 from ..template import TemplatePath
 from ..templatekey import StringKey
-from ..log import LogManager
-
-from . import constants
-
 from ..util import sgre as re
-from ..util.yaml_cache import g_yaml_cache
 from ..util.includes import resolve_include
+from ..util.yaml_cache import g_yaml_cache
+from . import constants
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/platform/events/__init__.py
+++ b/python/tank/platform/events/__init__.py
@@ -9,5 +9,5 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .event_engine import EngineEvent
-from .event_file_open import FileOpenEvent
 from .event_file_close import FileCloseEvent
+from .event_file_open import FileOpenEvent

--- a/python/tank/platform/framework.py
+++ b/python/tank/platform/framework.py
@@ -15,12 +15,10 @@ Defines the base class for all Tank Frameworks.
 
 import os
 
-from ..util.loader import load_plugin
-from . import constants
-
 from ..errors import TankError
+from ..util.loader import load_plugin
+from . import constants, validation
 from .bundle import TankBundle
-from . import validation
 
 
 class Framework(TankBundle):

--- a/python/tank/platform/qt/config_item.py
+++ b/python/tank/platform/qt/config_item.py
@@ -12,10 +12,10 @@ import os
 import shutil
 import sys
 
-from . import QtCore, QtGui
-from .ui_item import Ui_Item
 from ..bundle import resolve_default_value
 from ..engine import current_engine
+from . import QtCore, QtGui
+from .ui_item import Ui_Item
 
 
 class ConfigItem(QtGui.QWidget):

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -13,18 +13,14 @@ Default implementation for the Tank Dialog
 
 """
 
-from . import QtCore, QtGui
-from . import ui_tank_dialog
-from . import TankDialogBase
-from .config_item import ConfigItem
-from .. import engine
-from .. import application
-from .. import constants
-from ...errors import TankError
-
-import sys
-import os
 import inspect
+import os
+import sys
+
+from ...errors import TankError
+from .. import application, constants, engine
+from . import QtCore, QtGui, TankDialogBase, ui_tank_dialog
+from .config_item import ConfigItem
 
 
 class TankQDialog(TankDialogBase):

--- a/python/tank/platform/software_launcher.py
+++ b/python/tank/platform/software_launcher.py
@@ -13,20 +13,18 @@ Defines the base class for DCC application launchers all Toolkit engines
 should implement.
 """
 
-import os
-import sys
 import glob
+import os
 import pprint
+import sys
 
 from ..errors import TankError
 from ..log import LogManager
+from ..util import ShotgunPath, is_windows
+from ..util import sgre as re
 from ..util.loader import load_plugin
 from ..util.version import is_version_older
-from ..util import ShotgunPath, is_windows, sgre as re
-
-from . import constants
-from . import validation
-
+from . import constants, validation
 from .bundle import resolve_setting_value
 from .engine import get_env_and_descriptor_for_engine
 

--- a/python/tank/platform/util.py
+++ b/python/tank/platform/util.py
@@ -10,11 +10,11 @@
 
 import logging
 
-from .import_stack import ImportStack
 from ..errors import TankError
-from .errors import TankContextChangeNotSupportedError, TankCurrentModuleNotFoundError
-from .engine import current_engine, _restart_engine
 from ..log import LogManager
+from .engine import _restart_engine, current_engine
+from .errors import TankContextChangeNotSupportedError, TankCurrentModuleNotFoundError
+from .import_stack import ImportStack
 
 
 def _get_current_bundle():

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -16,12 +16,12 @@ App configuration and schema validation.
 import os
 import sys
 
-from . import constants
 from ..errors import TankError, TankNoDefaultValueError
-from ..template import TemplateString
-from .bundle import resolve_default_value
-from ..util.version import is_version_older, is_version_number
 from ..log import LogManager
+from ..template import TemplateString
+from ..util.version import is_version_number, is_version_older
+from . import constants
+from .bundle import resolve_default_value
 
 # We're potentially running here in an environment with
 # no engine available via current_engine(), so we'll have

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -16,11 +16,12 @@ Management of file and directory templates.
 import os
 import sys
 
-from . import templatekey
+from tank.util import is_linux, is_macos, is_windows
+from tank.util import sgre as re
+
+from . import constants, templatekey
 from .errors import TankError
-from . import constants
 from .template_path_parser import TemplatePathParser
-from tank.util import is_linux, is_macos, is_windows, sgre as re
 
 
 class Template(object):

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -30,8 +30,8 @@ c:\foo\bar\hello.yml - absolute path, windows
 
 import os
 
-from .errors import TankError
 from . import constants
+from .errors import TankError
 from .util import yaml_cache
 from .util.includes import resolve_include
 

--- a/python/tank/template_path_parser.py
+++ b/python/tank/template_path_parser.py
@@ -13,6 +13,7 @@ Parsing of template paths into values for specified keys using a list of static 
 """
 
 import os
+
 from .errors import TankError
 
 

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -12,9 +12,10 @@
 Classes for fields on TemplatePaths and TemplateStrings
 """
 
-import sys
 import collections.abc
 import datetime
+import sys
+
 from . import constants
 from .errors import TankError
 from .util import sgre as re

--- a/python/tank/util/__init__.py
+++ b/python/tank/util/__init__.py
@@ -8,51 +8,42 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .platforms import is_windows, is_linux, is_macos
-from .shotgun import register_publish
-from .shotgun import resolve_publish_path
-from .shotgun import find_publish
-from .shotgun import download_url
-from .shotgun import create_event_log_entry
-from .shotgun import get_entity_type_display_name
-from .shotgun import get_published_file_entity_type
-
-from .version import (
-    is_version_older,
-    is_version_newer,
-    is_version_older_or_equal,
-    is_version_newer_or_equal,
-    suppress_known_deprecation,
-    version_parse,
+from . import filesystem, json, pickle
+from .environment import append_path_to_env_var, prepend_path_to_env_var
+from .errors import (
+    EnvironmentVariableFileLookupError,
+    PublishPathNotDefinedError,
+    PublishPathNotSupported,
+    PublishResolveError,
+    ShotgunAttachmentDownloadError,
+    ShotgunPublishError,
+    UnresolvableCoreConfigurationError,
 )
-
-from .shotgun_entity import get_sg_entity_name_field
-
-from .environment import append_path_to_env_var
-from .environment import prepend_path_to_env_var
-
-from .login import get_shotgun_user
-from .login import get_current_user
+from .local_file_storage import LocalFileStorageManager
+from .login import get_current_user, get_shotgun_user
 
 # DO keep the following two log_user_*_metric to preserve retro
 # compatibility and prevent exception in legacy engine code.
-from .metrics import log_user_activity_metric
-from .metrics import log_user_attribute_metric
-from .metrics import EventMetric
+from .metrics import EventMetric, log_user_activity_metric, log_user_attribute_metric
+from .platforms import is_linux, is_macos, is_windows
+from .shotgun import (
+    create_event_log_entry,
+    download_url,
+    find_publish,
+    get_entity_type_display_name,
+    get_published_file_entity_type,
+    register_publish,
+    resolve_publish_path,
+)
+from .shotgun_entity import get_sg_entity_name_field
 from .shotgun_path import ShotgunPath
-
-from . import filesystem
-from . import pickle
-from . import json
-
-from .local_file_storage import LocalFileStorageManager
-
-from .errors import PublishResolveError
-from .errors import UnresolvableCoreConfigurationError, ShotgunAttachmentDownloadError
-from .errors import EnvironmentVariableFileLookupError, ShotgunPublishError
-from .errors import PublishResolveError
-from .errors import PublishPathNotDefinedError, PublishPathNotSupported
-
-from .user_settings import UserSettings
-
 from .storage_roots import StorageRoots
+from .user_settings import UserSettings
+from .version import (
+    is_version_newer,
+    is_version_newer_or_equal,
+    is_version_older,
+    is_version_older_or_equal,
+    suppress_known_deprecation,
+    version_parse,
+)

--- a/python/tank/util/environment.py
+++ b/python/tank/util/environment.py
@@ -13,6 +13,7 @@ Helper methods that do environment management
 """
 
 import os
+
 from .platforms import is_windows
 
 

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -11,15 +11,15 @@
 Utility methods for manipulating files and folders
 """
 
+import datetime
+import errno
+import functools
 import os
 import re
-import sys
-import errno
-import stat
 import shutil
-import datetime
-import functools
+import stat
 import subprocess
+import sys
 from contextlib import contextmanager
 
 from .. import LogManager

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -8,14 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import sys
-import posixpath
 import ntpath
+import os
+import posixpath
+import sys
 
-from .shotgun_path import ShotgunPath
-from .platforms import is_windows
 from ..errors import TankError
+from .platforms import is_windows
+from .shotgun_path import ShotgunPath
 
 
 def _is_abs(path):

--- a/python/tank/util/json.py
+++ b/python/tank/util/json.py
@@ -14,8 +14,9 @@ Utility methods for unserializing JSON documents.
 # We need to add this to the file or the import json will reimport this
 # module instead of importing the global json module.
 from __future__ import absolute_import
-import sys
+
 import json
+import sys
 
 from .unicode import ensure_contains_str
 

--- a/python/tank/util/loader.py
+++ b/python/tank/util/loader.py
@@ -13,13 +13,13 @@ Methods for loading and managing plugins, e.g. Apps, Engines, Hooks etc.
 
 """
 
-import sys
 import importlib.util
-import traceback
 import inspect
+import sys
+import traceback
 
-from ..errors import TankError
 from .. import LogManager
+from ..errors import TankError
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/metrics_cache.py
+++ b/python/tank/util/metrics_cache.py
@@ -29,9 +29,8 @@ import hashlib
 import json
 import os
 
-from . import metrics
-
 from .. import LogManager
+from . import metrics
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/util/process.py
+++ b/python/tank/util/process.py
@@ -8,11 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import subprocess
 import pprint
+import subprocess
 
-from .platforms import is_windows
 from ..log import LogManager
+from .platforms import is_windows
 
 logger = LogManager.get_logger(__name__)
 

--- a/python/tank/util/pyside2_patcher.py
+++ b/python/tank/util/pyside2_patcher.py
@@ -12,10 +12,10 @@
 PySide 2 backwards compatibility layer for use with PySide 1 code.
 """
 
-import os
-import sys
 import functools
+import os
 import subprocess
+import sys
 import types
 import warnings
 import webbrowser

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -498,8 +498,8 @@ class PySide6Patcher(PySide2Patcher):
         from PySide6 import (
             QtCore,
             QtGui,
-            QtWidgets,
             QtOpenGL,
+            QtWidgets,
         )
 
         # First create new modules to act as the PySide modules

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -158,8 +158,8 @@ class QtImporter(object):
         # throw an import error which will be handled by the calling code. Note that PySide2 can be
         # imported even if the Qt binaries are missing, so it's better to try importing QtCore for
         # testing.
-        from PySide2 import QtCore
         import shiboken2
+        from PySide2 import QtCore
 
         # List of all Qt 5 modules.
         sub_modules = [
@@ -233,8 +233,9 @@ class QtImporter(object):
         :returns: The (binding name, binding version, modules) tuple.
         """
         import PySide2
-        from PySide2 import QtCore, QtGui, QtWidgets
         import shiboken2
+        from PySide2 import QtCore, QtGui, QtWidgets
+
         from .pyside2_patcher import PySide2Patcher
 
         QtCore, QtGui = PySide2Patcher.patch(QtCore, QtGui, QtWidgets, PySide2)
@@ -268,6 +269,7 @@ class QtImporter(object):
 
         import PySide6
         import shiboken6
+
         from .pyside6_patcher import PySide6Patcher
 
         QtWebEngineWidgets, QtWebEngineCore = None, None

--- a/python/tank/util/sgre.py
+++ b/python/tank/util/sgre.py
@@ -13,28 +13,28 @@ Wrapper around the re module from Python. We're essentially back porting
 some functionality.
 """
 
-# Import constants and functions that won't be wrapped
-from re import (
-    DEBUG,
-    I,
-    IGNORECASE,
-    L,
-    LOCALE,  # noqa import into namespace
-    M,
-    MULTILINE,
-    S,
-    DOTALL,
-    U,
-    UNICODE,
-    X,
-    VERBOSE,
-)
-from re import escape  # noqa import into namespace
-
 # For Python 3, we'll wrap the re functions to inject the ASCII flag when necessary
 # to maintain the previous behavior.
 import re as _re
 import typing as _typing
+
+# Import constants and functions that won't be wrapped
+from re import LOCALE  # noqa import into namespace
+from re import escape  # noqa import into namespace
+from re import (
+    DEBUG,
+    DOTALL,
+    IGNORECASE,
+    MULTILINE,
+    UNICODE,
+    VERBOSE,
+    I,
+    L,
+    M,
+    S,
+    U,
+    X,
+)
 
 
 def _re_wrap(fn, flags_arg_position):

--- a/python/tank/util/shotgun/__init__.py
+++ b/python/tank/util/shotgun/__init__.py
@@ -10,25 +10,23 @@
 
 
 from .connection import (
-    get_project_name_studio_hook_location,
+    create_sg_connection,
     get_associated_sg_base_url,
     get_associated_sg_config_data,
     get_deferred_sg_connection,
+    get_project_name_studio_hook_location,
     get_sg_connection,
-    create_sg_connection,
 )
-
-from .publish_util import (
-    get_entity_type_display_name,
-    find_publish,
-    create_event_log_entry,
-    get_published_file_entity_type,
-)
-
-from .publish_creation import register_publish
-from .publish_resolve import resolve_publish_path
 from .download import (
-    download_url,
     download_and_unpack_attachment,
     download_and_unpack_url,
+    download_url,
+)
+from .publish_creation import register_publish
+from .publish_resolve import resolve_publish_path
+from .publish_util import (
+    create_event_log_entry,
+    find_publish,
+    get_entity_type_display_name,
+    get_published_file_entity_type,
 )

--- a/python/tank/util/shotgun/publish_util.py
+++ b/python/tank/util/shotgun/publish_util.py
@@ -13,9 +13,8 @@ Utility methods related to Published Files in Shotgun
 """
 
 from ...log import LogManager
+from .. import constants, login
 from ..shotgun_path import ShotgunPath
-from .. import constants
-from .. import login
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/shotgun_entity.py
+++ b/python/tank/util/shotgun_entity.py
@@ -12,8 +12,9 @@
 Utilities relating to Shotgun entities
 """
 
-from . import constants, sgre as re
 from ..errors import TankError
+from . import constants
+from . import sgre as re
 
 # A dictionary for Shotgun entities which do not store their name
 # in the standard "code" field.

--- a/python/tank/util/shotgun_path.py
+++ b/python/tank/util/shotgun_path.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
+
 from .platforms import is_linux, is_macos, is_windows
 
 

--- a/python/tank/util/storage_roots.py
+++ b/python/tank/util/storage_roots.py
@@ -14,10 +14,7 @@ from tank_vendor import yaml
 
 from .. import LogManager
 from ..errors import TankError
-
-from . import filesystem
-from . import ShotgunPath
-from . import yaml_cache
+from . import ShotgunPath, filesystem, yaml_cache
 
 log = LogManager.get_logger(__name__)
 

--- a/python/tank/util/user_settings.py
+++ b/python/tank/util/user_settings.py
@@ -15,9 +15,9 @@ User settings management.
 import configparser
 import os
 
-from .local_file_storage import LocalFileStorageManager
-from .errors import EnvironmentVariableFileLookupError, TankError
 from .. import LogManager
+from .errors import EnvironmentVariableFileLookupError, TankError
+from .local_file_storage import LocalFileStorageManager
 from .singleton import Singleton
 from .system_settings import SystemSettings
 

--- a/python/tank/util/yaml_cache.py
+++ b/python/tank/util/yaml_cache.py
@@ -13,12 +13,13 @@ Implements a caching mechanism to avoid loading the same yaml file multiple time
 unless it's changed on disk.
 """
 
-import os
 import copy
+import os
 import threading
 
 from tank_vendor import yaml
-from ..errors import TankError, TankUnreadableFileError, TankFileDoesNotExistError
+
+from ..errors import TankError, TankFileDoesNotExistError, TankUnreadableFileError
 
 
 class CacheItem(object):

--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -10,8 +10,9 @@
 
 import os
 import zipfile
-from . import filesystem
+
 from .. import LogManager
+from . import filesystem
 
 log = LogManager.get_logger(__name__)
 

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -8,36 +8,36 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
-import os
-from html import escape
-import logging
-import string
-import tank
-import textwrap
 import datetime
+import logging
+import os
+import string
+import sys
+import textwrap
+from html import escape
 
-from tank.errors import TankError, TankInitError
-from tank.commands.tank_command import get_actions, run_action
+import tank
+from tank import LogManager, pipelineconfig_utils
+from tank.authentication import (
+    AuthenticationCancelled,
+    AuthenticationError,
+    CoreDefaultsManager,
+    IncompleteCredentials,
+    ShotgunAuthenticationError,
+    ShotgunAuthenticator,
+)
+from tank.commands import constants as command_constants
+from tank.commands.action_base import Action
 from tank.commands.clone_configuration import clone_pipeline_configuration_html
 from tank.commands.core_upgrade import TankCoreUpdater
-from tank.commands.action_base import Action
-from tank.util import shotgun
-from tank.util import shotgun_entity
+from tank.commands.tank_command import get_actions, run_action
+from tank.errors import TankError, TankInitError
+from tank.platform import constants as platform_constants
+from tank.platform import engine
 from tank.util import is_windows
 from tank.util import sgre as re
-from tank.platform import constants as platform_constants
-from tank.authentication import ShotgunAuthenticator
-from tank.authentication import AuthenticationError
-from tank.authentication import ShotgunAuthenticationError
-from tank.authentication import AuthenticationCancelled
-from tank.authentication import IncompleteCredentials
-from tank.authentication import CoreDefaultsManager
-from tank.commands import constants as command_constants
+from tank.util import shotgun, shotgun_entity
 from tank_vendor import yaml
-from tank.platform import engine
-from tank import pipelineconfig_utils
-from tank import LogManager
 
 # the logger used by this file is sgtk.tank_cmd
 logger = LogManager.get_logger("tank_cmd")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
 
 

--- a/tests/authentication_tests/test_adsk_auth_file_store.py
+++ b/tests/authentication_tests/test_adsk_auth_file_store.py
@@ -15,7 +15,6 @@ import tempfile
 import unittest
 
 from tank_test.tank_test_base import setUpModule  # noqa
-
 from tank_vendor.adsk_auth import file_store
 
 

--- a/tests/authentication_tests/test_auth_settings.py
+++ b/tests/authentication_tests/test_auth_settings.py
@@ -12,17 +12,14 @@
 Tests settings retrieval through the DefaultsManager
 """
 
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
-from tank_test.tank_test_base import setUpModule  # noqa
-
-from tank.authentication import CoreDefaultsManager
-from tank.authentication import DefaultsManager
-from tank.util.user_settings import UserSettings
 import sgtk
+from tank.authentication import CoreDefaultsManager, DefaultsManager
+from tank.util.user_settings import UserSettings
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 
 
 class DefaultsManagerTest(ShotgunTestBase):

--- a/tests/authentication_tests/test_authentication_backwards_compatibility.py
+++ b/tests/authentication_tests/test_authentication_backwards_compatibility.py
@@ -12,8 +12,8 @@
 Unit tests for interactive authentication.
 """
 
-from unittest import TestCase
 import logging
+from unittest import TestCase
 
 from tank_vendor import shotgun_authentication
 

--- a/tests/authentication_tests/test_flow_auth.py
+++ b/tests/authentication_tests/test_flow_auth.py
@@ -12,12 +12,11 @@ import base64
 import json
 import time
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import mock, ShotgunTestBase
-
 from tank.authentication import flow_auth
 from tank.authentication.flow_auth import _authentication as flow_auth_impl
 from tank.authentication.flow_auth.errors import FlowAuthConfigurationError
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase, mock
 
 
 def _make_jwt(payload):

--- a/tests/authentication_tests/test_interactive_authentication.py
+++ b/tests/authentication_tests/test_interactive_authentication.py
@@ -13,40 +13,40 @@ Unit tests for interactive authentication.
 """
 
 import contextlib
-
-import sys
 import os
+import sys
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    ShotgunTestBase,
-    skip_if_pyside_missing,
-    interactive,
-    mock,
-    suppress_generated_code_qt_warnings,
-)
+import tank
+import tank_vendor.shotgun_api3
 from tank.authentication import (
-    console_authentication,
     ConsoleLoginNotSupportedError,
     ConsoleLoginWithSSONotSupportedError,
-    constants as auth_constants,
+    console_authentication,
+)
+from tank.authentication import constants as auth_constants
+from tank.authentication import (
     errors,
     interactive_authentication,
     invoker,
-    user_impl,
     site_info,
-)
-from tank.authentication.utils import sanitize_http_proxy
-from tank.authentication.sso_saml2.core.sso_saml2_core import (
-    SsoSaml2Core,
-    get_renew_path,
+    user_impl,
 )
 from tank.authentication.sso_saml2.core.authentication_session_data import (
     AuthenticationSessionData,
 )
-
-import tank
-import tank_vendor.shotgun_api3
+from tank.authentication.sso_saml2.core.sso_saml2_core import (
+    SsoSaml2Core,
+    get_renew_path,
+)
+from tank.authentication.utils import sanitize_http_proxy
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    interactive,
+    mock,
+    skip_if_pyside_missing,
+    suppress_generated_code_qt_warnings,
+)
 
 
 @skip_if_pyside_missing
@@ -585,7 +585,7 @@ class InteractiveTests(ShotgunTestBase):
         Make sure that the site and user fields are disabled when doing session renewal
         """
 
-        from tank.authentication.ui.qt_abstraction import QtGui, QtCore
+        from tank.authentication.ui.qt_abstraction import QtCore, QtGui
 
         # Test window close event
         with self._login_dialog() as ld:

--- a/tests/authentication_tests/test_saml_sso_core_utils.py
+++ b/tests/authentication_tests/test_saml_sso_core_utils.py
@@ -10,10 +10,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from tank.authentication.sso_saml2.core.utils import _encode_cookies, get_user_name
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
-
-from tank.authentication.sso_saml2.core.utils import get_user_name, _encode_cookies
 
 
 class SamlSsoCoreUtilsTests(ShotgunTestBase):

--- a/tests/authentication_tests/test_session_cache.py
+++ b/tests/authentication_tests/test_session_cache.py
@@ -10,15 +10,13 @@
 
 import os
 
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
-from tank_test.tank_test_base import setUpModule  # noqa
-
 from tank.authentication import session_cache
 from tank.util import LocalFileStorageManager
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 from tank_vendor import yaml
 
 

--- a/tests/authentication_tests/test_shotgun_authenticator.py
+++ b/tests/authentication_tests/test_shotgun_authenticator.py
@@ -8,22 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import base64
-
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
-from tank_test.tank_test_base import setUpModule  # noqa
+import os
 
 from tank.authentication import (
-    ShotgunAuthenticator,
-    IncompleteCredentials,
     DefaultsManager,
-    user_impl,
+    IncompleteCredentials,
+    ShotgunAuthenticator,
     user,
+    user_impl,
+)
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
 )
 
 # Create a set of valid cookies, for SSO and Web related tests.

--- a/tests/authentication_tests/test_shotgun_wrapper.py
+++ b/tests/authentication_tests/test_shotgun_wrapper.py
@@ -8,16 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
+from tank.authentication import ShotgunAuthenticationError, user_impl
 from tank_test.tank_test_base import setUpModule  # noqa
-
-
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 from tank_vendor.shotgun_api3 import AuthenticationFault
-from tank.authentication import user_impl, ShotgunAuthenticationError
 
 
 class ShotgunWrapperTests(ShotgunTestBase):

--- a/tests/authentication_tests/test_user.py
+++ b/tests/authentication_tests/test_user.py
@@ -11,15 +11,14 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import base64
-import pytest
 
+import pytest
+from tank.authentication import errors, user, user_impl
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
 )
-
-from tank.authentication import user, user_impl, errors
 from tank_vendor.shotgun_api3 import AuthenticationFault
 
 # Create a set of valid cookies, for SSO and Web related tests.

--- a/tests/authentication_tests/test_web_login.py
+++ b/tests/authentication_tests/test_web_login.py
@@ -10,14 +10,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from tank.authentication.sso_saml2.sso_saml2_toolkit import SsoSaml2Toolkit
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,
     only_run_on_nix,
     skip_if_pyside_missing,
 )
-
-from tank.authentication.sso_saml2.sso_saml2_toolkit import SsoSaml2Toolkit
 
 
 @only_run_on_nix  # This test issues a seg-fault on Windows

--- a/tests/bootstrap_tests/test_backups.py
+++ b/tests/bootstrap_tests/test_backups.py
@@ -8,18 +8,18 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import fnmatch
+import os
 import stat
+from shutil import copytree
+
 import sgtk
 from sgtk.pipelineconfig_utils import get_metadata
 from tank.util import is_windows
-from shutil import copytree
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
     temp_env_var,
 )
 

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -8,24 +8,23 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import uuid
 import os
 import sys
+import uuid
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-    TankTestBase,
-)
-
-from tank.bootstrap import constants
-from sgtk.bootstrap.cached_configuration import CachedConfiguration
-from sgtk.bootstrap.configuration import Configuration
-from sgtk.authentication import ShotgunAuthenticator, ShotgunSamlUser
-from sgtk.authentication.user_impl import SessionUser
 import sgtk
 import tank_vendor
+from sgtk.authentication import ShotgunAuthenticator, ShotgunSamlUser
+from sgtk.authentication.user_impl import SessionUser
+from sgtk.bootstrap.cached_configuration import CachedConfiguration
+from sgtk.bootstrap.configuration import Configuration
+from tank.bootstrap import constants
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    TankTestBase,
+    mock,
+)
 from tank_vendor import yaml
 
 REPO_ROOT = os.path.normpath(

--- a/tests/bootstrap_tests/test_configuration_writer.py
+++ b/tests/bootstrap_tests/test_configuration_writer.py
@@ -11,16 +11,15 @@
 import os
 import sys
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
 import sgtk
 from sgtk.bootstrap.configuration_writer import ConfigurationWriter
 from sgtk.util import ShotgunPath
 from tank.util import is_macos, is_windows
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 from tank_vendor import yaml
 
 

--- a/tests/bootstrap_tests/test_import_handler.py
+++ b/tests/bootstrap_tests/test_import_handler.py
@@ -9,15 +9,14 @@
 # not expressly granted therein are reserved by Autodesk.
 
 import os
-import sys
-import types
-import tempfile
 import shutil
-
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase
+import sys
+import tempfile
+import types
 
 from tank.bootstrap.import_handler import CoreImportHandler
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
 
 # creates a unique object instance that can never collide with any real value.
 _SENTINEL = object()

--- a/tests/bootstrap_tests/test_manager.py
+++ b/tests/bootstrap_tests/test_manager.py
@@ -11,14 +11,12 @@
 import os
 
 import sgtk
-
 from sgtk.bootstrap import ToolkitManager
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
     TankTestBase,
+    mock,
     temp_env_var,
 )
 

--- a/tests/bootstrap_tests/test_manager_flow_auth.py
+++ b/tests/bootstrap_tests/test_manager_flow_auth.py
@@ -12,14 +12,12 @@ import os
 
 from sgtk.bootstrap import ToolkitManager
 from sgtk.bootstrap.errors import TankBootstrapError
-
 from tank.authentication import flow_auth
 from tank.flowam import constants as flow_const
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
     temp_env_var,
 )
 

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -11,15 +11,15 @@
 import itertools
 import os
 import sys
+
 import sgtk
 from sgtk.util import ShotgunPath
-
+from tank.bootstrap import constants
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-from tank.bootstrap import constants
 
 
 class TestResolverBase(TankTestBase):

--- a/tests/commands_tests/test_core_update.py
+++ b/tests/commands_tests/test_core_update.py
@@ -14,15 +14,13 @@ Unit tests tank core update.
 
 import logging
 
+from sgtk.pipelineconfig_utils import get_core_descriptor
+from tank_test.mock_appstore import patch_app_store
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-
-from sgtk.pipelineconfig_utils import get_core_descriptor
-
-from tank_test.mock_appstore import patch_app_store
 
 
 # We need to patch the currently running core API version, as this will

--- a/tests/commands_tests/test_pipeconfig.py
+++ b/tests/commands_tests/test_pipeconfig.py
@@ -13,21 +13,19 @@ Unit tests tank pipeline configs.
 """
 
 import os
-import tempfile
 import shutil
 import stat
+import tempfile
 
 import sgtk
 from tank.errors import TankError
 from tank.util import is_windows
-
+from tank_test.mock_appstore import patch_app_store
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-
-from tank_test.mock_appstore import patch_app_store
 
 
 class TestPipelineConfig(TankTestBase):

--- a/tests/commands_tests/test_project_wizard.py
+++ b/tests/commands_tests/test_project_wizard.py
@@ -14,15 +14,13 @@ Unit tests tank updates.
 
 import datetime
 import os
+
 import sgtk
-
 from sgtk.util import ShotgunPath
-
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
 
 

--- a/tests/commands_tests/test_setupproject.py
+++ b/tests/commands_tests/test_setupproject.py
@@ -12,18 +12,17 @@
 Unit tests tank setup_project.
 """
 
-import os
 import logging
+import os
 
 import tank
 from tank.util import is_linux, is_macos, is_windows
+from tank_test.mock_appstore import patch_app_store
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-
-from tank_test.mock_appstore import patch_app_store
 
 
 class TestSetupProject(TankTestBase):

--- a/tests/commands_tests/test_updates.py
+++ b/tests/commands_tests/test_updates.py
@@ -12,15 +12,13 @@
 Unit tests tank updates.
 """
 
+import logging
 import os
 import sys
-import logging
-
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 
 from tank.platform.environment import InstalledEnvironment
-
 from tank_test.mock_appstore import TankMockStoreDescriptor, patch_app_store
+from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 
 
 class TestSimpleUpdates(TankTestBase):

--- a/tests/commands_tests/test_validate.py
+++ b/tests/commands_tests/test_validate.py
@@ -14,9 +14,8 @@ Unit tests tank validate.
 
 import logging
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
-
 from tank_test.mock_appstore import patch_app_store
+from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 
 
 class TestSimpleValidate(TankTestBase):

--- a/tests/core_tests/test_api.py
+++ b/tests/core_tests/test_api.py
@@ -13,12 +13,11 @@ import os
 import tank
 from tank.api import Tank
 from tank.template import TemplatePath, TemplateString
-from tank.templatekey import StringKey, IntegerKey, SequenceKey
-
+from tank.templatekey import IntegerKey, SequenceKey, StringKey
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
 
 

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -10,25 +10,24 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
 import datetime
-from sgtk.util import pickle
 import json
-
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    TankTestBase,
-)
+import os
 
 import tank
+from sgtk.util import pickle
 from tank import context
-from tank.errors import TankError, TankContextDeserializationError
-from tank.template import TemplatePath
-from tank.templatekey import StringKey, IntegerKey
-from tank_vendor import yaml
 from tank.authentication import ShotgunAuthenticator
+from tank.errors import TankContextDeserializationError, TankError
+from tank.template import TemplatePath
+from tank.templatekey import IntegerKey, StringKey
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    TankTestBase,
+    mock,
+)
+from tank_vendor import yaml
 
 USER_NAME = "Üser Ñâme AñoVolvió JiříVyčítal"
 

--- a/tests/core_tests/test_default_storage_root_hook.py
+++ b/tests/core_tests/test_default_storage_root_hook.py
@@ -12,11 +12,10 @@ import os
 
 import tank
 from tank import TankError
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
 
 

--- a/tests/core_tests/test_default_storage_root_hook/example3/default_storage_root.py
+++ b/tests/core_tests/test_default_storage_root_hook/example3/default_storage_root.py
@@ -1,6 +1,6 @@
 import os
-import sgtk
 
+import sgtk
 from tank import Hook
 from tank.util.storage_roots import StorageRoots
 

--- a/tests/core_tests/test_hook.py
+++ b/tests/core_tests/test_hook.py
@@ -10,10 +10,9 @@
 
 import sys
 
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
-from tank.util import is_windows
-
 import sgtk
+from tank.util import is_windows
+from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 
 
 class TestHookProperties(TankTestBase):

--- a/tests/core_tests/test_includes.py
+++ b/tests/core_tests/test_includes.py
@@ -8,21 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import itertools
+import os
 import sys
 
 import tank
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-    temp_env_var,
-)
-
-from tank.template_includes import _get_includes as get_template_includes
 from tank.platform.environment_includes import (
     _resolve_includes as get_environment_includes,
+)
+from tank.template_includes import _get_includes as get_template_includes
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+    temp_env_var,
 )
 
 

--- a/tests/core_tests/test_log.py
+++ b/tests/core_tests/test_log.py
@@ -9,15 +9,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
 import sgtk
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
 )
 
 

--- a/tests/core_tests/test_pipeline_configuration.py
+++ b/tests/core_tests/test_pipeline_configuration.py
@@ -8,23 +8,22 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import logging
+import os
 import shutil
 
+import tank
+from tank.bootstrap.configuration_writer import ConfigurationWriter
+from tank.commands import get_command
+from tank.descriptor import Descriptor, create_descriptor
+from tank.util import ShotgunPath, is_linux, is_macos, is_windows
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
     temp_env_var,
 )
-
-import tank
-from tank.commands import get_command
-from tank.bootstrap.configuration_writer import ConfigurationWriter
-from tank.descriptor import Descriptor, create_descriptor
 from tank_vendor import yaml
-from tank.util import ShotgunPath, is_linux, is_macos, is_windows
 
 
 class TestPipelineConfig(TankTestBase):

--- a/tests/core_tests/test_pipelineconfig_factory.py
+++ b/tests/core_tests/test_pipelineconfig_factory.py
@@ -11,19 +11,20 @@
 import os
 import pickle
 import sys
-from tank_vendor import yaml
+
 import sgtk
 import tank
-from tank.api import Tank
-from tank.util import is_windows
-from tank.errors import TankInitError
 from sgtk.util import ShotgunPath
+from tank.api import Tank
+from tank.errors import TankInitError
+from tank.util import is_windows
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
     TankTestBase,
+    mock,
 )
+from tank_vendor import yaml
 
 
 class TestTankFromPath(TankTestBase):

--- a/tests/core_tests/test_pipelineconfig_utils.py
+++ b/tests/core_tests/test_pipelineconfig_utils.py
@@ -9,26 +9,24 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import importlib.metadata
-import os
 import inspect
+import os
 import sys
 
 import sgtk
 import tank
-
-from tank import pipelineconfig_utils
 from tank import (
-    TankInvalidInterpreterLocationError,
     TankFileDoesNotExistError,
     TankInvalidCoreLocationError,
+    TankInvalidInterpreterLocationError,
     TankNotPipelineConfigurationError,
+    pipelineconfig_utils,
 )
 from tank.util import ShotgunPath, is_windows
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
     temp_env_var,
 )
 

--- a/tests/core_tests/test_root.py
+++ b/tests/core_tests/test_root.py
@@ -8,15 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
-
-from tank_vendor import yaml
-from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
+import os
 
 import tank
 from tank import TankError
 from tank.util import is_linux, is_macos, is_windows
+from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
+from tank_vendor import yaml
 
 
 class TestGetProjectRoots(TankTestBase):

--- a/tests/core_tests/test_template.py
+++ b/tests/core_tests/test_template.py
@@ -10,22 +10,27 @@
 
 import copy
 import os
-import time
 import sys
-
+import time
 import unittest
+
 import tank
 from tank import TankError
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule  # noqa
-from tank.template import Template, TemplatePath, TemplateString
-from tank.template import make_template_paths, make_template_strings
+from tank.template import (
+    Template,
+    TemplatePath,
+    TemplateString,
+    make_template_paths,
+    make_template_strings,
+)
 from tank.templatekey import (
-    TemplateKey,
-    StringKey,
     IntegerKey,
     SequenceKey,
+    StringKey,
+    TemplateKey,
     TimestampKey,
 )
+from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, setUpModule  # noqa
 
 
 class TestTemplate(unittest.TestCase):

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -12,18 +12,17 @@
 Tests for templatefield module.
 """
 
-from tank import TankError
 import copy
-import sys
 import datetime
+import sys
 
+from tank import TankError
+from tank.templatekey import IntegerKey, SequenceKey, StringKey, TimestampKey, make_keys
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
 )
-
-from tank.templatekey import StringKey, IntegerKey, SequenceKey, TimestampKey, make_keys
 
 
 class TestTemplateKey(ShotgunTestBase):

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -12,11 +12,10 @@ import os
 
 import tank
 from tank import TankError
-
 from tank.template import TemplatePath
-from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
-from tank.templatekey import StringKey, IntegerKey, SequenceKey
+from tank.templatekey import IntegerKey, SequenceKey, StringKey
 from tank.util import is_windows
+from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
 
 
 class TestTemplatePath(ShotgunTestBase):

--- a/tests/core_tests/test_templatestring.py
+++ b/tests/core_tests/test_templatestring.py
@@ -14,11 +14,10 @@ Tests of class TemplateString
 
 import os
 
-from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
-
 from tank.errors import TankError
 from tank.template import TemplateString
-from tank.templatekey import StringKey, IntegerKey
+from tank.templatekey import IntegerKey, StringKey
+from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
 
 
 class TestTemplateString(ShotgunTestBase):

--- a/tests/deploy_tests/test_descriptors.py
+++ b/tests/deploy_tests/test_descriptors.py
@@ -9,10 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import sgtk
 
-from tank_test.tank_test_base import *
+import sgtk
 from tank.errors import TankError
+from tank_test.tank_test_base import *
 
 
 class TestLegacyDescriptorSupport(TankTestBase):

--- a/tests/descriptor_tests/test_api.py
+++ b/tests/descriptor_tests/test_api.py
@@ -11,11 +11,11 @@
 import os
 import tempfile
 import uuid
+
 import sgtk
 import tank
-
-from tank_test.tank_test_base import ShotgunTestBase
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
 
 
 class TestApi(ShotgunTestBase):

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -12,22 +12,19 @@
 Unit tests tank updates.
 """
 
-import os
 import json
-
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
+import os
 
 import sgtk
-from sgtk.descriptor import Descriptor
+from sgtk.descriptor import Descriptor, create_descriptor
 from sgtk.descriptor.io_descriptor.base import IODescriptorBase
-from sgtk.descriptor import create_descriptor
-
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 
 
 class TestAppStoreLabels(ShotgunTestBase):

--- a/tests/descriptor_tests/test_descriptors.py
+++ b/tests/descriptor_tests/test_descriptors.py
@@ -9,34 +9,30 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import sgtk
-
 import unittest
 
+import sgtk
+from tank.descriptor import (
+    CheckVersionConstraintsError,
+    ConfigDescriptor,
+    CoreDescriptor,
+    Descriptor,
+    TankDescriptorError,
+    TankMissingManifestError,
+    create_descriptor,
+)
+from tank.descriptor.descriptor_installed_config import InstalledConfigDescriptor
+from tank.errors import TankError
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     SealedMock,
     ShotgunTestBase,
     TankTestBase,
+    mock,
 )
-
-
-from tank.errors import TankError
-from tank.descriptor import (
-    CheckVersionConstraintsError,
-    TankDescriptorError,
-    create_descriptor,
-    Descriptor,
-    TankMissingManifestError,
-    ConfigDescriptor,
-    CoreDescriptor,
-)
-from tank.descriptor.descriptor_installed_config import InstalledConfigDescriptor
-
-from tank_vendor.shotgun_api3.lib.mockgun import Shotgun as Mockgun
 from tank_vendor import yaml
 from tank_vendor.shotgun_api3.lib import httplib2
+from tank_vendor.shotgun_api3.lib.mockgun import Shotgun as Mockgun
 
 
 class TestCachedConfigDescriptor(ShotgunTestBase):

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -8,29 +8,28 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from functools import reduce
+import contextlib
 import multiprocessing
 import os
+import shutil
 import sys
 import tempfile
 import time
 import uuid
-import shutil
 import zipfile
-import contextlib
+from functools import reduce
+
 import pytest
-
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-    skip_if_git_missing,
-    temp_env_var,
-)
-
 import sgtk
 import tank
 from tank.util import is_windows
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+    skip_if_git_missing,
+    temp_env_var,
+)
 
 
 def _raise_exception(placeholder_a="default_a", placeholder_b="default_b"):

--- a/tests/descriptor_tests/test_io_descriptors.py
+++ b/tests/descriptor_tests/test_io_descriptors.py
@@ -10,10 +10,9 @@
 
 import os
 
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
-from tank_test.tank_test_base import setUpModule  # noqa
-
 import sgtk
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 
 
 class TestIODescriptors(ShotgunTestBase):

--- a/tests/descriptor_tests/test_shotgun.py
+++ b/tests/descriptor_tests/test_shotgun.py
@@ -11,11 +11,10 @@
 import os
 
 import sgtk
-
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
 )
 
 

--- a/tests/fixtures/config/bundles/test_engine/engine.py
+++ b/tests/fixtures/config/bundles/test_engine/engine.py
@@ -12,8 +12,9 @@
 A simple engine to support unit tests.
 """
 
-from tank.platform import Engine
 import sys
+
+from tank.platform import Engine
 
 
 class TestEngine(Engine):

--- a/tests/fixtures/config/bundles/test_engine/startup.py
+++ b/tests/fixtures/config/bundles/test_engine/startup.py
@@ -12,7 +12,7 @@ import os
 
 import sgtk
 from sgtk import TankError
-from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
+from sgtk.platform import LaunchInformation, SoftwareLauncher, SoftwareVersion
 
 
 class TestLauncher(SoftwareLauncher):

--- a/tests/fixtures/config/hooks/config_test_hook.py
+++ b/tests/fixtures/config/hooks/config_test_hook.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+
 from tank import Hook
 
 

--- a/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
+++ b/tests/fixtures/config/hooks/more_hooks/config_test_hook.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+
 import sgtk
 
 HookBaseClass = sgtk.get_hook_baseclass()

--- a/tests/fixtures/descriptor_tests/with_bootstrap_hook/core/hooks/bootstrap.py
+++ b/tests/fixtures/descriptor_tests/with_bootstrap_hook/core/hooks/bootstrap.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import importlib.util
+import os
 
 plugin_path = os.path.join(
     os.environ["TK_CORE_REPO_ROOT"], "docs", "examples", "bootstrap_hook.py"

--- a/tests/folder_tests/__init__.py
+++ b/tests/folder_tests/__init__.py
@@ -1,14 +1,12 @@
 import os
-import unittest
 import shutil
+import unittest
 
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank.path_cache import PathCache
 from tank_test.tank_test_base import *
+from tank_vendor import yaml
 
 ###############################################################################################
 # useful methods for folder creation tests.

--- a/tests/folder_tests/test_configuration.py
+++ b/tests/folder_tests/test_configuration.py
@@ -9,15 +9,14 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
+import unittest
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
+from tank_vendor import yaml
 
 
 class TestFolderConfiguration(TankTestBase):

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -11,13 +11,11 @@
 import copy
 import os
 import shutil
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import path_cache
-from tank import folder
+from tank import TankError, folder, hook, path_cache
 from tank_test.tank_test_base import *
+from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_deferred.py
+++ b/tests/folder_tests/test_deferred.py
@@ -10,12 +10,11 @@
 
 import os
 import shutil
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import *
+from tank_vendor import yaml
 
 
 class TestDeferredFolderCreation(TankTestBase):

--- a/tests/folder_tests/test_optional_fields.py
+++ b/tests/folder_tests/test_optional_fields.py
@@ -11,12 +11,11 @@
 import copy
 import os
 import shutil
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import *
+from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_secondary_entity.py
+++ b/tests/folder_tests/test_secondary_entity.py
@@ -10,13 +10,11 @@
 
 import os
 import shutil
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import path_cache
-from tank import folder
+from tank import TankError, folder, hook, path_cache
 from tank_test.tank_test_base import *
+from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_static_filter.py
+++ b/tests/folder_tests/test_static_filter.py
@@ -10,12 +10,11 @@
 
 import os
 import shutil
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import TankTestBase
+from tank_vendor import yaml
 
 
 class TestStaticFolderFilters(TankTestBase):

--- a/tests/folder_tests/test_step_node.py
+++ b/tests/folder_tests/test_step_node.py
@@ -9,17 +9,16 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
+import unittest
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
+from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_symlinks.py
+++ b/tests/folder_tests/test_symlinks.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+
 from tank import folder
 from tank.util import is_windows
 from tank_test.tank_test_base import *

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -9,16 +9,15 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
+import unittest
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import (
     TankTestBase,
 )
+from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_user_sandbox.py
+++ b/tests/folder_tests/test_user_sandbox.py
@@ -9,17 +9,16 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import unittest
 import shutil
+import unittest
+
 import tank
-from tank_vendor import yaml
-from tank import TankError
-from tank import hook
-from tank import folder
+from tank import TankError, folder, hook
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
+from tank_vendor import yaml
 
 
 class TestHumanUser(TankTestBase):

--- a/tests/integration_tests/bootstrap_hook.py
+++ b/tests/integration_tests/bootstrap_hook.py
@@ -15,10 +15,10 @@ default implementation.
 
 import os
 import tempfile
-
 import unittest
-from sgtk_integration_test import SgtkIntegrationTest
+
 import sgtk
+from sgtk_integration_test import SgtkIntegrationTest
 
 logger = sgtk.LogManager.get_logger(__name__)
 

--- a/tests/integration_tests/multi_bootstrap.py
+++ b/tests/integration_tests/multi_bootstrap.py
@@ -12,13 +12,13 @@
 This test makes sure that various tank command operations do not fail.
 """
 
-import sys
 import os
-
+import sys
 import traceback
 import unittest
-from sgtk_integration_test import SgtkIntegrationTest
+
 import sgtk
+from sgtk_integration_test import SgtkIntegrationTest
 
 logger = sgtk.LogManager.get_logger(__name__)
 

--- a/tests/integration_tests/offline_workflow.py
+++ b/tests/integration_tests/offline_workflow.py
@@ -13,13 +13,12 @@ This test ensures that the offline workflow using local bundle cached inside an 
 zipped config can be bootstrap into without requiring to download anything from Shotgun.
 """
 
-import unittest
 import os
 import sys
-
-from sgtk_integration_test import SgtkIntegrationTest
+import unittest
 
 import sgtk
+from sgtk_integration_test import SgtkIntegrationTest
 
 
 class OfflineWorkflow(SgtkIntegrationTest):

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -14,19 +14,16 @@ This test makes sure that various tank command operations do not fail.
 
 import os
 import re
-import sys
 import shutil
-
+import sys
 import unittest
-from tank.util import is_linux, is_macos, is_windows, filesystem
-from tank.util import yaml_cache, zip
 
+import sgtk
 from sgtk_integration_test import SgtkIntegrationTest
+from tank.util import filesystem, is_linux, is_macos, is_windows, yaml_cache, zip
 from tank_test.tank_test_base import (
     mock,
 )
-
-import sgtk
 
 logger = sgtk.LogManager.get_logger(__name__)
 

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -9,11 +9,11 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import inspect
-from io import StringIO
 import logging
 import os
 import shutil
 import tempfile
+from io import StringIO
 from unittest import mock
 
 import tank

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -8,16 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import copy
 import os
 import sys
 
 from tank.errors import TankError
+from tank.platform.environment import Environment
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 from tank_vendor import yaml
-from tank.platform.environment import Environment
-
-import copy
 
 
 class TestEnvironment(TankTestBase):

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -11,18 +11,18 @@
 import logging
 import os
 
+from tank.errors import TankEngineInitError
+from tank.platform import (
+    LaunchInformation,
+    SoftwareLauncher,
+    SoftwareVersion,
+    create_engine_launcher,
+)
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-
-from tank.platform import create_engine_launcher
-from tank.platform import SoftwareLauncher
-from tank.platform import SoftwareVersion
-from tank.platform import LaunchInformation
-
-from tank.errors import TankEngineInitError
 
 
 class TestEngineLauncher(TankTestBase):

--- a/tests/platform_tests/test_validation.py
+++ b/tests/platform_tests/test_validation.py
@@ -1,11 +1,10 @@
 import os
 
-from tank.templatekey import StringKey
-from tank_test.tank_test_base import ShotgunTestBase, TankTestBase
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank.platform.validation import *
-
 import tank
+from tank.platform.validation import *
+from tank.templatekey import StringKey
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase, TankTestBase
 
 
 class TestValidateSchema(ShotgunTestBase):

--- a/tests/python/sgtk_integration_test.py
+++ b/tests/python/sgtk_integration_test.py
@@ -12,20 +12,19 @@
 Provides a base class for integration tests.
 """
 
+import atexit
+import copy
 import os
+import subprocess
 import sys
 import tempfile
-import atexit
-import subprocess
 import threading
 import time
-import copy
-
 import unittest
 
 import sgtk
 from sgtk.util import sgre as re
-from sgtk.util.filesystem import safe_delete_folder, safe_delete_file
+from sgtk.util.filesystem import safe_delete_file, safe_delete_folder
 from tank_vendor import yaml
 
 

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -16,13 +16,12 @@ import functools
 import sys
 from unittest import mock
 
+from packaging import version
 from sgtk.descriptor import Descriptor, create_descriptor
 from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.util import sgre as re
 from tank import TankError
 from tank.platform.environment import InstalledEnvironment
-
-from packaging import version
 
 
 class MockStore(object):

--- a/tests/python/tank_test/tank_test_base.py
+++ b/tests/python/tank_test/tank_test_base.py
@@ -12,33 +12,30 @@
 Base class for engine and app testing
 """
 
-import sys
-import os
-import time
-import shutil
-import pprint
-import threading
-import tempfile
-import contextlib
 import atexit
-import uuid
+import contextlib
 import datetime
 import importlib.util
-from functools import wraps
-
-from collections import defaultdict
-
-from tank_vendor.shotgun_api3.lib import mockgun
-
+import os
+import pprint
+import shutil
+import sys
+import tempfile
+import threading
+import time
 import unittest
+import uuid
+from collections import defaultdict
+from functools import wraps
 from unittest import mock
 
 import sgtk
 import tank
 from tank import path_cache, pipelineconfig_factory
-from tank_vendor import yaml
 from tank.util import is_windows
 from tank.util.user_settings import UserSettings
+from tank_vendor import yaml
+from tank_vendor.shotgun_api3.lib import mockgun
 
 TANK_TEMP = None
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -9,9 +9,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
-import os
 import glob
+import os
+import sys
 import tempfile
 import traceback
 from optparse import OptionParser

--- a/tests/tank_test_tests/test_decorators.py
+++ b/tests/tank_test_tests/test_decorators.py
@@ -8,11 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import uuid
 import os
+import uuid
 
-from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase, temp_env_var
 
 
 class TestDecorators(ShotgunTestBase):

--- a/tests/tank_test_tests/test_mockstore.py
+++ b/tests/tank_test_tests/test_mockstore.py
@@ -12,12 +12,10 @@
 Unit tests tank updates.
 """
 
-from tank_test.tank_test_base import ShotgunTestBase
-from tank_test.tank_test_base import setUpModule  # noqa
+from sgtk.descriptor import Descriptor, create_descriptor
 from tank_test.mock_appstore import MockStore, TankMockStoreDescriptor, patch_app_store
-
-from sgtk.descriptor import Descriptor
-from sgtk.descriptor import create_descriptor
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
 
 
 class TestMockStore(ShotgunTestBase):

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -9,18 +9,17 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import shutil
+import stat
+import subprocess  # noqa
+
+import tank.util.filesystem as fs
 from tank.util import is_linux, is_macos, is_windows
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
+    mock,
 )
-
-import tank.util.filesystem as fs
-
-import subprocess  # noqa
-import shutil
-import stat
 
 
 class TestFileSystem(TankTestBase):

--- a/tests/util_tests/test_local_path.py
+++ b/tests/util_tests/test_local_path.py
@@ -11,9 +11,7 @@
 import os
 
 from tank import TankError
-from tank.util import LocalFileStorageManager
-from tank.util import is_macos, is_windows
-
+from tank.util import LocalFileStorageManager, is_macos, is_windows
 from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
 
 

--- a/tests/util_tests/test_login.py
+++ b/tests/util_tests/test_login.py
@@ -8,14 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from tank_test.tank_test_base import (
-    mock,
-    TankTestBase,
-)
-
 import tank
-from tank.util import login
 from tank.authentication import ShotgunAuthenticator
+from tank.util import login
+from tank_test.tank_test_base import (
+    TankTestBase,
+    mock,
+)
 
 
 class LoginTests(TankTestBase):

--- a/tests/util_tests/test_metrics_cache.py
+++ b/tests/util_tests/test_metrics_cache.py
@@ -10,13 +10,11 @@
 
 import os
 import unittest
-
 from unittest.mock import patch
 
 from tank.platform import (
     engine,
 )
-
 from tank.util import (
     metrics,
     metrics_cache,

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -14,11 +14,11 @@ import tank
 from tank import context, errors
 from tank.util import is_windows
 from tank_test.tank_test_base import (
-    mock,
     TankTestBase,
-    setUpModule,
-    only_run_on_windows,
+    mock,
     only_run_on_nix,
+    only_run_on_windows,
+    setUpModule,
 )
 
 

--- a/tests/util_tests/test_pyside6_patcher.py
+++ b/tests/util_tests/test_pyside6_patcher.py
@@ -8,13 +8,12 @@
 # agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk.
 
+from tank.util import pyside6_patcher
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,
     skip_if_pyside6,
 )
-
-from tank.util import pyside6_patcher
 
 
 @skip_if_pyside6(found=False)

--- a/tests/util_tests/test_qt_importer.py
+++ b/tests/util_tests/test_qt_importer.py
@@ -11,13 +11,13 @@
 import types
 import unittest.mock
 
+from tank.util import qt_importer
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,
     skip_if_pyside2,
     skip_if_pyside6,
 )
-from tank.util import qt_importer
 
 
 class QtImporterTests(TankTestBase):

--- a/tests/util_tests/test_sgre.py
+++ b/tests/util_tests/test_sgre.py
@@ -9,9 +9,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from unittest import TestCase
 import re
 import sys
+from unittest import TestCase
 
 from tank.util import sgre
 

--- a/tests/util_tests/test_shotgun_connect.py
+++ b/tests/util_tests/test_shotgun_connect.py
@@ -13,18 +13,17 @@ import unittest
 
 import tank
 from tank import errors
-
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-    temp_env_var,
-)
 from tank.authentication.user import ShotgunUser
 from tank.authentication.user_impl import SessionUser
 from tank.descriptor import Descriptor
 from tank.descriptor.io_descriptor.appstore import IODescriptorAppStore
 from tank.util.shotgun.connection import sanitize_url
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+    temp_env_var,
+)
 
 
 @mock.patch(

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -10,8 +10,8 @@
 
 import sgtk
 import tank
-from tank_test.tank_test_base import TankTestBase, ShotgunTestBase, setUpModule  # noqa
 from tank.util.shotgun_entity import get_sg_entity_name_field, sg_entity_to_string
+from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, setUpModule  # noqa
 
 KNOWN_SG_ENTITIES = [
     "ActionMenuItem",

--- a/tests/util_tests/test_shotgun_path.py
+++ b/tests/util_tests/test_shotgun_path.py
@@ -8,10 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from tank.util import ShotgunPath, is_linux, is_macos, is_windows
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
-
-from tank.util import ShotgunPath, is_linux, is_macos, is_windows
 
 
 class TestShotgunPath(ShotgunTestBase):

--- a/tests/util_tests/test_shotgun_publish_creation.py
+++ b/tests/util_tests/test_shotgun_publish_creation.py
@@ -10,9 +10,9 @@
 
 import os
 
-from tank_test.tank_test_base import TankTestBase
-from tank_test.tank_test_base import setUpModule  # noqa
 from tank.util.shotgun.publish_creation import _translate_abstract_fields
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestShotgunPublishCreation(TankTestBase):

--- a/tests/util_tests/test_storage_roots.py
+++ b/tests/util_tests/test_storage_roots.py
@@ -10,12 +10,10 @@
 
 import os
 
+from tank.errors import TankError
+from tank.util import ShotgunPath, StorageRoots
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase
-
-from tank.errors import TankError
-from tank.util import ShotgunPath
-from tank.util import StorageRoots
 
 
 class TestStorageRoots(ShotgunTestBase):

--- a/tests/util_tests/test_system_settings.py
+++ b/tests/util_tests/test_system_settings.py
@@ -10,13 +10,12 @@
 
 import os
 
+from tank.util.system_settings import SystemSettings
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
-    mock,
     ShotgunTestBase,
+    mock,
 )
-
-from tank.util.system_settings import SystemSettings
 
 
 class SystemSettingsTests(ShotgunTestBase):

--- a/tests/util_tests/test_unicode.py
+++ b/tests/util_tests/test_unicode.py
@@ -11,6 +11,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from unittest import TestCase
+
 import sgtk
 
 

--- a/tests/util_tests/test_user_settings.py
+++ b/tests/util_tests/test_user_settings.py
@@ -10,15 +10,14 @@
 
 import os
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import (
-    mock,
-    ShotgunTestBase,
-)
-
+from sgtk import TankError
 from tank.util import EnvironmentVariableFileLookupError
 from tank.util.user_settings import UserSettings
-from sgtk import TankError
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import (
+    ShotgunTestBase,
+    mock,
+)
 
 
 class UserSettingsTests(ShotgunTestBase):

--- a/tests/util_tests/test_version_compare.py
+++ b/tests/util_tests/test_version_compare.py
@@ -8,15 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from tank_test.tank_test_base import setUpModule  # noqa
-from tank_test.tank_test_base import ShotgunTestBase
+from sgtk import TankError
 from sgtk.util import (
-    is_version_older,
     is_version_newer,
     is_version_newer_or_equal,
+    is_version_older,
     is_version_older_or_equal,
 )
-from sgtk import TankError
+from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
 
 OLDER = "older"
 NEWER = "newer"

--- a/tests/util_tests/test_yaml_cache.py
+++ b/tests/util_tests/test_yaml_cache.py
@@ -8,15 +8,15 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import copy
+import os
 
 import sgtk
-from sgtk.util.yaml_cache import YamlCache
 from sgtk import TankError
-from tank_vendor import yaml
-from tank_test.tank_test_base import ShotgunTestBase
+from sgtk.util.yaml_cache import YamlCache
 from tank_test.tank_test_base import setUpModule  # noqa
+from tank_test.tank_test_base import ShotgunTestBase
+from tank_vendor import yaml
 
 
 class TestYamlCache(ShotgunTestBase):

--- a/tests/util_tests/test_zip.py
+++ b/tests/util_tests/test_zip.py
@@ -9,8 +9,9 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
+
 import tank
+from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
 
 
 def get_file_list(folder, prefix):


### PR DESCRIPTION
## Summary

* Add the `isort` pre-commit hook to `.pre-commit-config.yaml`, using the `black` profile so its output is compatible with our existing `black` formatting.
* Order `isort` before `black` in the hook list, per [SG-43836](https://autodesk.atlassian.net/browse/SG-43836) discussion, so `black` always has the final say on formatting.
* Reformat imports across the repo with `isort` so `pre-commit run --all` (run by CI's Code Style Validation job) passes on this and future PRs.

## Testing

* Ran `pre-commit run --all-files` locally: all hooks pass, including the new `isort` hook.
* Verified `isort` and `black` do not fight each other (single clean run, no oscillating diffs).


[SG-43836]: https://autodesk.atlassian.net/browse/SG-43836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ