### PR TITLE
SG-45189 Bypass Windows MAX_PATH in tk-core filesystem copy/delete

### DIFF
--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -45,7 +45,8 @@ def _to_extended_path(path, force=False):
     Drive-less rooted paths (``\\foo``) are not eligible for the prefix
     because the extended-length syntax requires a fully-qualified path.
 
-    :param path: Normalised path string.
+    :param path: Path string. It is normalised internally before the prefix is
+        applied (see note below), so callers need not pre-normalise it.
     :param force: If ``True``, apply the prefix regardless of the path
         length. This is needed when handing a (potentially short) root to an
         API that walks into it internally - e.g. ``shutil.rmtree`` or
@@ -54,21 +55,34 @@ def _to_extended_path(path, force=False):
     :returns: Path with the appropriate extended-length prefix on Windows
         when necessary, otherwise the original path unchanged.
     """
-    if sys.platform != "win32" or (not force and len(path) < 260):
+    if sys.platform != "win32":
         return path
 
     if path.startswith("\\\\?\\"):
-        # Already an extended-length path - don't double-prefix.
+        # Already an extended-length path - don't double-prefix (and don't
+        # normalise, which would corrupt the \\?\ prefix).
         return path
 
-    if path.startswith("\\\\"):
+    # The \\?\ prefix disables the automatic normalisation Windows applies to
+    # normal paths, so any ".", ".." or "/" left in the path would produce an
+    # invalid extended-length path (e.g. "...\\foo\\.." would no longer resolve
+    # to its parent). Normalise first - normpath collapses these without
+    # resolving relative paths against the current working directory.
+    normalized = os.path.normpath(path)
+
+    if not force and len(normalized) < 260:
+        # Short enough that the normal API - which normalises for us - is fine.
+        # Return the caller's original path untouched.
+        return path
+
+    if normalized.startswith("\\\\"):
         # UNC path (\\\\server\\share\\...). The extended-length form requires
         # \\\\?\\UNC\\ rather than \\\\?\\\\\\\\
-        return "\\\\?\\UNC\\" + path[2:]
+        return "\\\\?\\UNC\\" + normalized[2:]
 
-    if len(path) >= 3 and path[1] == ":" and path[2] == "\\":
+    if len(normalized) >= 3 and normalized[1] == ":" and normalized[2] == "\\":
         # Fully-qualified drive-letter path (C:\\...).
-        return "\\\\?\\" + path
+        return "\\\\?\\" + normalized
 
     # Drive-less rooted paths (\\foo) or relative paths are not eligible.
     return path

--- a/python/tank/util/filesystem.py
+++ b/python/tank/util/filesystem.py
@@ -31,6 +31,49 @@ log = LogManager.get_logger(__name__)
 SKIP_LIST_DEFAULT = [".svn", ".git", ".gitignore", ".hg", ".hgignore"]
 
 
+def _to_extended_path(path, force=False):
+    """
+    On Windows, prepend the extended-length path prefix to paths >= 260
+    characters to bypass the MAX_PATH limitation.
+
+    Extended-length paths come in two flavours:
+
+    * Drive-letter paths (``C:\\...``) are prefixed with ``\\\\?\\``.
+    * UNC paths (``\\\\server\\share\\...``) require the ``\\\\?\\UNC\\``
+      prefix; naively prepending ``\\\\?\\`` produces an invalid path.
+
+    Drive-less rooted paths (``\\foo``) are not eligible for the prefix
+    because the extended-length syntax requires a fully-qualified path.
+
+    :param path: Normalised path string.
+    :param force: If ``True``, apply the prefix regardless of the path
+        length. This is needed when handing a (potentially short) root to an
+        API that walks into it internally - e.g. ``shutil.rmtree`` or
+        ``os.walk`` - so that the deeply-nested children it generates inherit
+        the extended-length prefix and stay under the limit.
+    :returns: Path with the appropriate extended-length prefix on Windows
+        when necessary, otherwise the original path unchanged.
+    """
+    if sys.platform != "win32" or (not force and len(path) < 260):
+        return path
+
+    if path.startswith("\\\\?\\"):
+        # Already an extended-length path - don't double-prefix.
+        return path
+
+    if path.startswith("\\\\"):
+        # UNC path (\\\\server\\share\\...). The extended-length form requires
+        # \\\\?\\UNC\\ rather than \\\\?\\\\\\\\
+        return "\\\\?\\UNC\\" + path[2:]
+
+    if len(path) >= 3 and path[1] == ":" and path[2] == "\\":
+        # Fully-qualified drive-letter path (C:\\...).
+        return "\\\\?\\" + path
+
+    # Drive-less rooted paths (\\foo) or relative paths are not eligible.
+    return path
+
+
 def with_cleared_umask(func):
     """
     Decorator which clears the umask for a method.
