### PR TITLE
SG-38756 Fix parent property of PathTemplate in case of optional key

### DIFF
--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -586,6 +586,7 @@ class TemplatePath(Template):
         :returns: :class:`Template`
         """
         parent_definition = self._dirname()
+        # Only create a parent if the definition is non-empty and not a filesystem root.
         if (
             parent_definition
             and os.path.dirname(parent_definition) != parent_definition

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -556,7 +556,7 @@ class TemplatePath(Template):
         """
         return self._prefix
 
-    def _dirname(self):
+    def _dirname(self) -> str:
         """
         Returns the directory part of the template, preserving optional
         section brackets. Finds the last path separator outside any brackets.
@@ -570,7 +570,7 @@ class TemplatePath(Template):
                 bracket_depth += 1
             elif c == "]":
                 bracket_depth = max(0, bracket_depth - 1)
-            elif c == os.sep and bracket_depth == 0:
+            elif c == "/" and bracket_depth == 0:
                 last_sep_outside = i
         if last_sep_outside == -1:
             return ""

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -586,7 +586,10 @@ class TemplatePath(Template):
         :returns: :class:`Template`
         """
         parent_definition = self._dirname()
-        if parent_definition and os.path.dirname(parent_definition) != parent_definition:
+        if (
+            parent_definition
+            and os.path.dirname(parent_definition) != parent_definition
+        ):
             return TemplatePath(
                 parent_definition,
                 self.keys,

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -565,8 +565,8 @@ class TemplatePath(Template):
 
         :returns: :class:`Template`
         """
-        parent_definition = os.path.dirname(self.definition)
-        if parent_definition:
+        parent_definition = os.path.dirname(self._repr_def)
+        if parent_definition and parent_definition != "/":
             return TemplatePath(
                 parent_definition,
                 self.keys,

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -558,14 +558,23 @@ class TemplatePath(Template):
 
     def _dirname(self):
         """
-        Returns the directory part of the template.
+        Returns the directory part of the template, preserving optional
+        section brackets. Finds the last path separator outside any brackets.
 
         :returns: String
         """
-        dirname, basename = os.path.split(self._repr_def)
-        if "[" in basename and "]" not in basename:
-            return dirname.split("[")[0]
-        return dirname
+        bracket_depth = 0
+        last_sep_outside = -1
+        for i, c in enumerate(self._repr_def):
+            if c == "[":
+                bracket_depth += 1
+            elif c == "]":
+                bracket_depth = max(0, bracket_depth - 1)
+            elif c == os.sep and bracket_depth == 0:
+                last_sep_outside = i
+        if last_sep_outside == -1:
+            return ""
+        return self._repr_def[:last_sep_outside]
 
     @property
     def parent(self):
@@ -577,7 +586,7 @@ class TemplatePath(Template):
         :returns: :class:`Template`
         """
         parent_definition = self._dirname()
-        if parent_definition and parent_definition != "/":
+        if parent_definition and os.path.dirname(parent_definition) != parent_definition:
             return TemplatePath(
                 parent_definition,
                 self.keys,

--- a/python/tank/template.py
+++ b/python/tank/template.py
@@ -556,6 +556,17 @@ class TemplatePath(Template):
         """
         return self._prefix
 
+    def _dirname(self):
+        """
+        Returns the directory part of the template.
+
+        :returns: String
+        """
+        dirname, basename = os.path.split(self._repr_def)
+        if "[" in basename and "]" not in basename:
+            return dirname.split("[")[0]
+        return dirname
+
     @property
     def parent(self):
         """
@@ -565,7 +576,7 @@ class TemplatePath(Template):
 
         :returns: :class:`Template`
         """
-        parent_definition = os.path.dirname(self._repr_def)
+        parent_definition = self._dirname()
         if parent_definition and parent_definition != "/":
             return TemplatePath(
                 parent_definition,

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1180,3 +1180,16 @@ class TestParent(TestTemplatePath):
         template = TemplatePath(definition, keys, root_path=self.project_root)
         result = template.parent
         self.assertEqual("{new_name}", result.definition)
+
+    def test_parent_with_optional(self):
+        definition = "shots/{Sequence}[-{seq_num}]/{Shot}/{Step}/work"
+        parent_expected_definitions = [
+            "shots/{Sequence}-{seq_num}/{Shot}/{Step}",
+            "shots/{Sequence}/{Shot}/{Step}",
+        ]
+        parent_expected__repr_def = os.path.dirname(definition)
+
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        parent = template.parent
+        self.assertEqual(parent_expected_definitions, parent._definitions)
+        self.assertEqual(parent_expected__repr_def, parent._repr_def)

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1194,6 +1194,7 @@ class TestParent(TestTemplatePath):
         self.assertEqual(parent_expected_definitions, parent._definitions)
         self.assertEqual(parent_expected__repr_def, parent._repr_def)
 
+
 class TestDirname(TestTemplatePath):
     def test_dirname_with_word(self):
         definition = "shots/{Sequence}/{Shot}/{Step}/work"
@@ -1211,7 +1212,7 @@ class TestDirname(TestTemplatePath):
         self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
 
     def test_dirname_with_optional_word_and_key(self):
-        definition =  "shots/{Sequence}/{Shot}/[abc_{Step}]"
+        definition = "shots/{Sequence}/{Shot}/[abc_{Step}]"
         template = TemplatePath(definition, {}, root_path=self.project_root)
         self.assertEqual("", template.dirname)
 

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1199,24 +1199,24 @@ class TestDirname(TestTemplatePath):
     def test_dirname_with_word(self):
         definition = "shots/{Sequence}/{Shot}/{Step}/work"
         template = TemplatePath(definition, self.keys, root_path=self.project_root)
-        self.assertEqual("shots/{Sequence}/{Shot}/{Step}", template.dirname)
+        self.assertEqual("shots/{Sequence}/{Shot}/{Step}", template._dirname())
 
     def test_dirname_with_key(self):
         definition = "shots/{Sequence}/{Shot}/{Step}"
         template = TemplatePath(definition, self.keys, root_path=self.project_root)
-        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+        self.assertEqual("shots/{Sequence}/{Shot}", template._dirname())
 
     def test_dirname_with_optional(self):
         definition = "shots/{Sequence}/{Shot}[/{Step}]"
-        template = TemplatePath(definition, {}, root_path=self.project_root)
-        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}", template._dirname())
 
     def test_dirname_with_optional_word_and_key(self):
         definition = "shots/{Sequence}/{Shot}/[abc_{Step}]"
-        template = TemplatePath(definition, {}, root_path=self.project_root)
-        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}", template._dirname())
 
     def test_dirname_with_optional_key_and_key(self):
         definition = "shots/{Sequence}/[{Shot}]-{Step}"
-        template = TemplatePath(definition, {}, root_path=self.project_root)
-        self.assertEqual("shots/{Sequence}", template.dirname)
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}", template._dirname())

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1193,3 +1193,29 @@ class TestParent(TestTemplatePath):
         parent = template.parent
         self.assertEqual(parent_expected_definitions, parent._definitions)
         self.assertEqual(parent_expected__repr_def, parent._repr_def)
+
+class TestDirname(TestTemplatePath):
+    def test_dirname_with_word(self):
+        definition = "shots/{Sequence}/{Shot}/{Step}/work"
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}/{Step}", template.dirname)
+
+    def test_dirname_with_key(self):
+        definition = "shots/{Sequence}/{Shot}/{Step}"
+        template = TemplatePath(definition, self.keys, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+
+    def test_dirname_with_optional(self):
+        definition = "shots/{Sequence}/{Shot}[/{Step}]"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
+
+    def test_dirname_with_optional_word_and_key(self):
+        definition =  "shots/{Sequence}/{Shot}/[abc_{Step}]"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("", template.dirname)
+
+    def test_dirname_with_optional_key_and_key(self):
+        definition = "shots/{Sequence}/[{Shot}]-{Step}"
+        template = TemplatePath(definition, {}, root_path=self.project_root)
+        self.assertEqual("shots/{Sequence}", template.dirname)

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1214,7 +1214,7 @@ class TestDirname(TestTemplatePath):
     def test_dirname_with_optional_word_and_key(self):
         definition = "shots/{Sequence}/{Shot}/[abc_{Step}]"
         template = TemplatePath(definition, {}, root_path=self.project_root)
-        self.assertEqual("", template.dirname)
+        self.assertEqual("shots/{Sequence}/{Shot}", template.dirname)
 
     def test_dirname_with_optional_key_and_key(self):
         definition = "shots/{Sequence}/[{Shot}]-{Step}"

--- a/tests/core_tests/test_templatepath.py
+++ b/tests/core_tests/test_templatepath.py
@@ -1184,10 +1184,10 @@ class TestParent(TestTemplatePath):
     def test_parent_with_optional(self):
         definition = "shots/{Sequence}[-{seq_num}]/{Shot}/{Step}/work"
         parent_expected_definitions = [
-            "shots/{Sequence}-{seq_num}/{Shot}/{Step}",
-            "shots/{Sequence}/{Shot}/{Step}",
+            os.path.join("shots", "{Sequence}-{seq_num}", "{Shot}", "{Step}"),
+            os.path.join("shots", "{Sequence}", "{Shot}", "{Step}"),
         ]
-        parent_expected__repr_def = os.path.dirname(definition)
+        parent_expected__repr_def = "shots/{Sequence}[-{seq_num}]/{Shot}/{Step}"
 
         template = TemplatePath(definition, self.keys, root_path=self.project_root)
         parent = template.parent


### PR DESCRIPTION
Closes #1016

## Context
`TemplatePath.parent` dropped optional bracket syntax when computing the
parent template. For example, the parent of
`shots/{Sequence}[-{seq_num}]/{Shot}/{Step}/work` was returned as
`shots/{Sequence}-{seq_num}/{Shot}/{Step}` instead of
`shots/{Sequence}[-{seq_num}]/{Shot}/{Step}`, silently promoting the
optional key to required.

Root cause: `parent` used `os.path.dirname(self.definition)`, where
`self.definition` returns the first expanded variation with brackets
already stripped.

## Changes
Based on community PR #1016 by @ClementHector.

- Added `_dirname()` to `TemplatePath` that walks `self._repr_def` (the
  original string with brackets intact) and finds the last path separator
  outside any bracket group, preserving optional syntax in the returned
  parent template
- Fixed Windows-incompatible root path check (`!= "/"` replaced with
  `os.path.dirname` comparison)
- Fixed `TestDirname` tests referencing non-existent `dirname` property
  (now call `_dirname()` directly)
- Fixed `TestDirname` tests using empty key dict for definitions
  containing named keys

Compared to the community PR, the bracket-depth tracking algorithm
replaces the fragile bracket-in-basename heuristic flagged by Copilot.