### PR TITLE
SG-45110 Make QtOpenGL import optional in PySide6Patcher

### DIFF
--- a/python/tank/util/pyside6_patcher.py
+++ b/python/tank/util/pyside6_patcher.py
@@ -474,6 +474,7 @@ class PySide6Patcher(PySide2Patcher):
         cls,
         QtWebEngineWidgets,
         QtWebEngineCore,
+        QtOpenGL=None,
     ):
         """
         Patch the PySide6 modules, classes and function to conform to the PySide interface.
@@ -485,6 +486,10 @@ class PySide6Patcher(PySide2Patcher):
         :param QtCore: The QtCore module for PySide6.
         :param QtGui: The QtGui module for PySide6.
         :param QtWidgets: The QtWidgets module for PySide6.
+        :param QtOpenGL: The QtOpenGL module for PySide6, or None if it could not be
+            imported (e.g. missing OpenGL/EGL shared libraries on a headless server). When
+            None, the Qt4-compatibility classes normally moved back from QtOpenGL to QtGui
+            simply won't be available.
 
         :return: The PySide6 modules QtCore and QtGui patched as PySide modules.
         :rtype: tuple
@@ -494,7 +499,6 @@ class PySide6Patcher(PySide2Patcher):
         from PySide6 import (
             QtCore,
             QtGui,
-            QtOpenGL,
             QtWidgets,
         )
 
@@ -523,7 +527,15 @@ class PySide6Patcher(PySide2Patcher):
         # Some classes from QtGui have been moved to QtOpenGL, so put them back into QtGui for
         # compatibility with Qt4
         # https://doc.qt.io/qt-6/gui-changes-qt6.html#opengl-classes
-        cls._move_attributes(qt_gui_shim, QtOpenGL, cls._opengl_to_gui)
+        if QtOpenGL:
+            cls._move_attributes(qt_gui_shim, QtOpenGL, cls._opengl_to_gui)
+        else:
+            warnings.warn(
+                "Unable to import QtOpenGL from PySide6. Qt4-compatibility classes normally "
+                "moved back from QtOpenGL to QtGui (e.g. QOpenGLBuffer, QOpenGLShader) will "
+                "not be available.",
+                RuntimeWarning,
+            )
 
         if qt_web_engine_widgets_shim:
             # Move everything from QtWebEngineWidgets to the QtWebEngineWidgets shim

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -392,7 +392,13 @@ class QtImporter(object):
                 logger.debug("Imported PySide6 as PySide.")
                 return pyside6
             except ImportError:
-                pass
+                # TEMPORARY (SG-45110): this exception is normally swallowed silently, print
+                # the real traceback so we can diagnose why it still fails on Rundeck. Revert
+                # once root-caused.
+                import traceback
+
+                print("SG-45110 DEBUG: PySide6-as-PySide import failed:")
+                traceback.print_exc()
 
         elif interface_version_requested == self.QT5:
             try:

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -279,9 +279,15 @@ class QtImporter(object):
             )
             QtWebEngineCore = self._import_module_by_name("PySide6", "QtWebEngineCore")
 
+        # QtOpenGL requires OpenGL/EGL shared libraries that may be missing on headless
+        # servers, so import it separately rather than letting it take down the whole
+        # PySide6 import.
+        QtOpenGL = self._import_module_by_name("PySide6", "QtOpenGL")
+
         QtCore, QtGui, QtWebEngineWidgets = PySide6Patcher.patch(
             QtWebEngineWidgets,
             QtWebEngineCore,
+            QtOpenGL,
         )
 
         QtNetwork = self._import_module_by_name("PySide6", "QtNetwork")

--- a/python/tank/util/qt_importer.py
+++ b/python/tank/util/qt_importer.py
@@ -391,14 +391,8 @@ class QtImporter(object):
                 pyside6 = self._import_pyside6_as_pyside()
                 logger.debug("Imported PySide6 as PySide.")
                 return pyside6
-            except ImportError:
-                # TEMPORARY (SG-45110): this exception is normally swallowed silently, print
-                # the real traceback so we can diagnose why it still fails on Rundeck. Revert
-                # once root-caused.
-                import traceback
-
-                print("SG-45110 DEBUG: PySide6-as-PySide import failed:")
-                traceback.print_exc()
+            except ImportError as e:
+                logger.debug("Unable to import PySide6 as PySide: %s", e, exc_info=True)
 
         elif interface_version_requested == self.QT5:
             try:


### PR DESCRIPTION
## Problem

`PySide6Patcher.patch()` does an unconditional `from PySide6 import (QtCore, QtGui, QtOpenGL, QtWidgets)`. `QtOpenGL` requires OpenGL/EGL shared libraries (e.g. `libGL.so.1`, `libEGL`) that may not be present on headless servers, such as the machine that runs Rundeck's Sphinx doc-generation job for tk-framework-qtwidgets (SG-45110).

When that import fails, the `ImportError` propagates out of `PySide6Patcher.patch()`, and `qt_importer.py`'s `_import_modules()` silently swallows it (`except ImportError: pass`), so `QtImporter().QtCore` ends up `None` entirely, breaking all Qt functionality in that environment, not just the handful of Qt4-compat OpenGL classes `QtOpenGL` provides.

## Fix

Follow the same pattern already established for `QtWebEngineWidgets`/`QtWebEngineCore` (SG-38470, #1012): fetch `QtOpenGL` via the existing `_import_module_by_name()` helper, which catches any exception and returns `None` on failure, and pass it into `PySide6Patcher.patch()` as an optional parameter. When `QtOpenGL` is unavailable, `patch()` now degrades gracefully (skips restoring the ~15 Qt4-compat OpenGL classes into `QtGui`, emits a `RuntimeWarning`) instead of losing the entire PySide6 binding.

## Behavior impact

- No change when `QtOpenGL` imports successfully (the normal case for DCCs bundling a full Qt with OpenGL support).
- When `QtOpenGL` fails to import: previously `QtCore`/`QtGui` were both `None` (all Qt functionality broken). Now they're valid, minus `QOpenGLBuffer`, `QOpenGLShader`, and similar rarely used classes. A workspace-wide search across all `tk-*` repos found no app/engine/framework code referencing any of these classes through the Qt shim.

## Testing

- Existing `tests/util_tests/test_pyside6_patcher.py::PySide6PatcherTests::test_patch` still passes (now emits the new `RuntimeWarning` since it calls `patch(None, None)` without `QtOpenGL`).
- Manually verified locally with a PySide6 environment that `patch()` returns valid, working `QtCore`/`QtGui` shims both with and without `QtOpenGL` passed in.

Related to SG-45110 (Rundeck doc-build failure) and SG-44795 (PySide as a tk-toolchain dependency).