@@ -88,7 +131,10 @@ def compute_folder_size(path):
     :return: size in bytes
     """
     total_size = 0
-    for dirpath, dirnames, filenames in os.walk(path):
+    # os.walk descends into the tree internally, so we hand it a force-extended
+    # root: the deep dirpaths it yields inherit the \\?\ prefix and stay under
+    # MAX_PATH even when the root itself is short.
+    for dirpath, dirnames, filenames in os.walk(_to_extended_path(path, force=True)):
         for f in filenames:
             fp = os.path.join(dirpath, f)
             total_size += os.path.getsize(fp)
@@ -106,6 +152,7 @@ def touch_file(path, permissions=0o666):
 
     :raises: OSError - if there was a problem reading/writing the file
     """
+    path = _to_extended_path(path)
     if not os.path.exists(path):
         try:
             fh = open(path, "wb")
@@ -130,6 +177,9 @@ def ensure_folder_exists(path, permissions=0o775, create_placeholder_file=False)
 
     :raises: OSError - if there was a problem creating the folder
     """
+    # force-extend: os.makedirs *creates* directories, which Windows caps at
+    # MAX_PATH - 12 (248) rather than 260, so the length guard is not enough.
+    path = _to_extended_path(path, force=True)
     if not os.path.exists(path):
         try:
             os.makedirs(path, permissions)
@@ -175,19 +225,20 @@ def copy_file(src, dst, permissions=0o666):
     if is_windows():
         src = os.path.realpath(src)
         # Check if the dst is a directory and change it to a filename if it is
-        if os.path.isdir(dst):
+        if os.path.isdir(_to_extended_path(dst)):
             basename = os.path.basename(src)
             dst = os.path.join(dst, basename)
 
         dst = os.path.realpath(dst)
-        # Use larger copy buffer in the shutil.copyfileobj operation
-        with open(src, mode="rb") as windows_src:
-            with open(dst, mode="wb") as windows_dst:
+        # Use larger copy buffer in the shutil.copyfileobj operation.
+        # Extend both paths so deeply-nested files stay under MAX_PATH.
+        with open(_to_extended_path(src), mode="rb") as windows_src:
+            with open(_to_extended_path(dst), mode="wb") as windows_dst:
                 shutil.copyfileobj(windows_src, windows_dst, length=16 * 1024 * 1024)
         log.debug("Used shutil override on Windows")
     else:
         shutil.copy(src, dst)
-    os.chmod(dst, permissions)
+    os.chmod(_to_extended_path(dst), permissions)
 
 
 def safe_delete_file(path):
@@ -252,10 +303,20 @@ def copy_folder(src, dst, folder_permissions=0o775, skip_list=None):
 
     files = []
 
-    if not os.path.exists(dst):
-        os.mkdir(dst, folder_permissions)
+    # This function drives the recursion itself, so we extend each individual
+    # path right before the filesystem call. The length guard in
+    # _to_extended_path means only paths that actually exceed the limit get the
+    # \\?\ prefix, which covers the common case of a short bundle root with
+    # deeply-nested files/dirs that blow past MAX_PATH.
+    #
+    # Directory *creation* is special: Windows caps a new directory path at
+    # MAX_PATH - 12 (248), not 260, to leave room for 8.3 children. So os.mkdir
+    # is force-extended - a 248-260 char dir would be missed by the length
+    # guard yet still rejected by CreateDirectory.
+    if not os.path.exists(_to_extended_path(dst)):
+        os.mkdir(_to_extended_path(dst, force=True), folder_permissions)
 
-    names = os.listdir(src)
+    names = os.listdir(_to_extended_path(src))
     for name in names:
         # get rid of system files
         if name in actual_skip_list:
@@ -265,10 +326,12 @@ def copy_folder(src, dst, folder_permissions=0o775, skip_list=None):
         dstname = os.path.join(dst, name)
 
         try:
-            if os.path.isdir(srcname):
+            if os.path.isdir(_to_extended_path(srcname)):
                 files.extend(copy_folder(srcname, dstname, folder_permissions))
             else:
-                shutil.copy(srcname, dstname)
+                shutil.copy(_to_extended_path(srcname), _to_extended_path(dstname))
+                # Return the plain path; callers (e.g. move_folder) re-extend
+                # as needed when operating on it.
                 files.append(srcname)
                 # if the file extension is sh, set executable permissions
                 if (
@@ -278,7 +341,7 @@ def copy_folder(src, dst, folder_permissions=0o775, skip_list=None):
                 ):
                     try:
                         # make it readable and executable for everybody
-                        os.chmod(dstname, 0o775)
+                        os.chmod(_to_extended_path(dstname), 0o775)
                     except Exception as e:
                         log.error(
                             "Can't set executable permissions on %s: %s" % (dstname, e)
@@ -319,14 +382,17 @@ def move_folder(src, dst, folder_permissions=0o775):
         # now clear out the install location
         log.debug("Clearing out source location...")
         for f in src_files:
+            # f may be a deeply-nested path returned by copy_folder; extend it
+            # so os.stat/os.chmod/os.remove stay under MAX_PATH on Windows.
+            ext_f = _to_extended_path(f)
             try:
                 # on windows, ensure all files are writable
                 if is_windows():
-                    attr = os.stat(f)[0]
+                    attr = os.stat(ext_f)[0]
                     if not attr & stat.S_IWRITE:
                         # file is readonly! - turn off this attribute
-                        os.chmod(f, stat.S_IWRITE)
-                os.remove(f)
+                        os.chmod(ext_f, stat.S_IWRITE)
+                os.remove(ext_f)
             except Exception as e:
                 log.warning("Could not delete file %s: %s" % (f, e))
 
@@ -438,12 +504,16 @@ def safe_delete_folder(path):
         else:
             log.warning("Could not delete %s. Skipping." % path)
 
-    if os.path.exists(path):
+    # shutil.rmtree walks the tree internally, so we force-extend the (possibly
+    # short) root: every deeply-nested child rmtree generates inherits the \\?\
+    # prefix and stays under MAX_PATH on Windows.
+    ext_path = _to_extended_path(path, force=True)
+    if os.path.exists(ext_path):
         try:
             # On Windows, Python's shutil can't delete read-only files, so if we were trying to delete one,
             # remove the flag.
             # Inspired by http://stackoverflow.com/a/4829285/1074536
-            shutil.rmtree(path, onerror=_on_rm_error)
+            shutil.rmtree(ext_path, onerror=_on_rm_error)
         except Exception as e:
             log.warning("Could not delete %s: %s" % (path, e))
     else:

--- a/python/tank/util/zip.py
+++ b/python/tank/util/zip.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import sys
 import zipfile
 
 from .. import LogManager
@@ -103,44 +102,6 @@ def zip_file(source_folder, target_zip_file):
     log.debug("Zip complete. Size: %s" % os.path.getsize(target_zip_file))
 
 
-def _to_extended_path(path: str) -> str:
-    """
-    On Windows, prepend the extended-length path prefix to paths >= 260
-    characters to bypass the MAX_PATH limitation.
-
-    Extended-length paths come in two flavours:
-
-    * Drive-letter paths (``C:\\...``) are prefixed with ``\\\\?\\``.
-    * UNC paths (``\\\\server\\share\\...``) require the ``\\\\?\\UNC\\``
-      prefix; naively prepending ``\\\\?\\`` produces an invalid path.
-
-    Drive-less rooted paths (``\\foo``) are not eligible for the prefix
-    because the extended-length syntax requires a fully-qualified path.
-
-    :param path: Normalised path string.
-    :returns: Path with the appropriate extended-length prefix on Windows
-        when necessary, otherwise the original path unchanged.
-    """
-    if sys.platform != "win32" or len(path) < 260:
-        return path
-
-    if path.startswith("\\\\?\\"):
-        # Already an extended-length path - don't double-prefix.
-        return path
-
-    if path.startswith("\\\\"):
-        # UNC path (\\\\server\\share\\...). The extended-length form requires
-        # \\\\?\\UNC\\ rather than \\\\?\\\\\\\\
-        return "\\\\?\\UNC\\" + path[2:]
-
-    if len(path) >= 3 and path[1] == ":" and path[2] == "\\":
-        # Fully-qualified drive-letter path (C:\\...).
-        return "\\\\?\\" + path
-
-    # Drive-less rooted paths (\\foo) or relative paths are not eligible.
-    return path
-
-
 def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
     """
     Helper method used by unzip_file()
