### PR TITLE
SG-44086 Unzip long paths

### DIFF
--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -160,22 +160,22 @@ def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
 
     # On Windows, use the extended-length path prefix for paths >= 260 characters
     # to avoid MAX_PATH limitations.
-    os_path = _to_extended_path(target_path)
+    target_path = _to_extended_path(target_path)
 
     # Create all upper directories if necessary.
-    upperdirs = os.path.dirname(os_path)
+    upperdirs = os.path.dirname(target_path)
     if upperdirs and not os.path.exists(upperdirs):
         os.makedirs(upperdirs, 0o777)
 
     if item_path[-1] == "/":
         # this is a directory!
-        if not os.path.isdir(os_path):
-            os.mkdir(os_path, 0o777)
+        if not os.path.isdir(target_path):
+            os.mkdir(target_path, 0o777)
 
     else:
         # this is a file! - write it in a way which is compatible
         # with py25 zipfile library interface
-        target_obj = open(os_path, "wb")
+        target_obj = open(target_path, "wb")
         target_obj.write(zip_obj.read(item_path))
         target_obj.close()
         # Restore permissions on the extracted file
@@ -190,6 +190,6 @@ def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
         # If one execution bit is set, give execution rights to everyone
         mode = zip_info.external_attr >> 16 & 0x49
         if mode:
-            os.chmod(os_path, 0o777)
+            os.chmod(target_path, 0o777)
 
     return target_path

--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -103,7 +103,7 @@ def zip_file(source_folder, target_zip_file):
     log.debug("Zip complete. Size: %s" % os.path.getsize(target_zip_file))
 
 
-def _to_extended_path(path):
+def _to_extended_path(path: str) -> str:
     """
     On Windows, prepend the extended-length path prefix to paths >= 260
     characters to bypass the MAX_PATH limitation.
@@ -112,7 +112,12 @@ def _to_extended_path(path):
     :returns: Path with ``\\\\?\\`` prefix on Windows when necessary, otherwise
         the original path unchanged.
     """
-    if sys.platform == "win32" and len(path) >= 260 and not path.startswith("\\\\?\\"):
+    if (
+        sys.platform == "win32"
+        and os.path.isabs(path)
+        and len(path) >= 260
+        and not path.startswith("\\\\?\\")
+    ):
         return "\\\\?\\" + path
     return path
 

--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -108,17 +108,36 @@ def _to_extended_path(path: str) -> str:
     On Windows, prepend the extended-length path prefix to paths >= 260
     characters to bypass the MAX_PATH limitation.
 
-    :param path: Absolute, normalised path string.
-    :returns: Path with ``\\\\?\\`` prefix on Windows when necessary, otherwise
-        the original path unchanged.
+    Extended-length paths come in two flavours:
+
+    * Drive-letter paths (``C:\\...``) are prefixed with ``\\\\?\\``.
+    * UNC paths (``\\\\server\\share\\...``) require the ``\\\\?\\UNC\\``
+      prefix; naively prepending ``\\\\?\\`` produces an invalid path.
+
+    Drive-less rooted paths (``\\foo``) are not eligible for the prefix
+    because the extended-length syntax requires a fully-qualified path.
+
+    :param path: Normalised path string.
+    :returns: Path with the appropriate extended-length prefix on Windows
+        when necessary, otherwise the original path unchanged.
     """
-    if (
-        sys.platform == "win32"
-        and os.path.isabs(path)
-        and len(path) >= 260
-        and not path.startswith("\\\\?\\")
-    ):
+    if sys.platform != "win32" or len(path) < 260:
+        return path
+
+    if path.startswith("\\\\?\\"):
+        # Already an extended-length path - don't double-prefix.
+        return path
+
+    if path.startswith("\\\\"):
+        # UNC path (\\\\server\\share\\...). The extended-length form requires
+        # \\\\?\\UNC\\ rather than \\\\?\\\\\\\\
+        return "\\\\?\\UNC\\" + path[2:]
+
+    if len(path) >= 3 and path[1] == ":" and path[2] == "\\":
+        # Fully-qualified drive-letter path (C:\\...).
         return "\\\\?\\" + path
+
+    # Drive-less rooted paths (\\foo) or relative paths are not eligible.
     return path
 
 

--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import sys
 import zipfile
 
 from .. import LogManager
@@ -102,6 +103,20 @@ def zip_file(source_folder, target_zip_file):
     log.debug("Zip complete. Size: %s" % os.path.getsize(target_zip_file))
 
 
+def _to_extended_path(path):
+    """
+    On Windows, prepend the extended-length path prefix to paths >= 260
+    characters to bypass the MAX_PATH limitation.
+
+    :param path: Absolute, normalised path string.
+    :returns: Path with ``\\\\?\\`` prefix on Windows when necessary, otherwise
+        the original path unchanged.
+    """
+    if sys.platform == "win32" and len(path) >= 260 and not path.startswith("\\\\?\\"):
+        return "\\\\?\\" + path
+    return path
+
+
 def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
     """
     Helper method used by unzip_file()
