### PR TITLE
SG-44721 Fix tank core upgrade fails from ≤v0.23.6 to ≥v0.23.7

### DIFF
--- a/_core_upgrader.py
+++ b/_core_upgrader.py
@@ -51,11 +51,12 @@ CORE_CFG_OS_MAP = {
 
 # get yaml and our shotgun API from the local install
 # which comes with the upgrader. This is the code we are about to upgrade TO.
-vendor = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "python", "tank_vendor")
-)
-sys.path.append(vendor)
-import yaml
+python_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "python"))
+# Insert at the beginning to ensure local tk-core takes precedence over
+# any installed version in site-packages
+sys.path.insert(0, python_folder)
+
+from tank_vendor import yaml
 
 ###################################################################################################
 # migration utilities


### PR DESCRIPTION
`tank core` fails with `ModuleNotFoundError: No module named 'yaml'`.

Two related cases:
1. Running `_core_upgrader.py` directly (e.g. `python3 _core_upgrader.py`) fails unconditionally on any version >= v0.23.7, including current `master` - there's no prior process state to mask it.
2. Running the real `tank core` upgrade command fails specifically when the currently installed core is <= v0.23.6 and the target is >= v0.23.7. Upgrading between two cores that are both already >= v0.23.7 (or both <= v0.23.6) is unaffected - see Root Cause below for why.

# Root cause

SG-37222 / #996 reworked `tank_vendor` third-party dependency handling starting in `v0.23.7`: vendored packages moved from flat files under `python/tank_vendor/` into zip archives, loaded lazily through a `sys.meta_path` finder registered in `tank_vendor/__init__.py`.

`_core_upgrader.py` was never updated for this change. It still added `python/tank_vendor` directly to `sys.path` and did a bare `import yaml`, bypassing `tank_vendor/__init__.py` entirely, so the finder never registered and the flat `yaml` module it expected no longer existed on disk.

`tank core` runs as a single, uninterrupted Python process (the `tank` -> `tank_cmd.sh` -> `exec $interpreter tank_cmd.py` chain replaces the process in place, and the core swap is a plain `import _core_upgrader` within that process). The *currently installed* core's `core_upgrade.py` already does `from tank_vendor import yaml` before the swap. If that core is already >= v0.23.7, its vendor package's meta finder resolves this via `__import__("yaml")`, which as a side effect registers bare `sys.modules["yaml"]` - masking the target's broken bare `import yaml` entirely. If the installed core is <= v0.23.6, its pre-rework `tank_vendor` has no meta finder, so nothing gets cached, and the target's `import yaml` fails for real. This is why the bug only reproduces on the `<=v0.23.6 -> >=v0.23.7` transition, even though the underlying defect is unconditional.

## Fix

- Add `python/` (the parent of `tank_vendor`) to `sys.path` instead of `tank_vendor` itself.
- Import via `from tank_vendor import yaml` so `tank_vendor/__init__.py` runs and registers its lazy-loading finder.
- Use `sys.path.insert(0, ...)` instead of `append` for consistency with other core scripts.

## Testing

- Ran `_core_upgrader.py` directly; it no longer raises `ModuleNotFoundError` on import.
- Confirmed the old code path fails the same way against current `master`'s `tank_vendor` structure, matching the reported traceback.
- QA reproduced a real `tank core` upgrade from `v0.23.6 -> v0.24.0` failing without the fix and succeeding with it, and validated `v0.23.7 -> v0.24.0` as well; dedicated core-upgrade regression coverage has been added.
