### PR TITLE
SG-44526 Fetch dependencies on checkout

### DIFF
--- a/python/tank_vendor/flow_integration_sdk/fetch.py
+++ b/python/tank_vendor/flow_integration_sdk/fetch.py
@@ -334,7 +334,6 @@ def get_thumbnail_url(revision: medm_model.AssetRevision) -> str:
         raise ThumbnailError(revision_id=revision.id, details=msg) from exc
 
 
-@cache
 @trace
 def _iterate_uses(version_id: str) -> Iterator[medm_model.AssetRevision]:
     """Query uses relationships in this asset/revision.

--- a/python/tank_vendor/flow_integration_sdk/fetch.py
+++ b/python/tank_vendor/flow_integration_sdk/fetch.py
@@ -338,8 +338,6 @@ def get_thumbnail_url(revision: medm_model.AssetRevision) -> str:
 def _iterate_uses(version_id: str) -> Iterator[medm_model.AssetRevision]:
     """Query uses relationships in this asset/revision.
     Pagination is handled internally within this call via the V2 sdk.
-    If this query has already been performed, the cached result will be returned.
-    If refresh=True, do a fresh query.
 
     NOTE: This implementation grabs the entire uses tree because in practice
           this is usually what we need (to fetch dependencies).

--- a/python/tank_vendor/flow_integration_sdk/objects.py
+++ b/python/tank_vendor/flow_integration_sdk/objects.py
@@ -705,7 +705,6 @@ class FlowAsset(ComponentMixin, UsesMixin, FlowEntity):
         return None
 
     @property
-    @cache
     def type_ids(self) -> list[str]:
         """Return type ids explicitly assigned to asset.
         (This will not include base types.)

--- a/python/tank_vendor/flow_integration_sdk/sandbox.py
+++ b/python/tank_vendor/flow_integration_sdk/sandbox.py
@@ -514,6 +514,7 @@ def checkout_revision(
         revision,
         component_name=component_name,
         component_purpose=component_purpose,
+        fetch_dependencies=True,
     )
 
     # Create the draft folder so we can copy new files to it


### PR DESCRIPTION
Fixing migration bug where dependencies were not being fetched along with a revision.
Introduced because in the migration of the fetch function, a new fetch_dependencies parameter was introduced and set to False by default.  The original code did always fetched dependencies.  Migrated callers of fetch function did not explicitly set this parameter to True.