### PR TITLE
Fix [SG-43934]: Add displayname for layer component

### DIFF
--- a/python/tank/flowam/create.py
+++ b/python/tank/flowam/create.py
@@ -203,7 +203,9 @@ def get_or_create_workfile_parent(
             asset_id=container.id,
             components=[
                 LayerComponentSpec(
-                    layer_name=sg_pipeline_step, asset_id=pipeline_step.id
+                    layer_name=sg_pipeline_step,
+                    asset_id=pipeline_step.id,
+                    display_name=sg_pipeline_step,
                 )
             ],
             components_action=medm_model.ListAction.ADD,

--- a/python/tank_vendor/flow_integration_sdk/publish.py
+++ b/python/tank_vendor/flow_integration_sdk/publish.py
@@ -547,15 +547,17 @@ class LayerComponentSpec(ComponentSpec):
     ``targetAsset`` reference to the contributing child asset.
     """
 
-    def __init__(self, layer_name: str, asset_id: str):
+    def __init__(self, layer_name: str, asset_id: str, display_name: str = ""):
         """
         Args:
             layer_name: Name identifying this layer relationship
                         (e.g. the pipeline-step name).
             asset_id: MEDM id of the target asset the layer points to.
+            display_name: An optional human-readable display name for this layer.
         """
         self.layer_name = layer_name
         self.asset_id = asset_id
+        self.display_name = display_name
 
     @property
     def name(self) -> str:
@@ -568,6 +570,7 @@ class LayerComponentSpec(ComponentSpec):
             type_id=get_schema_id(LAYER_TYPE),
             layerName=self.layer_name,
             targetAsset=self.build_reference_value(self.asset_id),
+            displayName=self.display_name,
         )
 
 


### PR DESCRIPTION
This pull request adds support for an optional human-readable display name to `LayerComponentSpec`, improving clarity when working with layer components. The main changes involve updating the constructor, storing the new field, and ensuring it is included when creating components.