@@ -184,7 +145,7 @@ def _process_item(zip_obj, item_path, target_path, root_to_omit=None):
 
     # On Windows, use the extended-length path prefix for paths >= 260 characters
     # to avoid MAX_PATH limitations.
-    target_path = _to_extended_path(target_path)
+    target_path = filesystem._to_extended_path(target_path)
 
     # Create all upper directories if necessary.
     upperdirs = os.path.dirname(target_path)

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -398,7 +398,7 @@ class TestToExtendedPath(ShotgunTestBase):
     @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
     def test_dotdot_is_normalized_before_prefixing(self):
         """
-        The \\?\ prefix disables '..' resolution, so a path containing '..'
+        The \\?\\ prefix disables '..' resolution, so a path containing '..'
         must be normalized before the prefix is applied - otherwise the
         resulting path is invalid (regression test for the safe_delete_folder
         os.pardir case).

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -395,6 +395,19 @@ class TestToExtendedPath(ShotgunTestBase):
         path = "/short/path"
         self.assertEqual(fs._to_extended_path(path, force=True), path)
 
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_dotdot_is_normalized_before_prefixing(self):
+        """
+        The \\?\ prefix disables '..' resolution, so a path containing '..'
+        must be normalized before the prefix is applied - otherwise the
+        resulting path is invalid (regression test for the safe_delete_folder
+        os.pardir case).
+        """
+        path = "C:\\some\\folder\\..\\" + "a" * 255
+        result = fs._to_extended_path(path, force=True)
+        self.assertEqual(result, "\\\\?\\" + os.path.normpath(path))
+        self.assertNotIn("\\..\\", result)
+
 
 class TestCopyFolderLongPaths(ShotgunTestBase):
     """

