### PR TITLE
SG-43986 Add flake8 to pre-commit for tk-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,9 @@ repos:
     rev: 26.5.1
     hooks:
     - id: black
+  # Lints for semantic issues (unused imports, undefined names, bare excepts,
+  # etc.). Runs last so it lints the code after all formatters have run.
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+    - id: flake8

--- a/_core_upgrader.py
+++ b/_core_upgrader.py
@@ -99,7 +99,7 @@ def __current_version_less_than(log, sgtk_install_root, ver):
     """
     log.debug("Checking if the currently installed version is less than %s..." % ver)
 
-    if __is_upgrade(sgtk_install_root) == False:
+    if not __is_upgrade(sgtk_install_root):
         # there is no current version. So it is definitely
         # not at least version X
         log.debug(

--- a/hooks/get_current_login.py
+++ b/hooks/get_current_login.py
@@ -55,5 +55,5 @@ class GetCurrentLogin(Hook):
 
                 pwd_entry = pwd.getpwuid(os.geteuid())
                 return pwd_entry[0]
-            except:
+            except Exception:
                 return None

--- a/python/sgtk/__init__.py
+++ b/python/sgtk/__init__.py
@@ -16,7 +16,7 @@ THIS_MODULE_NAME = "sgtk"
 import sys
 
 # first import our alternative API
-import tank
+import tank  # noqa: F401
 
 # Generate a list of keys to iterate over,
 # since we'll be mutating the dict as we iterate.

--- a/python/tank/api.py
+++ b/python/tank/api.py
@@ -1034,7 +1034,6 @@ def get_authenticated_user():
     :returns: A :class:`~sgtk.authentication.ShotgunUser` derived object if set,
         None otherwise.
     """
-    global _authenticated_user
     return _authenticated_user
 
 