@@ -143,20 +158,24 @@ def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
 
     target_path = os.path.normpath(target_path)
 
+    # On Windows, use the extended-length path prefix for paths >= 260 characters
+    # to avoid MAX_PATH limitations.
+    os_path = _to_extended_path(target_path)
+
     # Create all upper directories if necessary.
-    upperdirs = os.path.dirname(target_path)
+    upperdirs = os.path.dirname(os_path)
     if upperdirs and not os.path.exists(upperdirs):
         os.makedirs(upperdirs, 0o777)
 
     if item_path[-1] == "/":
         # this is a directory!
-        if not os.path.isdir(target_path):
-            os.mkdir(target_path, 0o777)
+        if not os.path.isdir(os_path):
+            os.mkdir(os_path, 0o777)
 
     else:
         # this is a file! - write it in a way which is compatible
         # with py25 zipfile library interface
-        target_obj = open(target_path, "wb")
+        target_obj = open(os_path, "wb")
         target_obj.write(zip_obj.read(item_path))
         target_obj.close()
         # Restore permissions on the extracted file
@@ -171,6 +190,6 @@ def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
         # If one execution bit is set, give execution rights to everyone
         mode = zip_info.external_attr >> 16 & 0x49
         if mode:
-            os.chmod(target_path, 0o777)
+            os.chmod(os_path, 0o777)
 
     return target_path

--- a/tests/util_tests/test_zip.py
+++ b/tests/util_tests/test_zip.py
@@ -9,6 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import sys
+import unittest
 
 import tank
 from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
@@ -119,3 +121,41 @@ class TestUnzipping(ShotgunTestBase):
         self.assertEqual(
             set(get_file_list(output_path_2, output_path_2)), set(["/info.yml"])
         )
+
+
+class TestToExtendedPath(ShotgunTestBase):
+    """
+    Tests the tank.util.zip._to_extended_path() helper.
+    """
+
+    _LONG_ABS_PATH = "C:\\" + "a" * 257  # 260 chars, absolute
+
+    def test_short_path_unchanged(self):
+        """A path under 260 characters is returned unchanged on all platforms."""
+        path = "C:\\short\\path\\file.txt"
+        self.assertEqual(tank.util.zip._to_extended_path(path), path)
+
+    def test_relative_path_unchanged(self):
+        """A relative path >= 260 characters must NOT receive the prefix."""
+        path = "relative\\" + "a" * 257  # long but relative
+        self.assertFalse(os.path.isabs(path))
+        self.assertEqual(tank.util.zip._to_extended_path(path), path)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_long_absolute_path_prefixed_on_windows(self):
+        """A long absolute path on Windows receives the \\\\?\\ prefix."""
+        result = tank.util.zip._to_extended_path(self._LONG_ABS_PATH)
+        self.assertTrue(result.startswith("\\\\?\\"))
+        self.assertEqual(result, "\\\\?\\" + self._LONG_ABS_PATH)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_already_prefixed_path_unchanged(self):
+        """A path that already has the \\\\?\\ prefix is not double-prefixed."""
+        prefixed = "\\\\?\\" + self._LONG_ABS_PATH
+        self.assertEqual(tank.util.zip._to_extended_path(prefixed), prefixed)
+
+    @unittest.skipIf(sys.platform == "win32", "Non-Windows behaviour")
+    def test_long_absolute_path_unchanged_on_non_windows(self):
+        """A long absolute path on non-Windows platforms is returned unchanged."""
+        path = "/" + "a" * 260
+        self.assertEqual(tank.util.zip._to_extended_path(path), path)