--- a/tests/util_tests/test_filesystem.py
+++ b/tests/util_tests/test_filesystem.py
@@ -12,10 +12,14 @@ import os
 import shutil
 import stat
 import subprocess  # noqa
+import sys
+import tempfile
+import unittest
 
 import tank.util.filesystem as fs
 from tank.util import is_linux, is_macos, is_windows
 from tank_test.tank_test_base import (
+    ShotgunTestBase,
     TankTestBase,
     mock,
     setUpModule,  # noqa
@@ -320,3 +324,119 @@ class TestOpenInFileBrowser(TankTestBase):
             self.assertEqual(
                 args[0], ["cmd.exe", "/C", "start", os.path.dirname(self.test_sequence)]
             )
+
+
+class TestToExtendedPath(ShotgunTestBase):
+    """
+    Tests the tank.util.filesystem._to_extended_path() helper.
+    """
+
+    _LONG_ABS_PATH = "C:\\" + "a" * 257  # 260 chars, drive-letter absolute
+    _LONG_UNC_PATH = "\\\\server\\share\\" + "a" * 245  # 260 chars, UNC
+
+    def test_short_path_unchanged(self):
+        """A path under 260 characters is returned unchanged on all platforms."""
+        path = "C:\\short\\path\\file.txt"
+        self.assertEqual(fs._to_extended_path(path), path)
+
+    def test_relative_path_unchanged(self):
+        """A relative path >= 260 characters must NOT receive the prefix."""
+        path = "relative\\" + "a" * 257  # long but relative
+        self.assertFalse(os.path.isabs(path))
+        self.assertEqual(fs._to_extended_path(path), path)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_long_absolute_path_prefixed_on_windows(self):
+        """A long drive-letter path on Windows receives the \\\\?\\ prefix."""
+        result = fs._to_extended_path(self._LONG_ABS_PATH)
+        self.assertTrue(result.startswith("\\\\?\\"))
+        self.assertEqual(result, "\\\\?\\" + self._LONG_ABS_PATH)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_already_prefixed_path_unchanged(self):
+        """A path that already has the \\\\?\\ prefix is not double-prefixed."""
+        prefixed = "\\\\?\\" + self._LONG_ABS_PATH
+        self.assertEqual(fs._to_extended_path(prefixed), prefixed)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_long_unc_path_prefixed_with_unc_prefix(self):
+        """A long UNC path receives \\\\?\\UNC\\ prefix, not \\\\?\\\\\\\\."""
+        result = fs._to_extended_path(self._LONG_UNC_PATH)
+        self.assertTrue(result.startswith("\\\\?\\UNC\\"))
+        self.assertEqual(result, "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:])
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_already_extended_unc_path_unchanged(self):
+        """A path already using \\\\?\\UNC\\ is not double-prefixed."""
+        prefixed = "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:]
+        self.assertEqual(fs._to_extended_path(prefixed), prefixed)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_drive_less_rooted_path_unchanged(self):
+        """A drive-less rooted path (\\foo) must NOT receive the prefix."""
+        path = "\\" + "a" * 259  # rooted but no drive letter, >= 260 chars
+        self.assertEqual(fs._to_extended_path(path), path)
+
+    @unittest.skipIf(sys.platform == "win32", "Non-Windows behaviour")
+    def test_long_absolute_path_unchanged_on_non_windows(self):
+        """A long absolute path on non-Windows platforms is returned unchanged."""
+        path = "/" + "a" * 260
+        self.assertEqual(fs._to_extended_path(path), path)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_force_prefixes_short_absolute_path_on_windows(self):
+        """force=True adds the prefix even to a short absolute path on Windows."""
+        path = "C:\\short\\path"
+        self.assertEqual(fs._to_extended_path(path, force=True), "\\\\?\\" + path)
+
+    @unittest.skipIf(sys.platform == "win32", "Non-Windows behaviour")
+    def test_force_is_noop_on_non_windows(self):
+        """force=True is still a no-op on non-Windows platforms."""
+        path = "/short/path"
+        self.assertEqual(fs._to_extended_path(path, force=True), path)
+
+
+class TestCopyFolderLongPaths(ShotgunTestBase):
+    """
+    Tests that copy_folder (and the safe_delete_folder cleanup) cope with files
+    nested deeper than the Windows MAX_PATH limit - the SG-45189 scenario.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # A short-rooted temp dir; the test grows a deep tree beneath it.
+        self._tmp_root = tempfile.mkdtemp(prefix="sg45189_")
+
+    def tearDown(self):
+        fs.safe_delete_folder(self._tmp_root)
+        super().tearDown()
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
+    def test_copy_folder_with_leaf_exceeding_max_path(self):
+        """
+        A source tree with a short root but a leaf path >= 260 chars is copied
+        successfully. Without the extended-path handling this raises IOError.
+        """
+        src_root = os.path.join(self._tmp_root, "deep_src")
+
+        # Build a nested directory whose leaf file path exceeds MAX_PATH.
+        deep = src_root
+        while len(os.path.join(deep, "leaf.txt")) < 275:
+            deep = os.path.join(deep, "d" * 20)
+        os.makedirs(fs._to_extended_path(deep, force=True))
+
+        leaf = os.path.join(deep, "leaf.txt")
+        self.assertGreaterEqual(len(leaf), 260)
+        with open(fs._to_extended_path(leaf), "w") as fh:
+            fh.write("hello long path")
+
+        dst_root = os.path.join(self._tmp_root, "deep_dst")
+        copied = fs.copy_folder(src_root, dst_root)
+
+        dst_leaf = leaf.replace(src_root, dst_root, 1)
+        self.assertTrue(os.path.exists(fs._to_extended_path(dst_leaf)))
+        self.assertIn(leaf, copied)
+
+        # safe_delete_folder must also cope with the deep tree (force-extended root).
+        fs.safe_delete_folder(src_root)
+        self.assertFalse(os.path.exists(fs._to_extended_path(src_root, force=True)))

--- a/tests/util_tests/test_zip.py
+++ b/tests/util_tests/test_zip.py
@@ -9,8 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import sys
-import unittest
 
 import tank
 from tank_test.tank_test_base import ShotgunTestBase, setUpModule  # noqa
@@ -121,61 +119,3 @@ class TestUnzipping(ShotgunTestBase):
         self.assertEqual(
             set(get_file_list(output_path_2, output_path_2)), set(["/info.yml"])
         )
-
-
-class TestToExtendedPath(ShotgunTestBase):
-    """
-    Tests the tank.util.zip._to_extended_path() helper.
-    """
-
-    _LONG_ABS_PATH = "C:\\" + "a" * 257  # 260 chars, drive-letter absolute
-    _LONG_UNC_PATH = "\\\\server\\share\\" + "a" * 245  # 260 chars, UNC
-
-    def test_short_path_unchanged(self):
-        """A path under 260 characters is returned unchanged on all platforms."""
-        path = "C:\\short\\path\\file.txt"
-        self.assertEqual(tank.util.zip._to_extended_path(path), path)
-
-    def test_relative_path_unchanged(self):
-        """A relative path >= 260 characters must NOT receive the prefix."""
-        path = "relative\\" + "a" * 257  # long but relative
-        self.assertFalse(os.path.isabs(path))
-        self.assertEqual(tank.util.zip._to_extended_path(path), path)
-
-    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
-    def test_long_absolute_path_prefixed_on_windows(self):
-        """A long drive-letter path on Windows receives the \\\\?\\ prefix."""
-        result = tank.util.zip._to_extended_path(self._LONG_ABS_PATH)
-        self.assertTrue(result.startswith("\\\\?\\"))
-        self.assertEqual(result, "\\\\?\\" + self._LONG_ABS_PATH)
-
-    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
-    def test_already_prefixed_path_unchanged(self):
-        """A path that already has the \\\\?\\ prefix is not double-prefixed."""
-        prefixed = "\\\\?\\" + self._LONG_ABS_PATH
-        self.assertEqual(tank.util.zip._to_extended_path(prefixed), prefixed)
-
-    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
-    def test_long_unc_path_prefixed_with_unc_prefix(self):
-        """A long UNC path receives \\\\?\\UNC\\ prefix, not \\\\?\\\\\\\\."""
-        result = tank.util.zip._to_extended_path(self._LONG_UNC_PATH)
-        self.assertTrue(result.startswith("\\\\?\\UNC\\"))
-        self.assertEqual(result, "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:])
-
-    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
-    def test_already_extended_unc_path_unchanged(self):
-        """A path already using \\\\?\\UNC\\ is not double-prefixed."""
-        prefixed = "\\\\?\\UNC\\" + self._LONG_UNC_PATH[2:]
-        self.assertEqual(tank.util.zip._to_extended_path(prefixed), prefixed)
-
-    @unittest.skipUnless(sys.platform == "win32", "Windows-only behaviour")
-    def test_drive_less_rooted_path_unchanged(self):
-        """A drive-less rooted path (\\foo) must NOT receive the prefix."""
-        path = "\\" + "a" * 259  # rooted but no drive letter, >= 260 chars
-        self.assertEqual(tank.util.zip._to_extended_path(path), path)
-
-    @unittest.skipIf(sys.platform == "win32", "Non-Windows behaviour")
-    def test_long_absolute_path_unchanged_on_non_windows(self):
-        """A long absolute path on non-Windows platforms is returned unchanged."""
-        path = "/" + "a" * 260
-        self.assertEqual(tank.util.zip._to_extended_path(path), path)


### PR DESCRIPTION
## Problem

On Windows, the advanced project setup wizard fails part-way through with `OSError` / `FileNotFoundError` when copying bundles whose files are nested deeper than the 260-character `MAX_PATH` limit (e.g. `tk-framework-desktopserver`'s bundled per-platform Python, and `tk-framework-alias`'s Sphinx docs). The failing call chain is `core_localize.do_localize` → `descriptor.clone_cache` → `filesystem.copy_folder` → `shutil.copy`.

This is the follow-up flagged in **SG-44086** (PR #1118), which fixed the same limit for the **unzip/download** path only. As Joel noted there, "other tk-core filesystem calls (`os.path.exists`, copies, git descriptors) can still hit MAX_PATH elsewhere." This PR extends the same fix to the copy/delete path.

## Fix

The `_to_extended_path()` helper (previously private to `util/zip.py`) is moved to `util/filesystem.py` and given a `force` flag. On Windows it prepends the `\?\` extended-length prefix (`\?\UNC\` for network paths); off Windows and for ineligible/short paths it is a no-op. This requires **no** `LongPathsEnabled` registry key or app manifest — it works on any Windows machine.

It is applied across the deep-traversal helpers:

- `copy_folder` – extends each path at the point of use. Directory creation (`os.mkdir`) is **force**-extended because Windows caps a *new* directory at `MAX_PATH - 12` (248), not 260.
- `safe_delete_folder` / `compute_folder_size` – force-extend the root so `shutil.rmtree` / `os.walk` internal descent inherits the prefix.
- `move_folder` – extends each deep file before `os.stat`/`os.chmod`/`os.remove`.
- `copy_file`, `touch_file`, `ensure_folder_exists` – extend their file/dir paths (force for the dir-creating `makedirs`).

`copy_folder`'s returned file list is unchanged (plain paths); callers re-extend as needed.

`util/zip.py` now imports the helper from `filesystem` (no behaviour change).

## Tests

- Moved `TestToExtendedPath` into `tests/util_tests/test_filesystem.py` and added `force` coverage.
- Added `TestCopyFolderLongPaths` — a Windows-only integration test that builds a short-rooted tree with a leaf > 260 chars and verifies `copy_folder` + `safe_delete_folder` succeed (the exact SG-45189 scenario).
- Verified as a mutation check: with the `\?\` handling disabled, the new long-path tests fail (integration test errors, prefix-assertion tests fail) while all short-path tests still pass — confirming the tests genuinely exercise the fix.
- `util_tests` package: 223 passed / 6 skipped on Windows (Python 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)