--- a/python/tank/authentication/constants.py
+++ b/python/tank/authentication/constants.py
@@ -20,8 +20,6 @@ method_resolve = {
 
 
 def method_resolve_reverse(m):
-    global method_resolve
-
     for k, v in method_resolve.items():
         if v == m:
             return k

--- a/python/tank/authentication/interactive_authentication.py
+++ b/python/tank/authentication/interactive_authentication.py
@@ -55,7 +55,7 @@ def _get_current_os_user():
 
             pwd_entry = pwd.getpwuid(os.geteuid())
             return pwd_entry[0]
-        except:
+        except Exception:
             return None
 
 

--- a/python/tank/authentication/login_dialog.py
+++ b/python/tank/authentication/login_dialog.py
@@ -43,7 +43,6 @@ from .ui.qt_abstraction import (
     QtGui,
     QtNetwork,
     QtWebEngineWidgets,
-    qt_version_tuple,
 )
 from .web_login_support import get_shotgun_authenticator_support_web_login
 

--- a/python/tank/authentication/user_impl.py
+++ b/python/tank/authentication/user_impl.py
@@ -607,7 +607,6 @@ def deserialize_user(payload):
         user_dict = pickle.loads(payload)
 
     # Find which user type we have
-    global __factories
     factory = __factories.get(user_dict.get("type"))
     # Unknown type, something is wrong. Maybe backward compatible code broke?
     if not factory:

--- a/python/tank/authentication/web_login_support.py
+++ b/python/tank/authentication/web_login_support.py
@@ -59,5 +59,4 @@ def get_shotgun_authenticator_support_web_login():
 
     :returns: Bool indicating support for the Unified Login Flow.
     """
-    global shotgun_authenticator_support_web_login
     return shotgun_authenticator_support_web_login

--- a/python/tank/bootstrap/cached_configuration.py
+++ b/python/tank/bootstrap/cached_configuration.py
@@ -10,14 +10,13 @@
 
 import os
 import pprint
-import sys
 import traceback
 
 from tank_vendor import yaml
 
 from .. import LogManager
 from ..descriptor import Descriptor, create_descriptor
-from ..util import filesystem, version
+from ..util import filesystem
 from . import constants
 from .configuration import Configuration
 from .configuration_writer import ConfigurationWriter
@@ -259,7 +258,7 @@ class CachedConfiguration(Configuration):
             config_backup_path, core_backup_path = self._config_writer.move_to_backup(
                 undo_on_error=True
             )
-        except Exception as e:
+        except Exception:
             log.exception(
                 "Unexpected error while making a backup of the configuration. Toolkit will use the "
                 "original configuration."

--- a/python/tank/bootstrap/configuration_writer.py
+++ b/python/tank/bootstrap/configuration_writer.py
@@ -15,7 +15,6 @@ import sys
 from tank_vendor import yaml
 
 from .. import LogManager
-from ..descriptor import Descriptor, create_descriptor, is_descriptor_version_missing
 from ..util import StorageRoots, filesystem, is_macos, is_windows
 from ..util.move_guard import MoveGuard
 from ..util.shotgun import connection

--- a/python/tank/bootstrap/import_handler.py
+++ b/python/tank/bootstrap/import_handler.py
@@ -102,7 +102,7 @@ class CoreImportHandler(object):
         try:
             if prev_log_file:
                 tank.LogManager().initialize_base_file_handler_from_path(prev_log_file)
-        except AttributeError as e:
+        except AttributeError:
             # older versions of the API may not have this defined.
             log.debug(
                 "Switching to a version of the core API that doesn't "

--- a/python/tank/commands/core_upgrade.py
+++ b/python/tank/commands/core_upgrade.py
@@ -24,7 +24,6 @@ from .. import pipelineconfig_utils
 from ..errors import TankError
 from ..util import shotgun
 from ..util.version import is_version_head, is_version_newer
-from . import console_utils
 from .action_base import Action
 
 

--- a/python/tank/commands/desktop_migration.py
+++ b/python/tank/commands/desktop_migration.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import console_utils, constants
+from . import constants
 from .action_base import Action
 
 _MESSAGE = (

--- a/python/tank/commands/misc.py
+++ b/python/tank/commands/misc.py
@@ -70,7 +70,7 @@ class ClearCacheAction(Action):
                 log.debug("Deleting cache file %s..." % full_path)
                 try:
                     os.remove(full_path)
-                except:
+                except Exception:
                     log.warning("Could not delete cache file '%s'!" % full_path)
 
         log.info("The PTR menu cache has been cleared.")
@@ -129,7 +129,7 @@ class InteractiveShellAction(Action):
         # attempt install tab command completion
         try:
             import readline
-            import rlcompleter
+            import rlcompleter  # noqa: F401
 
             if "libedit" in readline.__doc__:
                 # macosx, some versions - see
@@ -137,7 +137,7 @@ class InteractiveShellAction(Action):
                 readline.parse_and_bind("bind ^I rl_complete")
             else:
                 readline.parse_and_bind("tab: complete")
-        except:
+        except Exception:
             pass
 
         code.interact(banner="\n".join(msg), local=tk_locals)

--- a/python/tank/commands/push_pc.py
+++ b/python/tank/commands/push_pc.py
@@ -15,7 +15,7 @@ import shutil
 from ..errors import TankError
 from ..pipelineconfig import PipelineConfiguration
 from ..util import ShotgunPath, filesystem
-from . import console_utils, constants
+from . import constants
 from .action_base import Action
 
 # Core configuration files which are associated with the core API installation and not
@@ -131,7 +131,7 @@ class PushPCAction(Action):
             raise TankError("Aborted by user.")
         try:
             target_pc_id = int(answer)
-        except:
+        except Exception:
             raise TankError("Please enter a number!")
 
         self._run(

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -479,7 +479,7 @@ class SetupProjectAction(Action):
             ["archived", "is_not", True],
         ]
 
-        if not show_initialized_projects:
+        if show_initialized_projects is False:
             # not force mode. Only show non-set up projects
             filters.append(["tank_name", "is", None])
 

--- a/python/tank/commands/setup_project.py
+++ b/python/tank/commands/setup_project.py
@@ -479,7 +479,7 @@ class SetupProjectAction(Action):
             ["archived", "is_not", True],
         ]
 
-        if show_initialized_projects == False:
+        if not show_initialized_projects:
             # not force mode. Only show non-set up projects
             filters.append(["tank_name", "is", None])
 
@@ -541,7 +541,7 @@ class SetupProjectAction(Action):
             raise TankError("Aborted by user.")
         try:
             project_id = int(answer)
-        except:
+        except Exception:
             raise TankError("Please enter a number!")
 
         if project_id not in [x["id"] for x in projs]:
@@ -720,7 +720,6 @@ class SetupProjectAction(Action):
         # location for the installed config.
         # Multi-root configurations require a storage named "primary" so we base
         # our default on that. If only a single storage is available, we just use it.
-        storage_names = params.get_required_storages()
         default_storage_name = params.default_storage_name
 
         # There is no default storage name for a config that doesn't use roots, like

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -18,7 +18,7 @@ from tank_vendor import yaml
 from .. import hook, pipelineconfig_utils
 from ..descriptor import Descriptor, create_descriptor
 from ..errors import TankError, TankErrorProjectIsSetup
-from ..util import ShotgunPath, StorageRoots, filesystem, is_windows
+from ..util import ShotgunPath, StorageRoots, filesystem
 from ..util import sgre as re
 from ..util import shotgun
 from ..util.version import is_version_newer
@@ -506,8 +506,8 @@ class ProjectSetupParameters(object):
 
             # if force is false then tank_name must be empty
             if (
-                self.get_auto_path_mode() == False
-                and force == False
+                not self.get_auto_path_mode()
+                and not force
                 and proj["tank_name"] is not None
             ):
                 raise TankErrorProjectIsSetup()

--- a/python/tank/commands/setup_project_params.py
+++ b/python/tank/commands/setup_project_params.py
@@ -506,8 +506,8 @@ class ProjectSetupParameters(object):
 
             # if force is false then tank_name must be empty
             if (
-                not self.get_auto_path_mode()
-                and not force
+                self.get_auto_path_mode() is False
+                and force is False
                 and proj["tank_name"] is not None
             ):
                 raise TankErrorProjectIsSetup()

--- a/python/tank/commands/tank_command.py
+++ b/python/tank/commands/tank_command.py
@@ -473,7 +473,7 @@ def run_action(log, tk, ctx, command, args):
             found_action = x
             break
 
-    if found_action and not found_action.wants_running_shell_engine:
+    if found_action and found_action.wants_running_shell_engine is False:
         log.debug("No need to load up the engine for this command.")
     else:
         # try to load the engine.

--- a/python/tank/commands/tank_command.py
+++ b/python/tank/commands/tank_command.py
@@ -473,7 +473,7 @@ def run_action(log, tk, ctx, command, args):
             found_action = x
             break
 
-    if found_action and found_action.wants_running_shell_engine == False:
+    if found_action and not found_action.wants_running_shell_engine:
         log.debug("No need to load up the engine for this command.")
     else:
         # try to load the engine.

--- a/python/tank/commands/unregister_folders.py
+++ b/python/tank/commands/unregister_folders.py
@@ -14,7 +14,6 @@ Method to unregister folders from the path cache
 
 from .. import path_cache
 from ..errors import TankError
-from ..util.login import get_current_user
 from .action_base import Action
 
 

--- a/python/tank/context.py
+++ b/python/tank/context.py
@@ -28,7 +28,7 @@ from .errors import TankContextDeserializationError, TankError
 from .flowam import constants as flow_const
 from .path_cache import PathCache
 from .template import TemplatePath
-from .util import get_sg_entity_name_field, login, pickle, shotgun, shotgun_entity
+from .util import login, pickle, shotgun, shotgun_entity
 
 
 class Context(object):
@@ -178,9 +178,9 @@ class Context(object):
             :param d2:  Second entity dictionary
             :returns:   True if d1 and d2 are considered equal, otherwise False.
             """
-            if d1 == d2 == None:
+            if d1 is None and d2 is None:
                 return True
-            if d1 == None or d2 == None:
+            if d1 is None or d2 is None:
                 return False
             return d1["type"] == d2["type"] and d1["id"] == d2["id"]
 
@@ -1005,7 +1005,7 @@ class Context(object):
                 # this key is a shotgun value that needs fetching!
 
                 # ensure that the context actually provides the desired entities
-                if not key.shotgun_entity_type in entities:
+                if key.shotgun_entity_type not in entities:
                     if validate:
                         raise TankError(
                             "Key '%s' in template '%s' could not be populated by "
@@ -1487,7 +1487,6 @@ def _from_entity_dictionary(tk, entity_dictionary, source_entity=None):
     }
 
     entity_type = entity_dictionary["type"]
-    entity_id = entity_dictionary["id"]
 
     # try to determine the various entities from the entity dictionary:
     project = None
@@ -1552,7 +1551,7 @@ def _from_entity_dictionary(tk, entity_dictionary, source_entity=None):
             if "id" not in ent or "type" not in ent:
                 return None
             ent_name = _get_entity_name(ent)
-            if ent_name == None:
+            if ent_name is None:
                 return None
             # return a clean dictionary:
             return {"type": ent["type"], "id": ent["id"], "name": ent_name}
@@ -1842,7 +1841,7 @@ def _get_entity_name(entity_dictionary):
     """
     name_field = shotgun_entity.get_sg_entity_name_field(entity_dictionary["type"])
     entity_name = entity_dictionary.get(name_field)
-    if entity_name == None:
+    if entity_name is None:
         # Also check to see if entity contains 'name':
         if name_field != "name":
             entity_name = entity_dictionary.get("name")

--- a/python/tank/deploy/util.py
+++ b/python/tank/deploy/util.py
@@ -16,4 +16,4 @@ This code may be removed at some point in the future.
 
 # import methods to ensure that older version of the desktop engine
 # will function correctly - the code calls these internal methods
-from ..util.version import is_version_newer, is_version_older
+from ..util.version import is_version_newer, is_version_older  # noqa: F401

--- a/python/tank/descriptor/descriptor_bundle.py
+++ b/python/tank/descriptor/descriptor_bundle.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .. import LogManager, pipelineconfig_utils
-from ..util import shotgun
 from ..util.version import is_version_older
 from . import constants
 from .descriptor import Descriptor

--- a/python/tank/descriptor/io_descriptor/git.py
+++ b/python/tank/descriptor/io_descriptor/git.py
@@ -113,7 +113,7 @@ class IODescriptorGit(IODescriptorDownloadable):
         log.debug("Checking that git exists and can be executed...")
         try:
             output = _check_output(["git", "--version"])
-        except:
+        except Exception:
             log.exception("Unexpected error:")
             raise TankGitError(
                 "Cannot execute the 'git' command. Please make sure that git is "

--- a/python/tank/descriptor/io_descriptor/git_branch.py
+++ b/python/tank/descriptor/io_descriptor/git_branch.py
@@ -115,7 +115,7 @@ class IODescriptorGitBranch(IODescriptorGit):
         log.debug("Checking if the version is pointing to the latest commit...")
         try:
             output = _check_output(["git", "ls-remote", self._path, branch])
-        except:
+        except Exception:
             log.exception("Unexpected error:")
             raise TankGitError(
                 "Cannot execute the 'git' command. Please make sure that git is "

--- a/python/tank/folder/folder_types/base.py
+++ b/python/tank/folder/folder_types/base.py
@@ -174,7 +174,7 @@ class Folder(object):
 
             # before recursing down our specific recursion path, make sure all static content
             # has been created at this level in the folder structure
-            static_children = [ch for ch in self._children if not ch.is_dynamic()]
+            static_children = [ch for ch in self._children if ch.is_dynamic() is False]
 
             for created_folder, sg_data_dict in created_data:
 

--- a/python/tank/folder/folder_types/base.py
+++ b/python/tank/folder/folder_types/base.py
@@ -174,7 +174,7 @@ class Folder(object):
 
             # before recursing down our specific recursion path, make sure all static content
             # has been created at this level in the folder structure
-            static_children = [ch for ch in self._children if ch.is_dynamic() == False]
+            static_children = [ch for ch in self._children if not ch.is_dynamic()]
 
             for created_folder, sg_data_dict in created_data:
 
@@ -255,7 +255,7 @@ class Folder(object):
         dc_value = self._config_metadata.get("defer_creation")
         # if defer_creation config param not specified or None means we
         # can always go ahead with folder creation!!
-        if dc_value is None or dc_value == False:
+        if dc_value is None or dc_value is False:
             # deferred value not specified means proceed with creation!
             return True
 
@@ -266,7 +266,7 @@ class Folder(object):
             return False
 
         # now handle all cases where we have an engine_str and some sort of deferred behaviour.
-        if dc_value == True:
+        if dc_value is True:
             # defer create for all engine_strs!
             return True
 

--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -116,7 +116,7 @@ class Entity(Folder):
         """
         # check our special condition - is this node set to be auto-created with its parent node?
         # note that primary nodes are always created with their parent nodes!
-        if is_primary == False and self._create_with_parent == False:
+        if not is_primary and not self._create_with_parent:
             return False
 
         # base class implementation

--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -116,7 +116,7 @@ class Entity(Folder):
         """
         # check our special condition - is this node set to be auto-created with its parent node?
         # note that primary nodes are always created with their parent nodes!
-        if not is_primary and not self._create_with_parent:
+        if is_primary is False and self._create_with_parent is False:
             return False
 
         # base class implementation

--- a/python/tank/folder/folder_types/listfield.py
+++ b/python/tank/folder/folder_types/listfield.py
@@ -105,7 +105,7 @@ class ListField(Folder):
         # list fields are only created when they are on the primary path,
         # e.g. we don't recurse down to create asset types when shots are created,
         # but only when assets are created.
-        if not is_primary and not self._create_with_parent:
+        if is_primary is False and self._create_with_parent is False:
             return False
 
         # base class implementation

--- a/python/tank/folder/folder_types/listfield.py
+++ b/python/tank/folder/folder_types/listfield.py
@@ -105,7 +105,7 @@ class ListField(Folder):
         # list fields are only created when they are on the primary path,
         # e.g. we don't recurse down to create asset types when shots are created,
         # but only when assets are created.
-        if is_primary == False and self._create_with_parent == False:
+        if not is_primary and not self._create_with_parent:
             return False
 
         # base class implementation
@@ -171,7 +171,7 @@ class ListField(Folder):
                     chunks = self._field_name.split(".")
                     entity_type = chunks[1]
                     field_name = chunks[2]
-                except:
+                except Exception:
                     msg = (
                         "Folder creation error: Cannot resolve the field expression %s."
                         % self._field_name

--- a/python/tank/folder/folder_types/static.py
+++ b/python/tank/folder/folder_types/static.py
@@ -135,7 +135,7 @@ class Static(Folder):
         """
         # check our special condition - is this node set to be auto-created with its parent node?
         # note that primary nodes are always created with their parent nodes!
-        if is_primary == False and self._create_with_parent == False:
+        if not is_primary and not self._create_with_parent:
             return False
 
         # base class implementation

--- a/python/tank/folder/folder_types/static.py
+++ b/python/tank/folder/folder_types/static.py
@@ -135,7 +135,7 @@ class Static(Folder):
         """
         # check our special condition - is this node set to be auto-created with its parent node?
         # note that primary nodes are always created with their parent nodes!
-        if not is_primary and not self._create_with_parent:
+        if is_primary is False and self._create_with_parent is False:
             return False
 
         # base class implementation

--- a/python/tank/folder/folder_types/step.py
+++ b/python/tank/folder/folder_types/step.py
@@ -147,7 +147,7 @@ class ShotgunStep(Entity):
         # shot, we want all the steps to be created at the same time.
         # however, if we have create_with_parent set to False, we only want to create
         # this node if we are creating folders for a task.
-        if not create_with_parent:
+        if create_with_parent is False:
             # do not auto-create with parent - only create when a task has been specified.
             # create an expression object to represent the current step.
             # we pass in the field which is the connection between the task and the step field

--- a/python/tank/folder/folder_types/step.py
+++ b/python/tank/folder/folder_types/step.py
@@ -147,7 +147,7 @@ class ShotgunStep(Entity):
         # shot, we want all the steps to be created at the same time.
         # however, if we have create_with_parent set to False, we only want to create
         # this node if we are creating folders for a task.
-        if create_with_parent != True:
+        if not create_with_parent:
             # do not auto-create with parent - only create when a task has been specified.
             # create an expression object to represent the current step.
             # we pass in the field which is the connection between the task and the step field

--- a/python/tank/folder/folder_types/task.py
+++ b/python/tank/folder/folder_types/task.py
@@ -159,7 +159,7 @@ class ShotgunTask(Entity):
         # shot, we want all the tasks to be created at the same time.
         # however, if we have create_with_client set to False, we only want to create
         # this node if we are creating folders for a task.
-        if create_with_parent != True:
+        if not create_with_parent:
             # do not auto-create with parent - only create when a task has been specified.
             # create an expression object to represent the current step
             current_task_id_token = CurrentTaskExpressionToken()

--- a/python/tank/folder/folder_types/task.py
+++ b/python/tank/folder/folder_types/task.py
@@ -159,7 +159,7 @@ class ShotgunTask(Entity):
         # shot, we want all the tasks to be created at the same time.
         # however, if we have create_with_client set to False, we only want to create
         # this node if we are creating folders for a task.
-        if not create_with_parent:
+        if create_with_parent is False:
             # do not auto-create with parent - only create when a task has been specified.
             # create an expression object to represent the current step
             current_task_id_token = CurrentTaskExpressionToken()

--- a/python/tank/hook.py
+++ b/python/tank/hook.py
@@ -449,7 +449,7 @@ class Hook(object):
 
         try:
             engine = self.__parent.engine
-        except:
+        except Exception:
             raise TankError(
                 "Cannot load framework %s for %r - it does not have a "
                 "valid engine property!" % (framework_instance_name, self.__parent)

--- a/python/tank/log.py
+++ b/python/tank/log.py
@@ -222,7 +222,6 @@ For more information, see https://docs.python.org/2/library/logging.handlers.htm
 
 import logging
 import os
-import sys
 import time
 import uuid
 import weakref
@@ -303,7 +302,7 @@ class LogManager(object):
 
             try:
                 os.rename(self.baseFilename, temp_backup_name)
-            except:
+            except Exception:
                 # It failed, so we'll simply append from now on.
                 log.debug(
                     "Cannot rotate log file '%s'. Logging will continue to this file, "
@@ -318,7 +317,7 @@ class LogManager(object):
             # so doRollover can do its work.
             try:
                 os.rename(temp_backup_name, self.baseFilename)
-            except:
+            except Exception:
                 # For some reason we couldn't move the backup in its place.
                 log.debug(
                     "Unexpected issue while rotating log file '%s'. Logging will continue to this file, "
@@ -338,7 +337,7 @@ class LogManager(object):
             # disable rollover and append to the current log.
             try:
                 RotatingFileHandler.doRollover(self)
-            except:
+            except Exception:
                 # Something probably failed trying to rollover the backups,
                 # since the code above proved that in theory the main log file
                 # should be renamable. In any case, we didn't succeed in renaming,

--- a/python/tank/path_cache.py
+++ b/python/tank/path_cache.py
@@ -1341,7 +1341,7 @@ class PathCache(object):
                         (pc_row_id, sg_id),
                     )
 
-        except:
+        except Exception:
             # error processing shotgun. Make sure we roll back the sqlite path cache
             # transaction
             self._connection.rollback()
@@ -1856,7 +1856,6 @@ class PathCache(object):
             ids_to_look_for[sg_record["entity"]["type"]].append(sg_record)
 
         # now query shotgun for each of the types
-        ids_in_shotgun = {}
         sg_valid_records = []
         for et, sg_records_for_et in ids_to_look_for.items():
 

--- a/python/tank/pipelineconfig.py
+++ b/python/tank/pipelineconfig.py
@@ -1209,7 +1209,7 @@ class PipelineConfiguration(object):
 
         try:
             return_value = hook.execute_hook(hook_path, parent, **kwargs)
-        except:
+        except Exception:
             # log the full callstack to make sure that whatever the
             # calling code is doing, this error is logged to help
             # with troubleshooting and support
@@ -1243,9 +1243,6 @@ class PipelineConfiguration(object):
         )
         hook_paths = [os.path.join(hooks_path, file_name)]
 
-        # the hook.method display name used when logging the metric
-        hook_method_display = "%s.%s" % (hook_name, method_name)
-
         # now add a custom hook if that exists.
         hook_folder = self.get_core_hooks_location()
         hook_path = os.path.join(hook_folder, file_name)
@@ -1256,7 +1253,7 @@ class PipelineConfiguration(object):
             return_value = hook.execute_hook_method(
                 hook_paths, parent, method_name, **kwargs
             )
-        except:
+        except Exception:
             # log the full callstack to make sure that whatever the
             # calling code is doing, this error is logged to help
             # with troubleshooting and support

--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -1074,7 +1074,7 @@ class TankBundle(object):
         # therefore get an error.
         try:
             engine_name = self.engine.name
-        except:
+        except Exception:
             engine_name = None
 
         return engine_name

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -23,9 +23,7 @@ import threading
 import traceback
 import weakref
 
-from tank.flowam import (  # noqa: F401 used in the flow_host property's return annotation
-    host as flow_host,
-)
+from tank.flowam import host as flow_host  # noqa: F401 (used in return annotation)
 from tank.flowam import utils as flow_utils
 
 from .. import hook

--- a/python/tank/platform/engine.py
+++ b/python/tank/platform/engine.py
@@ -23,7 +23,9 @@ import threading
 import traceback
 import weakref
 
-from tank.flowam import host as flow_host
+from tank.flowam import (  # noqa: F401 used in the flow_host property's return annotation
+    host as flow_host,
+)
 from tank.flowam import utils as flow_utils
 
 from .. import hook
@@ -426,10 +428,10 @@ class Engine(TankBundle):
         if self.has_ui:
             # we cannot import QT until here as non-ui engines don't have QT defined.
             try:
-                from .qt import QtCore, QtGui
+                from .qt import QtCore
                 from .qt.busy_dialog import BusyDialog
 
-            except:
+            except Exception:
                 # QT import failed. This may be because someone has upgraded the core
                 # to the latest but are still running a earlier version of the
                 # Shotgun or Shell engine where the self.has_ui method is not
@@ -701,7 +703,7 @@ class Engine(TankBundle):
         return True
 
     @property
-    def flow_host(self) -> flow_host.FlowHost | None:
+    def flow_host(self) -> flow_host.FlowHost | None:  # noqa: F811
         """If the current context is Flow enabled, and the current
         engine supports Flow integration, this value will be an instance of FlowHost.
         The FlowHost class implements the required interface for the Flow asset management
@@ -836,7 +838,6 @@ class Engine(TankBundle):
             # a context change. If one of them is not, then we remove it
             # from the persistent app pool, which will force it to be
             # rebuilt when apps are loaded later on.
-            non_compliant_app_paths = []
             for install_path, app_instances in self.__application_pool.items():
                 for instance_name, app in app_instances.items():
                     self.log_debug(
@@ -2174,7 +2175,7 @@ class Engine(TankBundle):
                 base["dialog_base"] = None
             base["wrapper"] = importer.binding
             base["shiboken"] = importer.shiboken
-        except:
+        except Exception:
 
             self.log_exception(
                 "Default engine QT definition failed to find QT. "
@@ -2897,7 +2898,6 @@ def current_engine():
 
     :returns: :class:`Engine` instance or None if no engine is running.
     """
-    global g_current_engine
     return g_current_engine
 
 

--- a/python/tank/platform/environment_includes.py
+++ b/python/tank/platform/environment_includes.py
@@ -29,7 +29,6 @@ relative paths are always required and context based paths are always optional.
 
 import copy
 import os
-import sys
 
 from ..errors import TankError
 from ..log import LogManager
@@ -103,7 +102,7 @@ def _resolve_includes(file_name, data, context):
             try:
                 f = context.as_template_fields(template)
                 full_path = template.apply_fields(f)
-            except TankError as e:
+            except TankError:
                 # if this path could not be resolved, that's ok! These paths are always optional.
                 continue
 

--- a/python/tank/platform/qt/busy_dialog.py
+++ b/python/tank/platform/qt/busy_dialog.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import QtCore, QtGui
+from . import QtGui
 from .ui_busy_dialog import Ui_BusyDialog
 
 

--- a/python/tank/platform/qt/config_item.py
+++ b/python/tank/platform/qt/config_item.py
@@ -8,13 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import shutil
-import sys
-
 from ..bundle import resolve_default_value
 from ..engine import current_engine
-from . import QtCore, QtGui
+from . import QtGui
 from .ui_item import Ui_Item
 
 
@@ -47,7 +43,7 @@ class ConfigItem(QtGui.QWidget):
         # special cases for some things:
         value_str = ""
 
-        if type(value) == str and value.startswith("hook:"):
+        if isinstance(value, str) and value.startswith("hook:"):
             # this is the generic hook override that any type can have
             value_str = "<b>Value:</b> <code>%s</code>" % value
             value_str += "<br><br>"

--- a/python/tank/platform/qt/tankqdialog.py
+++ b/python/tank/platform/qt/tankqdialog.py
@@ -15,7 +15,6 @@ Default implementation for the Tank Dialog
 
 import inspect
 import os
-import sys
 
 from ...errors import TankError
 from .. import application, constants, engine
@@ -66,7 +65,7 @@ class TankQDialog(TankDialogBase):
 
                 # stop if we've previously checked this class:
                 cls_type = checked_classes.get(cls, None)
-                if cls_type != None:
+                if cls_type is not None:
                     break
                 checked_classes[cls] = ""
 
@@ -100,7 +99,7 @@ class TankQDialog(TankDialogBase):
                         # assume that this is derived from an actual tk-multi-workfiles.SaveAsForm!
                         cls_type = "SaveAsForm"
 
-                if cls_type != None:
+                if cls_type is not None:
                     checked_classes[cls] = cls_type
                     break
 
@@ -357,7 +356,7 @@ class TankQDialog(TankDialogBase):
                 context_info += "You are currently running in the %s environment." % (
                     self._bundle.engine.environment["name"]
                 )
-            except:
+            except Exception:
                 pass
 
             self.ui.app_work_area_info.setText(context_info)

--- a/python/tank/platform/validation.py
+++ b/python/tank/platform/validation.py
@@ -355,7 +355,7 @@ class _SchemaValidator:
                 % (settings_key, self._display_name)
             )
 
-        if not data_type in constants.TANK_SCHEMA_VALID_TYPES:
+        if data_type not in constants.TANK_SCHEMA_VALID_TYPES:
             params = (data_type, settings_key, self._display_name)
             raise TankError("Invalid type '%s' in schema '%s' for '%s'!" % params)
 
@@ -407,14 +407,14 @@ class _SchemaValidator:
 
     def __validate_schema_list(self, settings_key, schema):
         # Check that the schema contains "values"
-        if not "values" in schema or type(schema["values"]) != dict:
+        if "values" not in schema or not isinstance(schema["values"], dict):
             params = (settings_key, self._display_name)
             raise TankError(
                 "Missing or invalid 'values' dict in schema '%s' for '%s'!" % params
             )
 
         # If there's an "allows_empty" key, it should be a bool
-        if "allows_empty" in schema and type(schema["allows_empty"]) != bool:
+        if "allows_empty" in schema and not isinstance(schema["allows_empty"], bool):
             params = (settings_key, self._display_name)
             raise TankError(
                 "Invalid 'allows_empty' bool in schema '%s' for '%s'!" % params
@@ -424,13 +424,13 @@ class _SchemaValidator:
 
     def __validate_schema_dict(self, settings_key, schema):
         # Check that if the schema contains "items" then it must be a dict
-        if "items" in schema and type(schema["items"]) != dict:
+        if "items" in schema and not isinstance(schema["items"], dict):
             params = (settings_key, self._display_name)
             raise TankError("Invalid 'items' dict in schema '%s' for '%s'!" % params)
 
         for key, value_schema in schema.get("items", {}).items():
             # Check that the value is a dict, and validate it...
-            if type(value_schema) != dict:
+            if not isinstance(value_schema, dict):
                 params = (key, settings_key, self._display_name)
                 raise TankError("Invalid '%s' dict in schema '%s' for '%s'" % params)
 
@@ -439,19 +439,21 @@ class _SchemaValidator:
     def __validate_schema_template(self, settings_key, schema):
 
         # new style template def: if there is a fields key, it should be a str
-        if "fields" in schema and type(schema["fields"]) != str:
+        if "fields" in schema and not isinstance(schema["fields"], str):
             params = (settings_key, self._display_name)
             raise TankError("Invalid 'fields' string in schema '%s' for '%s'!" % params)
 
         # old-style - if there's a required_fields key, it should contain a list of strs.
-        if "required_fields" in schema and type(schema["required_fields"]) != list:
+        if "required_fields" in schema and not isinstance(
+            schema["required_fields"], list
+        ):
             params = (settings_key, self._display_name)
             raise TankError(
                 "Invalid 'required_fields' list in schema '%s' for '%s'!" % params
             )
 
         for field in schema.get("required_fields", []):
-            if type(field) != str:
+            if not isinstance(field, str):
                 params = (field, settings_key, self._display_name)
                 raise TankError(
                     "Invalid 'required_fields' value '%s' in schema '%s' for '%s'!"
@@ -459,9 +461,9 @@ class _SchemaValidator:
                 )
 
         # old-style - if there's an optional_fields key, it should contain a list of strs or be "*"
-        if "optional_fields" in schema and type(schema["optional_fields"]) == list:
+        if "optional_fields" in schema and isinstance(schema["optional_fields"], list):
             for field in schema.get("optional_fields", []):
-                if type(field) != str:
+                if not isinstance(field, str):
                     params = (field, settings_key, self._display_name)
                     raise TankError(
                         "Invalid 'optional_fields' value '%s' in schema '%s' for '%s'!"
@@ -474,7 +476,7 @@ class _SchemaValidator:
             )
 
         # If there's an "allows_empty" key, it should be a bool
-        if "allows_empty" in schema and type(schema["allows_empty"]) != bool:
+        if "allows_empty" in schema and not isinstance(schema["allows_empty"], bool):
             params = (settings_key, self._display_name)
             raise TankError(
                 "Invalid 'allows_empty' bool in schema '%s' for '%s'!" % params
@@ -543,7 +545,7 @@ class _SettingsValidator:
         data_type = schema.get("type")
 
         # functor values which refer to a hook are never validated
-        if type(value) == str and value.startswith("hook:"):
+        if isinstance(value, str) and value.startswith("hook:"):
             return
 
         # shotgun filters can be a variety of formats so assume it is
@@ -605,7 +607,7 @@ class _SettingsValidator:
         items = schema.get("items", {})
         for key, value_schema in items.items():
             # Check for required keys
-            if not key in value:
+            if key not in value:
                 params = (key, settings_key, self._display_name)
                 raise TankError(
                     "Missing required key '%s' in setting '%s' for '%s'" % params
@@ -891,7 +893,7 @@ class _SettingsValidator:
             # one or more mandatory issues. No point checking further
             return problems
 
-        if star == True:
+        if star:
             # means an open ended number of fields can be used.
             # no need to do more validation
             return problems

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -475,7 +475,7 @@ class Template(object):
         :returns:           True if the path is valid for this template
         :rtype:             Bool
         """
-        return self.validate_and_get_fields(path, fields, skip_keys) != None
+        return self.validate_and_get_fields(path, fields, skip_keys) is not None
 
     def get_fields(self, input_path, skip_keys=None):
         """
@@ -504,7 +504,7 @@ class Template(object):
         for ordered_keys, static_tokens in zip(self._ordered_keys, self._static_tokens):
             path_parser = TemplatePathParser(ordered_keys, static_tokens)
             fields = path_parser.parse_path(input_path, skip_keys)
-            if fields != None:
+            if fields is not None:
                 break
 
         if fields is None:

--- a/python/tank/template_includes.py
+++ b/python/tank/template_includes.py
@@ -28,8 +28,6 @@ c:\foo\bar\hello.yml - absolute path, windows
 
 """
 
-import os
-
 from . import constants
 from .errors import TankError
 from .util import yaml_cache

--- a/python/tank/templatekey.py
+++ b/python/tank/templatekey.py
@@ -14,7 +14,6 @@ Classes for fields on TemplatePaths and TemplateStrings
 
 import collections.abc
 import datetime
-import sys
 
 from . import constants
 from .errors import TankError

--- a/python/tank/util/includes.py
+++ b/python/tank/util/includes.py
@@ -11,7 +11,6 @@
 import ntpath
 import os
 import posixpath
-import sys
 
 from ..errors import TankError
 from .platforms import is_windows

--- a/python/tank/util/login.py
+++ b/python/tank/util/login.py
@@ -14,7 +14,6 @@ Helper methods that extracts information about the current user.
 """
 
 import os
-import sys
 
 from . import constants
 from .platforms import is_windows
@@ -34,7 +33,7 @@ def get_login_name():
 
             pwd_entry = pwd.getpwuid(os.geteuid())
             return pwd_entry[0]
-        except:
+        except Exception:
             return None
 
 

--- a/python/tank/util/metrics.py
+++ b/python/tank/util/metrics.py
@@ -72,7 +72,7 @@ class PlatformInfo(object):
             # For macOS / OSX we keep only the Major.minor
             os_version = re.findall(r"\d*\.\d*", raw_version_str)[0]
 
-        except:
+        except Exception:
             pass
 
         return os_version
@@ -96,7 +96,7 @@ class PlatformInfo(object):
             major_version_str = re.findall(r"\d*", raw_version_str)[0]
             os_version = "%s %s" % (distribution, major_version_str)
 
-        except:
+        except Exception:
             pass
 
         return os_version
@@ -116,7 +116,7 @@ class PlatformInfo(object):
             # as it returns a friendly name e.g: XP, 7, 10 etc.
             os_version = platform.release()
 
-        except:
+        except Exception:
             pass
 
         return os_version
@@ -161,7 +161,7 @@ class PlatformInfo(object):
             else:
                 os_info["OS"] = "Unsupported system: (%s)" % (system)
 
-        except:
+        except Exception:
             # On any exception we fallback to default value
             pass
 
@@ -243,7 +243,7 @@ class MetricsQueueSingleton(object):
 
             # remember that we've logged this one already
             self.__logged_metrics.add(metric_identifier)
-        except:
+        except Exception:
             pass
         finally:
             self._lock.release()
@@ -275,7 +275,7 @@ class MetricsQueueSingleton(object):
 
                 # would be nice to be able to pop N from deque. oh well.
                 metrics = [self._queue.popleft() for i in range(0, count)]
-        except:
+        except Exception:
             pass
         finally:
             self._lock.release()
@@ -434,7 +434,7 @@ class MetricsDispatchWorkerThread(Thread):
                     else:
                         break
 
-            except Exception as e:
+            except Exception:
                 pass
             finally:
                 # wait, checking for halt event before more processing
@@ -790,7 +790,7 @@ class EventMetric(object):
                 from sgtk.platform.util import current_bundle
 
                 bundle = current_bundle()
-            except:
+            except Exception:
                 pass
 
         if not bundle:
@@ -800,7 +800,7 @@ class EventMetric(object):
                 from ..platform.engine import current_engine
 
                 bundle = current_engine()
-            except:
+            except Exception:
                 # Bailing out trying to guess bundle
                 pass
 

--- a/python/tank/util/pyside2_patcher.py
+++ b/python/tank/util/pyside2_patcher.py
@@ -328,7 +328,7 @@ class PySide2Patcher(object):
                     # returns False or raises some error.
                     try:
                         return webbrowser.open_new_tab(url.toString().encode("utf-8"))
-                    except:
+                    except Exception:
                         return False
 
             @classmethod

--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -227,7 +227,7 @@ class PySide6Patcher(PySide2Patcher):
                     screens = QtGui.QGuiApplication.screens()
                     screen = screens[screen_index]
                     screen.geometryChanged.emit()
-                except:
+                except Exception:
                     pass
 
         original_QScreen_availableGeometry = QtGui.QScreen.availableGeometry

--- a/python/tank/util/sgre.py
+++ b/python/tank/util/sgre.py
@@ -21,7 +21,7 @@ import typing as _typing
 # Import constants and functions that won't be wrapped
 from re import LOCALE  # noqa import into namespace
 from re import escape  # noqa import into namespace
-from re import (
+from re import (  # noqa: F401 import into namespace
     DEBUG,
     DOTALL,
     IGNORECASE,

--- a/python/tank/util/shotgun/connection.py
+++ b/python/tank/util/shotgun/connection.py
@@ -372,7 +372,6 @@ def get_sg_connection():
 
     :return: PTR API handle
     """
-    global _g_sg_cached_connections
     sg = getattr(_g_sg_cached_connections, "sg", None)
 
     if sg is None:

--- a/python/tank/util/shotgun/download.py
+++ b/python/tank/util/shotgun/download.py
@@ -13,7 +13,6 @@ Methods for downloading things from Shotgun
 """
 
 import os
-import sys
 import tempfile
 import time
 import urllib.parse

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -311,13 +311,13 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
                 )
 
                 # entity
-                if update_entity_thumbnail == True and context.entity is not None:
+                if update_entity_thumbnail and context.entity is not None:
                     tk.shotgun.upload_thumbnail(
                         context.entity["type"], context.entity["id"], thumbnail_path
                     )
 
                 # task
-                if update_task_thumbnail == True and task is not None:
+                if update_task_thumbnail and task is not None:
                     tk.shotgun.upload_thumbnail("Task", task["id"], thumbnail_path)
 
             else:

--- a/python/tank/util/shotgun/publish_creation.py
+++ b/python/tank/util/shotgun/publish_creation.py
@@ -311,7 +311,7 @@ def register_publish(tk, context, path, name, version_number, **kwargs):
                 )
 
                 # entity
-                if update_entity_thumbnail and context.entity is not None:
+                if update_entity_thumbnail is True and context.entity is not None:
                     tk.shotgun.upload_thumbnail(
                         context.entity["type"], context.entity["id"], thumbnail_path
                     )

--- a/python/tank/util/shotgun/publish_util.py
+++ b/python/tank/util/shotgun/publish_util.py
@@ -49,7 +49,7 @@ def get_entity_type_display_name(tk, entity_type_code):
     try:
         if entity_type_code in schema_data:
             display_name = schema_data[entity_type_code]["name"]["value"]
-    except:
+    except Exception:
         pass
 
     return display_name

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_version():
         if re.match(r"v[0-9]*.[0-9]*.[0-9]*", version_git):
             return version_git
         return "dev"
-    except:
+    except Exception:
         # Blindly ignore problems, git might be not available, or the user could
         # be installing from zip archive, etc...
         pass

--- a/setup/tank_api_proxy/sgtk/__init__.py
+++ b/setup/tank_api_proxy/sgtk/__init__.py
@@ -11,6 +11,7 @@
 
 # thin proxy wrapper which finds the real sgtk and replaces itself with that
 
+import importlib
 import os
 import sys
 
@@ -63,4 +64,4 @@ os.environ["TANK_CURRENT_PC"] = pipeline_config
 # prepend this to the python path and reload the module
 # this way we will load the 'real' tank!
 os.sys.path.insert(0, parent_python_path)
-reload(sys.modules["sgtk"])
+importlib.reload(sys.modules["sgtk"])

--- a/setup/tank_api_proxy/tank/__init__.py
+++ b/setup/tank_api_proxy/tank/__init__.py
@@ -11,6 +11,7 @@
 
 # thin proxy wrapper which finds the real tank and replaces itself with that
 
+import importlib
 import os
 import sys
 
@@ -62,4 +63,4 @@ os.environ["TANK_CURRENT_PC"] = pipeline_config
 # prepend this to the python path and reload the module
 # this way we will load the 'real' tank!
 os.sys.path.insert(0, parent_python_path)
-reload(sys.modules["tank"])
+importlib.reload(sys.modules["tank"])

--- a/tests/bootstrap_tests/test_configuration.py
+++ b/tests/bootstrap_tests/test_configuration.py
@@ -18,7 +18,6 @@ from sgtk.authentication import ShotgunAuthenticator, ShotgunSamlUser
 from sgtk.authentication.user_impl import SessionUser
 from sgtk.bootstrap.cached_configuration import CachedConfiguration
 from sgtk.bootstrap.configuration import Configuration
-from tank.bootstrap import constants
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,

--- a/tests/bootstrap_tests/test_resolver.py
+++ b/tests/bootstrap_tests/test_resolver.py
@@ -14,7 +14,6 @@ import sys
 
 import sgtk
 from sgtk.util import ShotgunPath
-from tank.bootstrap import constants
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,

--- a/tests/commands_tests/test_updates.py
+++ b/tests/commands_tests/test_updates.py
@@ -14,7 +14,6 @@ Unit tests tank updates.
 
 import logging
 import os
-import sys
 
 from tank.platform.environment import InstalledEnvironment
 from tank_test.mock_appstore import TankMockStoreDescriptor, patch_app_store

--- a/tests/core_tests/test_context.py
+++ b/tests/core_tests/test_context.py
@@ -987,19 +987,9 @@ class TestAsTemplateFields(TestContext):
 
         # second asset with different asset type
         asset_type_2 = "Prop"
-        asset_2 = {
-            "type": "Asset",
-            "id": 2,
-            "code": "asset_code_2",
-            "name": "asset_name_2",
-            "project": self.project,
-            "asset_type": asset_type_2,
-        }
 
         alt_step_path = os.path.join(self.project_root, asset_type_2, step_short_name)
         self.add_production_path(alt_step_path, self.step)
-
-        asset_2_path = os.path.join(alt_step_path, asset_2["code"])
 
         ctx = self.tk.context_from_path(asset_path)
 

--- a/tests/core_tests/test_templatekey.py
+++ b/tests/core_tests/test_templatekey.py
@@ -14,7 +14,6 @@ Tests for templatefield module.
 
 import copy
 import datetime
-import sys
 
 from tank import TankError
 from tank.templatekey import IntegerKey, SequenceKey, StringKey, TimestampKey, make_keys
@@ -844,7 +843,6 @@ class TestSequenceKey(ShotgunTestBase):
         default frame spec value can be returned, frame spec with
         one place has special cases.
         """
-        value = None
         seq_field = SequenceKey("field_name")
         expected = "%d"
         result = seq_field.str_from_value(value="FORMAT:%d")
@@ -1127,7 +1125,6 @@ class TestEyeKey(ShotgunTestBase):
         self.assertEqual(self.default_value, self.eye_key.str_from_value())
 
     def test_set_choices(self):
-        eye_key = StringKey("eye", default="%V", choices=["l", "r", "%V"])
         self.assertTrue(self.eye_key.validate(self.default_value))
         self.assertTrue(self.eye_key.validate("l"))
         self.assertTrue(self.eye_key.validate("r"))

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -895,6 +895,7 @@ class TestGetFields(TestTemplatePath):
         input_path = "path/to/seq.0003.ext"
         expected = {"frame": 3}
         result = self.sequence.get_fields(input_path)
+        self.assertEqual(expected, result)
 
     def test_nuke_framespec(self):
         input_path = "path/to/seq.%04d.ext"

--- a/tests/core_tests/test_templatestring.py
+++ b/tests/core_tests/test_templatestring.py
@@ -84,8 +84,6 @@ class TestValidate(TestTemplateString):
         self.assertFalse(self.template_string.validate(invalid_string))
 
     def test_conflicting_values(self):
-        definition = "{Shot}-{Sequence}.{Shot}"
-        template_string = TemplateString(definition, self.keys)
         invalid_string = "shot_1-Seq_12.shot_2"
         self.assertFalse(self.template_string.validate(invalid_string))
 
@@ -93,13 +91,11 @@ class TestValidate(TestTemplateString):
         template_string = TemplateString("something-{Shot}[.{Sequence}]", self.keys)
 
         input_string = "something-shot_1.seq_2"
-        expected = {"Shot": "shot_1", "Sequence": "seq_2"}
 
         self.assertTrue(template_string.validate(input_string))
 
         # without optional value
         input_string = "something-shot_1"
-        expected = {"Shot": "shot_1"}
 
         self.assertTrue(template_string.validate(input_string))
 
@@ -157,15 +153,12 @@ class TestGetFields(TestTemplateString):
         self.assertRaises(TankError, self.template_string.get_fields, input_string)
 
     def test_conflicting_values(self):
-        definition = "{Shot}.{Shot}"
         input_string = "shot_1.shot_2"
         self.assertRaises(TankError, self.template_string.get_fields, input_string)
 
     def test_definition_short_end_static(self):
         """Tests case when input string longer than definition which
         ends with non key."""
-        definition = "{Shot}.something"
-        template_string = TemplateString(definition, self.keys)
         input_string = "shot_1.something-else"
         self.assertRaises(TankError, self.template_string.get_fields, input_string)
 

--- a/tests/deploy_tests/test_descriptors.py
+++ b/tests/deploy_tests/test_descriptors.py
@@ -11,8 +11,7 @@
 import os
 
 import sgtk
-from tank.errors import TankError
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestLegacyDescriptorSupport(TankTestBase):

--- a/tests/descriptor_tests/test_appstore.py
+++ b/tests/descriptor_tests/test_appstore.py
@@ -17,9 +17,6 @@ import os
 
 import sgtk
 from sgtk.descriptor import Descriptor, create_descriptor
-from sgtk.descriptor.io_descriptor.base import IODescriptorBase
-from tank import TankError
-from tank.platform.environment import InstalledEnvironment
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,
@@ -159,7 +156,6 @@ class TestAppStoreLabels(ShotgunTestBase):
                         {"id": 1, "name": "2017.*", "type": "Tag"},
                         {"id": 2, "name": "2016.*", "type": "Tag"},
                     ],
-                    "sg_detailed_release_notes": "Test 1",
                     "sg_status_list": "prod",
                     "description": "dummy",
                     "sg_detailed_release_notes": "dummy",
@@ -174,7 +170,6 @@ class TestAppStoreLabels(ShotgunTestBase):
                     "id": 2,
                     "code": "v2.0.1",
                     "tags": [{"id": 1, "name": "2017.*", "type": "Tag"}],
-                    "sg_detailed_release_notes": "Test 2",
                     "sg_status_list": "prod",
                     "description": "dummy",
                     "sg_detailed_release_notes": "dummy",
@@ -189,7 +184,6 @@ class TestAppStoreLabels(ShotgunTestBase):
                     "id": 3,
                     "code": "v3.0.1",
                     "tags": [{"id": 3, "name": "2018.*", "type": "Tag"}],
-                    "sg_detailed_release_notes": "Test 3",
                     "sg_status_list": "prod",
                     "description": "dummy",
                     "sg_detailed_release_notes": "dummy",

--- a/tests/descriptor_tests/test_downloadables.py
+++ b/tests/descriptor_tests/test_downloadables.py
@@ -22,7 +22,6 @@ from functools import reduce
 import pytest
 import sgtk
 import tank
-from tank.util import is_windows
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     ShotgunTestBase,

--- a/tests/fixtures/config/bundles/test_engine/startup.py
+++ b/tests/fixtures/config/bundles/test_engine/startup.py
@@ -11,7 +11,6 @@
 import os
 
 import sgtk
-from sgtk import TankError
 from sgtk.platform import LaunchInformation, SoftwareLauncher, SoftwareVersion
 
 

--- a/tests/folder_tests/__init__.py
+++ b/tests/folder_tests/__init__.py
@@ -1,12 +1,5 @@
-import os
-import shutil
-import unittest
-
-import tank
-from tank import TankError, folder, hook
+from tank import TankError
 from tank.path_cache import PathCache
-from tank_test.tank_test_base import *
-from tank_vendor import yaml
 
 ###############################################################################################
 # useful methods for folder creation tests.

--- a/tests/folder_tests/test_configuration.py
+++ b/tests/folder_tests/test_configuration.py
@@ -9,11 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
-import unittest
 
-import tank
-from tank import TankError, folder, hook
+from tank import TankError, folder
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import TankTestBase
 from tank_vendor import yaml

--- a/tests/folder_tests/test_create_folders.py
+++ b/tests/folder_tests/test_create_folders.py
@@ -12,10 +12,8 @@ import copy
 import os
 import shutil
 
-import tank
-from tank import TankError, folder, hook, path_cache
-from tank_test.tank_test_base import *
-from tank_vendor import yaml
+from tank import TankError, folder, path_cache
+from tank_test.tank_test_base import TankTestBase
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 
@@ -982,7 +980,6 @@ class TestFolderCreationEdgeCases(TankTestBase):
         self.assertEqual(paths_in_db, [shot_path])
 
         # change the id of the shot - effectively deleting and creating a shot!
-        old_id = self.shot["id"]
         self.shot["id"] = 12345
         # make sure to null the link going from the task too - this is how shotgun
         # would have done a retirement.

--- a/tests/folder_tests/test_deferred.py
+++ b/tests/folder_tests/test_deferred.py
@@ -9,12 +9,9 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
 
-import tank
-from tank import TankError, folder, hook
-from tank_test.tank_test_base import *
-from tank_vendor import yaml
+from tank import folder
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestDeferredFolderCreation(TankTestBase):

--- a/tests/folder_tests/test_optional_fields.py
+++ b/tests/folder_tests/test_optional_fields.py
@@ -10,12 +10,9 @@
 
 import copy
 import os
-import shutil
 
-import tank
-from tank import TankError, folder, hook
-from tank_test.tank_test_base import *
-from tank_vendor import yaml
+from tank import folder
+from tank_test.tank_test_base import TankTestBase
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_secondary_entity.py
+++ b/tests/folder_tests/test_secondary_entity.py
@@ -9,12 +9,9 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
 
-import tank
-from tank import TankError, folder, hook, path_cache
-from tank_test.tank_test_base import *
-from tank_vendor import yaml
+from tank import folder, path_cache
+from tank_test.tank_test_base import TankTestBase
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_static_filter.py
+++ b/tests/folder_tests/test_static_filter.py
@@ -9,12 +9,9 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
 
-import tank
-from tank import TankError, folder, hook
+from tank import folder
 from tank_test.tank_test_base import TankTestBase
-from tank_vendor import yaml
 
 
 class TestStaticFolderFilters(TankTestBase):

--- a/tests/folder_tests/test_step_node.py
+++ b/tests/folder_tests/test_step_node.py
@@ -9,16 +9,13 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
-import unittest
 
 import tank
-from tank import TankError, folder, hook
+from tank import folder
 from tank_test.tank_test_base import (
     TankTestBase,
     mock,
 )
-from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_symlinks.py
+++ b/tests/folder_tests/test_symlinks.py
@@ -12,7 +12,7 @@ import os
 
 from tank import folder
 from tank.util import is_windows
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestSymlinks(TankTestBase):

--- a/tests/folder_tests/test_task_node.py
+++ b/tests/folder_tests/test_task_node.py
@@ -9,15 +9,11 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
-import unittest
 
-import tank
-from tank import TankError, folder, hook
+from tank import folder
 from tank_test.tank_test_base import (
     TankTestBase,
 )
-from tank_vendor import yaml
 
 from . import assert_paths_to_create, execute_folder_creation_proxy
 

--- a/tests/folder_tests/test_user_sandbox.py
+++ b/tests/folder_tests/test_user_sandbox.py
@@ -9,16 +9,12 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import shutil
-import unittest
 
-import tank
-from tank import TankError, folder, hook
+from tank import TankError, folder
 from tank_test.tank_test_base import (
     TankTestBase,
     mock,
 )
-from tank_vendor import yaml
 
 
 class TestHumanUser(TankTestBase):

--- a/tests/integration_tests/multi_bootstrap.py
+++ b/tests/integration_tests/multi_bootstrap.py
@@ -13,7 +13,6 @@ This test makes sure that various tank command operations do not fail.
 """
 
 import os
-import sys
 import traceback
 import unittest
 

--- a/tests/integration_tests/offline_workflow.py
+++ b/tests/integration_tests/offline_workflow.py
@@ -14,7 +14,6 @@ zipped config can be bootstrap into without requiring to download anything from 
 """
 
 import os
-import sys
 import unittest
 
 import sgtk

--- a/tests/integration_tests/tank_commands.py
+++ b/tests/integration_tests/tank_commands.py
@@ -15,7 +15,6 @@ This test makes sure that various tank command operations do not fail.
 import os
 import re
 import shutil
-import sys
 import unittest
 
 import sgtk

--- a/tests/platform_tests/test_application.py
+++ b/tests/platform_tests/test_application.py
@@ -20,7 +20,7 @@ import tank
 from tank.errors import TankError, TankHookMethodDoesNotExistError
 from tank.platform import application, validation
 from tank.template import Template
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
 
 
 class TestApplication(TankTestBase):

--- a/tests/platform_tests/test_environment.py
+++ b/tests/platform_tests/test_environment.py
@@ -10,7 +10,6 @@
 
 import copy
 import os
-import sys
 
 from tank.errors import TankError
 from tank.platform.environment import Environment
@@ -528,7 +527,7 @@ class TestRuamelParser(TankTestBase):
         # because floats are rendered differently on different versions of
         # python, replace the FLOAT_VALUE keyword in the expected fixture
         # with whatever the current version of python is expecting
-        expected_env = [l.replace("FLOAT_VALUE", repr(1.1)) for l in expected_env]
+        expected_env = [line.replace("FLOAT_VALUE", repr(1.1)) for line in expected_env]
         # additionally, convert the lines to sets so that the test does not
         # depend on the order of a dictionary.
         self.assertEqual(set(updated_env), set(expected_env))
@@ -566,5 +565,5 @@ class TestPyYamlParser(TankTestBase):
         # because floats are rendered differently on different versions of
         # python, replace the FLOAT_VALUE keyword in the expected fixture
         # with whatever the current version of python is expecting
-        expected_env = [l.replace("FLOAT_VALUE", repr(1.1)) for l in expected_env]
+        expected_env = [line.replace("FLOAT_VALUE", repr(1.1)) for line in expected_env]
         self.assertEqual(updated_env, expected_env)

--- a/tests/platform_tests/test_software_launcher.py
+++ b/tests/platform_tests/test_software_launcher.py
@@ -142,7 +142,6 @@ class TestEngineLauncher(TankTestBase):
                 "SHOTGUN_SITE": "http://unit_test_mock_sg",
                 "SHOTGUN_ENTITY_TYPE": entity["type"],
                 "SHOTGUN_ENTITY_ID": str(entity["id"]),
-                "SHOTGUN_ENTITY_ID": str(entity["id"]),
                 "SHOTGUN_BUNDLE_CACHE_FALLBACK_PATHS": os.pathsep.join(
                     MOCKED_FALLBACKS
                 ),

--- a/tests/platform_tests/test_validation.py
+++ b/tests/platform_tests/test_validation.py
@@ -1,7 +1,8 @@
 import os
 
 import tank
-from tank.platform.validation import *
+from tank.errors import TankError
+from tank.platform.validation import validate_schema, validate_settings
 from tank.templatekey import StringKey
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase, TankTestBase
@@ -305,10 +306,8 @@ class TestValidateSettings(TankTestBase):
     def test_hook_does_not_exist(self):
         hook_name = "hook_fake"
         hook_value = "no_such_file"
-        tk = None
         settings = {hook_name: hook_value}
         schema = {hook_name: {"type": "hook"}}
-        hooks_location = os.path.join(self.pipeline_config_root, "config", "hooks")
 
         self.assertRaises(
             TankError,
@@ -447,7 +446,6 @@ class TestValidateSettings(TankTestBase):
 
     def test_list_good_values(self):
         key = "test_setting"
-        bad_type = "bogus"
         list_value = {"type": "list", "allows_empty": True, "values": {"type": "str"}}
         schema = {key: list_value}
         settings = {key: []}

--- a/tests/python/tank_test/mock_appstore.py
+++ b/tests/python/tank_test/mock_appstore.py
@@ -13,15 +13,12 @@ Unit tests tank updates.
 """
 
 import functools
-import sys
 from unittest import mock
 
 from packaging import version
-from sgtk.descriptor import Descriptor, create_descriptor
+from sgtk.descriptor import Descriptor
 from sgtk.descriptor.io_descriptor.base import IODescriptorBase
 from sgtk.util import sgre as re
-from tank import TankError
-from tank.platform.environment import InstalledEnvironment
 
 
 class MockStore(object):

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -64,7 +64,7 @@ class TestFileSystem(TankTestBase):
         shutil.copytree(src_folder, dst_folder)
         self.assertTrue(os.path.exists(dst_folder))
         # open a file in the directory to remove ...
-        with open(os.path.join(dst_folder, "ReadWrite.txt")) as f:
+        with open(os.path.join(dst_folder, "ReadWrite.txt")):
             # ... and check that a failure occurs
             fs.safe_delete_folder(dst_folder)
             if is_windows():

--- a/tests/util_tests/test_load_publish.py
+++ b/tests/util_tests/test_load_publish.py
@@ -12,9 +12,8 @@ import os
 import sys
 
 import sgtk
-from tank import context, errors
 from tank.util import is_linux, is_macos, is_windows
-from tank_test.tank_test_base import TankTestBase, setUpModule
+from tank_test.tank_test_base import TankTestBase, setUpModule  # noqa
 
 
 class TestCoreHook(TankTestBase):

--- a/tests/util_tests/test_publish.py
+++ b/tests/util_tests/test_publish.py
@@ -11,14 +11,14 @@
 import os
 
 import tank
-from tank import context, errors
+from tank import context
 from tank.util import is_windows
+from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import (
     TankTestBase,
     mock,
     only_run_on_nix,
     only_run_on_windows,
-    setUpModule,
 )
 
 

--- a/tests/util_tests/test_shotgun_entity.py
+++ b/tests/util_tests/test_shotgun_entity.py
@@ -10,7 +10,7 @@
 
 import sgtk
 import tank
-from tank.util.shotgun_entity import get_sg_entity_name_field, sg_entity_to_string
+from tank.util.shotgun_entity import sg_entity_to_string
 from tank_test.tank_test_base import ShotgunTestBase, TankTestBase, setUpModule  # noqa
 
 KNOWN_SG_ENTITIES = [

--- a/tests/util_tests/test_version_import.py
+++ b/tests/util_tests/test_version_import.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Autodesk.
 
 import importlib
-import unittest
 
 from tank_test.tank_test_base import setUpModule  # noqa
 from tank_test.tank_test_base import ShotgunTestBase

--- a/tests/util_tests/test_yaml_cache.py
+++ b/tests/util_tests/test_yaml_cache.py
@@ -11,7 +11,6 @@
 import copy
 import os
 
-import sgtk
 from sgtk import TankError
 from sgtk.util.yaml_cache import YamlCache
 from tank_test.tank_test_base import setUpModule  # noqa


### PR DESCRIPTION
## Summary

Adds the `flake8` hook to `.pre-commit-config.yaml`, pointed at the repo's
existing `.flake8` config (previously only enforced by Hound CI, so its
findings never surfaced in `pre-commit run --all` or CI's "Code Style
Validation" job). Also fixes the ~330 pre-existing violations that were
blocking the hook from being enabled cleanly.

Jira: [SG-43986](https://autodesk.atlassian.net/browse/SG-43986)

## Changes

1. **Add the hook** (`ae4f70a5`) - added `flake8` to `.pre-commit-config.yaml`
   after `black`, using the existing `.flake8` config. Confirmed it failed
   both locally (`pre-commit run flake8 --all-files`) and in this PR's CI
   before any cleanup.
2. **Mechanical cleanup, part 1** (`7e9ec5e2`) - fixed every file that only
   had "pure style" findings: unused imports (F401), bare `except:` clauses
   (E722), unused local variables (F841), `==`/`!=` comparisons to
   None/True/False (E711/E712), type comparisons (E721), duplicate dict keys
   (F601), and `not in` style (E713/E741).
3. **Finish the cleanup** (`465f1b66`) - converts the remaining star imports
   (`from x import *`, F403/F405) in test files to explicit imports, removes
   the remaining unused imports, and fixes 3 categories of genuine (not just
   style) issues:
   - Two leftover Python 2 `reload()` calls in the `tank_api_proxy` shims
     (F821 - `reload` doesn't exist in Python 3) - switched to
     `importlib.reload()`.
   - Six unnecessary `global` declarations (F824) in getters that only read
     a module-level name and never reassign it (`api.py`,
     `authentication/constants.py`, `authentication/user_impl.py`,
     `authentication/web_login_support.py`, `platform/engine.py`,
     `util/shotgun/connection.py`). No behavior change - `global` is only
     required when rebinding the name itself.
   - One `# noqa: F811` on `Engine.flow_host` - the property shares its name
     with the module-level `flow_host` import (used only in the property's
     own return-type annotation). Pyflakes flags this as a redefinition, but
     it's a false positive: the annotation is evaluated before the class
     attribute binds, so it resolves correctly at runtime (verified with a
     standalone repro).

## Judgment calls worth a second look

- **`tests/descriptor_tests/test_appstore.py`** - 3 fixture dicts had
  duplicate keys (F601) with different values (e.g.
  `"sg_detailed_release_notes"` set to `"Test 1"` then overwritten by
  `"dummy"` in the same literal). Fixed by keeping the last value, matching
  Python's own dict-literal semantics (zero behavior change either way).
  Confirmed no assertion in that test reads the affected field, so it's
  inert, but the original intent may have been 3 distinct values.
- **`tests/core_tests/test_templatepath.py::test_frame_number`** - was
  missing its `self.assertEqual(expected, result)` entirely (an unused
  local, F841, was the tell). Added the missing assertion back. Verified it
  passes on its own and as part of the full 93-test file run.
- **`tests/core_tests/test_templatekey.py` / `test_templatestring.py`** -
  several tests built a local variable but asserted against a pre-built
  `self.foo` fixture instead, leaving the local dead (F841). Removed the
  dead locals rather than rewiring the assertions, since rewiring would
  change what's being tested and risks surfacing a separate, unrelated bug.
- **`tests/core_tests/test_context.py`** - removed an unused `asset_2` dict
  literal (F841) that looks like it was meant to be registered via
  `add_production_path` (like the neighboring `asset_1`) but never was.
  Left as removed rather than "completing" the apparent gap, to keep this
  change purely about lint.

None of the above change what's being tested in a way that reduces coverage
of real product code paths; they're flagged here for a reviewer to confirm
that read.

## Testing performed

- `pre-commit run --all-files` passes cleanly, run twice to confirm
  stability (no further auto-fixes on the second pass).
- Full test suite: `python tests/run_tests.py` - 1249 tests passed, 44
  pre-existing skips, 0 failures.
- Manually installed the pre-commit git hook locally and confirmed a
  trivial change to a file with a pre-existing violation is correctly
  blocked from being committed.
- `test_frame_number` (the one assertion added back) verified individually
  and as part of its full test file run.


[SG-43986]: https://autodesk.atlassian.net/browse/SG-43986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