--- a/tests/util_tests/test_zip.py
+++ b/tests/util_tests/test_zip.py
@@ -128,7 +128,8 @@ class TestToExtendedPath(ShotgunTestBase):
     Tests the tank.util.zip._to_extended_path() helper.
     """
 
-    _LONG_ABS_PATH = "C:\\" + "a" * 257  # 260 chars, absolute
+    _LONG_ABS_PATH = "C:\\" + "a" * 257  # 260 chars, drive-letter absolute
+    _LONG_UNC_PATH = "\\\\server\\share\\" + "a" * 245  # 260 chars, UNC
 
     def test_short_path_unchanged(self):
         """A path under 260 characters is returned unchanged on all platforms."""
@@ -143,7 +144,7 @@ class TestToExtendedPath(ShotgunTestBase):
 
     @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
     def test_long_absolute_path_prefixed_on_windows(self):
-        """A long absolute path on Windows receives the \\\\?\\ prefix."""
+        """A long drive-letter path on Windows receives the \\\\?\\ prefix."""
         result = tank.util.zip._to_extended_path(self._LONG_ABS_PATH)
         self.assertTrue(result.startswith("\\\\?\\"))
         self.assertEqual(result, "\\\\?\\" + self._LONG_ABS_PATH)
@@ -153,6 +154,25 @@ class TestToExtendedPath(ShotgunTestBase):
         """A path that already has the \\\\?\\ prefix is not double-prefixed."""
         prefixed = "\\\\?\\" + self._LONG_ABS_PATH
         self.assertEqual(tank.util.zip._to_extended_path(prefixed), prefixed)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_long_unc_path_prefixed_with_unc_prefix(self):
+        """A long UNC path receives \\\\?\\UNC\\ prefix, not \\\\?\\\\\\\\."""
+        result = tank.util.zip._to_extended_path(self._LONG_UNC_PATH)
+        self.assertTrue(result.startswith("\\\\?\\UNC\\"))
+        self.assertEqual(result, "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:])
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_already_extended_unc_path_unchanged(self):
+        """A path already using \\\\?\\UNC\\ is not double-prefixed."""
+        prefixed = "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:]
+        self.assertEqual(tank.util.zip._to_extended_path(prefixed), prefixed)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_drive_less_rooted_path_unchanged(self):
+        """A drive-less rooted path (\\foo) must NOT receive the prefix."""
+        path = "\\" + "a" * 259  # rooted but no drive letter, >= 260 chars
+        self.assertEqual(tank.util.zip._to_extended_path(path), path)
 
     @unittest.skipIf(sys.platform == "win32", "Non-Windows behaviour")
     def test_long_absolute_path_unchanged_on_non_windows(self):


### PR DESCRIPTION
This pull request enhances the zip extraction utilities to better support long file paths on Windows by introducing handling for extended-length paths. The main changes ensure that file and directory operations during extraction bypass the Windows MAX_PATH limitation.

## Windows extended-length path support:

The registry key alone isn't enough - Python's zipfile module doesn't use extended-length paths (\\?\) automatically. The application itself also needs the longPathAware manifest entry, and the bundled FPT Desktop Python likely doesn't have it.

The real fix needs to be in tk-core's zip utility: prefix to file paths longer than 260 characters on Windows, allowing the code to work with very long paths.

## What if FPT desktop enables `longPathAware` manifest someday

The fix is still worth keeping for these reasons:

- No system config required - The `\\?\` approach works on any Windows machine regardless of registry settings or manifest, so users don't need to do anything extra.

- Defense in depth - The `longPathAware` + registry approach requires both to be true simultaneously. If either is missing (e.g., customer hasn't set the registry key, or the bundled Python doesn't have the manifest), the unzip still fails. The `\\?\` fix has no such dependencies.

- Older Python builds - Python 3.6+ includes `longPathAware` in its manifest, but the Python bundled with older FPT Desktop versions may not. The fix works everywhere.

- Works without reboot - The `\\?\` prefix bypasses the limit at the API call level, no reboot or registry change needed.

## Reference

https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
