### PR TITLE
SG-43935 data model derivative update

### DIFF
--- a/python/tank/flowam/config.json
+++ b/python/tank/flowam/config.json
@@ -1,6 +1,6 @@
 {
   "name": "demo_pipeline",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Flow Toolkit pipeline schema definitions",
   "schemas": [
     {
@@ -181,6 +181,46 @@
         {
           "name": "fileFormat",
           "data_type": "String"
+        }
+      ]
+    },
+    {
+      "name": "component.variantSet",
+      "version": "1.0.0",
+      "display_name": "Variant Set",
+      "kind": "component",
+      "description": "The target asset is a selectable realization of this asset for setName=variantName.",
+      "inherits": [],
+      "properties": [
+        {
+          "name": "setName",
+          "data_type": "String"
+        },
+        {
+          "name": "variantName",
+          "data_type": "String"
+        },
+        {
+          "name": "targetAsset",
+          "data_type": "$id:autodesk.me:reference-2.0.0"
+        },
+        {
+          "name": "displayName",
+          "data_type": "String"
+        }
+      ]
+    },
+    {
+      "name": "component.source",
+      "version": "1.0.0",
+      "display_name": "Source",
+      "kind": "component",
+      "description": "The target asset represents provenance or derivation lineage.",
+      "inherits": [],
+      "properties": [
+        {
+          "name": "targetVersion",
+          "data_type": "$id:autodesk.me:reference-2.0.0"
         }
       ]
     }

--- a/python/tank/flowam/create.py
+++ b/python/tank/flowam/create.py
@@ -167,9 +167,7 @@ def get_or_create_workfile_parent(
 
     container = root_folder.find_child(sg_entity_name)
     container_type = (
-        ASSET_CONTAINER_TYPE
-        if sg_entity_type == ASSET_TYPE
-        else SHOT_CONTAINER_TYPE
+        ASSET_CONTAINER_TYPE if sg_entity_type == ASSET_TYPE else SHOT_CONTAINER_TYPE
     )
     if not container:
         logger.info(
@@ -180,9 +178,7 @@ def get_or_create_workfile_parent(
             name=sg_entity_name,
             parent_id=root_folder.id,
             components=[
-                TypeComponentSpec(
-                    type_id=get_schema_id(container_type), name=f"Type"
-                )
+                TypeComponentSpec(type_id=get_schema_id(container_type), name=f"Type")
             ],
         )
         container = FlowAsset(medm_asset)

--- a/python/tank/flowam/create.py
+++ b/python/tank/flowam/create.py
@@ -106,7 +106,7 @@ def get_or_create_root_folder(inputs: BaseInputs) -> FlowAsset:
         if not folder:
             logger.info(f'Creating "{SHOT_TYPE}" folder...')
             raw_asset = publish_new_asset(
-                name=ensure_unique_name(SHOT_TYPE, project),
+                name=SHOT_TYPE,
                 parent_id=project.id,
                 description="Folder for Shot assets.",
                 components=[
@@ -119,7 +119,7 @@ def get_or_create_root_folder(inputs: BaseInputs) -> FlowAsset:
         if not folder:
             logger.info(f'Creating "{ASSET_FOLDER}" folder...')
             raw_asset = publish_new_asset(
-                name=ensure_unique_name(ASSET_FOLDER, project),
+                name=ASSET_FOLDER,
                 parent_id=project.id,
                 description="Folder for Asset Build assets.",
                 components=[
@@ -132,7 +132,7 @@ def get_or_create_root_folder(inputs: BaseInputs) -> FlowAsset:
         if not folder:
             logger.info(f'Creating "{GENERIC_FOLDER}" folder...')
             raw_asset = publish_new_asset(
-                name=ensure_unique_name(GENERIC_FOLDER, project),
+                name=GENERIC_FOLDER,
                 parent_id=project.id,
                 description="Folder for Generic assets.",
                 components=[
@@ -164,59 +164,63 @@ def get_or_create_workfile_parent(
     sg_entity_type = inputs.sg_entity_type
     sg_entity_name = inputs.sg_entity_name
     sg_pipeline_step = inputs.sg_pipeline_step
-    sg_task_name = inputs.sg_task_name
 
     container = root_folder.find_child(sg_entity_name)
+    container_type = (
+        ASSET_CONTAINER_TYPE
+        if sg_entity_type == ASSET_TYPE
+        else SHOT_CONTAINER_TYPE
+    )
     if not container:
         logger.info(
             f'Creating container asset for "{sg_entity_name}" under '
             f'folder "{root_folder.name}"...'
         )
-        container_type = (
-            ASSET_CONTAINER_TYPE
-            if sg_entity_type == ASSET_TYPE
-            else SHOT_CONTAINER_TYPE
-        )
-        raw_asset = publish_new_asset(
-            name=ensure_unique_name(sg_entity_name, root_folder),
+        medm_asset = publish_new_asset(
+            name=sg_entity_name,
             parent_id=root_folder.id,
             components=[
                 TypeComponentSpec(
-                    type_id=get_schema_id(container_type), name=f"Type {container_type}"
+                    type_id=get_schema_id(container_type), name=f"Type"
                 )
             ],
         )
-        container = FlowAsset(raw_asset)
+        container = FlowAsset(medm_asset)
 
     pipeline_step = container.find_child(sg_pipeline_step)
     if not pipeline_step:
-        logger.info(f'Creating pipeline step asset for "{sg_pipeline_step}"...')
-        raw_asset = publish_new_asset(
-            name=ensure_unique_name(sg_pipeline_step, container),
+        logger.info(f'Creating pipeline step folder for "{sg_pipeline_step}"...')
+        medm_asset = publish_new_asset(
+            name=sg_pipeline_step,
             parent_id=container.id,
-            components=[
-                TypeComponentSpec(
-                    type_id=get_schema_id(PIPELINE_STEP_TYPE),
-                    name=f"Type {PIPELINE_STEP_TYPE}",
-                )
-            ],
+            components=[TypeComponentSpec(type_id=FOLDER_TYPE_ID, name="Type")],
         )
-        pipeline_step = FlowAsset(raw_asset)
+        pipeline_step = FlowAsset(medm_asset)
 
-    task_folder = pipeline_step.find_child(sg_task_name)
-    if not task_folder:
-        logger.info(f'Creating task folder asset for "{sg_task_name}"...')
-        raw_asset = publish_new_asset(
-            name=ensure_unique_name(sg_task_name, pipeline_step),
-            parent_id=pipeline_step.id,
-            description=f'Folder for task "{sg_task_name}".',
-            components=[
-                TypeComponentSpec(type_id=FOLDER_TYPE_ID, name=f"Type {FOLDER_TYPE_ID}")
-            ],
-        )
-        task_folder = FlowAsset(raw_asset)
+    if inputs.create_mode == CreateMode.GENERIC:
+        # Parent generic assets directly under pipeline step
+        parent = pipeline_step
+    else:
+        # For dcc assets, parent them under a root asset
+        # that will house the dcc asset as one of its "representations"
+        # NOTE: the root asset will be container type for now
+        asset_root = pipeline_step.find_child(sg_entity_name)
+        if not asset_root:
+            logger.info(f'Creating root asset for "{sg_entity_name}"...')
+            medm_asset = publish_new_asset(
+                name=sg_entity_name,
+                parent_id=pipeline_step.id,
+                description=f'Root asset for "{sg_entity_name}".',
+                components=[
+                    TypeComponentSpec(
+                        type_id=get_schema_id(container_type), name=f"Type"
+                    )
+                ],
+            )
+            asset_root = FlowAsset(medm_asset)
+        parent = asset_root
 
-    return task_folder
+    return parent
 
 
 def ensure_unique_name(name: str, parent: FlowAsset | FlowProject) -> str:

--- a/python/tank_vendor/flow_integration_sdk/globals.py
+++ b/python/tank_vendor/flow_integration_sdk/globals.py
@@ -39,9 +39,6 @@ BASE_PROPERTY_TYPE_ID = "autodesk.me:property-1.0.0"
 BASE_TYPE_ID = "autodesk.me:type-1.1.0"
 BINARY_TYPE_ID = "autodesk.me:component.binary-1.0.0"
 COMMENT_TYPE_ID = "autodesk.me:component.publishComment-1.0.0"
-# NOTE: This is a temporary schema being annexed for representing derivative source
-#       which should be switched for a dedicated schema later.
-DER_SOURCE_TYPE_ID = "autodesk.me:component.dynamicPlaylistSource-1.0.0"
 FOLDER_TYPE_ID = "autodesk.me:type.folder-1.0.0"
 IMAGE_TYPE_ID = "autodesk.me:component.binary.image-1.0.0"
 
@@ -58,6 +55,8 @@ KIND_BASE_TYPE_ID = {
 # This should be a temporary measure, only necessary while some types
 # are not yet added to the autodesk domain, and must be created per collection.
 FILE_SEQ_TYPE = "type.fileSequence"
+DER_SOURCE_TYPE = "component.source"
+VARIANT_SET_TYPE = "component.variantSet"
 
 
 # Component purposes

--- a/python/tank_vendor/flow_integration_sdk/objects.py
+++ b/python/tank_vendor/flow_integration_sdk/objects.py
@@ -44,11 +44,13 @@ from .globals import (
     BASE_TYPE_ID,
     BINARY_TYPE_ID,
     COMMENT_TYPE_ID,
-    DER_SOURCE_TYPE_ID,
+    DER_SOURCE_COMP,
+    DER_SOURCE_TYPE,
     get_client,
     get_webapp_url,
 )
 from .sandbox import CheckoutDraftInfo, get_asset_drafts
+from .schema import get_schema_id
 from .storage import (
     _cache_asset_info,
     get_storage_asset_dir,
@@ -820,38 +822,25 @@ class FlowAsset(ComponentMixin, UsesMixin, FlowEntity):
             raise FlowError(msg) from exc
 
     @trace
-    def find_derivative(
-        self,
-        target_type_id: str,
-        target_component_name: str,
-    ) -> FlowAsset | None:
-        """Search asset to find an outbound derivative where the target
-        matches the criteria provided.
+    def get_derivatives(self) -> list[FlowAsset]:
+        """Find siblings of this asset that were derived from it.
+        (i.e. have a Source component that points to this asset)
 
-        This function searches across ALL revisions of the source asset to find
-        any existing derivative relationship.
-
-        Args:
-            target_type_id: Type of target revision.
-            target_component_name: Name of component on target revision to be matched.
-                                   (Derivative relationships are component to component.)
-
-        Returns:
-            The first derivative asset found, or None.
+        Raises:
+            FlowError
         """
-        # This target id should match the beginning of any revision id belonging to this asset
-        target_id = self.id.replace(self.MEDM_ENTITY, FlowRevision.MEDM_ENTITY)
 
-        # Generate a query to find assets which contain a source-derivative
-        # component with a matching target id
+        # This target id should match the beginning of any version id belonging to this asset
+        target_id = self.id.replace(self.MEDM_ENTITY, FlowVersion.MEDM_ENTITY)
+        der_source_type_id = get_schema_id(DER_SOURCE_TYPE)
+
+        # Generate a query to find assets which contain a Source component with a matching target id
         # Since we know derivative assets will be siblings of the current asset
         # we can safely scope this query to the parent asset with depth of 1.
         client = get_client()
-        q_filter = f"has.component.type=={DER_SOURCE_TYPE_ID};"
-        q_filter += f"components[typeId:{DER_SOURCE_TYPE_ID}].data.folder.objectId=like={target_id}*;"
-        q_filter += (
-            f"components[typeId:{DER_SOURCE_TYPE_ID}].name=='{target_component_name}'"
-        )
+        q_filter = f"has.component.type=={der_source_type_id};"
+        q_filter += f"components[typeId:{der_source_type_id}].data.targetVersion=like={target_id}*;"
+        q_filter += f"components[typeId:{der_source_type_id}].name=='{DER_SOURCE_COMP}'"
         q_input = medm_model.AssetsByTraversalInput(
             start_at_id=self.parent_id,  # search under parent
             depth=1,  # search immediate children only
@@ -871,6 +860,24 @@ class FlowAsset(ComponentMixin, UsesMixin, FlowEntity):
         der_assets = [
             FlowAsset(a) for a in q_derivatives.assets if a.id != self.parent_id
         ]
+        return der_assets
+
+    @trace
+    def find_derivative(
+        self,
+        target_type_id: str,
+    ) -> FlowAsset | None:
+        """Search asset to find an outbound derivative where the target
+        matches the criteria provided.
+
+        Args:
+            target_type_id: Type of target revision.
+
+        Returns:
+            The first derivative asset found, or None.
+        """
+        # Get list of assets that are derivatives of this asset
+        der_assets = self.get_derivatives()
         # Now filter out derivatives of the wrong type
         der_assets = [a for a in der_assets if target_type_id in a.type_ids]
 

--- a/python/tank_vendor/flow_integration_sdk/objects.py
+++ b/python/tank_vendor/flow_integration_sdk/objects.py
@@ -839,7 +839,7 @@ class FlowAsset(ComponentMixin, UsesMixin, FlowEntity):
         # we can safely scope this query to the parent asset with depth of 1.
         client = get_client()
         q_filter = f"has.component.type=={der_source_type_id};"
-        q_filter += f"components[typeId:{der_source_type_id}].data.targetVersion=like={target_id}*;"
+        q_filter += f"components[typeId:{der_source_type_id}].data.targetVersion.objectId.id=like={target_id}*;"
         q_filter += f"components[typeId:{der_source_type_id}].name=='{DER_SOURCE_COMP}'"
         q_input = medm_model.AssetsByTraversalInput(
             start_at_id=self.parent_id,  # search under parent

--- a/python/tank_vendor/flow_integration_sdk/objects.py
+++ b/python/tank_vendor/flow_integration_sdk/objects.py
@@ -48,6 +48,7 @@ from .globals import (
     DER_SOURCE_TYPE,
     get_client,
     get_webapp_url,
+    VARIANT_SET_TYPE,
 )
 from .sandbox import CheckoutDraftInfo, get_asset_drafts
 from .schema import get_schema_id
@@ -374,6 +375,57 @@ class ComponentMixin:
         if matches:
             return matches[0]
         return None
+
+    @trace
+    def get_sources(self) -> list[str]:
+        """Find any Source components within the component list and
+        return a list of target versions that they point to.
+
+        NOTE: A source relationship designates provenance. The target
+              source cab be considered the entity from which this entity
+              was derived.
+
+        Returns:
+            List of version ids that this revision designates as a source.
+
+        Raises:
+            FlowError
+        """
+        source_type_id = get_schema_id(DER_SOURCE_TYPE)
+        source_comps = self.find_components(type_id=source_type_id)
+        try:
+            return [c.properties["targetVersion"] for c in source_comps]
+        except KeyError as exc:
+            msg = f"Malformed source component detected. {exc}"
+            raise FlowError(msg) from exc
+
+    @trace
+    def get_variant_sets(self) -> dict[str, list[tuple[str, str]]]:
+        """Find any VariantSet components within the component list and
+        return a dictionary of variant sets of the structure
+
+            set name -> list of variants
+
+        where each variant is a tuple (variant name, asset id).
+
+        Returns:
+            Dictionary of variant set names to lists of variants.
+        """
+        varset_type_id = get_schema_id(VARIANT_SET_TYPE)
+        varset_comps = self.find_components(type_id=varset_type_id)
+        varsets = {}
+        try:
+            for comp in varset_comps:
+                set_name = comp.properties["setName"]
+                variant_name = comp.properties["variantName"]
+                variant_id = comp.properties["targetAsset"]
+                if set_name not in varsets:
+                    varsets[set_name] = []
+                varsets[set_name].append((variant_name, variant_id))
+        except KeyError as exc:
+            msg = f"Malformed variant set component detected. {exc}"
+            raise FlowError(msg) from exc
+        return varsets
 
 
 class FlowProject(FlowEntity):
@@ -1369,7 +1421,16 @@ class FlowComponent:
         for prop, val in component.data.items():
             if prop in ["data", "purpose"]:
                 continue  # already processed these
-            self.properties[prop] = val
+            if isinstance(val, dict) and "reference" in val["typeid"]:
+                try:
+                    # For reference typed properties, store the target entity id
+                    # as the property value
+                    self.properties[prop] = val["objectId"]["id"]
+                except KeyError:
+                    # Ignore malformed properties
+                    continue
+            else:
+                self.properties[prop] = val
 
     @trace
     def get_blob_path(self, blob_index: int = 0) -> str:

--- a/python/tank_vendor/flow_integration_sdk/publish.py
+++ b/python/tank_vendor/flow_integration_sdk/publish.py
@@ -57,7 +57,7 @@ from .storage import (
     _find_component,
     get_storage_revision_dir,
 )
-from .utils import cleanpath, get_logger, mimetype, trace
+from .utils import build_reference_value, cleanpath, get_logger, mimetype, trace
 
 
 @dataclass
@@ -267,7 +267,7 @@ class DerivativeSourceComponentSpec(ComponentSpec):
         return self.create_component(
             name=self.name,
             type_id=get_schema_id(DER_SOURCE_TYPE),
-            targetVersion=self.version_id,
+            targetVersion=build_reference_value(self.version_id),
         )
 
 
@@ -418,7 +418,7 @@ class VariantSetComponentSpec(ComponentSpec):
             type_id=get_schema_id(VARIANT_SET_TYPE),
             setName=self.set_name,
             variantName=self.variant_name,
-            targetAsset=self.asset_id,
+            targetAsset=build_reference_value(self.asset_id),
             displayName=self.display_name,
         )
 

--- a/python/tank_vendor/flow_integration_sdk/publish.py
+++ b/python/tank_vendor/flow_integration_sdk/publish.py
@@ -40,7 +40,8 @@ from .globals import (
     COMMENT_COMP,
     COMMENT_TYPE_ID,
     DER_SOURCE_COMP,
-    DER_SOURCE_TYPE_ID,
+    DER_SOURCE_TYPE,
+    FILE_SEQ_TYPE,
     get_client,
     IMAGE_TYPE_ID,
     SOURCE_COMP,
@@ -48,8 +49,9 @@ from .globals import (
     THUMBNAIL_COMP,
     THUMBNAIL_PURPOSE,
     TYPE_COMP,
+    VARIANT_SET_TYPE,
 )
-from .schema import is_sub_type
+from .schema import get_schema_id, is_sub_type
 from .storage import (
     _cache_asset_info,
     _find_component,
@@ -249,12 +251,12 @@ class DerivativeSourceComponentSpec(ComponentSpec):
     There is only expected to be one of these per revision.
     """
 
-    def __init__(self, revision_id: str):
+    def __init__(self, version_id: str):
         """
         Args:
-            revision_id: Id of source revision.
+            version_id: Id of source version.
         """
-        self.revision_id = revision_id
+        self.version_id = version_id
 
     @property
     def name(self) -> str:
@@ -264,8 +266,8 @@ class DerivativeSourceComponentSpec(ComponentSpec):
         """Create an MEDM component based on specifications."""
         return self.create_component(
             name=self.name,
-            type_id=DER_SOURCE_TYPE_ID,
-            folder={"objectId": self.revision_id},
+            type_id=get_schema_id(DER_SOURCE_TYPE),
+            targetVersion=self.version_id,
         )
 
 
@@ -363,6 +365,64 @@ class TypeComponentSpec(ComponentSpec):
         )
 
 
+class VariantSetComponentSpec(ComponentSpec):
+    """Specifications for creating a variant set component.
+    This is a component used in a conceptually atomic asset
+    to list available variant sets and variants for the asset.
+    There can be multiple such components on an asset with
+    that may span multiple variant sets.
+
+    Example: If an asset were to have two orthogonal variant
+             sets for model representation, and surfacing look
+             as outlined below.
+
+        -> Set 1 = Representation
+                - Variant (Maya)
+                - Variant (Alembic)
+        -> Set 2 = Look
+                - Variant (Default)
+                - Variant (Dirty)
+
+            This would require four VariantSet components to
+            be added to the asset.
+
+        -> VariantSet 1 = Representation-Maya
+        -> VariantSet 2 = Representation-Alembic
+        -> VariantSet 3 = Look-Default
+        -> VariantSet 4 = Look-Dirty
+    """
+
+    def __init__(
+        self, set_name: str, variant_name: str, asset_id: str, display_name: str = ""
+    ):
+        """
+        Args:
+            set_name: Name of variant set under which this variant belongs.
+            variant_name: Name of this specific variant under the set name.
+            asset_id: The asset which represents this variant.
+            display_name: An optional display name for this set+variant combo.
+        """
+        self.set_name = set_name
+        self.variant_name = variant_name
+        self.asset_id = asset_id
+        self.display_name = display_name
+
+    @property
+    def name(self) -> str:
+        return f"{self.set_name}-{self.variant_name}"
+
+    def create(self) -> medm_model.Component:
+        """Create an MEDM component based on specifications."""
+        return self.create_component(
+            name=self.name,
+            type_id=get_schema_id(VARIANT_SET_TYPE),
+            setName=self.set_name,
+            variantName=self.variant_name,
+            targetAsset=self.asset_id,
+            displayName=self.display_name,
+        )
+
+
 class FileSeqComponentSpec(TypeComponentSpec):
     """Specifications for creating a file sequence type component.
     This is a component used to designate an asset as containing a file sequence.
@@ -371,7 +431,6 @@ class FileSeqComponentSpec(TypeComponentSpec):
 
     def __init__(
         self,
-        type_id: str,
         frame_start: int,
         frame_end: int,
         frame_set: str,
@@ -380,7 +439,6 @@ class FileSeqComponentSpec(TypeComponentSpec):
     ):
         """
         Args:
-            type_id: The MEDM type identifier for the type component.
             frame_start: First frame of file sequence.
             frame_end: End frame of file sequence.
             frame_set: A string expression denoting the set of frames
@@ -401,11 +459,11 @@ class FileSeqComponentSpec(TypeComponentSpec):
         #       global constant and use that instead.
 
         # If provided, type id must be subtype of base type
+        type_id = get_schema_id(FILE_SEQ_TYPE)
         if not is_sub_type(BASE_TYPE_ID, type_id):
             msg = f"Type id {type_id} is not a subclass of base type."
             raise ComponentSpecError(details=msg)
 
-        self.type_id = type_id
         self.frame_start = frame_start
         self.frame_end = frame_end
         self.frame_set = frame_set
@@ -421,7 +479,7 @@ class FileSeqComponentSpec(TypeComponentSpec):
         """Create an MEDM component based on specifications."""
         return self.create_component(
             name=self.name,
-            type_id=self.type_id,
+            type_id=get_schema_id(FILE_SEQ_TYPE),
             frameStart=self.frame_start,
             frameEnd=self.frame_end,
             frameSet=self.frame_set,
@@ -496,6 +554,7 @@ def publish_new_revision(
     asset_id: str,
     components: list[ComponentSpec] | None = None,
     used_versions: list[str] | None = None,
+    components_action: medm_model.ListAction = medm_model.ListAction.REPLACE,
 ) -> medm_model.Asset:
     """Publish a new version of an existing asset.
 
@@ -506,6 +565,10 @@ def publish_new_revision(
                     (Components are used to store binaries and metadata on revisions.)
         used_versions: List of version ids of other assets used by this asset.
                        (Stored as "uses" relationships with other asset versions.)
+        components_action: Should component list replace existing components or append to them?
+                          Valid values are:
+                            * ListAction.REPLACE (default)
+                            * ListAction.ADD
 
     Returns:
         Updated asset object.
@@ -524,7 +587,7 @@ def publish_new_revision(
     m_input = medm_model.UpdateAssetInput(
         id=asset_id,
         components=medm_components,
-        components_action=medm_model.ListAction.REPLACE.value,
+        components_action=components_action.value,
         named_version_change=medm_model.NamedVersionChangeEnum.CREATE_NEW.value,
         uses=medm_uses,
     )

--- a/python/tank_vendor/flow_integration_sdk/publish.py
+++ b/python/tank_vendor/flow_integration_sdk/publish.py
@@ -57,7 +57,7 @@ from .storage import (
     _find_component,
     get_storage_revision_dir,
 )
-from .utils import build_reference_value, cleanpath, get_logger, mimetype, trace
+from .utils import cleanpath, get_logger, mimetype, trace
 
 
 @dataclass
@@ -105,6 +105,26 @@ class ComponentSpec(ABC):
             Component object that can be added to an AssetRevision.
         """
         return medm_model.ComponentDataInput(name=name, data=data, type_id=type_id)
+
+    @staticmethod
+    def build_reference_value(object_id: str) -> dict:
+        """Build a component property value for a reference-2.0.0 typed property.
+
+        Build the nested object required for component properties typed as
+        autodesk.me:reference-2.0.0, which inherits from autodesk.data:reference-2.0.0
+        and stores the referenced entity ID under objectId.id.
+
+        Args:
+            object_id: The URN or ID of the entity being referenced.
+
+        Returns:
+            Dict matching the autodesk.data:reference-2.0.0 schema structure.
+
+        Examples:
+            >>> ComponentSpec.build_reference_value("urn:medm:asset:c:p:abc")
+            {'objectId': {'id': 'urn:medm:asset:c:p:abc'}}
+        """
+        return {"objectId": {"id": object_id}}
 
 
 class BinaryComponentSpec(ComponentSpec):
@@ -267,7 +287,7 @@ class DerivativeSourceComponentSpec(ComponentSpec):
         return self.create_component(
             name=self.name,
             type_id=get_schema_id(DER_SOURCE_TYPE),
-            targetVersion=build_reference_value(self.version_id),
+            targetVersion=self.build_reference_value(self.version_id),
         )
 
 
@@ -418,7 +438,7 @@ class VariantSetComponentSpec(ComponentSpec):
             type_id=get_schema_id(VARIANT_SET_TYPE),
             setName=self.set_name,
             variantName=self.variant_name,
-            targetAsset=build_reference_value(self.asset_id),
+            targetAsset=self.build_reference_value(self.asset_id),
             displayName=self.display_name,
         )
 

--- a/python/tank_vendor/flow_integration_sdk/schema.py
+++ b/python/tank_vendor/flow_integration_sdk/schema.py
@@ -28,7 +28,6 @@ from .globals import (
     BASE_TYPE_ID,
     BINARY_TYPE_ID,
     COMMENT_TYPE_ID,
-    DER_SOURCE_TYPE_ID,
     FOLDER_TYPE_ID,
     get_client,
     get_session_collection,
@@ -51,7 +50,6 @@ _schema_tree[BASE_PROPERTY_TYPE_ID] = []
 _schema_tree[BASE_TYPE_ID] = []
 _schema_tree[BINARY_TYPE_ID] = [BASE_COMPONENT_TYPE_ID]
 _schema_tree[COMMENT_TYPE_ID] = [BASE_COMPONENT_TYPE_ID]
-_schema_tree[DER_SOURCE_TYPE_ID] = [BASE_COMPONENT_TYPE_ID]
 _schema_tree[FOLDER_TYPE_ID] = [BASE_TYPE_ID]
 _schema_tree[IMAGE_TYPE_ID] = [BINARY_TYPE_ID]
 

--- a/python/tank_vendor/flow_integration_sdk/schema.py
+++ b/python/tank_vendor/flow_integration_sdk/schema.py
@@ -126,9 +126,7 @@ def cache_schema_config(config_path: str):
         type_name = schema.get("name", "")
         kind = schema.get("kind")
         if not kind:
-            raise ValueError(
-                f"Schema '{type_name}' is missing required 'kind' field."
-            )
+            raise ValueError(f"Schema '{type_name}' is missing required 'kind' field.")
         parent_types = schema.get("inherits", [])
         # strip "$ref:" prefix
         parent_types = [pt[5:] for pt in parent_types]

--- a/python/tank_vendor/flow_integration_sdk/schema_builder.py
+++ b/python/tank_vendor/flow_integration_sdk/schema_builder.py
@@ -274,9 +274,7 @@ class SchemaBuilder:
         # Build property list for CreateSchemaInput
         properties = []
         for property_dict in self.schema_dict.get("properties", []):
-            properties.append(
-                self._create_properties_definition_input(property_dict)
-            )
+            properties.append(self._create_properties_definition_input(property_dict))
 
         try:
             # Create CreateSchemaInput for the mutation
@@ -323,7 +321,9 @@ class SchemaBuilder:
         """
 
         if not self.schema:
-            raise FlowSchemaBuilderError(details="Schema instance has not been built yet.")
+            raise FlowSchemaBuilderError(
+                details="Schema instance has not been built yet."
+            )
 
         client = get_client()
         schema_display_data = None
@@ -372,7 +372,9 @@ class SchemaBuilder:
         display_name = self.schema_dict.get("display_name")
 
         if not self.schema:
-            raise FlowSchemaBuilderError(details="Schema instance has not been built yet.")
+            raise FlowSchemaBuilderError(
+                details="Schema instance has not been built yet."
+            )
 
         if not display_name:
             raise FlowSchemaBuilderError(
@@ -494,9 +496,7 @@ def _create_schema_library(
             project_id=project_id,
         )
         # Create and call the schema mutation
-        schema_query = client.service_schema.create_schema_library(
-            variables=input_data
-        )
+        schema_query = client.service_schema.create_schema_library(variables=input_data)
         query_response = schema_query.call()
         # Extract the created schema library from the response
         schema_library = query_response.schema_library
@@ -542,7 +542,9 @@ def create_pipeline_schemas(project_id: str, config_path: str):
 
     config = schema._read_schema_config(config_path)
     if "schemas" not in config:
-        raise KeyError("The schema config file must contain a 'schemas' key with a list of schemas to create.")
+        raise KeyError(
+            "The schema config file must contain a 'schemas' key with a list of schemas to create."
+        )
     client = get_client()
     collection_id = FlowProject.get_collection_id(project_id)
 

--- a/python/tank_vendor/flow_integration_sdk/utils.py
+++ b/python/tank_vendor/flow_integration_sdk/utils.py
@@ -384,3 +384,23 @@ def download_file(url, local_filename):
         msg = f'Request to get url "{url}" failed. {exc}'
         traceback.print_exc()
         raise FlowError(msg) from exc
+
+
+def build_reference_value(object_id: str) -> dict:
+    """Build a component property value for a reference-2.0.0 typed property.
+
+    Build the nested object required for component properties typed as
+    autodesk.me:reference-2.0.0, which inherits from autodesk.data:reference-2.0.0
+    and stores the referenced entity ID under objectId.id.
+
+    Args:
+        object_id: The URN or ID of the entity being referenced.
+
+    Returns:
+        Dict matching the autodesk.data:reference-2.0.0 schema structure.
+
+    Examples:
+        >>> build_reference_value("urn:medm:asset:c:p:abc")
+        {'objectId': {'id': 'urn:medm:asset:c:p:abc'}}
+    """
+    return {"objectId": {"id": object_id}}

--- a/python/tank_vendor/flow_integration_sdk/utils.py
+++ b/python/tank_vendor/flow_integration_sdk/utils.py
@@ -384,23 +384,3 @@ def download_file(url, local_filename):
         msg = f'Request to get url "{url}" failed. {exc}'
         traceback.print_exc()
         raise FlowError(msg) from exc
-
-
-def build_reference_value(object_id: str) -> dict:
-    """Build a component property value for a reference-2.0.0 typed property.
-
-    Build the nested object required for component properties typed as
-    autodesk.me:reference-2.0.0, which inherits from autodesk.data:reference-2.0.0
-    and stores the referenced entity ID under objectId.id.
-
-    Args:
-        object_id: The URN or ID of the entity being referenced.
-
-    Returns:
-        Dict matching the autodesk.data:reference-2.0.0 schema structure.
-
-    Examples:
-        >>> build_reference_value("urn:medm:asset:c:p:abc")
-        {'objectId': {'id': 'urn:medm:asset:c:p:abc'}}
-    """
-    return {"objectId": {"id": object_id}}


### PR DESCRIPTION
- added Source and VariantSet components to custom schema config
- removed use of temporary DER_SOURCE_TYPE_ID
- removed Task folder from asset hierarchy
- replaced with root asset which will point to variant sets of workfiles and derivatives under the root
- generic assets parented directly under pipeline step
- removed redundant calls to ensure_unique_name() when building asset hierarchy
- added get_sources() and get_variant_sets() utilities to ComponentMixin
- handle reference properties explicitly in FlowComponent for easier use
- added get_derivatives() utilities to FlowAsset
- added component_action parameter to publish_new_revision() function, allowing publishes to append components rather than always replace them